### PR TITLE
Add UWB integration research and rollout plan

### DIFF
--- a/docs/planning/uwb_peripheral_rollout.md
+++ b/docs/planning/uwb_peripheral_rollout.md
@@ -1,0 +1,86 @@
+# UWB Peripheral Rollout Plan
+
+## Opening abstract
+
+We are introducing ultra-wideband ranging to the Heart ecosystem so peripherals and hubs can localize each other within ±10 cm indoors. The rollout balances hardware integration of Qorvo DWM3001C modules, Zephyr/Nordic firmware updates, and automation platform changes that interpret high-resolution ranging data. **Why now:** Competitors are shipping UWB accessories, DW3000 module supply has stabilized, and customer research shows demand for room-level automations that current BLE solutions cannot provide reliably.
+
+Primary stakeholders include the firmware platform crew, hardware engineering, automation experiences, telemetry, and privacy. Success hinges on validating accuracy in real homes, proving that installers can deploy anchors without RF surprises, and ensuring privacy messaging lands with pilot customers.
+
+## Success criteria
+
+| Outcome | Signal check | Owner |
+| --- | --- | --- |
+| Maintain ±10 cm 95th percentile ranging accuracy in pilot homes | Weekly Grafana dashboard aggregates `uwb_ranging_event` residuals \<0.1 m at P95 | Firmware lead |
+| EVT anchor enclosures require zero antenna retunes | RF validation report shows \<1 dB mismatch across channels 5 and 9 | Hardware PM |
+| Automations trigger within 150 ms median after zone entry | Automation latency telemetry links `uwb_ranging_event` to rule execution \<150 ms median | Experiences EM |
+| Privacy expectations remain positive throughout beta | Interview synthesis doc shows ≥4/5 satisfaction on privacy comfort scale | Privacy research lead |
+
+## Discovery phase checklist
+
+- [ ] Audit hub MCU GPIO/SPI availability and update `docs/architecture/hub_io.md` with spare high-speed buses.
+- [ ] Evaluate DWM3001C and DW3110 reference designs; document BOM, layout constraints, and antenna keep-out in a comparative sheet.
+- [ ] Run bench tests with DWM3001C evaluation kits to measure SS-TWR accuracy, logging channel impulse response captures.
+- [ ] Interview at least three pilot customers about indoor positioning privacy; summarize findings in `docs/research/privacy_guardrails.md`.
+- [ ] Benchmark Zephyr UWB stack versus Qorvo reference firmware, recording CPU load, latency, and memory footprint.
+
+## Build phase checklist
+
+- [ ] Fork firmware branch enabling SS-TWR ranging service and BLE commissioning; include Nordic DFU path.
+- [ ] Spin rev-A anchor PCB around DWM3001C with documented antenna keep-out and shield can placement; archive Altium source.
+- [ ] Integrate `uwb_ranging_event` telemetry schema and end-to-end ingestion path; link to staging Grafana dashboard.
+- [ ] Implement automation engine adapter that transforms UWB coordinates into zone entry/exit events with hysteresis.
+- [ ] Prototype installer mobile app flow for anchor placement and calibration, including visual alignment aids.
+
+## Rollout phase checklist
+
+- [ ] Deploy UWB firmware to 10 employee pilot homes, capturing accuracy and battery metrics in a shared spreadsheet.
+- [ ] Conduct RF validation sweep in anechoic chamber and document results in compliance tracker.
+- [ ] Deliver support training session plus quick-reference FAQ hosted in Guru.
+- [ ] Finalize FCC/ETSI submission package with lab booking confirmation and duty-cycle evidence.
+- [ ] Publish customer-facing privacy and calibration FAQ on internal launch portal.
+
+## Narrative walkthrough
+
+Discovery begins with firmware and hardware sharing bench space to validate that the hub MCU can drive a DW3110 at 8 MHz over SPI without starving other peripherals. Simultaneously, the hardware team tests DWM3001C evaluation boards to confirm antenna clearance, while privacy researchers run structured interviews to surface concerns about indoor tracking. Weekly discovery standups collect metrics—CIR captures, CPU utilization, and interview quotes—and record them in the shared tracking sheet. By the end of discovery we will have a preferred module, a crisp view of firmware complexity, and documented privacy guardrails.
+
+The build phase opens with firmware implementing HRP SS-TWR in Zephyr and instrumenting the Nordic DFU flow so anchors can update over BLE. Hardware spins the rev-A anchor PCB, integrates shield cans, and schedules S-parameter sweeps for the EVT run. Telemetry engineers deploy the `uwb_ranging_event` schema into staging, while automation engineers create a translation layer that maps trilaterated coordinates into zone entry events with hysteresis to avoid jitter. Installer experience designers produce a mobile tool that walks technicians through anchor placement with augmented overlays and verifies clock sync before they leave the site. Twice-weekly async updates in Notion track progress and escalate blockers—especially around RF layout and firmware timing.
+
+Rollout overlaps with late build once firmware and hardware stabilize. Ten employee pilot homes receive the new anchors and firmware, each logging accuracy, latency, and battery drain. RF engineers conduct anechoic chamber sweeps to certify that the enclosure does not detune channels 5 and 9. Support leads run training sessions and publish troubleshooting guides so first-line agents can diagnose calibration issues. Compliance teams assemble FCC and ETSI submissions, including duty-cycle measurements captured during pilot sessions. Marketing and privacy leads craft customer-facing messaging, ensuring opt-in flows clearly state data handling policies.
+
+## Signal propagation diagram
+
+```
+Tag Device      Hub Anchor      Telemetry Ingest      Automation Engine
+    |                |                 |                       |
+    |---- Blink ---->|                 |                       |
+    |<-- Poll  ------|                 |                       |
+    |---- Final ---->|                 |                       |
+    |                |---- Event ----->|                       |
+    |                |                 |---- Stream ---------> |
+    |                |                 |<--- Rule Eval --------|
+    |                |<--- Action -----|                       |
+```
+
+*Tip:* Capture the channel impulse response (CIR) for each ranging exchange and store it alongside the telemetry event. These samples speed up post-mortem analysis when accuracy drifts.
+
+## Risk analysis
+
+| Risk | Probability | Impact | Mitigation | Early warning |
+| --- | --- | --- | --- | --- |
+| Antenna detuning in production enclosure | Medium | High | Schedule RF + ID review, prototype 3D-printed enclosures, run S-parameter sweeps | VNA sweep shows >3 dB mismatch |
+| DW3001C supply disruption | Medium | High | Reserve buffer inventory, qualify DW3110 cost-down path | Supplier lead-time extension notice |
+| Firmware power consumption exceeds battery targets | Medium | Medium | Implement adaptive ranging intervals, log battery trends in pilot homes | Pilot spreadsheet shows >10% daily drain |
+| Privacy backlash during pilot | Low | Medium | Provide explicit opt-in, anonymize telemetry, co-review messaging with legal | Interview notes show discomfort or low satisfaction |
+| Secure ranging key compromise | Low | High | Use secure element provisioning, monitor for anomalous round-trip variance | Telemetry flags repeated authentication failures |
+
+### Mitigation checklist
+
+- [ ] Lock manufacturing slots for primary and fallback module SKUs.
+- [ ] Complete RF/ID enclosure review with thermal chamber validation booked.
+- [ ] Ship firmware update enabling adaptive duty cycling before pilot expansion.
+- [ ] Draft privacy comms playbook and route for legal approval.
+- [ ] Exercise key rotation pipeline in staging with red-team validation.
+
+## Outcome snapshot
+
+Once the plan lands, Heart hubs and peripherals will maintain synchronized SS-TWR ranging with ±10 cm accuracy at the 95th percentile. Installers will rely on a guided mobile flow to position anchors, confirm calibration, and export compliance logs. Telemetry dashboards will expose accuracy, latency, and battery trends, giving the experiences team confidence to launch zone-based automations. Customers will opt into privacy-safe positioning, and compliance teams will hold FCC/ETSI approvals with documented duty-cycle evidence. Follow-on experiments will focus on multi-floor localization and automated calibration routines.

