### PR TITLE
docs: expand research note guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,7 @@ Running `make check` is recommended to verify formatting and linting without app
 ## Documentation Guidelines
 
 If any meaningful changes are made to the runtime architecture or service boundaries, update `docs/code_flow.md` and re-render the diagram via `scripts/render_code_flow.py` so that the documentation stays accurate.
+
+Any meaningfully innovative or thoughtful implementation should be paired with a research note in `docs/research/` that captures the reasoning, trade-offs, or techniques involved.
+When you touch areas of the codebase that already have related research notes, skim `docs/research/` to see whether an existing document needs an update or a new companion note.
+Research notes should cite the source files or external references that informed the write-up.

--- a/docs/research/hsv_color_conversion.md
+++ b/docs/research/hsv_color_conversion.md
@@ -1,0 +1,25 @@
+# HSV Conversion Fallback Strategy
+
+This note documents the HSV/BGR conversion strategy that keeps the renderer functional even when OpenCV is unavailable. The fallback lives in `src/heart/environment.py` alongside the `GameLoop` orchestration code and supports colour-sensitive renderers by mirroring OpenCV's behaviour as closely as possible.【F:src/heart/environment.py†L1-L138】【F:src/heart/environment.py†L138-L207】
+
+## Fallback detection and module loading
+
+- `_load_cv2_module()` uses `importlib.util.find_spec` to probe for OpenCV at runtime, returning `None` if the dependency or its loader is missing.【F:src/heart/environment.py†L1-L33】
+- `CV2_MODULE` caches the import result so detection happens once per process. Callers branch on this sentinel to choose between the native OpenCV implementation and the numpy fallback.【F:src/heart/environment.py†L33-L42】
+
+## Pure numpy HSV conversion
+
+- `_numpy_hsv_from_bgr` reproduces OpenCV's BGR→HSV pipeline using float math for hue and integer math for saturation/value, which reduces rounding drift relative to naive conversions.【F:src/heart/environment.py†L42-L93】
+- `_convert_bgr_to_hsv` first defers to OpenCV when available. Otherwise, it calls the numpy routine, then calibrates hue by testing neighbouring offsets until the forward/backward round-trip exactly matches the original BGR triple.【F:src/heart/environment.py†L93-L140】
+- The function also memoizes high-usage HSV tuples in `HSV_TO_BGR_CACHE`, evicting with an `OrderedDict` LRU policy once more than 4096 entries accumulate. This cache smooths repeated lookups for identical colours in successive frames.【F:src/heart/environment.py†L29-L41】【F:src/heart/environment.py†L118-L138】
+
+## Pure numpy HSV→BGR conversion
+
+- `_numpy_bgr_from_hsv` implements the inverse conversion, translating hue sectors into piecewise RGB formulas before scaling back to uint8 BGR.【F:src/heart/environment.py†L95-L128】
+- `_convert_hsv_to_bgr` mirrors the OpenCV branch/fallback split. The numpy path calibrates well-known hues (pure yellow and cyan) to match hardware expectations and then probes a 3×3×3 neighbourhood to correct any remaining round-trip mismatches.【F:src/heart/environment.py†L140-L199】
+- After calibration, cached mappings from `HSV_TO_BGR_CACHE` are applied to keep the fallback consistent with previous frames and to reuse hand-tuned corrections discovered earlier in the run.【F:src/heart/environment.py†L29-L41】【F:src/heart/environment.py†L199-L207】
+
+## Operational considerations
+
+- Because the fallback executes per pixel, it benefits from keeping images small (e.g., 64×64 LED panels) and leverages numpy's vectorisation to stay performant without GPU support.【F:src/heart/environment.py†L42-L140】
+- When integrating new renderers, prefer HSV manipulations that reuse cached hues to take advantage of the memoized conversions. Testing with and without OpenCV installed helps ensure both code paths stay healthy.【F:src/heart/environment.py†L93-L207】

--- a/docs/research/peripheral_manager.md
+++ b/docs/research/peripheral_manager.md
@@ -1,0 +1,49 @@
+# Peripheral Manager Detection Notes
+
+The `PeripheralManager` (`src/heart/peripheral/core/manager.py`) centralizes detection and
+lifecycle management for every runtime peripheral. Understanding its flow is helpful when
+introducing new input devices or sensors.
+
+## Detection pipeline
+
+The manager builds its registry by iterating several detection helpers. Order matters because
+switches set up a "main" switch fallback before any other peripherals are registered.
+
+1. **Switches** – On a Raspberry Pi without X11 forwarding the manager asks both
+   `Switch.detect()` and `BluetoothSwitch.detect()` for hardware handles. When no
+   hardware is present it logs a warning and falls back to `FakeSwitch.detect()`. Non-Pi
+   environments always use the fake switch path, ensuring development machines can test
+   mode transitions without hardware.
+2. **Sensors** – `Accelerometer.detect()` surfaces motion data sources.
+3. **Gamepads** – `Gamepad.detect()` integrates joystick-style controllers.
+4. **Heart rate monitors** – `HeartRateManager.detect()` aggregates pulse sensors under a
+   single manager instance.
+5. **Phone text** – `PhoneText.detect()` enables remote text input (via websocket polling
+   or whatever transport the implementation supports).
+
+Each detected object is appended to `self._peripherals` for later retrieval. The first switch
+registered is cached as a deprecated "main switch" to support older APIs while still using
+`PeripheralManager` as the single entry point.
+
+## Threaded execution
+
+Calling `start()` spins a daemon thread per peripheral. Each thread invokes the peripheral's
+`run()` method. The manager tracks every thread for graceful shutdown: `close()` walks the
+thread list and joins any active thread with a configurable timeout, reporting failures via
+structured logging.
+
+## Adding a new peripheral
+
+When introducing a new peripheral type:
+
+1. Implement a class that satisfies the `Peripheral` interface and provides a `detect()`
+   classmethod returning an iterable of instances.
+2. Extend `_iter_detected_peripherals()` (or a helper like `_detect_sensors()`) to yield the
+   new objects.
+3. Provide a dedicated accessor (similar to `get_gamepad()` or `get_phyphox_peripheral()`)
+   if other subsystems need the device.
+4. Consider how the peripheral should behave on developer machines. Supplying a "fake"
+   implementation lets contributors exercise code paths without specialized hardware.
+
+Following this pattern keeps peripheral discovery deterministic and ensures new devices plug
+into the existing threading and lifecycle controls.


### PR DESCRIPTION
## Summary
- remind contributors to review docs/research and add citations when writing research notes
- document the HSV/BGR conversion fallback that mirrors OpenCV when the dependency is unavailable

## Testing
- make format *(fails: unable to download dependencies from pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_690a23d3b724832197ac1f17aff20368