### PR TITLE
Move AGENTS reminder to repository root

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -1,0 +1,3 @@
+# Documentation Guidelines
+
+- If any meaningful changes are made to the runtime architecture or service boundaries, update `docs/code_flow.md` and re-render the diagram via `scripts/render_code_flow.py` so that the documentation stays accurate.

--- a/docs/code_flow.md
+++ b/docs/code_flow.md
@@ -1,0 +1,78 @@
+# Runtime Code Flow
+
+The diagram below summarizes how a `totem run` invocation moves through the CLI, runtime loop, peripherals, and display devices. It highlights where the system crosses service boundaries such as hardware peripherals and external LED drivers.
+
+```mermaid
+flowchart TD
+    subgraph Launch["Launch & Configuration"]
+        CLI[`totem run --configuration <name>`]
+        Typer[`heart.loop.run()` Typer CLI]
+        Registry["ConfigurationRegistry.get(name)"]
+        ConfigFn["configure(loop) in heart.programs.configurations.*"]
+    end
+
+    subgraph Core["Core GameLoop Runtime"]
+        LoopStart["GameLoop.start()\n(initializes once)"]
+        InitScreen["_initialize_screen()\npygame surfaces + clock"]
+        InitPeripherals["_initialize_peripherals()\nPeripheralManager.detect()/start()"]
+        EventLoop["while running:\n_handle_events()\n_preprocess_setup()"]
+        AppCtrl["AppController/GameModes\nselect active mode"]
+        Renderers["Active renderers\nreturn pygame surfaces"]
+        Compose["_render_fn()\nmerge surfaces"]
+    end
+
+    subgraph Inputs["Peripheral Threads & Signals"]
+        PeripheralMgr["PeripheralManager\nbackground threads"]
+        Switch["Switch/BluetoothSwitch"]
+        Gamepad["Gamepad"]
+        Sensors["Accelerometer / Phyphox"]
+        HeartRate["HeartRateManager"]
+        PhoneText["PhoneText"]
+    end
+
+    subgraph Display["Display & Device Output"]
+        ScreenFlip["pygame.display.flip\n+ capture surface"]
+        DeviceOut["Device.set_image(image)"]
+        subgraph LocalDisplay["Local PC Display"]
+            LocalScreen["LocalScreen\nscaled pygame window"]
+        end
+        subgraph LedHardware["RGB LED Hardware"]
+            MatrixWorker["MatrixDisplayWorker thread"]
+            LedMatrix["LEDMatrix (rgbmatrix driver)"]
+        end
+    end
+
+    CLI --> Typer --> Registry --> ConfigFn
+    Typer --> LoopStart
+    LoopStart --> InitScreen
+    LoopStart --> InitPeripherals
+    InitPeripherals --> PeripheralMgr
+    PeripheralMgr --> Switch
+    PeripheralMgr --> Gamepad
+    PeripheralMgr --> Sensors
+    PeripheralMgr --> HeartRate
+    PeripheralMgr --> PhoneText
+
+    ConfigFn -->|adds modes/scenes| AppCtrl
+    LoopStart --> EventLoop
+    EventLoop --> AppCtrl
+    AppCtrl --> Renderers --> Compose --> ScreenFlip --> DeviceOut
+    DeviceOut --> LocalScreen
+    DeviceOut --> MatrixWorker --> LedMatrix
+
+    Switch --> AppCtrl
+    Gamepad --> AppCtrl
+    Sensors --> AppCtrl
+    HeartRate --> AppCtrl
+    PhoneText --> AppCtrl
+```
+
+## Rendering the diagram
+
+Run `scripts/render_code_flow.py` to regenerate an SVG (or PNG/PDF via `--format`) from the mermaid source whenever the architecture changes:
+
+```bash
+python scripts/render_code_flow.py --output docs/code_flow.svg
+```
+
+If `mmdc` is not already installed, the script will fall back to using `npx @mermaid-js/mermaid-cli`.

