### PR TITLE
Clarify code flow documentation instructions

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -1,3 +1,5 @@
 # Documentation Guidelines
 
-- If any meaningful changes are made to the runtime architecture or service boundaries, update `docs/code_flow.md` and re-render the diagram via `scripts/render_code_flow.py` so that the documentation stays accurate.
+- If any meaningful changes are made to the runtime architecture or service boundaries, update `docs/code_flow.md`.
+- After updating the mermaid source, always regenerate the rendered diagram by running `python scripts/render_code_flow.py --output docs/code_flow.svg` (and include any additional formats you maintain).
+- Commit the updated `docs/code_flow.md`, regenerated diagram assets (e.g., `docs/code_flow.svg`), and any script output so the documentation stays accurate.


### PR DESCRIPTION
## Summary
- update the documentation agent guidelines to require regenerating the code flow diagram whenever the mermaid source changes
- instruct contributors to commit both the markdown source and rendered assets so the diagram stays current

## Testing
- make format *(fails: proxy prevented downloading build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_690627071c108321b194ebf8b426d6ba

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies documentation to require updating `docs/code_flow.md`, regenerating code flow diagrams, and committing rendered assets/scripts output.
> 
> - **Documentation**:
>   - Update `AGENTS.MD` to:
>     - Require updating `docs/code_flow.md` when runtime architecture changes.
>     - Instruct regenerating the diagram via `python scripts/render_code_flow.py --output docs/code_flow.svg` (and other maintained formats).
>     - Require committing updated markdown and rendered diagram assets (e.g., `docs/code_flow.svg`) and any script output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba7c8b2b8aac164ef74ec7f3cc4db97c4a93c9bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->