### PR TITLE
Refresh documentation for v0.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,130 @@
 # Heart
 
-Visual display project for LED screens.
+Heart powers an interactive LED totem used at events, dance floors, and art
+installations. The project combines a pygame-based runtime, a library of animated
+scenes, and hardware integrations for sensors, heart-rate monitors, and Bluetooth
+controllers. The v0.2 release consolidates tooling under a modern Typer CLI,
+ships a refreshed renderer playlist, and documents the full deployment workflow
+for both laptops and Raspberry Pi installations.
 
-## Development
+![Heart totem rendering](docs/code_flow.svg)
 
-**Installation**
+## Feature highlights
 
-`make install`
+- **Modular renderer ecosystem** – dozens of animations, sprite loops, and text
+  overlays live under `heart.display.renderers` and can be composed into custom
+  playlists.
+- **Event-ready configurations** – the dynamic configuration registry lets you
+  switch between curated playlists (for example `lib_2025`) or run custom shows
+  created for a specific venue.
+- **Hardware-aware runtime** – peripherals such as Bluetooth gamepads, ANT+
+  heart-rate monitors, and accelerometers feed real-time data into scenes.
+- **First-class debugging tools** – the `totem_debug` CLI merges every hardware
+  helper into a single Typer application so field technicians can diagnose
+  devices quickly.
+- **Flexible deployment targets** – run locally on macOS/Linux for development or
+  push frames to an RGB LED matrix driven by a Raspberry Pi.
 
-**Formatting**
+## Quick start
 
-`make format` should install and run the correct formatting and linting tools
+1. Create and activate a Python 3.11+ virtual environment.
+2. Install dependencies and tooling:
+   ```bash
+   make install
+   ```
+3. Launch the default playlist in a window:
+   ```bash
+   totem run --configuration lib_2025
+   ```
+4. Explore the [`docs/getting_started.md`](docs/getting_started.md) guide for Pi
+   deployment, hardware wiring, and advanced CLI flags.
 
-**Hardware debugging helpers**
+## Command-line interface
 
-Legacy scripts for inspecting peripherals have moved into a single Typer-based command line interface. After installing the
-project in editable mode (for example via `uv pip install -e .[dev]`), run `totem_debug --help` for a summary of entry
-points. See [`docs/hardware_debug_cli.md`](docs/hardware_debug_cli.md) for details on each helper.
-**Linting**
+The project installs two Typer applications via console scripts:
 
-`make lint` runs static analysis with ruff over the Python sources
+| Command        | Description                                                     |
+| -------------- | --------------------------------------------------------------- |
+| `totem`        | Runs the runtime (`totem run`), benchmarks devices, and flashes
+|                | firmware (`totem update-driver`).                                |
+| `totem_debug`  | Groups hardware debugging helpers, including Bluetooth gamepad
+|                | utilities, UART sniffers, and accelerometer readers.            |
 
-**Testing Locally**
+Key `totem run` flags:
 
-The command: `totem run --configuration full_screen_test` should display a scene locally. If you see a scene, then the setup is correct.
+- `--configuration <name>` – selects a configuration module from
+  `heart.programs.configurations`. Use `lib_2025` for the flagship playlist or
+  author your own (see [Program configuration guide](docs/program_configuration.md)).
+- `--x11-forward` – forces a pygame window even when `HEART_USE_ISOLATED_RENDERER`
+  is set, making remote debugging over SSH+XQuartz possible.
+- `--add-low-power-mode/--no-add-low-power-mode` – toggles the standby mode that
+  keeps the LEDs dim when no primary scenes are active.
 
-**Supported Platforms**
+Run `totem --help` or `totem_debug --help` for the full command tree.
 
-- MacOSX for local development
-- An appropriately setup Raspberry Pi 4 for portable use
+## Architecture overview
 
-## Peripheral MQTT sidecar (experimental)
+Heart's runtime centers on the `GameLoop` defined in
+[`heart/environment.py`](src/heart/environment.py). The loop pulls configuration
+from the registry, manages renderer playlists through the `AppController`, and
+streams frames to the active `Device` implementation. The supporting documents
+provide deeper dives:
 
