### PR TITLE
Thread input event bus through game loop

### DIFF
--- a/docs/planning/input_event_bus.md
+++ b/docs/planning/input_event_bus.md
@@ -17,7 +17,7 @@ queries, we need a project-local event bus paired with a shared state store.
 
 1. [x] Land an `EventBus` core module with subscribe/emit/unsubscribe helpers and unit tests
    covering subscriber ordering, decorator registration, and failure isolation.
-1. [ ] Thread the event bus through the `GameLoop`, bridging pygame/system events to
+1. [x] Thread the event bus through the `GameLoop`, bridging pygame/system events to
    subscribers while maintaining current behavior.
 1. [ ] Introduce a shared `StateStore` that the bus can update on every emission,
    exposing `State.get()` helpers for consumers.
@@ -31,3 +31,86 @@ queries, we need a project-local event bus paired with a shared state store.
 - Keep the bus synchronous for now; if latency becomes an issue we can explore
   background dispatchers.
 - Focus early tests on pure Python logic so they remain deterministic in CI.
+
+## Architecture Overview
+
+The first iteration keeps the event bus and state store in-process alongside the
+`GameLoop`. The loop will hydrate a singleton `InputEventBus` on start-up and
+pass it to peripherals during initialization. Peripherals emit domain events to
+the bus, which immediately notifies registered subscribers and writes the latest
+payload into the `StateStore`.
+
+```
+pygame -> GameLoop -> InputEventBus.emit() -> subscribers
+                                   \-> StateStore.update()
+```
+
+- `GameLoop` remains the orchestrator that polls pygame and exposes lifecycle
+  hooks for peripherals.
+- `InputEventBus` exposes `subscribe`, `unsubscribe`, `emit`, and
+  `subscription` decorator helpers.
+- `StateStore` provides `get(path, default=None)` and `snapshot()` accessors.
+- Peripherals focus on translating hardware state to typed events without
+  retaining global mutable state.
+
+## Event Model & Schema
+
+Each event is a dataclass or `TypedDict` containing:
+
+1. `type`: namespaced event label (`"switch/pressed"`).
+1. `timestamp`: `datetime` in UTC; the emitter is responsible for populating it.
+1. `payload`: arbitrary structured data (e.g., `{"port": 1, "pressed": True}`).
+
+Guidelines:
+
+- Prefer namespaced event types (`<device>/<action>`) to avoid collisions.
+- Keep payloads JSON-serializable to enable future persistence/telemetry.
+- Standardize common fields (`device_id`, `user_id`, `strength`) so consumers
+  can merge multiple devices.
+
+### Helper Types
+
+Add `InputEvent` protocol in `src/heart/events/types.py` to capture the shape
+above and enable static typing in subscribers.
+
+## State Store Semantics
+
+- The store tracks the latest event per `type` and optionally per `device_id`.
+- `StateStore.update(event)` stores the payload and timestamp under a composite
+  key. Provide helpers:
+  - `StateStore.get_latest(type, device_id=None)`
+  - `StateStore.get_all(type)`
+- Expose a read-only `StateSnapshot` mapping for consumers who need bulk state
+  without mutating rights.
+- The bus is responsible for invoking `StateStore.update()` before dispatching
+  subscribers so synchronous consumers always observe the latest state.
+
+## Migration Strategy
+
+1. Introduce a thin compatibility layer inside each peripheral that wraps the
+   existing imperative code and emits equivalent events. Maintain the old code
+   path until downstream consumers migrate.
+1. Add toggleable feature flags (e.g., `ENABLE_INPUT_EVENT_BUS`) to allow staged
+   rollout and quick rollback.
+1. Update mode/navigation controllers to read from `StateStore` while leaving
+   their public API unchanged.
+1. Remove deprecated peripheral state mutations once confidence is gained.
+
+## Testing Approach
+
+- Unit test `InputEventBus` for ordering guarantees, subscriber isolation, and
+  decorator ergonomics.
+- Add integration tests in `tests/integration/input/` that simulate pygame
+  events, drive the bus through the game loop, and assert that both the state
+  store and subscribers see expected results.
+- Include regression tests around multi-device arbitration to confirm that the
+  state store resolves conflicts deterministically.
+
+## Open Questions
+
+- Do we need backpressure or batching for high-frequency devices (e.g., analog
+  joysticks)? For now, the plan assumes no.
+- Should we persist event history for debugging? Consider adding optional
+  ring-buffer support to `StateStore` if visibility becomes an issue.
+- How do remote inputs (cloud, web) plug into the bus? Define adapters once the
+  local pathway stabilizes.

