### PR TITLE
Add rendered code flow diagram

### DIFF
--- a/docs/code_flow.svg
+++ b/docs/code_flow.svg
@@ -1,0 +1,177 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 960">
+  <defs>
+    <style>
+      text { font-family: "Inter", "Helvetica", "Arial", sans-serif; fill: #1a1a1a; }
+      .title { font-weight: 600; font-size: 22px; }
+      .node { fill: #ffffff; stroke: #2f4f6f; stroke-width: 2; rx: 12; ry: 12; }
+      .subgraph { fill: #eef3ff; stroke: #97a6c3; stroke-dasharray: 8 6; stroke-width: 2; }
+      .subgraph-fill { fill: #eef3ff; opacity: 0.7; }
+      .connector { stroke: #2f4f6f; stroke-width: 2.4; fill: none; }
+      .connector.arrow { marker-end: url(#arrow); }
+      .label { font-size: 15px; font-weight: 500; }
+      .node-text { font-size: 15px; font-weight: 500; }
+    </style>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#2f4f6f" />
+    </marker>
+  </defs>
+
+  <!-- Launch & Configuration -->
+  <g transform="translate(40,60)">
+    <rect class="subgraph" width="260" height="360" rx="18" ry="18" fill="none" />
+    <text class="title" x="130" y="32">Launch &amp; Configuration</text>
+
+    <rect class="node" x="20" y="60" width="220" height="60" />
+    <text class="node-text" x="130" y="95" text-anchor="middle">totem run --configuration &lt;name&gt;</text>
+
+    <rect class="node" x="20" y="140" width="220" height="60" />
+    <text class="node-text" x="130" y="175" text-anchor="middle">heart.loop.run() Typer CLI</text>
+
+    <rect class="node" x="20" y="220" width="220" height="60" />
+    <text class="node-text" x="130" y="255" text-anchor="middle">ConfigurationRegistry.get(name)</text>
+
+    <rect class="node" x="20" y="300" width="220" height="60" />
+    <text class="node-text" x="130" y="327" text-anchor="middle">configure(loop)</text>
+    <text class="node-text" x="130" y="347" text-anchor="middle">heart.programs.configurations.*</text>
+  </g>
+
+  <!-- Core Runtime -->
+  <g transform="translate(360,40)">
+    <rect class="subgraph" width="320" height="600" rx="18" ry="18" fill="none" />
+    <text class="title" x="160" y="32">Core GameLoop Runtime</text>
+
+    <rect class="node" x="30" y="60" width="260" height="60" />
+    <text class="node-text" x="160" y="90" text-anchor="middle">GameLoop.start()</text>
+    <text class="node-text" x="160" y="110" text-anchor="middle">initializes once</text>
+
+    <rect class="node" x="30" y="140" width="260" height="60" />
+    <text class="node-text" x="160" y="170" text-anchor="middle">_initialize_screen()</text>
+    <text class="node-text" x="160" y="190" text-anchor="middle">pygame surfaces + clock</text>
+
+    <rect class="node" x="30" y="220" width="260" height="60" />
+    <text class="node-text" x="160" y="250" text-anchor="middle">_initialize_peripherals()</text>
+    <text class="node-text" x="160" y="270" text-anchor="middle">PeripheralManager.detect()/start()</text>
+
+    <rect class="node" x="30" y="300" width="260" height="60" />
+    <text class="node-text" x="160" y="330" text-anchor="middle">while running:</text>
+    <text class="node-text" x="160" y="350" text-anchor="middle">_handle_events()</text>
+    <text class="node-text" x="160" y="370" text-anchor="middle">_preprocess_setup()</text>
+
+    <rect class="node" x="30" y="380" width="260" height="60" />
+    <text class="node-text" x="160" y="410" text-anchor="middle">AppController / GameModes</text>
+    <text class="node-text" x="160" y="430" text-anchor="middle">select active mode</text>
+
+    <rect class="node" x="30" y="460" width="260" height="60" />
+    <text class="node-text" x="160" y="490" text-anchor="middle">Active renderers</text>
+    <text class="node-text" x="160" y="510" text-anchor="middle">return pygame surfaces</text>
+
+    <rect class="node" x="30" y="540" width="260" height="60" />
+    <text class="node-text" x="160" y="570" text-anchor="middle">_render_fn()</text>
+    <text class="node-text" x="160" y="590" text-anchor="middle">merge surfaces</text>
+  </g>
+
+  <!-- Inputs -->
+  <g transform="translate(40,440)">
+    <rect class="subgraph" width="260" height="400" rx="18" ry="18" fill="none" />
+    <text class="title" x="130" y="32">Peripheral Threads &amp; Signals</text>
+
+    <rect class="node" x="20" y="60" width="220" height="60" />
+    <text class="node-text" x="130" y="95" text-anchor="middle">PeripheralManager</text>
+    <text class="node-text" x="130" y="115" text-anchor="middle">background threads</text>
+
+    <rect class="node" x="20" y="140" width="220" height="56" />
+    <text class="node-text" x="130" y="170" text-anchor="middle">Switch / BluetoothSwitch</text>
+
+    <rect class="node" x="20" y="216" width="220" height="56" />
+    <text class="node-text" x="130" y="246" text-anchor="middle">Gamepad</text>
+
+    <rect class="node" x="20" y="292" width="220" height="56" />
+    <text class="node-text" x="130" y="322" text-anchor="middle">Accelerometer / Phyphox</text>
+
+    <rect class="node" x="20" y="368" width="220" height="56" />
+    <text class="node-text" x="130" y="398" text-anchor="middle">HeartRateManager</text>
+
+    <rect class="node" x="20" y="444" width="220" height="56" />
+    <text class="node-text" x="130" y="474" text-anchor="middle">PhoneText</text>
+  </g>
+
+  <!-- Display -->
+  <g transform="translate(720,160)">
+    <rect class="subgraph" width="320" height="420" rx="18" ry="18" fill="none" />
+    <text class="title" x="160" y="32">Display &amp; Device Output</text>
+
+    <rect class="node" x="40" y="60" width="240" height="60" />
+    <text class="node-text" x="160" y="95" text-anchor="middle">pygame.display.flip</text>
+    <text class="node-text" x="160" y="115" text-anchor="middle">capture surface</text>
+
+    <rect class="node" x="40" y="140" width="240" height="60" />
+    <text class="node-text" x="160" y="175" text-anchor="middle">Device.set_image(image)</text>
+
+    <!-- Local display subgroup -->
+    <g transform="translate(20,220)">
+      <rect class="subgraph" width="140" height="140" rx="14" ry="14" fill="none" />
+      <text class="label" x="70" y="28" text-anchor="middle">Local PC Display</text>
+      <rect class="node" x="10" y="56" width="120" height="60" />
+      <text class="node-text" x="70" y="86" text-anchor="middle">LocalScreen</text>
+      <text class="node-text" x="70" y="106" text-anchor="middle">scaled pygame window</text>
+    </g>
+
+    <!-- LED hardware subgroup -->
+    <g transform="translate(180,220)">
+      <rect class="subgraph" width="140" height="180" rx="14" ry="14" fill="none" />
+      <text class="label" x="70" y="28" text-anchor="middle">RGB LED Hardware</text>
+      <rect class="node" x="10" y="56" width="120" height="60" />
+      <text class="node-text" x="70" y="86" text-anchor="middle">MatrixDisplayWorker</text>
+      <text class="node-text" x="70" y="106" text-anchor="middle">thread</text>
+      <rect class="node" x="10" y="136" width="120" height="60" />
+      <text class="node-text" x="70" y="166" text-anchor="middle">LEDMatrix</text>
+      <text class="node-text" x="70" y="186" text-anchor="middle">rgbmatrix driver</text>
+    </g>
+  </g>
+
+  <!-- Connectors -->
+  <g>
+    <!-- Launch chain -->
+    <path class="connector arrow" d="M 170 180 L 170 200" />
+    <path class="connector arrow" d="M 170 260 L 170 280" />
+    <path class="connector arrow" d="M 170 340 L 170 360" />
+
+    <!-- Typer to GameLoop.start -->
+    <path class="connector arrow" d="M 280 230 C 360 230 400 150 520 130" />
+
+    <!-- ConfigFn to AppController -->
+    <path class="connector arrow" d="M 280 390 C 360 390 420 450 520 450" />
+
+    <!-- LoopStart fan-out -->
+    <path class="connector arrow" d="M 520 160 L 520 180" />
+    <path class="connector arrow" d="M 520 160 C 620 200 620 260 520 260" />
+    <path class="connector arrow" d="M 520 160 C 640 240 640 340 520 340" />
+
+    <!-- Runtime progression -->
+    <path class="connector arrow" d="M 520 400 L 520 420" />
+    <path class="connector arrow" d="M 520 480 L 520 500" />
+    <path class="connector arrow" d="M 520 560 L 520 580" />
+
+    <!-- Render pipeline -->
+    <path class="connector arrow" d="M 650 610 C 720 610 760 250 880 250" />
+    <path class="connector arrow" d="M 880 280 L 880 300" />
+    <path class="connector arrow" d="M 880 360 C 820 360 820 436 810 436" />
+    <path class="connector arrow" d="M 880 360 C 940 360 960 436 970 436" />
+    <path class="connector arrow" d="M 970 496 L 970 516" />
+
+    <!-- Peripheral initialization -->
+    <path class="connector arrow" d="M 470 290 C 360 320 260 480 170 500" />
+    <path class="connector arrow" d="M 170 560 L 170 580" />
+    <path class="connector arrow" d="M 170 560 C 150 600 150 640 170 664" />
+    <path class="connector arrow" d="M 170 560 C 150 620 150 700 170 736" />
+    <path class="connector arrow" d="M 170 560 C 150 640 150 780 170 812" />
+    <path class="connector arrow" d="M 170 560 C 150 660 150 860 170 888" />
+
+    <!-- Peripheral signals into AppController -->
+    <path class="connector arrow" d="M 280 608 C 360 608 420 450 520 450" />
+    <path class="connector arrow" d="M 280 684 C 360 684 420 450 520 450" />
+    <path class="connector arrow" d="M 280 760 C 360 760 420 450 520 450" />
+    <path class="connector arrow" d="M 280 836 C 360 836 420 450 520 450" />
+    <path class="connector arrow" d="M 280 912 C 360 912 420 450 520 450" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add a rendered SVG code flow diagram that visualizes the CLI, runtime, peripherals, and display paths

## Testing
- make format *(fails: missing network access to install build dependencies)*
- make test *(fails: missing network access to install build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_690626f19a148321afd8b5b44676c8e4