### PR TITLE
Add pre-commit hooks for formatting and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ ant_hr.log
 *.ini
 *.pkl
 .vscode
+.dev_install.stamp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,21 @@
 repos:
   - repo: local
     hooks:
+      - id: make-format
+        name: Run "make format"
+        entry: make format
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
       - id: make-check
         name: Run "make check"
         entry: make check
         language: system
         pass_filenames: false
-        stages: [pre-push]  
+        stages: [pre-push]
+      - id: make-test
+        name: Run "make test"
+        entry: make test
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,30 @@
 PYTHON_SOURCES = src scripts test
+DEV_INSTALL_STAMP = .dev_install.stamp
 
-.PHONY: dev_install pi_install format lint check test
+.PHONY: pi_install format lint check test clean-dev-install
 
-dev_install:
+dev_install: $(DEV_INSTALL_STAMP)
+
+$(DEV_INSTALL_STAMP):
 	@pip install -e ".[dev]"
-	@pre-commit install --hook-type pre-push
+	@pre-commit install --hook-type pre-commit --hook-type pre-push
+	@touch $(DEV_INSTALL_STAMP)
+
+clean-dev-install:
+	@rm -f $(DEV_INSTALL_STAMP)
 
 pi_install:
 	@sudo bash src/heart/manage/install_rgb_matrix.sh
 	@sudo pip install -e . --break-system-packages
 
-format: dev_install
+format: $(DEV_INSTALL_STAMP)
 	@ruff check $(PYTHON_SOURCES) --fix
 	@isort $(PYTHON_SOURCES)
 	@black $(PYTHON_SOURCES)
 	@docformatter -i -r --config ./pyproject.toml --black $(PYTHON_SOURCES)
 	@mdformat .
 
-lint:
+lint: $(DEV_INSTALL_STAMP)
 	@ruff check $(PYTHON_SOURCES)
 
 check: lint
@@ -26,5 +33,5 @@ check: lint
 	@docformatter --check -r --config ./pyproject.toml --black $(PYTHON_SOURCES)
 	@mdformat --check .
 
-test: dev_install
+test: $(DEV_INSTALL_STAMP)
 	@pytest test


### PR DESCRIPTION
## Summary
- add a cached development install stamp to avoid redundant dependency installs
- extend pre-commit hooks to run formatting on commit and lint/tests on push
- ignore the development install stamp artifact in version control

## Testing
- make format *(fails: proxy prevents downloading build dependencies)*
- make test *(fails: proxy prevents downloading build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_69066d7cc34883219f237f5fc0535341