### PR TITLE
Emphasize automated QC in direct sensor access plan

### DIFF
--- a/docs/debugging/circuitpython_peripherals.md
+++ b/docs/debugging/circuitpython_peripherals.md
@@ -1,0 +1,31 @@
+# Debugging CircuitPython Peripheral Drivers
+
+CircuitPython targets microcontrollers with limited RAM, storage, and tooling. The tips below capture the workflow we use for iterating on drivers in `drivers/` and the supporting scripts that speak to the board over USB.
+
+## Preparing the board
+
+1. **Install the latest CircuitPython build** that supports the device. Adafruit publishes UF2 images for common boards.
+1. **Copy the project bundle**: upload the `lib/` dependencies and the driver under test to the board's storage volume.
+1. **Open a serial REPL** using `screen`, `minicom`, or the `adafruit-ampy` tooling. Set the baud rate published in the board manual (typically `115200`).
+
+## Iterating on code
+
+- **Hot reload with `code.py`**: save the driver to `code.py` or import it from a helper script. CircuitPython automatically restarts execution after the file write.
+- **Keep scripts tiny**: the board restarts when memory is exhausted. Split optional helpers into separate files that can be deleted from the board when chasing bugs.
+- **Toggle diagnostics via constants**: wrap verbose prints in `if DEBUG:` checks to avoid flooding the serial console.
+
+## Capturing sensor traffic
+
+- **Single-sensor probes**: write a `probe.py` script that only initializes the sensor under test, reads a handful of values, and prints them. This isolates hardware problems from the rest of the runtime.
+- **Record sample sessions**: copy the serial output to a text file and check it into `docs/debugging/logs/` (or discard after investigating) so regressions are easier to spot.
+- **Use deterministic timing**: avoid floating-point sleeps. Prefer `time.sleep(0.05)` or integer millisecond counters to make traces easier to compare.
+
+## Handling failures
+
+- **Hard crashes / safe mode**: if the board boots into safe mode, remove the offending driver, reset, and reintroduce pieces incrementally.
+- **Bus lockups**: power-cycle the board and unplug other peripherals. Many I2C/SPI sensors need a full power reset to clear a wedged bus.
+- **Peripheral-specific notes**: document any errata or quirks directly in the driver docstrings per the guidance in `drivers/AGENTS.md`.
+
+## Desktop reproduction harness
+
+When possible, mirror the driver API with a desktop shim (for example, `drivers/i2c/some_sensor_sim.py`) so pytest can exercise the core logic. This is invaluable when the only reproduction requires the real hardware.

--- a/docs/planning/direct_sensor_access.md
+++ b/docs/planning/direct_sensor_access.md
@@ -1,0 +1,43 @@
+# Direct Sensor Access Plan
+
+Goal: allow developers to interrogate a hardware sensor from the host machine without launching the full game runtime. The tool should stream readings over USB serial and expose a thin API for automated tests.
+
+## Requirements
+
+- **Board connection**: reuse the existing CircuitPython USB serial channel.
+- **Selectable sensors**: support choosing a sensor by module path (e.g., `drivers.sensors.imu`).
+- **Minimal dependencies**: run under CircuitPython with only built-in modules plus our driver.
+- **Host-side convenience**: provide a Python CLI in `scripts/` that sends commands and prints parsed readings.
+- **Automated quality check (QC)**: make it effortless to flash a new board, confirm the sensor responds, and record a short
+  diagnostic trace without manual intervention.
+
+## Proposed flow
+
+1. **Probe script template**
+   - Add `drivers/utils/probe_base.py` with a helper class that handles argument parsing from `sys.argv` and loops over reads.
+   - Each sensor provides a `probe.py` that subclasses the helper and implements `read_once()`.
+1. **Host CLI**
+   - Create `scripts/sensor_probe.py` that opens the board serial port, flashes the requested `probe.py`, and streams the responses.
+   - Support a `--record` flag to write samples to disk for offline analysis.
+1. **Documentation & examples**
+   - Extend `docs/debugging/circuitpython_peripherals.md` with instructions for running the probes.
+   - Ship one example (e.g., accelerometer) to validate the flow.
+
+## Automated QC happy-path
+
+1. **Automated flashing**: wrap the UF2 copy procedure in a `scripts/flash_board.py` helper so CI or a developer can reset a
+   board and load the probe script with a single command.
+1. **Connectivity verification**: after flashing, issue a lightweight `ping` command over serial that expects a known response
+   (for example, firmware version plus sensor ID). Fail fast if the response is absent or malformed.
+1. **Sensor self-test**: run the associated `probe.py` in a bounded loop (e.g., 10 samples) and assert that the readings fall
+   within expected sanity ranges defined per sensor.
+1. **Report aggregation**: persist the flash log, ping outcome, and sample statistics to `docs/debugging/logs/` so hardware can
+   be baselined over time and regressions are obvious.
+
+Keeping this QC path automated and low-friction is critical—every fresh board flash should produce a deterministic pass/fail
+signal within seconds so driver regressions are caught before they reach the wider runtime.
+
+## Open questions
+
+- How do we bundle per-sensor dependencies without filling the board storage? Possibly generate probes on the fly from templates.
+- Should the host CLI support live plotting (e.g., matplotlib) or stay text-only initially?

--- a/drivers/AGENTS.md
+++ b/drivers/AGENTS.md
@@ -1,0 +1,15 @@
+# Drivers Agent Instructions
+
+## CircuitPython constraints
+- Assume these drivers will run under CircuitPython first and CPython second. Keep dependencies to the built-ins that ship with CircuitPython or a clearly documented external bundle.
+- Avoid dynamic imports, reflection, or heavy use of Python metaprogramming features that CircuitPython omits.
+- Prefer small, synchronous functions. CircuitPython lacks threads and has very limited heap space, so do not allocate large temporary buffers or rely on recursion.
+
+## Debugging guidance
+- When adding diagnostic output, use `print` statements guarded behind a module-level `DEBUG` flag rather than logging frameworks that CircuitPython does not ship with by default.
+- Keep exception handling minimal; allow errors to propagate so they can be inspected over the serial REPL. Only catch exceptions when you can recover or to add chip-specific hints.
+- Include docstrings that describe how to reproduce hardware issues via the REPL so that future debugging does not require the full game runtime.
+
+## Testing philosophy
+- Provide a pure-Python shim or simulator whenever practical so unit tests can run on CI. Hardware-specific modules should be isolated behind thin adapters that can be mocked.
+- Document any hardware timing requirements (debounce, sensor warm-up delays, etc.) in the module docstring.


### PR DESCRIPTION
## Summary
- add an automated QC requirement to the direct sensor access plan
- document an end-to-end flashing and verification happy-path for new boards
- highlight the need for fast, deterministic QC feedback after each flash

## Testing
- make format

------
https://chatgpt.com/codex/tasks/task_e_690c86e9892c83218d9c98a6ddca8dff