### PR TITLE
Add IR sensor array plan and research note

### DIFF
--- a/docs/planning/ir_sensor_array_peripheral.md
+++ b/docs/planning/ir_sensor_array_peripheral.md
@@ -1,0 +1,92 @@
+# IR Sensor Array Peripheral & Directional Remote Plan
+
+## Abstract
+
+The Heart hardware stack needs an infrared (IR) sensor array peripheral capable of decoding remote-style bit streams while estimating the three-dimensional origin of those transmissions. The target operators are hardware R&D, embedded firmware, and UX engineers who depend on sub-10-centimetre positional accuracy to unlock gesture-like interactions. **Why now:** the robotics roadmap demands centimeter-level indoor localization without adding radio-frequency complexity, and IR triangulation offers the fastest route to cross-team value. This plan orchestrates hardware, firmware, and experience threads so the first release lands with verifiable positioning accuracy, manufacturable prototypes, and observability hooks.
+
+## Success criteria
+
+| Celebration moment | Signal check | Owner |
+| --- | --- | --- |
+| Sensor rig resolves IR remote position within ±10 cm at a 3 m range | Lab calibration logs report \<10 cm mean error across 30 azimuth/elevation pairs | Hardware R&D |
+| Firmware streams decoded bit packets and per-sensor timestamps at 200 Hz | Telemetry dashboard plots synchronized bit frames and inter-sensor timing deltas | Embedded firmware |
+| Arrayed remote broadcasts directional patterns recognized in under 50 ms | Hardware-in-the-loop (HIL) test suite passes directional burst scenarios with \<50 ms latency | Controls & QA |
+
+## Phase breakdown
+
+### Discovery
+
+- [ ] Map the existing IR decoding flow in `drivers/` and document timing resolution limits in `docs/research/ir_sensor_array_positioning.md`.
+- [ ] Benchmark wide-angle versus narrow field-of-view IR sensor packages; capture a comparison table with responsivity, latency, and ambient rejection metrics.
+- [ ] Prototype a four-sensor breadboard with synchronized capture, saving logic analyzer traces and timestamp alignment notes to the lab share.
+- [ ] Draft a communications spec for the peripheral-to-MCU interface (SPI vs. I²C + DMA) and solicit asynchronous feedback via architecture review notes.
+- [ ] Interview firmware and UX partners about directional interaction scenarios to align on success narratives and telemetry requirements.
+
+### Build
+
+- [ ] Design PCB v1 with radial IR sensor placement, precision clock distribution, and diagnostic headers; store KiCad sources alongside BOM revisions.
+- [ ] Implement the embedded driver module `src/hw/ir_array.rs` that streams timestamped interrupts into a double-buffered DMA queue with CRC tagging.
+- [ ] Extend the signal processing pipeline with a multilateration solver, confidence scoring, and unit tests using synthetic pulse fixtures.
+- [ ] Create an arrayed remote prototype with three IR LEDs at 120° offsets, each modulating distinct preamble sequences and payload slots.
+- [ ] Develop a calibration CLI (`scripts/ir_calibrate.py`) that records sweeps, solves for sensor offsets, and uploads results to the telemetry store.
+
+### Rollout
+
+- [ ] Integrate a telemetry panel into the developer dashboard visualizing 3D pose estimates, signal strengths, and per-sensor status.
+- [ ] Author the operator playbook covering placement, calibration cadence, and troubleshooting flows for missed pulses.
+- [ ] Run a 48-hour soak test in the staging lab, logging positional drift, packet-loss events, and temperature correlations to observability sinks.
+- [ ] Prepare launch communications (demo video, metrics snapshot, FAQ) for customer success and solution engineering partners.
+- [ ] Capture win stories from early adopters and funnel them into the next roadmap review alongside backlog adjustments.
+
+## Narrative walkthrough
+
+Discovery focuses on proving feasibility and bounding timing performance. Hardware researchers map the current IR decoder to understand interrupt latency and sampling jitter while cataloguing sensor package trade-offs. The breadboard prototype validates that we can latch interrupts in microsecond windows and align them across four sensors with a shared reference clock. In parallel, architecture discussions lock in a low-latency peripheral interface, and partner interviews define the directional interaction stories that downstream teams expect to demo.
+
+Build advances on three intertwined threads. Hardware spins the first PCB with radial sensor placement that maximizes baseline lengths while preserving a compact footprint. Firmware teams implement the timestamped data plane and multilateration solver, leaning on synthetic pulse fixtures to validate geometry maths before hardware arrives. Experience engineers craft the directional remote so the positional solver receives a structured burst sequence that encodes spatial cues as well as payload bits. The calibration CLI unblocks lab technicians by automating sensor offset estimation and uploading coefficients to shared storage.
+
+Rollout layers on observability and enablement. The telemetry panel provides live dashboards for engineering reviews and soak tests. Operator enablement materials equip onsite teams to install, calibrate, and troubleshoot with minimal assistance. The extended soak test validates thermal stability, positional drift, and packet resilience before customer-facing demos. Launch communications and win-story capture ensure commercial and product stakeholders understand the gains and funnel real-world feedback into the follow-on backlog.
+
+## Visual references
+
+```
+            Arrayed Remote (3-beam IR emitter)
+                   /       |       \
+                  /        |        \
+       Sensor A ----- Sensor B ----- Sensor C ----- Sensor D
+           (Δt₁)         (Δt₂)         (Δt₃)         (Δt₄)
+                  \        |        /
+                   \       |       /
+          Multilateration solver → 3D pose + confidence score
+```
+
+| Frame segment | Emitter | Purpose | Duration |
+| --- | --- | --- | --- |
+| 1 | Beam 1 | Preamble P1 + payload burst | 10 ms |
+| 2 | — | Guard gap to avoid cross-talk | 3 ms |
+| 3 | Beam 2 | Preamble P2 + payload burst | 10 ms |
+| 4 | — | Guard gap | 3 ms |
+| 5 | Beam 3 | Preamble P3 + sync pulse | 5 ms |
+
+> **Tip:** Record guard-gap timing with ±0.5 ms tolerance; exceeding this window is the earliest indicator of PLL drift or firmware scheduling hiccups.
+
+## Risk analysis
+
+| Risk | Probability | Impact | Mitigation | Early warning |
+| --- | --- | --- | --- | --- |
+| Sensor timing jitter exceeds multilateration tolerance | Medium | High | Add PLL-based clocking and oversample interrupts with hardware timestamping | Calibration residuals above 15 cm |
+| Arrayed remote beams interfere in reflective rooms | Medium | Medium | Stagger modulation frequencies, widen guard gaps, and add error correction coding | Spike in checksum failures during soak tests |
+| Firmware throughput saturates MCU DMA bandwidth | Low | High | Use double-buffered DMA, compress timestamp payloads, and enforce watchdog telemetry | Telemetry backlog or dropped frames |
+| Calibration drift correlates with ambient temperature | Medium | Medium | Integrate temperature sensors and bake compensation curves into solver inputs | Drift trend exceeds 5 cm per day |
+| Assembly variance reduces baseline accuracy | Medium | Medium | Design jigs for sensor placement and add automated production tests | Factory QA flags positional bias |
+
+### Mitigation checklist
+
+- [ ] Validate PLL timing stability across temperature chamber sweeps and log phase-noise metrics.
+- [ ] Prototype modulation frequency hopping and measure cross-talk under mirrored-surface scenarios.
+- [ ] Profile DMA throughput under worst-case burst loads; store benchmarking scripts and results alongside firmware modules.
+- [ ] Extend the solver to ingest ambient temperature telemetry and re-fit compensation curves during calibration runs.
+- [ ] Define assembly tolerances and integrate jig verification into manufacturing QA documentation.
+
+## Outcome snapshot
+
+Post-launch, the IR sensor array peripheral streams timestamped data at 200 Hz into the multilateration solver, delivering sub-10-centimetre pose estimates with confidence scoring. The directional remote’s sequenced beams provide unambiguous spatial cues while preserving standard bitstream semantics, enabling robots to interpret gestures and align themselves relative to operators. Operators calibrate the system in under five minutes via the CLI, dashboards visualise live pose and drift metrics, and follow-on experiments explore multi-remote interactions and ambient light resilience.

