### PR TITLE
Add flow toy RF planning and research notes

### DIFF
--- a/docs/planning/flow_toy_signal_interface.md
+++ b/docs/planning/flow_toy_signal_interface.md
@@ -1,0 +1,89 @@
+# Flow Toy Signal Capture & Control Plan
+
+## Abstract
+
+Flow toys such as pixel whips and LED poi broadcast status telemetry over low-power radios so companion apps can synchronize color patterns. We aim to first observe those passive emissions, then mature into a full duplex integration where Heart can both read and control the toys. The primary operators are the hardware integration team and the runtime maintainers who manage device orchestration.
+
+**Why now.** Multi-output experiences are central to Heart's roadmap. Flow toy control delivers the first lighting peripheral able to mirror Heart's state. Establishing a capture-to-control pipeline now lets us validate spectrum use, message formats, and latency while the hardware group prototypes the next wave of ambient devices.
+
+## Success criteria
+
+| Target behaviour | Observable signal | Validation owner |
+| --- | --- | --- |
+| Reliable passive capture of toy telemetry packets within 3 m | Replayed IQ captures reconstructed into packets with <5% packet loss during 10-minute capture windows | RF tooling lead |
+| Accurate protocol reverse-engineering | Decoder produces fields matching vendor mobile app logs with <2% variance over 100 messages | Embedded architect |
+| Bidirectional control from Heart runtime | Heart orchestrator toggles toy modes with end-to-end latency <150 ms | Runtime maintainer |
+| Safe multi-device arbitration | Two toys driven concurrently retain independent addressing without command bleed-over across 30 test cycles | QA automation |
+
+## Phase breakdown
+
+### Discovery – capture and protocol reconnaissance
+
+- [ ] Inventory available flow toys, document hardware revisions, and confirm their companion transports (BLE, proprietary 2.4 GHz, Wi-Fi).
+- [ ] Collect FCC filings or teardown notes for PCB photos, antenna design, and MCU choices to inform spectrum scans.
+- [ ] Acquire SDR samples (HackRF + GQRX or PlutoSDR + SoapySDR) across 2.4 GHz and sub-GHz bands while toys operate in default modes.
+- [ ] Use `inspectrum`/`Universal Radio Hacker` to segment bursts, identify preambles, and estimate symbol rates.
+- [ ] Align captured messages with mobile app actions to map cadence and infer directionality.
+
+### Implementation – decoding and runtime integration
+
+- [ ] Build a Python-based demodulation toolchain (GNU Radio flowgraph + custom demod script) that outputs timestamped payloads.
+- [ ] Reverse-engineer frame structure: sync word, address fields, checksums, and payload encoding; document findings in `docs/research/`.
+- [ ] Prototype a `FlowToyReceiver` that ingests demodulated payloads over a socket or file interface and publishes events on the input bus.
+- [ ] Evaluate candidate transceivers (nRF52840, TI CC2652, ESP32-C6) for transmit capability at the discovered modulation scheme.
+- [ ] Design a command serializer mirroring decoded frames, supporting sequence numbers and HMAC/signature fields if detected.
+
+### Validation – closed-loop testing & UX handoff
+
+- [ ] Assemble a test jig with two flow toys, the SDR capture device, and the selected transceiver dev board for transmission tests.
+- [ ] Run soak tests measuring Heart-to-toy latency, error rates, and interference when co-located with Wi-Fi/Bluetooth devices.
+- [ ] Integrate multi-toy control scenarios into the sandbox demo, logging state transitions and verifying deterministic arbitration policies.
+- [ ] Document operator workflows covering capture setup, firmware flashing, and troubleshooting in `docs/ops/flow_toys.md`.
+- [ ] Align choreography cues with UX/audio stakeholders once control paths are stable.
+
+## Narrative walkthrough
+
+Discovery anchors the plan by capturing real radio activity before any code is written. FCC artifacts narrow candidate bands, and IQ recordings aligned with app actions reveal whether we face BLE, Enhanced ShockBurst, or custom GFSK. That baseline prevents premature assumptions about pairing or crypto.
+
+Implementation begins once payload captures are repeatable. GNU Radio handles filtering, but we export symbol streams into Python so contributors can iterate without the GUI. Frame structure notes become the contract for runtime integration as the `FlowToyReceiver` feeds the event bus. In parallel we evaluate Nordic nRF52840, TI CC2652, and Espressif ESP32-C6 options against modulation support, stack maturity, and firmware pipeline fit.
+
+Validation closes the loop. A bench jig replays Heart commands while the SDR monitors on-air responses to verify legal waveforms. Long-duration trials quantify packet loss and interference susceptibility. Multi-device arbitration tests guarantee the command serializer respects per-toy addresses, and documentation plus UX coordination ensure operators can stage synchronized shows quickly.
+
+## Data path overview
+
+```
+[Flow Toy Radio] --(GFSK bursts)--> [SDR Frontend] --(IQ stream)--> [GNU Radio demod]
+       |                                                         |
+       |                                                     (UDP/TCP)
+       |                                                         v
+       +<--(Command frames)-- [Transceiver Dev Board] <-- [Heart FlowToyDriver]
+```
+
+## Hardware evaluation matrix
+
+| Chipset | Protocol coverage | Max TX power | Dev ecosystem | Notable constraints |
+| --- | --- | --- | --- | --- |
+| Nordic nRF52840 | BLE 5.0, 2.4 GHz proprietary (ESB) | +8 dBm | Zephyr RTOS, nRF Connect SDK, mature packet sniffer firmware | Requires precise matching network; limited open tooling for non-BLE proprietary stacks |
+| TI CC2652R7 | BLE, Zigbee, Thread, 2.4 GHz OOK/FSK | +5 dBm | TI SimpleLink SDK, SmartRF Studio | Zigbee-centric examples; custom modulation needs RF Studio scripting |
+| Espressif ESP32-C6 | BLE 5, Wi-Fi 6, 802.15.4 | +20 dBm (Wi-Fi), +10 dBm (BLE) | ESP-IDF, open-source MAC layers | Custom GFSK requires co-processor or firmware patching |
+| ADI ADF7242 + MCU | 2.4 GHz O-QPSK/FSK with raw mode | +4 dBm | Registers exposed for direct PHY manipulation | Requires separate MCU; limited community support |
+
+## Risk analysis
+
+| Risk | Probability | Impact | Mitigation | Early warning |
+| --- | --- | --- | --- | --- |
+| Protocol uses encrypted BLE with rolling keys | Medium | Blocks command injection | Monitor BLE pairing traffic for LTK exchanges; prepare to leverage MITM via BLE proxy and request vendor debug firmware | Companion app demands re-pair every session |
+| SDR capture quality insufficient in noisy venues | High | Packet loss >10% | Deploy band-pass filters and shielded enclosures; schedule captures in RF isolation chamber before field trials | IQ recordings show inconsistent preamble detection |
+| Transmit experiments violate regional RF regulations | Low | Regulatory exposure | Use shielded box for initial TX tests, document channel/frequency, adhere to FCC Part 15 limits | SDR waterfall shows out-of-band splatter |
+| Toy firmware updates shift protocol | Medium | Decoder obsolescence | Automate nightly captures from toys with auto-update enabled; add version fingerprinting to frame parser | App release notes mention RF fixes |
+
+**Mitigation checklist**
+
+- [ ] Validate BLE security posture with `btproxy` before investing in custom PHY tooling.
+- [ ] Budget for an RF isolation enclosure and calibrated attenuators in Q2 hardware spend.
+- [ ] Draft a regulatory compliance note covering duty cycle, frequency plan, and conducted power limits.
+- [ ] Implement frame versioning in the Heart runtime so protocol shifts trigger alerts.
+
+## Outcome snapshot
+
+Once delivered, Heart will ingest flow toy telemetry through a dedicated driver that feeds the input event bus and state store. Operators can toggle choreographed modes from the runtime while a paired transceiver board maintains RF compliance and addressing. We will have reproducible capture scripts, a validated decoder, and a transmitter integration that extends Heart's output channel repertoire beyond audio and screens.

