### PR TITLE
Add event bus skeleton and planning checklist

### DIFF
--- a/docs/planning/input_event_bus.md
+++ b/docs/planning/input_event_bus.md
@@ -1,0 +1,33 @@
+# Input Event Bus & State Store Plan
+
+## Background
+
+The current input pathway drains the global pygame queue inside `GameLoop` and has
+peripherals mutating their own state. To support reactive listeners and simple state
+queries, we need a project-local event bus paired with a shared state store.
+
+## Goals
+
+- Normalize how peripherals publish input and requests.
+- Let systems subscribe to events with lightweight callbacks or decorators.
+- Provide a `State.get()`-style API for the latest input snapshots.
+- Incrementally adopt the bus without breaking existing device integrations.
+
+## Incremental Checklist
+
+1. [x] Land an `EventBus` core module with subscribe/emit/unsubscribe helpers and unit tests
+   covering subscriber ordering, decorator registration, and failure isolation.
+1. [ ] Thread the event bus through the `GameLoop`, bridging pygame/system events to
+   subscribers while maintaining current behavior.
+1. [ ] Introduce a shared `StateStore` that the bus can update on every emission,
+   exposing `State.get()` helpers for consumers.
+1. [ ] Migrate representative peripherals (switch, bluetooth switch, gamepad) to emit
+   structured events via the bus instead of mutating device-level state.
+1. [ ] Update high-level consumers (navigation, modes) to read from the state store and
+   add regression tests demonstrating multi-device arbitration.
+
+## Notes
+
+- Keep the bus synchronous for now; if latency becomes an issue we can explore
+  background dispatchers.
+- Focus early tests on pure Python logic so they remain deterministic in CI.

--- a/tests/peripheral/test_event_bus.py
+++ b/tests/peripheral/test_event_bus.py
@@ -1,0 +1,48 @@
+import pytest
+
+from heart.peripheral.core import Input
+from heart.peripheral.core.event_bus import EventBus
+
+
+def test_emit_orders_callbacks_by_priority_then_fifo():
+    bus = EventBus()
+    order: list[str] = []
+
+    bus.subscribe("button", lambda evt: order.append("low"), priority=0)
+    bus.subscribe("button", lambda evt: order.append("mid"), priority=5)
+    bus.subscribe("button", lambda evt: order.append("mid-2"), priority=5)
+    bus.subscribe("button", lambda evt: order.append("high"), priority=10)
+
+    bus.emit("button", data=None)
+
+    assert order == ["high", "mid", "mid-2", "low"]
+
+
+def test_run_on_event_decorator_registers_handler():
+    bus = EventBus()
+    captured: list[int] = []
+
+    @bus.run_on_event("tick")
+    def _handler(event: Input) -> None:
+        captured.append(event.producer_id)
+
+    bus.emit("tick", data="value", producer_id=42)
+
+    assert captured == [42]
+
+
+def test_subscriber_failures_do_not_block_others(caplog: pytest.LogCaptureFixture):
+    bus = EventBus()
+    caplog.set_level("ERROR")
+    calls: list[str] = []
+
+    def _bad(_: Input) -> None:
+        raise RuntimeError("boom")
+
+    bus.subscribe("sensor", _bad)
+    bus.subscribe("sensor", lambda event: calls.append(event.event_type))
+
+    bus.emit(Input(event_type="sensor", data={}))
+
+    assert calls == ["sensor"]
+    assert any("EventBus subscriber" in message for message in caplog.messages)


### PR DESCRIPTION
## Summary
- add a planning document describing the staged rollout of an input event bus and state store
- implement an `EventBus` core module with subscription helpers and failure-tolerant dispatching
- cover the bus with unit tests for ordering, decorator usage, and error isolation

## Testing
- make format
- make test


------
https://chatgpt.com/codex/tasks/task_e_690c2d2330848321b2be55bee5b61bde