### PR TITLE
Add coverage for GameLoop rendering and color conversion logic

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,46 @@
 import os
+import sys
+import types
 
 import pytest
+
+
+class _StubMode:
+    def __init__(self) -> None:
+        self.renderers: list[object] = []
+
+    def add_renderer(self, renderer: object) -> None:
+        self.renderers.append(renderer)
+
+
+class _StubAppController:
+    def __init__(self) -> None:
+        self.modes: list[_StubMode] = []
+
+    def add_mode(self, title: str | None = None) -> _StubMode:
+        mode = _StubMode()
+        self.modes.append(mode)
+        return mode
+
+    def add_scene(self) -> object:
+        return object()
+
+    def initialize(self, *args, **kwargs) -> None:  # pragma: no cover - stub
+        return None
+
+    def get_renderers(self, *args, **kwargs) -> list[object]:
+        return self.modes[0].renderers if self.modes else []
+
+    def is_empty(self) -> bool:
+        return not self.modes
+
+
+if "heart.navigation" not in sys.modules:
+    navigation_stub = types.ModuleType("heart.navigation")
+    navigation_stub.AppController = _StubAppController
+    navigation_stub.ComposedRenderer = object
+    navigation_stub.MultiScene = object
+    sys.modules["heart.navigation"] = navigation_stub
 
 from heart.device import Cube, Device
 from heart.environment import GameLoop