--- a/docs/research/flow_toy_rf_chain.md
+++ b/docs/research/flow_toy_rf_chain.md
@@ -1,0 +1,55 @@
+# Flow Toy RF Research Chain
+
+## Research objective
+
+Characterize the passive radio emissions from commercially available light-up flow toys, reconstruct their protocol, and design a bidirectional control interface that Heart can own. This chain establishes repeatable discovery, decoding, and control validation so contributors can iterate without rediscovering foundational RF details.
+
+## Chain overview
+
+1. **Device fingerprinting** – Document the toy lineup, firmware revisions, and companion app versions. Capture FCC IDs and PCB photos to infer RF front-ends and antenna topology.
+1. **Spectrum reconnaissance** – Sweep 100 kHz–6 GHz with a wideband SDR. Correlate peaks with toy activity and annotate center frequencies, bandwidth, and modulation cues (e.g., GFSK, BLE advertising).
+1. **Capture pipeline** – Configure a reproducible IQ capture flow using GNU Radio Companion (GRC) scripts checked into `experimental/rf/flow_toys/`. Provide presets for HackRF One and PlutoSDR including gain, sample rate, and decimation settings.
+1. **Burst extraction** – Feed raw IQ into Universal Radio Hacker or custom Python notebooks that implement energy detection, preamble search, and symbol timing recovery. Output decoded symbol streams into `npz` datasets for collaborative analysis.
+1. **Protocol reconstruction** – Apply differential analysis by aligning captured bursts with annotated app actions. Use Kaitai Struct or Construct to define tentative frame schemas and verify them against multiple captures. Track hypotheses in `docs/research/logs/flow_toys/` with timestamped entries.
+1. **Security assessment** – Evaluate whether payloads incorporate encryption or pairing handshakes. For BLE-based toys, use `btproxy` or `nRF Sniffer` to inspect LTK exchange. For proprietary 2.4 GHz links, examine checksums for cryptographic strength and attempt known-plaintext attacks.
+1. **Transmitter prototyping** – Once frame structure is understood, implement a replay tool using `pyspinel`, `nRF ESB` libraries, or raw PHY generation in GNU Radio. Validate on-air using a shielded enclosure to avoid interference.
+1. **Runtime integration** – Build a `FlowToyLink` abstraction in `src/heart/peripheral/flow_toy/` that can operate in capture-only or full-duplex modes. Integrate telemetry parsing and command emission with the existing event bus/state store infrastructure.
+1. **Regression harness** – Create automated tests that replay captured IQ files and assert deterministic decoding. Mirror those tests with hardware-in-the-loop runs triggered via `make flow-toy-hil` to ensure the transmitter path stays aligned with firmware updates.
+
+## Software toolchain
+
+| Layer | Tooling | Repository location |
+| --- | --- | --- |
+| SDR configuration | GNU Radio Companion flows (`flow_toy_capture.grc`) | `experimental/rf/flow_toys/` |
+| Burst analysis | Python notebooks (`burst_characterization.ipynb`) using `numpy`, `scipy`, `scikit-dsp-comm` | `docs/research/notebooks/flow_toys/` |
+| Protocol spec | Kaitai Struct (`flow_toy_frame.ksy`) with generated Python parser | `src/heart/protocols/flow_toy/` |
+| Runtime bridge | Python driver + CFFI bindings for transceiver firmware | `src/heart/peripheral/flow_toy/driver.py` |
+| Test harness | Pytest suite with `pytest-sdr` fixtures and capture fixtures | `tests/peripherals/flow_toy/` |
+
+## Hardware platform options
+
+| Role | Candidate | Rationale | Integration notes |
+| --- | --- | --- | --- |
+| Wideband capture | HackRF One | 1–6 GHz coverage, community tooling, supported by URH | Requires external TCXO upgrade for stability |
+| High-fidelity capture | Ettus B205mini-i | Better dynamic range, UHD support | Higher cost; use when modulation demands precision |
+| BLE/proprietary TX/RX | Nordic nRF52840 Dongle | Native BLE + ESB support, open-source sniffer firmware | USB form factor integrates with existing host tools |
+| Multi-protocol TX/RX | TI CC2652P LaunchPad | Amplified 2.4 GHz radio, multiprotocol SDK | Needs firmware build via Code Composer or `tiarmclang` |
+| Wi-Fi / 802.15.4 bridge | ESP32-C6 DevKitC | Combines Wi-Fi telemetry with BLE fallback | Custom RF path requires IDF 5.1+; ensure coexistence settings tuned |
+
+## Interfaces & firmware strategy
+
+- **Passive capture mode.** SDR streams IQ over USB to the host laptop. GNU Radio demodulates to symbols and forwards newline-delimited hex packets via ZeroMQ. The Heart runtime subscribes to the socket and records packets for offline analysis.
+- **Active control mode.** A USB-attached transceiver (nRF52840 or CC2652) runs custom firmware exposing a UART command channel. Heart sends serialized frame descriptors (address, opcode, payload, checksum), and firmware handles PHY timing. Responses are echoed back to Heart for logging.
+- **Safety interlocks.** Firmware enforces a whitelist of permitted frequencies and duty cycles. Host software requests a session lease before enabling transmit, and leases auto-expire after 120 seconds of inactivity.
+
+## Open questions
+
+1. Do vendors rotate device addresses or session keys after each app pairing? Requires longitudinal captures post power-cycle.
+1. Are there fallback IR or magnetic sensors for legacy flow toys that could serve as alternative control paths?
+1. What minimum timing precision does choreography require? Need latency studies comparing BLE write-without-response versus custom GFSK frames.
+
+## Next steps
+
+- Draft detailed capture scripts referencing specific GNU Radio blocks and publish them with example IQ files.
+- Prototype the ZeroMQ bridge and integrate it into the sandbox demo for passive telemetry visualization.
+- Begin RF compliance review to ensure future transmit testing can occur within lab constraints.


### PR DESCRIPTION
## Summary
- add a planning playbook for capturing and controlling RF-enabled flow toys
- document a reusable research chain covering spectrum capture, decoding, and transmission hardware selection

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690c8f9a3e1c832181e0905f87ceb95d