### PR TITLE
Move tiling to base renderer

### DIFF
--- a/src/heart/display/renderers/slide.py
+++ b/src/heart/display/renderers/slide.py
@@ -1,7 +1,7 @@
 import pygame
 
 from heart import DeviceDisplayMode
-from heart.device import Orientation
+from heart.device import Orientation, Rectangle
 from heart.display.renderers import BaseRenderer
 from heart.peripheral.core.manager import PeripheralManager
 
@@ -80,10 +80,10 @@ class SlideTransitionRenderer(BaseRenderer):
         surf_B = pygame.Surface(size, pygame.SRCALPHA)
 
         result_A = self.renderer_A._internal_process(
-            surf_A, clock, peripheral_manager, orientation
+            surf_A, clock, peripheral_manager, Rectangle.with_layout(1, 1)
         )
         result = self.renderer_B._internal_process(
-            surf_B, clock, peripheral_manager, orientation
+            surf_B, clock, peripheral_manager, Rectangle.with_layout(1, 1)
         )
 
         # ----------------------------------------------------------------- #

--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -120,19 +120,7 @@ class GameLoop:
 
     def process_renderer(self, renderer: "BaseRenderer") -> pygame.Surface | None:
         try:
-            match renderer.device_display_mode:
-                case DeviceDisplayMode.FULL:
-                    # The screen is the full size of the device
-                    screen = pygame.Surface(
-                        self.device.full_display_size(), pygame.SRCALPHA
-                    )
-                case DeviceDisplayMode.MIRRORED:
-                    # The screen is the full size of the device
-                    screen = pygame.Surface(
-                        self.device.individual_display_size(), pygame.SRCALPHA
-                    )
-
-            # Process the screen
+            screen = pygame.Surface(self.device.full_display_size(), pygame.SRCALPHA)
 
             kwargs = {
                 "window": screen,
@@ -140,18 +128,8 @@ class GameLoop:
                 "peripheral_manager": self.peripheral_manager,
                 "orientation": self.device.orientation,
             }
-
             renderer._internal_process(**kwargs)
 
-            match renderer.device_display_mode:
-                case DeviceDisplayMode.MIRRORED:
-                    layout: Layout = self.device.orientation.layout
-                    screen = self._tile_surface(
-                        screen=screen, rows=layout.rows, cols=layout.columns
-                    )
-
-                case DeviceDisplayMode.FULL:
-                    pass
             return screen
         except Exception as e:
             logger.error(f"Error processing renderer: {e}", exc_info=True)
@@ -165,21 +143,6 @@ class GameLoop:
         image = np.transpose(image, (1, 0, 2))
         image = Image.fromarray(image, RGBA_IMAGE_FORMAT)
         return image
-
-    def _tile_surface(
-        self, screen: pygame.Surface, rows: int, cols: int
-    ) -> pygame.Surface:
-        tile_width, tile_height = screen.get_size()
-        tiled_surface = pygame.Surface(
-            (tile_width * cols, tile_height * rows), pygame.SRCALPHA
-        )
-
-        for row in range(rows):
-            for col in range(cols):
-                dest_pos = (col * tile_width, row * tile_height)
-                tiled_surface.blit(screen, dest_pos)
-
-        return tiled_surface
 
     def merge_surfaces(
         self, surface1: pygame.Surface, surface2: pygame.Surface


### PR DESCRIPTION
Continued work to move this out of the top level.  Overall having the mirroring vs not be a top-level thing made it really hard to control the interaction between .FULL and .MIRRORED scenes

Still haven't figured out how the slide transition should look when there is a multi-screen view; todo I suppose.  I think the answer is some sort of mask instead of the offset approach, where we incrementally increase the mask for each mirror side