### PR TITLE
Refine peripheral infrastructure and detection

### DIFF
--- a/src/heart/peripheral/bluetooth.py
+++ b/src/heart/peripheral/bluetooth.py
@@ -1,7 +1,9 @@
 import asyncio
 import functools
 import json
+import logging
 import threading
+import time
 from collections import deque
 from typing import Any, Iterator, NoReturn
 
@@ -19,13 +21,14 @@ OBJECT_SEPARATOR = "\n"
 class UartListener:
     """Listeners for data come in as raw bytes from a UART Service."""
 
-    __slots__ = ("device", "buffer", "events", "disconnected")
+    __slots__ = ("device", "buffer", "events", "disconnected", "_logger")
 
     def __init__(self, device: BLEDevice) -> None:
         self.device = device
         self.buffer: str = ""
         self.events: deque[dict[str, Any]] = deque([], maxlen=50)
         self.disconnected = False
+        self._logger = logging.getLogger(f"{__name__}.{type(self).__name__}")
 
     @classmethod
     def _discover_devices(cls) -> Iterator[BLEDevice]:
@@ -36,11 +39,17 @@ class UartListener:
                 yield device
 
     def start(self) -> None:
-        t = threading.Thread(target=lambda: asyncio.run(self.connect_and_listen()))
+        self._logger.debug("Starting UART listener thread for %s", self.device.address)
+        t = threading.Thread(
+            target=lambda: asyncio.run(self.connect_and_listen()),
+            daemon=True,
+            name=f"UartListener-{self.device.address}",
+        )
         t.start()
 
     def close(self) -> None:
-        pass
+        self._logger.debug("Closing UART listener for %s", self.device.address)
+        self.disconnected = True
 
     def consume_events(self) -> Iterator[dict[str, Any]]:
         while self.events:
@@ -49,14 +58,16 @@ class UartListener:
             yield self.events.popleft()
 
     async def connect_and_listen(self) -> NoReturn:
-        print("Found a device, starting listener loop")
+        self._logger.info("Found a device, starting listener loop")
         await self.__start_listener_loop(self.device)
 
     async def __start_listener_loop(self, device: BLEDevice) -> NoReturn:
         while True:
             # We still tend to loe a decent amount of data (~5 seconds worth)
             # as part of the reconnection process, but if the timeout is infrequent enough it would be hard to notice
-            print(f"Attempting to connect to {device.address} ({device.name}).")
+            self._logger.info(
+                "Attempting to connect to %s (%s).", device.address, device.name
+            )
 
             # For now we just restart the listener, as whatever we lost in the reconnection
             # is likely going to be discarded as misaligned anyway
@@ -109,8 +120,8 @@ class UartListener:
 
             try:
                 self.events.append(json.loads(line))
-            except json.decoder.JSONDecodeError as e:
-                pass
+            except json.decoder.JSONDecodeError:
+                self._logger.debug("Failed to decode payload: %s", line, exc_info=True)
 
     def __decode_read_data(self, data: bytearray) -> str:
         return data.decode("utf-8", errors="ignore")

--- a/src/heart/peripheral/core/__init__.py
+++ b/src/heart/peripheral/core/__init__.py
@@ -1,28 +1,57 @@
+from __future__ import annotations
+
 import abc
+import logging
 from dataclasses import dataclass
-from typing import Any, Iterator, Self
-
-import pygame
+from typing import Any, Iterable, Mapping, Self
 
 
-@dataclass
+@dataclass(slots=True)
 class Input:
+    """Normalized structure for messages emitted by peripherals."""
+
     event_type: str
     data: Any
     producer_id: int = 0
 
 
 class Peripheral(abc.ABC):
-    def run(self) -> None:
-        pass
+    """Abstract base class for all peripherals."""
 
-    @staticmethod
-    def detect() -> Iterator[Self]:
-        raise NotImplementedError("'detect' is not implemented")
+    _logger = logging.getLogger(__name__)
+
+    @abc.abstractmethod
+    def run(self) -> None:
+        """Start the peripheral's processing loop."""
+
+    @classmethod
+    @abc.abstractmethod
+    def detect(cls) -> Iterable[Self]:
+        """Discover available peripherals of this type."""
 
     def handle_input(self, input: Input) -> None:
