### PR TITLE
Allow format/test targets to tolerate dev_install failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PYTHON_SOURCES = src scripts test
 DEV_INSTALL_STAMP = .dev_install.stamp
 
-.PHONY: pi_install format lint check test clean-dev-install
+.PHONY: pi_install format lint check test clean-dev-install ensure-dev-install
 
 dev_install: $(DEV_INSTALL_STAMP)
 
@@ -17,14 +17,14 @@ pi_install:
 	@sudo bash src/heart/manage/install_rgb_matrix.sh
 	@sudo pip install -e . --break-system-packages
 
-format: $(DEV_INSTALL_STAMP)
+format: ensure-dev-install
 	@ruff check $(PYTHON_SOURCES) --fix
 	@isort $(PYTHON_SOURCES)
 	@black $(PYTHON_SOURCES)
 	@docformatter -i -r --config ./pyproject.toml --black $(PYTHON_SOURCES)
 	@mdformat .
 
-lint: $(DEV_INSTALL_STAMP)
+lint: ensure-dev-install
 	@ruff check $(PYTHON_SOURCES)
 
 check: lint
@@ -33,5 +33,9 @@ check: lint
 	@docformatter --check -r --config ./pyproject.toml --black $(PYTHON_SOURCES)
 	@mdformat --check .
 
-test: $(DEV_INSTALL_STAMP)
+test: ensure-dev-install
 	@pytest test
+
+ensure-dev-install:
+	@$(MAKE) --no-print-directory dev_install \
+	|| (echo "Warning: dev_install failed; continuing without reinstalling dev dependencies." && true)

--- a/scripts/render_code_flow.py
+++ b/scripts/render_code_flow.py
@@ -325,7 +325,7 @@ def build_svg(layout: DiagramLayout) -> ET.Element:
         source = layout.get_node(edge.source)
         target = layout.get_node(edge.target)
         path_d, label_pos = _edge_path(source, target)
-        path = ET.SubElement(edges_group, "path", {"d": path_d, "marker-end": "url(#arrowhead)"})
+        ET.SubElement(edges_group, "path", {"d": path_d, "marker-end": "url(#arrowhead)"})
         if edge.label:
             label_width = max(86.0, len(edge.label) * 7.0 + 16.0)
             label_height = 20.0


### PR DESCRIPTION
## Summary
- add an ensure-dev-install helper target so format/lint/test still run even if dev_install fails
- drop the unused `path` assignment in `scripts/render_code_flow.py` to keep Ruff clean

## Testing
- make format
- make test *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_69067320dd008321998c928015805f36