### PR TITLE
Switch project tooling to uv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ DEV_INSTALL_STAMP = .dev_install.stamp
 dev_install: $(DEV_INSTALL_STAMP)
 
 $(DEV_INSTALL_STAMP):
-	@pip install -e ".[dev]"
-	@pre-commit install --hook-type pre-commit --hook-type pre-push
+	@uv pip install --system -e ".[dev]"
+	@uvx pre-commit install --hook-type pre-commit --hook-type pre-push
 	@touch $(DEV_INSTALL_STAMP)
 
 clean-dev-install:
@@ -15,26 +15,26 @@ clean-dev-install:
 
 pi_install:
 	@sudo bash src/heart/manage/install_rgb_matrix.sh
-	@sudo pip install -e . --break-system-packages
+	@sudo uv pip install --system -e . --break-system-packages
 
 format: ensure-dev-install
-	@ruff check $(PYTHON_SOURCES) --fix
-	@isort $(PYTHON_SOURCES)
-	@black $(PYTHON_SOURCES)
-	@docformatter -i -r --config ./pyproject.toml --black $(PYTHON_SOURCES)
-	@mdformat .
+	@uvx ruff check $(PYTHON_SOURCES) --fix
+	@uvx isort $(PYTHON_SOURCES)
+	@uvx black $(PYTHON_SOURCES)
+	@uvx docformatter -i -r --config ./pyproject.toml --black $(PYTHON_SOURCES)
+	@uvx mdformat .
 
 lint: ensure-dev-install
-	@ruff check $(PYTHON_SOURCES)
+	@uvx ruff check $(PYTHON_SOURCES)
 
 check: lint
-	@isort --check-only $(PYTHON_SOURCES)
-	@black --check $(PYTHON_SOURCES)
-	@docformatter --check -r --config ./pyproject.toml --black $(PYTHON_SOURCES)
-	@mdformat --check .
+	@uvx isort --check-only $(PYTHON_SOURCES)
+	@uvx black --check $(PYTHON_SOURCES)
+	@uvx docformatter --check -r --config ./pyproject.toml --black $(PYTHON_SOURCES)
+	@uvx mdformat --check .
 
 test: ensure-dev-install
-	@pytest test
+	@uvx pytest test
 
 ensure-dev-install:
 	@$(MAKE) --no-print-directory dev_install \

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Visual display project for LED screens.
 **Hardware debugging helpers**
 
 Legacy scripts for inspecting peripherals have moved into a single Typer-based command line interface. After installing the
-project in editable mode (for example via `pip install -e .[dev]`), run `totem_debug --help` for a summary of entry
+project in editable mode (for example via `uv pip install -e .[dev]`), run `totem_debug --help` for a summary of entry
 points. See [`docs/hardware_debug_cli.md`](docs/hardware_debug_cli.md) for details on each helper.
 **Linting**
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -51,10 +51,9 @@ setup_script_lines = [
     "set -euo pipefail",
 ] + python_probe_lines + [
     'if [ ! -d "%s" ]; then' % venv_dir,
-    '  "$python_bin" -m venv %s' % venv_dir,
+    '  uv venv --python "$python_bin" %s' % venv_dir,
     "fi",
-    "%s/bin/python -m ensurepip --upgrade" % venv_dir,
-    "%s/bin/pip install --no-build-isolation -e .[dev]" % venv_dir,
+    "uv pip install --python %s/bin/python --no-build-isolation -e .[dev]" % venv_dir,
 ]
 setup_script = "\n".join(setup_script_lines)
 

--- a/docs/hardware_debug_cli.md
+++ b/docs/hardware_debug_cli.md
@@ -5,7 +5,7 @@ The legacy helpers from the `scripts/` directory have been folded into the
 Install the project in editable mode first:
 
 ```bash
-pip install -e .[dev]
+uv pip install -e .[dev]
 ```
 
 Run `totem_debug --help` to see the full command tree. The most common entry

--- a/drivers/bluetooth-bridge/Notes.md
+++ b/drivers/bluetooth-bridge/Notes.md
@@ -21,7 +21,7 @@ https://github.com/adafruit/Adafruit_nRF52_Arduino/tree/master?tab=readme-ov-fil
 
 Try to run the test sketch: nordicsemi.exceptions.NordicSemiException:
 
-- pip install nrfutil
+- uv tool install nrfutil
 - ls /dev/tty.\*
 
 I tried to download some drivers etc., what fixed it was hitting the double reset button fast.

--- a/drivers/lampe-controller/Notes.md
+++ b/drivers/lampe-controller/Notes.md
@@ -21,7 +21,7 @@ https://github.com/adafruit/Adafruit_nRF52_Arduino/tree/master?tab=readme-ov-fil
 
 Try to run the test sketch: nordicsemi.exceptions.NordicSemiException:
 
-- pip install nrfutil
+- uv tool install nrfutil
 - ls /dev/tty.\*
 
 I tried to download some drivers etc., what fixed it was hitting the double reset button fast.

--- a/experimental/peripheral_sidecar/README.md
+++ b/experimental/peripheral_sidecar/README.md
@@ -10,10 +10,10 @@ react to device activity without coupling to the hardware drivers.
 Create a virtual environment and install both `heart` and the sidecar package::
 
 ```bash
-python -m venv .venv
+uv venv .venv
 source .venv/bin/activate
-pip install -e ../..
-pip install -e .
+uv pip install -e ../..
+uv pip install -e .
 ```
 
 The sidecar declares a runtime dependency on the `heart` package, so you can


### PR DESCRIPTION
## Summary
- replace pip installation steps with uv across the Makefile, docs, and driver notes
- update Tiltfile setup script to create and populate the Tilt environment with uv
- refresh documentation references to use uv and uvx for editable installs and helper tooling

## Testing
- make format *(fails: uvx could not download required packages in the offline environment)*
- make test *(fails: uvx could not download required packages in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_690982054cc88321bd83cd42c31a272a