--- a/src/heart/peripheral/core/manager.py
+++ b/src/heart/peripheral/core/manager.py
@@ -3,6 +3,7 @@ import threading
 from typing import Iterable, Iterator
 
 from heart.peripheral.core import Peripheral
+from heart.peripheral.core.event_bus import EventBus
 from heart.peripheral.gamepad import Gamepad
 from heart.peripheral.heart_rates import HeartRateManager
 from heart.peripheral.phone_text import PhoneText
@@ -19,11 +20,21 @@ logger = get_logger(__name__)
 class PeripheralManager:
     """Coordinate detection and execution of available peripherals."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, event_bus: EventBus | None = None) -> None:
         self._peripherals: list[Peripheral] = []
         self._deprecated_main_switch: BaseSwitch | None = None
         self._threads: list[threading.Thread] = []
         self._started = False
+        self._event_bus = event_bus
+
+    @property
+    def event_bus(self) -> EventBus | None:
+        return self._event_bus
+
+    def attach_event_bus(self, event_bus: EventBus) -> None:
+        """Register ``event_bus`` for peripherals managed by this instance."""
+
+        self._event_bus = event_bus
 
     @property
     def peripherals(self) -> tuple[Peripheral, ...]:

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,8 +1,12 @@
+import types
+
+import pygame
 import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
 
 from heart.display.renderers.pixels import RandomPixel
 from heart.environment import GameLoop, RendererVariant
+from heart.peripheral.core import events
 
 
 @pytest.mark.parametrize("num_renderers", [1, 5, 10, 25, 50, 100, 1000])
@@ -26,3 +30,55 @@ def test_rendering_many_objects(
             mode.renderers, override_renderer_variant=renderer_variant
         )
     )
+
+
+def test_game_loop_shares_event_bus_with_manager(loop: GameLoop) -> None:
+    assert loop.peripheral_manager.event_bus is loop.event_bus
+
+
+def test_handle_events_emits_to_event_bus(loop: GameLoop, monkeypatch) -> None:
+    captured: list[dict[str, object]] = []
+
+    loop.event_bus.subscribe("pygame/quit", lambda evt: captured.append(evt.data))
+
+    fake_event = types.SimpleNamespace(type=pygame.QUIT, dict={})
+    monkeypatch.setattr(pygame.event, "get", lambda: [fake_event])
+
+    loop.running = True
+    loop._handle_events()
+
+    assert captured == [
+        {
+            "pygame_type": pygame.QUIT,
+            "pygame_event_name": pygame.event.event_name(pygame.QUIT),
+        }
+    ]
+    assert loop.running is False
+
+
+def test_handle_events_emits_custom_system_event(loop: GameLoop, monkeypatch) -> None:
+    captured: list[int] = []
+    joystick_reset = events.REQUEST_JOYSTICK_MODULE_RESET
+
+    loop.event_bus.subscribe(
+        "system/request_joystick_module_reset", lambda evt: captured.append(evt.data["pygame_type"])
+    )
+
+    fake_event = types.SimpleNamespace(type=joystick_reset, dict={})
+
+    calls: dict[str, int] = {"quit": 0, "init": 0}
+
+    def _mark_quit() -> None:
+        calls["quit"] += 1
+
+    def _mark_init() -> None:
+        calls["init"] += 1
+
+    monkeypatch.setattr(pygame.joystick, "quit", _mark_quit)
+    monkeypatch.setattr(pygame.joystick, "init", _mark_init)
+    monkeypatch.setattr(pygame.event, "get", lambda: [fake_event])
+
+    loop._handle_events()
+
+    assert calls == {"quit": 1, "init": 1}
+    assert captured == [joystick_reset]


### PR DESCRIPTION
## Summary
- update the planning checklist to reflect the GameLoop integration step
- instantiate and expose the input event bus from GameLoop while emitting pygame/system events to subscribers
- allow PeripheralManager to track the shared event bus and cover the integration with new tests

## Testing
- make format
- make test

------
https://chatgpt.com/codex/tasks/task_e_690c2fb7c1f883219e1cf04320142bcf