--- a/docs/research/uwb_peripheral_integration.md
+++ b/docs/research/uwb_peripheral_integration.md
@@ -1,0 +1,90 @@
+# Ultra-Wideband Peripheral Integration Options for Heart
+
+## Executive summary
+
+Ultra-wideband (UWB) enables centimeter-level ranging, giving Heart hubs and peripherals spatial awareness that BLE RSSI and Wi-Fi RTT cannot achieve consistently. Qorvo's DW3000 family raises the ceiling with IEEE 802.15.4z High Rate Pulse (HRP) support, improved power efficiency, and compatibility with FiRa and Apple Nearby Interaction ecosystems. This note summarizes hardware, antenna, firmware, and service integration considerations so the platform can estimate peer-to-peer distance within ±10 cm indoors while respecting tight power and privacy budgets.
+
+## Problem statement
+
+Heart needs a repeatable method for estimating the location of a battery-powered peripheral relative to a central hub or to other peripherals. Indoor multipath, orientation drift, and enclosure detuning regularly push Bluetooth-based techniques beyond ±1 m. UWB time-of-flight ranging remains resilient to multipath and supports cryptographic distance bounding. The research objective is to compare module and discrete options, outline firmware integration points, and flag backend and regulatory dependencies.
+
+## Candidate hardware landscape
+
+| Vendor | Part/module | Key traits | Integration notes |
+| --- | --- | --- | --- |
+| Qorvo | **DW1000**, **DWM1001** | Production-proven, 3.5–6.5 GHz, community firmware (Mynewt, Zephyr). No 802.15.4z. TX 130 mA. | Requires external MCU, larger power budget. Consider only if BOM pressure is extreme. |
+| Qorvo | **DW3000** SoC (DW3110) and modules (**DWM3000**, **DWM3001C**) | IEEE 802.15.4z HRP, FiRa certified profiles, RX ~60 mA, integrated antennas in modules. | DWM3001C bundles nRF52833 + BLE, simplifies RF; discrete DW3110 mates with existing STM32/NRF boards. |
+| NXP | **SR150/SR040** | Combines UWB, BLE, Cortex-M33. | Ecosystem thinner, dev kits available, but supply limited; evaluate only if co-packaged BLE is mandatory. |
+| Pozyx | **Tag/Anchor kits** | Turnkey anchor network built on DW1000. | Useful for rapid proof-of-concept or lab benchmarking. |
+| Nanotrack | **NTK3000** | DW3000-based modules with integrated MCU. | Attractive for ODM partnership if in-house RF resources are constrained. |
+
+**Recommendation:** Prioritize DWM3001C for first hardware spin. The module ships with FCC/CE modular approvals, exposes both UWB and BLE, and allows reuse of Nordic SDK build infrastructure. Keep DW3110 on the radar as a cost-down once the RF design is proven.
+
+## Antenna and mechanical considerations
+
+- Maintain a 15 mm × 12 mm ground clearance under the ceramic antenna and avoid copper pour. Follow the DWM3001C hardware design guide for microstrip impedance.
+- Shield the UWB section when co-located with switching regulators or high-speed digital lines. Early EVT builds should include S-parameter sweeps to catch detuning.
+- Provide three-dimensional placement guidelines for industrial design so that anchors can be oriented orthogonally when triangulating tags.
+- Budget plastic thickness below 2 mm directly above the antenna. Validate final enclosures with a near-field scanner or anechoic chamber sweeps.
+
+## Firmware and stack integration
+
+- **Operating system**: Zephyr already includes `drivers/uwb` for DW1000/3000. Nordic's nRF Connect SDK (NCS) bundles DW3000 drivers compatible with the DWM3001C onboard MCU.
+- **Ranging protocol**: Implement IEEE 802.15.4z HRP Single-Sided Two-Way Ranging (SS-TWR) for low-latency interactions. Provide a switch to fall back to Double-Sided TWR when multipath dominates.
+- **Synchronization**: Anchors require \<1 µs clock drift. Use Periodic Sync Frames (PSF) or rely on BLE-connected time sync when the hub acts as master.
+- **Commissioning**: Boot the DWM3001C via Nordic DFU over BLE; include a BLE advertising payload that exposes firmware version and supported channels.
+- **Security**: Enable STS (Secure Time Stamping) with AES-128 keys provisioned in the Nordic secure bootloader. Pairing can bootstrap via existing Heart manufacturing flows.
+- **Telemetry**: Emit raw timestamps and computed ranges into a new protobuf schema (`uwb_ranging_event`). Annotate records with channel, preamble index, and diagnostics (CIR peak, FP quality) for analytics.
+
+## Localization algorithms and software hooks
+
+- Start with centralized trilateration inside the hub. Compute distances to at least three anchors and solve via nonlinear least squares (e.g., Levenberg–Marquardt) using R^3 coordinates.
+- Wrap results in a Kalman filter that fuses IMU accelerometer data when available. Treat UWB ranges as absolute position updates and IMU integration as prediction steps.
+- For peer-to-peer interactions (peripheral-to-peripheral), expose a "tag" firmware mode that allows a device to act as both responder and initiator. Evaluate Qorvo's ranging library for low-level waveform timing management.
+- Integrate with Heart's automation engine by creating presence zones. When a device's estimated coordinate enters a zone, fire an event identical to current geofence triggers.
+- Prototype cloud-side analytics to detect drift. When residuals exceed ±15 cm, prompt recalibration or anchor repositioning.
+
+## Cloud and service touchpoints
+
+- Extend the telemetry ingestion pipeline to support UWB payloads. Ensure the event stream includes device IDs, session IDs, and security metadata for traceability.
+- Build dashboards that plot range statistics, filter by firmware version, and visualize anchor geometry per install.
+- Update privacy controls so users can opt into or out of fine-grained localization. Provide transparency logs for data retention and anonymization policies.
+
+## Power and duty cycle budgeting
+
+- DW3000 tags draw ~60 mA in RX and ~115 mA in TX. With a 100 ms SS-TWR interval and 2 ms active window, average current drops near 2 mA. Adjust polling frequency dynamically based on motion or automation urgency.
+- Enable deep sleep between ranging sessions. Nordic's nRF52833 on DWM3001C supports \<5 µA sleep; ensure interrupts wake only when necessary.
+- Model thermal load with 10% duty cycle bursts. Place UWB modules away from Li-ion cells to maintain \<85 °C junction temperature.
+
+## Regulatory and regional compliance
+
+- UWB falls under FCC Part 15 Subpart F. DWM3001C modular approval simplifies certification, but final products still require unintentional radiator testing.
+- ETSI EN 302 065 governs EU operation. Channel 5 is restricted in India; maintain a region-aware channel map and disable unsupported bands at runtime.
+- Capture duty cycle and Effective Isotropic Radiated Power (EIRP) metrics during validation. Store results in compliance documentation for audit readiness.
+
+## Security posture
+
+- Mandate mutual authentication via STS; reject frames with unexpected sequence numbers or clock skew.
+- Monitor round-trip time variance to detect relay attacks. Combine with BLE proximity as a secondary factor for high-stakes automations.
+- Ensure firmware updates enforce secure boot and signed images. Align with Heart's existing provisioning pipeline.
+
+## Open questions and next steps
+
+- Does the current hub MCU expose a free high-speed SPI capable of 8 MHz+ for DW3110 integration if we choose the discrete route?
+- Should we embed UWB into existing peripherals (thermostats, switches), or release dedicated anchors and tags?
+- What manufacturing fixtures are required for factory calibration of antenna delays and crystal trimming?
+- How do we surface calibration workflows to installers without overwhelming them? Consider augmented reality alignment aids or guided mobile apps.
+
+## Recommended experiments
+
+1. Order DWM3001C evaluation kits and validate SS-TWR accuracy across varied multipath environments. Log channel impulse response (CIR) data for future machine learning enhancements.
+1. Benchmark Nordic's UWB stack against Qorvo's reference to quantify latency, CPU usage, and memory footprint.
+1. Prototype backend processing with simulated ranges to evaluate trilateration convergence and automation latency.
+1. Run privacy workshops to test messaging around indoor positioning. Capture responses to opt-in flows and anonymization promises.
+
+## References
+
+- Qorvo DW3000 product brief and hardware design guidelines (downloaded 2024-05-12).
+- IEEE 802.15.4z HRP ranging specification, Annex E.
+- Nordic Semiconductor nRF Connect SDK documentation (UWB preview branch).
+- Internal Heart automation engine specification (`docs/architecture/automation_engine.md`).


### PR DESCRIPTION
## Summary
- add a research note capturing hardware, firmware, and service considerations for UWB peripherals
- document the phased rollout plan with success criteria, checklists, risk mitigations, and outcomes

## Testing
- `make format`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_690c8bcedeb88321bf73947a0ed40743