### PR TITLE
[lampe] Couple small bug-fix / feature adjacent things

### DIFF
--- a/src/heart/assets/loader.py
+++ b/src/heart/assets/loader.py
@@ -17,12 +17,6 @@ class Loader:
     @classmethod
     def load_spirtesheet(cls, path):
         resolved_path = cls._resolve_path(path)
-        from PIL import Image
-        
-        img = Image.open(resolved_path)
-        ff = "sheet.png"
-        if not os.path.exists(ff):
-            img.save(ff)
         return spritesheet(resolved_path)
 
     @classmethod

--- a/src/heart/display/renderers/spritesheet_loop.py
+++ b/src/heart/display/renderers/spritesheet_loop.py
@@ -57,7 +57,7 @@ class SpritesheetLoop(BaseRenderer):
         self.initialized = True
         
     def __duration_scale_factor(self):
-        current_value = SwitchSubscriber.get().get_rotational_value()
+        current_value = SwitchSubscriber.get().get_normalized_rotational_value()
         return current_value / 20.00
         
     def process(self, window, clock) -> None:

--- a/src/heart/display/renderers/spritesheet_loop.py
+++ b/src/heart/display/renderers/spritesheet_loop.py
@@ -57,7 +57,7 @@ class SpritesheetLoop(BaseRenderer):
         self.initialized = True
         
     def __duration_scale_factor(self):
-        current_value = SwitchSubscriber.get().get_normalized_rotational_value()
+        current_value = SwitchSubscriber.get().get_rotation_since_last_button_press()
         return current_value / 20.00
         
     def process(self, window, clock) -> None:

--- a/src/heart/input/environment.py
+++ b/src/heart/input/environment.py
@@ -172,5 +172,5 @@ class GameLoop:
             
         self.time_last_debugging_press = current_time
             
-        pygame.display.set_caption(f"R: {switch.get_rotational_value()}, NR: {switch.get_normalized_rotational_value()}, B: {switch.get_button_value()}")
+        pygame.display.set_caption(f"R: {switch.get_rotational_value()}, NR: {switch.get_rotation_since_last_button_press()}, B: {switch.get_button_value()}")
 

--- a/src/heart/input/environment.py
+++ b/src/heart/input/environment.py
@@ -148,19 +148,29 @@ class GameLoop:
             return
         
         switch = SwitchSubscriber.get().get_switch()
+        payload = None
         if keys[pygame.K_LEFT]:
-            switch.rotational_value -= 1
+            payload = {
+                "event_type": "rotation",
+                "data": switch.rotational_value - 1
+            }
 
         if keys[pygame.K_RIGHT]:
-            switch.rotational_value += 1
+            payload = {
+                "event_type": "rotation",
+                "data": switch.rotational_value + 1
+            }
 
         if keys[pygame.K_UP]:
-            switch.button_value += 1
-
-        if keys[pygame.K_DOWN]:
-            switch.button_value -= 1
+            payload = {
+                "event_type": "button",
+                "data": 1
+            }
+        
+        if payload is not None:
+            switch._update_due_to_data(payload)
             
         self.time_last_debugging_press = current_time
             
-        pygame.display.set_caption(f"Rotation: {switch.get_rotational_value()}, Button: {switch.get_button_value()}")
+        pygame.display.set_caption(f"R: {switch.get_rotational_value()}, NR: {switch.get_normalized_rotational_value()}, B: {switch.get_button_value()}")
 

--- a/src/heart/input/switch.py
+++ b/src/heart/input/switch.py
@@ -8,13 +8,13 @@ class BaseSwitch:
     def __init__(self) -> None:
         self.rotational_value = 0
         self.button_value = 0
-        self.last_rotational_value = self.rotational_value
+        self.rotation_value_at_last_button_press = self.rotational_value
         
     def run(self) -> None:
         return
     
-    def get_normalized_rotational_value(self) -> int:
-        return self.rotational_value - self.last_rotational_value
+    def get_rotation_since_last_button_press(self) -> int:
+        return self.rotational_value - self.rotation_value_at_last_button_press
     
     def get_rotational_value(self) -> int:
         return self.rotational_value
@@ -32,7 +32,7 @@ class BaseSwitch:
         if event_type == "button":
             self.button_value += int(data_value)
             # Button was pressed, update last_rotational_value
-            self.last_rotational_value = self.rotational_value
+            self.rotation_value_at_last_button_press = self.rotational_value
 
 class FakeSwitch(BaseSwitch):
     def __init__(self, *args, **kwargs) -> None:
@@ -95,8 +95,8 @@ class SwitchSubscriber:
     def get_switch(self):
         return self.switch
     
-    def get_normalized_rotational_value(self) -> int:
-        return self.get_switch().get_normalized_rotational_value()
+    def get_rotation_since_last_button_press(self) -> int:
+        return self.get_switch().get_rotation_since_last_button_press()
     
     def get_rotational_value(self) -> int:
         return self.get_switch().get_rotational_value()


### PR DESCRIPTION
## Debugging Code Fix
* Remove the sheet.png debugging code

## Event Bus / Local vs PI code parity
* Switch the local debugging to match the event-based structure on device
* This means I removed the "down button"

## Rotation Since Last Button Press
* Have the Switch store a normalized version of the rotation, which is rotation since last button press.
* This was wired into the spritesheet loop (Renamed KirbyLoop) that I accidentally pushed to main.  It controls a scaling factor for the keyframe of the animation

# Serial Bus Reconnect
* First attempt at trying to have the serial bus auto-reconnect instead of just hard-crashing things 😄 