### PR TITLE
Remove residual type ignore annotations

### DIFF
--- a/experimental/isolated_rendering/src/isolated_rendering/renderer.py
+++ b/experimental/isolated_rendering/src/isolated_rendering/renderer.py
@@ -1,6 +1,7 @@
 import threading
 import time
 from dataclasses import dataclass
+from typing import Optional, cast
 
 from heart.device import Cube, Device
 from heart.device.local import LocalScreen
@@ -10,9 +11,11 @@ from heart.utilities.logging import get_logger
 from .buffer import FrameBuffer
 
 try:
-    from heart.device.rgb_display import LEDMatrix
+    from heart.device.rgb_display import LEDMatrix as _LEDMatrix
 except ImportError:  # pragma: no cover - not available outside Pi
-    LEDMatrix = None  # type: ignore[assignment]
+    _LEDMatrix = None
+
+LEDMatrix: Optional[type[Device]] = cast(Optional[type[Device]], _LEDMatrix)
 
 logger = get_logger(__name__)
 

--- a/scripts/render_code_flow.py
+++ b/scripts/render_code_flow.py
@@ -426,7 +426,6 @@ def build_svg(layout: DiagramLayout) -> ET.Element:
                 tspan = ET.SubElement(text_element, "tspan", tspan_attrib)
                 tspan.text = line
 
-    ET.indent(svg)  # type: ignore[arg-type]
     return svg
 
 
@@ -435,6 +434,7 @@ def render(output_path: pathlib.Path) -> None:
     svg = build_svg(layout)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     tree = ET.ElementTree(svg)
+    ET.indent(tree)
     tree.write(output_path, encoding="utf-8", xml_declaration=True)
 
 


### PR DESCRIPTION
## Summary
- replace optional hardware integrations with typed fallbacks so type ignores are unnecessary
- tighten the MQTT sidecar module loader to avoid dynamic attribute errors
- update SVG rendering indentation to operate on the ElementTree instead of the root element

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_690c876734e0832189f86a25bdc1193a