### PR TITLE
Add uv sources entry for heart workspace package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,9 @@ members = [
     "experimental/isolated_rendering",
 ]
 
+[tool.uv.sources]
+heart = { workspace = true }
+
 [tool.mypy]
 python_version = "3.11"
 mypy_path = "src"


### PR DESCRIPTION
## Summary
- add a `[tool.uv.sources]` section so the `heart` package is explicitly marked as a workspace member for uv

## Testing
- `make format` *(fails: missing docformatter dependency due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_690991f632bc83218a042949bb2d5639