-The peripheral MQTT sidecar now lives in the standalone project under
-`experimental/peripheral_sidecar`. Install it alongside the main `heart`
-package and launch it via the `heart-peripheral-sidecar` console script.
-See that directory's README for setup details and configuration options.
+- [`docs/runtime_overview.md`](docs/runtime_overview.md) – textual explanation of
+  the runtime, renderer stack, and peripheral workers.
+- [`docs/code_flow.md`](docs/code_flow.md) – mermaid diagram showing the launch
+  sequence, background threads, and display pipeline.
+- [`docs/program_configuration.md`](docs/program_configuration.md) – building
+  custom playlists and accessing sensor data inside scenes.
 
-For a local MQTT broker, use the Mosquitto Docker Compose setup in
-`experimental/mqtt_broker`.
+## Hardware and peripherals
 
-## Drivers setup
+- **Display devices** – `LocalScreen` renders to a pygame window. `LEDMatrix`
+  writes frames to an RGB matrix using the `rgbmatrix` bindings when
+  `HEART_USE_ISOLATED_RENDERER=1`.
+- **Peripheral manager** – `heart.peripheral.core.manager.PeripheralManager`
+  spawns threads for Bluetooth switches, gamepads, accelerometers, and heart-rate
+  monitors. Renderers can consume readings via helper modules such as
+  `heart.peripheral.heart_rates`.
+- **Firmware updates** – device-specific flashers live under `drivers/`. Invoke
+  them with `totem update-driver --name <driver>`.
+- **Debug CLI** – `docs/hardware_debug_cli.md` documents the consolidated
+  diagnostics, including UART sniffers and Bluetooth pairing helpers.
 
-### ANT
+## Development workflow
 