--- a/test/test_environment_core_logic.py
+++ b/test/test_environment_core_logic.py
@@ -1,0 +1,154 @@
+"""Additional tests for core logic in :mod:`heart.environment`."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from heart.environment import (
+    RendererVariant,
+    _convert_bgr_to_hsv,
+    _convert_hsv_to_bgr,
+)
+
+
+@pytest.fixture(autouse=True)
+def disable_cv2(monkeypatch):
+    """Force the environment color helpers to use the numpy fallbacks."""
+
+    monkeypatch.setattr("heart.environment.CV2_MODULE", None)
+
+
+@pytest.mark.parametrize(
+    "bgr,expected",
+    [
+        (
+            np.array([0, 0, 255], dtype=np.uint8),
+            np.array([0, 255, 255], dtype=np.uint8),
+        ),
+        (
+            np.array([0, 255, 0], dtype=np.uint8),
+            np.array([60, 255, 255], dtype=np.uint8),
+        ),
+        (
+            np.array([255, 0, 0], dtype=np.uint8),
+            np.array([120, 255, 255], dtype=np.uint8),
+        ),
+        (np.array([50, 50, 50], dtype=np.uint8), np.array([0, 0, 50], dtype=np.uint8)),
+    ],
+)
+def test_convert_bgr_to_hsv_known_colors(bgr: np.ndarray, expected: np.ndarray) -> None:
+    image = bgr.reshape(1, 1, 3)
+    hsv = _convert_bgr_to_hsv(image)
+    np.testing.assert_array_equal(hsv.reshape(3), expected)
+
+
+@pytest.mark.parametrize(
+    "hsv,expected",
+    [
+        (
+            np.array([0, 255, 255], dtype=np.uint8),
+            np.array([0, 0, 255], dtype=np.uint8),
+        ),
+        (
+            np.array([60, 255, 255], dtype=np.uint8),
+            np.array([0, 255, 0], dtype=np.uint8),
+        ),
+        (
+            np.array([120, 255, 255], dtype=np.uint8),
+            np.array([255, 0, 0], dtype=np.uint8),
+        ),
+        (np.array([0, 0, 50], dtype=np.uint8), np.array([50, 50, 50], dtype=np.uint8)),
+    ],
+)
+def test_convert_hsv_to_bgr_known_colors(hsv: np.ndarray, expected: np.ndarray) -> None:
+    image = hsv.reshape(1, 1, 3)
+    bgr = _convert_hsv_to_bgr(image)
+    np.testing.assert_array_equal(bgr.reshape(3), expected)
+
+
+@pytest.mark.parametrize("seed", [0, 1, 42])
+def test_color_round_trip(seed: int) -> None:
+    rng = np.random.default_rng(seed)
+    bgr = rng.integers(0, 256, size=(4, 5, 3), dtype=np.uint8)
+
+    hsv = _convert_bgr_to_hsv(bgr)
+    round_trip = _convert_hsv_to_bgr(hsv)
+
+    np.testing.assert_array_equal(round_trip, bgr)
+
+
+def _sequential_binary_merge(values: list[str]) -> str:
+    surfaces = list(values)
+    while len(surfaces) > 1:
+        pairs = [(surfaces[i], surfaces[i + 1]) for i in range(0, len(surfaces) - 1, 2)]
+        merged_surfaces = [f"merge({a},{b})" for a, b in pairs]
+        if len(surfaces) % 2 == 1:
+            merged_surfaces.append(surfaces[-1])
+        surfaces = merged_surfaces
+    return surfaces[0]
+
+
+@pytest.mark.parametrize("values", [list("abcd"), list("abcde")])
+def test_render_surfaces_binary_merges_all(
+    loop, monkeypatch, values: list[str]
+) -> None:
+    sequence = {value: f"surface-{value}" for value in values}
+
+    def fake_process(renderer: str) -> str:
+        return sequence[renderer]
+
+    def fake_merge(surface1: str, surface2: str) -> str:
+        return f"merge({surface1},{surface2})"
+
+    monkeypatch.setattr(loop, "process_renderer", fake_process)
+    monkeypatch.setattr(loop, "merge_surfaces", fake_merge)
+
+    result = loop._render_surfaces_binary(values)
+    expected = _sequential_binary_merge(list(sequence.values()))
+    assert result == expected
+
+
+def test_render_surfaces_binary_handles_empty(loop) -> None:
+    assert loop._render_surfaces_binary([]) is None
+
+
+def test_render_surface_iterative_skips_missing(loop, monkeypatch) -> None:
+    renderers = ["r1", "r2", "r3"]
+    responses = {"r1": "surface-1", "r2": None, "r3": "surface-3"}
+    merges: list[tuple[str, str]] = []
+
+    def fake_process(renderer: str) -> str | None:
+        return responses[renderer]
+
+    def fake_merge(surface1: str, surface2: str) -> str:
+        merges.append((surface1, surface2))
+        return f"merge({surface1},{surface2})"
+
+    monkeypatch.setattr(loop, "process_renderer", fake_process)
+    monkeypatch.setattr(loop, "merge_surfaces", fake_merge)
+
+    result = loop._render_surface_iterative(renderers)
+
+    assert result == "merge(surface-1,surface-3)"
+    assert merges == [("surface-1", "surface-3")]
+
+
+def test_render_fn_selects_renderer(loop) -> None:
+    assert loop._render_fn(RendererVariant.BINARY) is loop._render_surfaces_binary
+    assert loop._render_fn(RendererVariant.ITERATIVE) is loop._render_surface_iterative
+
+
+def test_render_fn_default_uses_loop_variant(loop) -> None:
+    loop.renderer_variant = RendererVariant.BINARY
+    assert loop._render_fn(None) is loop._render_surfaces_binary
+    loop.renderer_variant = RendererVariant.ITERATIVE
+    assert loop._render_fn(None) is loop._render_surface_iterative
+
+
+@pytest.mark.parametrize(
+    "variant",
+    list(RendererVariant),
+)
+def test_render_fn_handles_unknown_variant(loop, variant: RendererVariant) -> None:
+    assert callable(loop._render_fn(variant))


### PR DESCRIPTION
## Summary
- add targeted tests for the color conversion helpers in `heart.environment`
- cover the GameLoop binary and iterative renderer workflows with deterministic stubs
- stub the navigation module in the shared pytest fixtures so that core logic can be imported during tests

## Testing
- make format *(fails: missing `docformatter` dependency because dev install cannot reach package index)*
- make test *(fails: editable install step cannot reach package index; import then fails before tests run)*
- PYTHONPATH=src pytest test/test_environment_core_logic.py *(fails: module import stops on non-postponed annotations in `heart.environment` under Python 3.11)*

------
https://chatgpt.com/codex/tasks/task_e_690981331aa08321b786c0f77f45fec1