--- a/docs/research/ir_sensor_array_positioning.md
+++ b/docs/research/ir_sensor_array_positioning.md
@@ -1,0 +1,50 @@
+# IR Sensor Array Positioning Research Note
+
+## Context
+
+This note captures the technical rationale for adding an IR sensor array peripheral that decodes remote-control bit streams while estimating emitter pose. It complements the implementation plan documented in `docs/planning/ir_sensor_array_peripheral.md` by diving into timing tolerances, sensor geometry, and signal processing trade-offs.
+
+## Timing and sampling requirements
+
+- Target end-to-end latency is \<50 ms from photon detection to multilateration output, matching the success criteria in the plan.
+- Each sensor channel must support microsecond-scale timestamping. With sensors spaced 15–20 cm apart, a 10 cm path difference corresponds to ~333 ns in air; sub-microsecond precision with oversampling and interpolation is required to differentiate arrival times reliably.
+- Use a phase-locked loop (PLL) disciplined clock distributed to all capture channels. Breadboard experiments should log phase noise and drift across temperature ranges before committing to PCB layout.
+
+## Sensor package evaluation
+
+| Package | FOV | Responsivity | Rise time | Notes |
+| --- | --- | --- | --- | --- |
+| TSOP-like demodulators | 90° | High | 400 µs | Integrated AGC may mask fine timing; suitable for decoding but weak for triangulation |
+| PIN photodiodes + transimpedance | 60° (with lens) | Medium | \<10 µs | Requires custom amplification but preserves edge timing |
+| Multi-element IR receivers | 120° | Medium | 50 µs | Wider coverage but higher crosstalk risk; useful for hybrid arrays |
+
+**Recommendation:** Combine narrow-FOV PIN photodiodes for timing accuracy with secondary demodulation channels to retain compatibility with legacy remotes.
+
+## Geometry and solver design
+
+- Arrange four sensors in a non-coplanar radial geometry to maximize baseline diversity. A tetrahedral layout yields better vertical resolution than a flat plane.
+- Implement a multilateration solver that ingests time-of-arrival (ToA) differences plus binary hit flags for robustness when signals clip.
+- Confidence scoring should weight solutions by the variance of measured ToA residuals and ambient light noise captured during calibration sweeps.
+
+## Directional remote encoding
+
+- Prototype a remote with three IR LEDs spaced at 120° and mounted on a small dome to project distinct beams.
+- Assign unique preambles (P1, P2, P3) per emitter and stagger bursts with 3 ms guard intervals. This approach aligns with the frame sequencing table in the plan and mitigates reflective interference.
+- Encode pose hints within payload bits when possible (e.g., beam ID + sync pulse) so the solver can reject ambiguous detections.
+
+## Calibration and observability
+
+- Calibration CLI should capture static sweeps at multiple distances (1–3 m) and solve for sensor offsets, temperature coefficients, and photodiode gain factors.
+- Store calibration artifacts in the telemetry backend so soak tests can correlate drift with environment data.
+- Dashboard visualizations must expose per-sensor status, timing residuals, and confidence metrics to aid troubleshooting.
+
+## Open research questions
+
+1. What modulation frequencies minimize ambient sunlight interference while staying within component tolerances?
+1. How does reflective clutter (glass, metal) impact ToA measurements, and can adaptive filtering compensate without increasing latency?
+1. Can we multiplex multiple directional remotes without sacrificing ToA resolution? Potential solutions include orthogonal frequency codes or time-sliced frames beyond the current five-segment schedule.
+
+## References
+
+- Implementation plan: `docs/planning/ir_sensor_array_peripheral.md`
+- DMA and timestamping prototypes: to be stored in `src/hw/ir_array.rs` and accompanying test fixtures once development begins.


### PR DESCRIPTION
## Summary
- add an implementation plan for the IR sensor array peripheral and directional remote under docs/planning
- document timing, geometry, and calibration research considerations for the IR positioning work under docs/research

## Testing
- make format

------
https://chatgpt.com/codex/tasks/task_e_690c8a6ec81c8321afdec9817ffdc5c2