--- a/scripts/render_code_flow.py
+++ b/scripts/render_code_flow.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Render the runtime code flow mermaid diagram to an image file."""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Iterable
+
+
+def extract_mermaid_blocks(markdown: str) -> Iterable[str]:
+    """Yield mermaid code blocks from a markdown document."""
+    lines = markdown.splitlines()
+    in_block = False
+    block_lines: list[str] = []
+
+    for line in lines:
+        if not in_block:
+            if line.strip().lower().startswith("```mermaid"):
+                in_block = True
+                block_lines = []
+            continue
+
+        if line.strip().startswith("```"):
+            in_block = False
+            if block_lines:
+                yield "\n".join(block_lines).strip() + "\n"
+            block_lines = []
+        else:
+            block_lines.append(line)
+
+
+def ensure_renderer() -> list[str]:
+    """Return the command to invoke the mermaid CLI."""
+    mmdc = shutil.which("mmdc")
+    if mmdc:
+        return [mmdc]
+
+    npx = shutil.which("npx")
+    if npx:
+        return [npx, "--yes", "@mermaid-js/mermaid-cli"]
+
+    raise SystemExit(
+        "Neither 'mmdc' nor 'npx' with @mermaid-js/mermaid-cli is available. "
+        "Install the mermaid CLI (https://github.com/mermaid-js/mermaid-cli) "
+        "or ensure Node.js with npx is on PATH."
+    )
+
+
+def render_diagram(source: str, output: pathlib.Path, fmt: str) -> None:
+    render_cmd = ensure_renderer()
+
+    with tempfile.NamedTemporaryFile("w", suffix=".mmd", delete=False) as tmp:
+        tmp.write(source)
+        tmp_path = pathlib.Path(tmp.name)
+
+    try:
+        cmd = [*render_cmd, "-i", str(tmp_path), "-o", str(output), "-t", "neutral", "-e", fmt]
+        subprocess.run(cmd, check=True)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source",
+        type=pathlib.Path,
+        default=pathlib.Path("docs/code_flow.md"),
+        help="Markdown file that contains a mermaid diagram.",
+    )
+    parser.add_argument(
+        "--output",
+        type=pathlib.Path,
+        default=pathlib.Path("docs/code_flow.svg"),
+        help="Output image path (format inferred from extension).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["svg", "png", "pdf"],
+        help="Explicit format override (otherwise derived from output extension).",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.source.exists():
+        raise SystemExit(f"Markdown source not found: {args.source}")
+
+    markdown = args.source.read_text(encoding="utf-8")
+    blocks = list(extract_mermaid_blocks(markdown))
+    if not blocks:
+        raise SystemExit(f"No mermaid diagram found in {args.source}")
+
+    mermaid_source = blocks[0]
+
+    output_format = args.format
+    if output_format is None:
+        output_format = args.output.suffix.lstrip(".").lower() or "svg"
+
+    if output_format not in {"svg", "png", "pdf"}:
+        raise SystemExit(f"Unsupported output format: {output_format}")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    render_diagram(mermaid_source, args.output, output_format)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- move the documentation update reminder from docs/AGENTS.MD to AGENTS.MD at the repository root so it applies repo-wide

## Testing
- not run (docs-only change)

------
https://chatgpt.com/codex/tasks/task_e_69061f1a25b4832182e58d9fbcdeb80b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Mermaid-based runtime code flow doc with a renderer script and a repo-root documentation guideline.
> 
> - **Documentation**:
>   - Add `docs/code_flow.md` with a Mermaid diagram detailing CLI → runtime loop → peripherals → display flow, plus instructions to render outputs.
>   - Add `AGENTS.MD` at repo root with a guideline to update `docs/code_flow.md` and re-render when architecture changes.
> - **Tooling**:
>   - Add `scripts/render_code_flow.py` to extract Mermaid blocks from markdown and render to `svg/png/pdf` via `mmdc` or `npx @mermaid-js/mermaid-cli`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 204b1d1e10e50e916a6e03323c99dd271c45616d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->