-For ant you will need to run drivers/ant_dongle/setup.sh on the raspberry pi. Then unplug and replug the dongle
+- `make install` – install the package and development extras using `uv`.
+- `make format` – apply Ruff fixes, isort, Black, docformatter, and mdformat to
+  the source tree and documentation (run before committing).
+- `make test` – execute the pytest suite in parallel.
+- `make check` – optional lint/format verification without applying fixes.
+
+We recommend using `uv` for dependency management because it provides reproducible
+lock files (`uv.lock`) and fast resolver performance.
+
+## Repository layout
+
+```
+heart/
+├── docs/                     # Architecture guides, dev logs, hardware notes
+├── drivers/                  # Firmware flashing utilities
+├── experimental/             # Prototypes (MQTT sidecar, broker helpers)
+├── src/heart/                # Runtime, renderers, peripherals, utilities
+├── tests/                    # Pytest suite
+├── Makefile                  # Common developer tasks
+└── pyproject.toml            # Packaging metadata and tool configuration
+```
+
+Explore the `docs/devlog/` directory for chronological field notes on hardware
+bring-up, auto-boot flows, and rendering experiments.
+
+## Contributing
+
+1. Fork the repository and create a topic branch.
+2. Run `make format` and `make test` before pushing changes.
+3. Update documentation whenever you add new renderers, configuration modules, or
+   hardware capabilities. Major architecture changes should include updated
+   diagrams via `scripts/render_code_flow.py`.
+
+Issues and pull requests are welcome! Share videos or photos of your installations
+in the issue tracker so others can learn from your setup.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,146 @@
+# Getting started
+
+This guide walks through the essentials for running the Heart totem locally and
+on production hardware. It assumes the v0.2+ release line where the runtime,
+configuration registry, and debugging tooling have been consolidated around the
+`totem` and `totem_debug` Typer applications.
+
+## Prerequisites
+
+- Python 3.11 or newer. We ship tooling through [`uv`](https://docs.astral.sh/uv/)
+  to keep environments reproducible, but any virtual environment manager works.
+- SDL-compatible GPU drivers. On macOS the system libraries are sufficient; on
+  Linux you may need Mesa packages installed for pygame to create a window.
+- For Raspberry Pi deployments: Raspberry Pi OS (Bookworm or newer) with SPI
+  enabled and the RGB Matrix hat wired according to the
+  [`rpi-rgb-led-matrix`](https://github.com/hzeller/rpi-rgb-led-matrix)
+  documentation.
+
+Clone the repository and create a virtual environment before moving forward.
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install --upgrade pip
+```
+
+## Installing dependencies
+
+All development dependencies, including linting and documentation tooling, can
+be installed via the make helpers in the project root.
+
+```bash
+make install
+```
+
+This resolves the base `heart` package alongside the `dev` dependency group. If
+you prefer manual control, the equivalent `uv` invocation is:
+
+```bash
+uv pip install -e .[dev]
+```
+
+## Running the totem locally
+
+The Heart runtime ships as the `totem` console script. Running the totem locally
+renders to a pygame window so you can iterate on scenes and peripheral logic
+without hardware.
+
+```bash
+totem run --configuration lib_2025
+```
+
+Key flags:
+
+- `--configuration <name>` selects a configuration module from
+  `heart.programs.configurations`. The default `lib_2025` set is a curated mix of
+  interactive and ambient scenes used at live installations.
+- `--x11-forward` forces a pygame window even on a Raspberry Pi with the RGB
+  matrix attached. This is invaluable for remote debugging through X forwarding.
+- `--add-low-power-mode/--no-add-low-power-mode` toggles the fallback sleep mode
+  that keeps the LED wall idle when no scenes are active.
+
+On macOS you can run the command directly. On Linux desktops make sure the SDL
+windowing dependencies are present (Ubuntu/Debian packages `libsdl2-dev` and
+`libsdl2-image-dev`).
+
+## Deploying to a Raspberry Pi
+
+1. Install system dependencies:
+   ```bash
+   sudo apt update
+   sudo apt install -y git python3-dev python3-venv libsdl2-dev libsdl2-image-dev \
+       libopenjp2-7 libtiff5 libatlas-base-dev libboost-all-dev
+   ```
+2. Clone the project and install it in editable mode:
+   ```bash
+   git clone https://github.com/<your-org>/heart.git
+   cd heart
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install --upgrade pip
+   pip install -e .[dev]
+   ```
+3. Configure the environment for the RGB matrix by exporting:
+   ```bash
+   export SDL_VIDEODRIVER="dummy"
+   export HEART_USE_ISOLATED_RENDERER=1
+   ```
+   The first variable allows pygame to create surfaces without an attached HDMI
+   display; the second routes rendering to the isolated RGBMatrix driver.
+4. Launch the runtime:
+   ```bash
+   totem run --configuration lib_2025
+   ```
+
+The configuration loader automatically instantiates the LED matrix renderer when
+`HEART_USE_ISOLATED_RENDERER` is present. If you connect through SSH with X11
+forwarding and still want a preview window, run with `--x11-forward`.
+
+## Peripheral setup
+
+Peripheral workers are managed by
+`heart.peripheral.core.manager.PeripheralManager`. The following devices are
+supported out of the box:
+
+- **Bluetooth switches** for triggering scene changes. Pair controllers with
+  the `totem_debug gamepad` helpers documented in
+  [`docs/hardware_debug_cli.md`](hardware_debug_cli.md).
+- **Heart-rate monitors** (ANT+ or BLE) feeding into
+  `heart.peripheral.heart_rates`. Connect receivers before starting the loop so
+  the worker discovers them during startup.
+- **Accelerometers and sensor boards** wired over serial. Use
+  `totem_debug accelerometer` to validate wiring before letting the runtime read
+  from them.
+
+All peripheral threads start when `totem run` boots the `GameLoop`. Sensors that
+are not connected will log warnings but will not crash the runtime.
+
+## Debugging tools
+
+The `totem_debug` command groups all hardware debugging scripts. Refer to the
+[dedicated guide](hardware_debug_cli.md) for details on each helper. Typical
+workflows include scanning for Bluetooth gamepads, tailing UART frames, and
+streaming accelerometer data.
+
+## Updating device firmware
+
+Device firmware drivers live under `drivers/`. Use the consolidated `totem`
+entry point to flash them:
+
+```bash
+totem update-driver --name <driver-name>
+```
+
+Driver modules implement `heart.manage.update.main` and are resolved from the
+`drivers/` directory. The command reports success or failure directly in the
+terminal output.
+
+## Where to go next
+
+- Read the [runtime overview](runtime_overview.md) to understand the main loop
+  architecture.
+- Explore [program configurations](program_configuration.md) to build your own
+  playlists of renderers and scenes.
+- Keep an eye on the `docs/devlog/` folder for historical notes about hardware
+  bring-up and operations.

--- a/docs/program_configuration.md
+++ b/docs/program_configuration.md
@@ -1,0 +1,117 @@
+# Program configuration guide
+
+Program configurations define the playlist of scenes, overlays, and behaviors
+that run on the Heart totem. Each configuration is a Python module in
+`heart/programs/configurations/` and must expose a single `configure(loop)`
+function. This guide explains how the registry works and how to build your own
+configuration for events or installations.
+
+## Registry basics
+
+`heart.programs.registry.ConfigurationRegistry` discovers configuration modules
+on demand. When you run `totem run --configuration lib_2025` the CLI:
+
+1. Imports `heart.programs.registry.ConfigurationRegistry`.
+2. Loads every module under `heart.programs.configurations` and stores the
+   `configure` callable in a dictionary keyed by the module name.
+3. Retrieves the requested entry and executes it with the active
+   `GameLoop` instance.
+
+Any import errors are surfaced at startup so failures are easy to spot.
+
+## Anatomy of a configuration module
+
+A minimal configuration looks like this:
+
+```python
+from heart.display.renderers.text import TextRendering
+from heart.environment import GameLoop
+
+
+def configure(loop: GameLoop) -> None:
+    hello_mode = loop.add_mode("hello")
+    hello_mode.add_renderer(
+        TextRendering.default(text="Hello, world!", y_location=16)
+    )
+```
+
+Key concepts:
+
+- `loop.add_mode(<name or renderer>)` registers a selectable mode in the UI. You
+  can pass a string label or a renderer instance that provides its own title
+  screen.
+- `mode.add_renderer(...)` attaches one or more renderers that draw each frame
+  for the mode. Renderers run sequentially, so you can stack overlays on top of
+  base animations.
+- `loop.app_controller.add_sleep_mode()` appends a low-power fallback that keeps
+  the LED wall dim when no primary scenes are playing. The CLI toggles this
+  behavior with the `--add-low-power-mode/--no-add-low-power-mode` flag.
+
+## Building playlists
+
+The `heart.navigation` module includes helpers for composing scenes:
+
+- `MultiScene` rotates through renderers on a timer. Use this to build playlists
+  that cycle automatically.
+- `ComposedRenderer` stacks multiple renderers together. A common pattern is to
+  place a text overlay on top of an animation.
+
+Example snippet from `lib_2025.py`:
+
+```python
+from heart.display.renderers.water_cube import WaterCube
+from heart.display.renderers.water_title_screen import WaterTitleScreen
+from heart.navigation import ComposedRenderer
+
+
+def configure(loop: GameLoop) -> None:
+    water_mode = loop.add_mode(
+        ComposedRenderer([WaterTitleScreen(), TextRendering.default("water")])
+    )
+    water_mode.add_renderer(WaterCube())
+```
+
+## Accessing peripherals
+
+Peripherals publish data through modules under `heart.peripheral`. Renderers can
+pull the latest readings directly:
+
+```python
+from heart.peripheral.heart_rates import current_bpms
+
+
+class HeartRateVisualization(BaseRenderer):
+    def render(self, surface: pygame.Surface, *_: Any) -> None:
+        bpm = current_bpms().average
+        # Draw something based on bpm
+```
+
+Peripheral managers start automatically when the loop boots. You do not need to
+instantiate them manually inside configurations.
+
+## Testing new configurations
+
+1. Create your module under `heart/programs/configurations/`. Name it with a
+   descriptive suffix (for example `festival_2025.py`).
+2. Run the configuration locally:
+   ```bash
+   totem run --configuration festival_2025
+   ```
+3. Iterate until the playlist looks right. Use `--no-add-low-power-mode` if you
+   want the scenes to loop continuously without the sleep fallback.
+
+Check the console output for `Importing configuration: ...` lines to confirm that
+your module loads successfully. When satisfied, commit the module alongside any
+assets it requires (sprite sheets, sound files, etc.).
+
+## Shipping configurations
+
+- Store large assets in `src/heart/assets/` so they ship with the package.
+- Document special hardware dependencies in `docs/devlog/` or in a dedicated
+  README within the configuration folder.
+- Consider adding unit or integration tests under `tests/` if the configuration
+  includes complex business logic (for example, custom scheduling or state
+  machines).
+
+With these guidelines you can create repeatable playlists that take advantage of
+Heart's renderer ecosystem and hardware integrations.

--- a/docs/runtime_overview.md
+++ b/docs/runtime_overview.md
@@ -1,0 +1,93 @@
+# Runtime overview
+
+The Heart runtime is built around a pygame-powered game loop that streams
+content to either a simulated window or the LED matrix wall. This document
+explains how the major services interact and where to hook in new behavior for a
+major release.
+
+## High-level architecture
+
+At startup the `totem` CLI wires together three primary subsystems:
+
+1. **Configuration loader** – `heart.programs.registry.ConfigurationRegistry`
+   discovers configuration modules under `heart/programs/configurations`. Each
+   module exposes a `configure(loop: GameLoop)` function that mutates the loop
+   with new modes, renderers, and playlists.
+2. **Game loop orchestration** – `heart.environment.GameLoop` encapsulates the
+   pygame window, timing, and peripheral integration. The loop owns the
+   `AppController`, a router that handles scene transitions and renders composed
+   surfaces.
+3. **Device abstraction** – `heart.device.Device` implementations translate
+   pygame surfaces into concrete display updates. `LocalScreen` targets desktop
+   development while `LEDMatrix` (from `heart.device.rgb_display`) streams frames
+   to the RGB matrix via the `rgbmatrix` bindings.
+
+The code-flow diagram in [`docs/code_flow.md`](code_flow.md) visualizes these
+relationships and the threads used to communicate with peripherals.
+
+## Renderers and modes
+
+Renderers implement `heart.display.renderers.BaseRenderer` (or a concrete
+specialization) and draw into the pygame surface supplied by the runtime. A
+configuration file typically:
+
+- Calls `loop.add_mode(<name or renderer>)` to create a new selectable mode.
+- Registers one or more renderers via `mode.add_renderer(...)`.
+- Optionally wraps renderers in `heart.navigation.MultiScene` or
+  `heart.navigation.ComposedRenderer` to build playlists and stacked overlays.
+
+For example, `lib_2025.py` mixes ambient animations (`WaterCube`), interactive
+scenes (`ArtistScene`), and text overlays. The default configuration also adds a
+sleep mode for low-power intervals.
+
+## Peripheral integration
+
+Peripheral workers are instantiated by
+`heart.peripheral.core.manager.PeripheralManager`. The manager spawns background
+threads for:
+
+- Bluetooth switches and controllers (`heart.peripheral.switch`,
+  `heart.peripheral.gamepad`).
+- Serial-connected sensors such as accelerometers (`heart.peripheral.uart`).
+- Heart-rate monitors aggregated via `heart.peripheral.heart_rates`.
+
+Each worker pushes events into the `AppController`, where they can trigger scene
+changes, animations, or custom render logic. Scenes can subscribe to the shared
+state exposed through helper modules like `heart.peripheral.heart_rates`.
+
+## Display pipeline
+
+Every frame follows the same rendering pipeline:
+
+1. The active mode asks each renderer for a frame. Complex modes often combine
+   multiple renderers via `ComposedRenderer` or `MultiScene`.
+2. The resulting surface is passed to `heart.display.service.DisplayService`,
+   which manages timing and double buffering to avoid tearing.
+3. The `Device` implementation converts the surface into the final output. The
+   local screen writes to a pygame window, whereas the LED matrix driver extracts
+   raw pixel data and streams it over SPI.
+
+The pipeline supports frame capture (`heart.device.bridge.DeviceBridge`) for the
+peripheral sidecar and for streaming previews to remote observers.
+
+## Extending the runtime
+
+To add a new scene:
+
+1. Implement a renderer under `heart/display/renderers/`. See `water_cube.py` or
+   `kirby.py` for patterns that leverage numpy-based effects and sprite sheets.
+2. Update an existing configuration module or create a new one under
+   `heart/programs/configurations/` and expose a `configure(loop)` function.
+3. Run `totem run --configuration <your-module>` to verify the scene locally.
+
+New peripheral integrations should live under `heart/peripheral/`. They can
+register event handlers with the `PeripheralManager` so that the runtime picks
+them up automatically.
+
+## Related tools
+
+- [`docs/getting_started.md`](getting_started.md) – end-to-end setup guide.
+- [`docs/program_configuration.md`](program_configuration.md) – deep dive into
+  authoring and composing configuration modules.
+- [`docs/hardware_debug_cli.md`](hardware_debug_cli.md) – command reference for
+  the Typer-based hardware debugging suite.


### PR DESCRIPTION
## Summary
- expand the README with a full project overview, CLI usage notes, and contributor guidance for the v0.2 release
- add a getting started guide that covers installation, deployment, and peripheral setup across desktop and Raspberry Pi targets
- document the runtime architecture and configuration system to help authors build and maintain renderer playlists

## Testing
- `make format` *(fails: unable to download isort from pypi due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_690a0691223483218455b55f7b93001a