-        pass
+        """Process input data sent to the peripheral.
 
-    def update_due_to_data(self, data: dict) -> None:
-        i = Input(**data)
-        self.handle_input(i)
+        Subclasses can override this method to react to events emitted by
+        other components.  The base implementation is intentionally a no-op to
+        keep backwards compatibility with peripherals that do not yet
+        implement input handling.
+        """
+
+    def update_due_to_data(self, data: Mapping[str, Any]) -> None:
+        """Convert a raw payload into an :class:`Input` instance.
+
+        Parameters
+        ----------
+        data:
+            Mapping produced by external sources.  The mapping must contain at
+            least the keys ``event_type`` and ``data``.  Additional keys are
+            passed through to :class:`Input`.
+        """
+
+        try:
+            self.handle_input(Input(**data))
+        except TypeError:
+            self._logger.debug(
+                "Ignoring malformed peripheral payload: %s", data, exc_info=True
+            )

--- a/src/heart/peripheral/core/manager.py
+++ b/src/heart/peripheral/core/manager.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
+
 import itertools
 import threading
-from dataclasses import dataclass
-from enum import StrEnum
-from typing import Iterator
+from typing import Iterable, Iterator
 
 from heart.peripheral.core import Peripheral
 from heart.peripheral.gamepad import Gamepad
@@ -18,25 +18,32 @@ logger = get_logger(__name__)
 
 
 class PeripheralManager:
+    """Coordinate detection and execution of available peripherals."""
+
     def __init__(self) -> None:
-        self.peripheral: list[Peripheral] = []
+        self._peripherals: list[Peripheral] = []
         self._deprecated_main_switch: BaseSwitch | None = None
         self._threads: list[threading.Thread] = []
+        self._started = False
 
-        self.started = False
+    @property
+    def peripherals(self) -> tuple[Peripheral, ...]:
+        return tuple(self._peripherals)
 
     def get_gamepad(self) -> Gamepad:
-        # todo: we're just assuming there's at most one gamepad plugged in and hence
-        #  always exactly one Gamepad entry point. could generalize to more
-        gamepads = [
-            peripheral
-            for peripheral in self.peripheral
-            if isinstance(peripheral, Gamepad)
-        ]
-        return gamepads[0]
+        """Return the first detected gamepad."""
+
+        for peripheral in self._peripherals:
+            if isinstance(peripheral, Gamepad):
+                return peripheral
+        raise ValueError("No Gamepad peripheral registered")
 
     def detect(self) -> None:
-        peripherials = itertools.chain(
+        for peripheral in self._iter_detected_peripherals():
+            self._register_peripheral(peripheral)
+
+    def _iter_detected_peripherals(self) -> Iterable[Peripheral]:
+        yield from itertools.chain(
             self._detect_switches(),
             self._detect_sensors(),
             self._detect_gamepads(),
@@ -44,28 +51,20 @@ class PeripheralManager:
             self._detect_phone_text(),
         )
 
-        for peripherial in peripherials:
-            self._register_peripherial(peripherial=peripherial)
-
     def start(self) -> None:
-        if self.started:
+        if self._started:
             raise ValueError("Manager has already been started")
 
-        self.started = True
-        for peripherial in self.peripheral:
-            # TODO (lampe): Should likely keep a handle on all these threads
-            def peripherial_run_fn() -> None:
-                peripherial.run()
-
-            # TODO: Doing the threading automatically might cause issues with the local switch?
-            peripherial_thread = threading.Thread(
-                target=peripherial_run_fn,
+        self._started = True
+        for peripheral in self._peripherals:
+            logger.info("Starting peripheral thread for %s", type(peripheral).__name__)
+            thread = threading.Thread(
+                target=peripheral.run,
                 daemon=True,
-                name=f"Peripherial - {type(peripherial).__name__}",
+                name=f"Peripheral - {type(peripheral).__name__}",
             )
-            peripherial_thread.start()
-
-            self._threads.append(peripherial_thread)
+            thread.start()
+            self._threads.append(thread)
 
     def _detect_switches(self) -> Iterator[Peripheral]:
         if Configuration.is_pi() and not Configuration.is_x11_forward():
@@ -84,7 +83,7 @@ class PeripheralManager:
             switches = list(FakeSwitch.detect())
 
         for switch in switches:
-            logger.info(f"Adding switch - {switch}")
+            logger.info("Adding switch - %s", switch)
 
             if self._deprecated_main_switch is None:
                 self._deprecated_main_switch = switch
@@ -102,8 +101,8 @@ class PeripheralManager:
     def _detect_heart_rate_sensor(self) -> Iterator[Peripheral]:
         yield from itertools.chain(HeartRateManager.detect())
 
-    def _register_peripherial(self, peripherial: Peripheral) -> None:
-        self.peripheral.append(peripherial)
+    def _register_peripheral(self, peripheral: Peripheral) -> None:
+        self._peripherals.append(peripheral)
 
     def _deprecated_get_main_switch(self) -> BaseSwitch:
         """Added this to make the legacy conversion easier, SwitchSubscriber is now
@@ -114,36 +113,49 @@ class PeripheralManager:
         return self._deprecated_main_switch
 
     def bluetooth_switch(self) -> BluetoothSwitch | None:
-        for p in self.peripheral:
+        for p in self._peripherals:
             if isinstance(p, BluetoothSwitch):
                 return p
         return None
 
     def get_heart_rate_peripheral(self) -> HeartRateManager:
         """There should be only one instance managing all the heart rate sensors."""
-        for p in self.peripheral:
+        for p in self._peripherals:
             if isinstance(p, HeartRateManager):
                 return p
         raise ValueError("No HeartRateManager peripheral registered")
 
     def get_phyphox_peripheral(self) -> Phyphox:
         """There should be only one instance of Phyphox."""
-        for p in self.peripheral:
+        for p in self._peripherals:
             if isinstance(p, Phyphox):
                 return p
         raise ValueError("No Phyphox peripheral registered")
 
     def get_accelerometer(self) -> Accelerometer:
-        for p in self.peripheral:
+        for p in self._peripherals:
             if isinstance(p, Accelerometer):
                 return p
         raise ValueError("No Accelerometer peripheral registered")
 
     def get_phone_text(self) -> PhoneText:
-        for p in self.peripheral:
+        for p in self._peripherals:
             if isinstance(p, PhoneText):
                 return p
         raise ValueError("No PhoneText peripheral registered")
+
+    def close(self, join_timeout: float = 3.0) -> None:
+        """Attempt to stop all background threads started by the manager."""
+
+        for thread in self._threads:
+            if thread.is_alive():
+                logger.debug(
+                    "Joining peripheral thread %s with timeout %.1f", thread.name, join_timeout
+                )
+                try:
+                    thread.join(timeout=join_timeout)
+                except Exception:
+                    logger.exception("Failed to join thread %s", thread.name)
 
     def __del__(self) -> None:
         """Attempt to clean up threads and peripherals at object deletion time.
@@ -152,9 +164,4 @@ class PeripheralManager:
         or context-manager approach for reliability.
 
         """
-        for t in self._threads:
-            if t.is_alive():
-                try:
-                    t.join(timeout=3.0)
-                except Exception as e:
-                    print(f"Error joining thread {t}: {e}")
+        self.close()

--- a/src/heart/peripheral/gamepad/gamepad.py
+++ b/src/heart/peripheral/gamepad/gamepad.py
@@ -162,12 +162,12 @@ class Gamepad(Peripheral):
                 if t0 is not None and now - t0 <= self.TAP_THRESHOLD_MS:
                     self._tap_flag[axis_key] = True
 
-    @staticmethod
-    def detect() -> Iterator["Gamepad"]:
+    @classmethod
+    def detect(cls) -> Iterator["Gamepad"]:
         try:
             pygame.joystick.quit()
             pygame.joystick.init()
-            return [Gamepad()]
+            return [cls()]
         except pygame.error as e:
             print(f"Error initializing joystick module: {e}")
             return []

--- a/src/heart/peripheral/heart_rates.py
+++ b/src/heart/peripheral/heart_rates.py
@@ -75,9 +75,9 @@ class HeartRateManager(Peripheral):
 
     # ---------- Peripheral framework ----------
 
-    @staticmethod
-    def detect() -> Iterator["HeartRateManager"]:
-        yield HeartRateManager()
+    @classmethod
+    def detect(cls) -> Iterator["HeartRateManager"]:
+        yield cls()
 
     # ---------- Callbacks -----------------------------------------------------
 

--- a/src/heart/peripheral/phone_text.py
+++ b/src/heart/peripheral/phone_text.py
@@ -123,6 +123,6 @@ class PhoneText(Peripheral):
             # Clear the buffer for the next message
             self._buffer.clear()
 
-    @staticmethod
-    def detect() -> Iterator["PhoneText"]:
-        yield PhoneText()
+    @classmethod
+    def detect(cls) -> Iterator["PhoneText"]:
+        yield cls()

--- a/src/heart/peripheral/phyphox.py
+++ b/src/heart/peripheral/phyphox.py
@@ -16,7 +16,7 @@ class Phyphox(Peripheral):
 
     @classmethod
     def detect(cls) -> Iterator[Self]:
-        return [Phyphox("http://192.168.1.42")]
+        return [cls("http://192.168.1.42")]
 
     def run(self) -> NoReturn:
         while True:

--- a/src/heart/peripheral/sensor.py
+++ b/src/heart/peripheral/sensor.py
@@ -48,7 +48,7 @@ class Accelerometer(Peripheral):
     @classmethod
     def detect(cls) -> Iterator[Self]:
         return [
-            Accelerometer(port=port, baudrate=115200)
+            cls(port=port, baudrate=115200)
             for port in get_device_ports("usb-Adafruit_KB2040")
         ]
 

--- a/src/heart/peripheral/switch.py
+++ b/src/heart/peripheral/switch.py
@@ -61,9 +61,9 @@ class FakeSwitch(BaseSwitch):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-    @staticmethod
-    def detect() -> Iterator[Self]:
-        return [FakeSwitch()]
+    @classmethod
+    def detect(cls) -> Iterator[Self]:
+        return [cls()]
 
     def run(self) -> None:
         return
@@ -75,10 +75,10 @@ class Switch(BaseSwitch):
         self.baudrate = baudrate
         super().__init__(*args, **kwargs)
 
-    @staticmethod
-    def detect() -> Iterator[Self]:
+    @classmethod
+    def detect(cls) -> Iterator[Self]:
         return [
-            Switch(port=port, baudrate=115200)
+            cls(port=port, baudrate=115200)
             for port in get_device_ports(
                 "usb-Adafruit_Industries_LLC_Rotary_Trinkey_M0"
             )


### PR DESCRIPTION
## Summary
- tighten the Peripheral base contract with logging for malformed messages
- refactor the PeripheralManager to manage peripheral lifecycle threads and provide cleanup
- align detection helpers and improve bluetooth UART listener diagnostics across peripherals

## Testing
- `python -m compileall src/heart/peripheral` *(fails: pyenv does not provide the configured interpreter)*
- `python3 -m compileall src/heart/peripheral`


------
https://chatgpt.com/codex/tasks/task_e_69061ddd8eb483218d20011b4f04531f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes peripheral detection to classmethods, strengthens base input handling with logging, refactors PeripheralManager thread lifecycle, and enhances Bluetooth UART listener diagnostics.
> 
> - **Core**:
>   - **`Peripheral`**: Make `detect()` an abstract `@classmethod` returning `Iterable[Self]`; add `_logger`; refine `handle_input()` no-op; `update_due_to_data()` now accepts `Mapping` and logs malformed payloads.
>   - **`Input`**: Convert to `@dataclass(slots=True)`.
> - **Manager** (`core/manager.py`):
>   - Track peripherals via `_peripherals` with `peripherals` property; refactor detection pipeline; start daemon threads with explicit names; add `close(join_timeout)` and use in `__del__`; improve logging and errors when required peripherals are missing.
> - **Peripherals** (standardized detection):
>   - Convert `detect()` to `@classmethod` returning `cls()` for `Gamepad`, `HeartRateManager`, `PhoneText`, `Phyphox`, `Accelerometer`, `Switch`, and `FakeSwitch`.
> - **Bluetooth** (`bluetooth.UartListener`):
>   - Add structured logging, named daemon thread, `close()` to mark disconnected, and debug logging for JSON decode failures; clearer reconnect loop messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69929d513a7a6e9935cf819d9d842a6da40efc60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->