### PR TITLE
Add virtual drawing pad peripheral

### DIFF
--- a/src/heart/peripheral/core/manager.py
+++ b/src/heart/peripheral/core/manager.py
@@ -4,6 +4,7 @@ from typing import Iterable, Iterator
 
 from heart.peripheral.core import Peripheral
 from heart.peripheral.core.event_bus import EventBus
+from heart.peripheral.drawing_pad import DrawingPad
 from heart.peripheral.gamepad import Gamepad
 from heart.peripheral.heart_rates import HeartRateManager
 from heart.peripheral.microphone import Microphone
@@ -63,6 +64,7 @@ class PeripheralManager:
             self._detect_heart_rate_sensor(),
             self._detect_phone_text(),
             self._detect_microphones(),
+            self._detect_drawing_pads(),
         )
 
     def start(self) -> None:
@@ -116,6 +118,9 @@ class PeripheralManager:
 
     def _detect_microphones(self) -> Iterator[Peripheral]:
         yield from itertools.chain(Microphone.detect())
+
+    def _detect_drawing_pads(self) -> Iterator[Peripheral]:
+        yield from itertools.chain(DrawingPad.detect())
 
     def _register_peripheral(self, peripheral: Peripheral) -> None:
         self._peripherals.append(peripheral)

--- a/src/heart/peripheral/drawing_pad.py
+++ b/src/heart/peripheral/drawing_pad.py
@@ -1,0 +1,269 @@
+"""In-memory model of a low-power drawing pad peripheral.
+
+The :class:`DrawingPad` peripheral models a 6"×6" slate that supports a
+battery-friendly stylus and a dedicated erase mode.  The implementation keeps
+state entirely in-memory so that the rest of the runtime can experiment with the
+input vocabulary before we have real hardware.  The backing grid uses a modest
+48×48 resolution so updates remain cheap on slower hosts such as microcontrollers
+or older Raspberry Pi models.
+
+Each input event is expected to provide a coordinate pair.  Callers can specify
+coordinates either as relative values in the ``[0.0, 1.0]`` range or in inches by
+setting ``units="inches"``.  A stylus event writes pressure values into the
+underlying grid, while an erase event clears a circular region.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any, Iterator, Mapping, Self
+
+from heart.peripheral.core import Input, Peripheral
+
+__all__ = ["DrawingPad", "StylusSample"]
+
+
+@dataclass(slots=True)
+class StylusSample:
+    """Snapshot of a stylus interaction on the drawing pad."""
+
+    x: float
+    y: float
+    pressure: float
+    radius: float
+    is_erase: bool = False
+
+
+class DrawingPad(Peripheral):
+    """Virtual 6"×6" drawing surface with stylus and erase support.
+
+    Parameters
+    ----------
+    width_inches:
+        Physical width of the pad.  Defaults to 6 inches.
+    height_inches:
+        Physical height of the pad.  Defaults to 6 inches.
+    resolution:
+        Number of discrete cells along each axis.  Higher values increase
+        fidelity at the cost of additional memory and CPU when filling regions.
+    polling_interval:
+        Sleep duration used by :meth:`run` when idling.  The default keeps CPU
+        usage negligible on single-board computers.
+    """
+
+    WIDTH_INCHES = 6.0
+    HEIGHT_INCHES = 6.0
+    DEFAULT_RESOLUTION = 48
+
+    def __init__(
+        self,
+        *,
+        width_inches: float | None = None,
+        height_inches: float | None = None,
+        resolution: int = DEFAULT_RESOLUTION,
+        polling_interval: float = 0.1,
+    ) -> None:
+        if resolution <= 0:
+            raise ValueError("resolution must be positive")
+
+        self.width_inches = width_inches or self.WIDTH_INCHES
+        self.height_inches = height_inches or self.HEIGHT_INCHES
+        if self.width_inches <= 0 or self.height_inches <= 0:
+            raise ValueError("physical dimensions must be positive")
+
+        self.resolution = resolution
+        self._grid = [
+            [0.0 for _ in range(self.resolution)] for _ in range(self.resolution)
+        ]
+        self._stylus_history: list[StylusSample] = []
+        self._polling_interval = polling_interval
+        self._stop = threading.Event()
+        super().__init__()
+
+    # ------------------------------------------------------------------
+    # Peripheral API
+    # ------------------------------------------------------------------
+    def run(self) -> None:  # noqa: D401 – keeping signature of base class
+        """Idle loop to match the :class:`Peripheral` contract.
+
+        The loop simply waits until :meth:`stop` is invoked.  This keeps the
+        interface compatible with other peripherals without burning CPU cycles
+        when no new input arrives.
+        """
+
+        while not self._stop.is_set():
+            time.sleep(self._polling_interval)
+
+    def stop(self) -> None:
+        """Signal the background loop started by :meth:`run` to exit."""
+
+        self._stop.set()
+
+    # ------------------------------------------------------------------
+    # Drawing helpers
+    # ------------------------------------------------------------------
+    def handle_input(self, input: Input) -> None:  # noqa: D401 - signature fixed
+        """Process stylus or erase events and update the backing grid."""
+
+        if input.event_type == "drawing_pad.stroke":
+            self._apply_stylus(**self._parse_payload(input.data, is_erase=False))
+        elif input.event_type == "drawing_pad.erase":
+            self._apply_stylus(**self._parse_payload(input.data, is_erase=True))
+
+    def apply_stylus(
+        self,
+        *,
+        x: float,
+        y: float,
+        pressure: float = 1.0,
+        radius: float = 0.05,
+        units: str = "relative",
+    ) -> None:
+        """Public helper to draw with the stylus programmatically."""
+
+        payload = {
+            "x": x,
+            "y": y,
+            "pressure": pressure,
+            "radius": radius,
+            "units": units,
+        }
+        self._apply_stylus(**self._parse_payload(payload, is_erase=False))
+
+    def erase(
+        self,
+        *,
+        x: float,
+        y: float,
+        radius: float = 0.1,
+        units: str = "relative",
+    ) -> None:
+        """Erase a circular area centred at ``(x, y)``."""
+
+        payload = {
+            "x": x,
+            "y": y,
+            "radius": radius,
+            "units": units,
+            "pressure": 0.0,
+        }
+        self._apply_stylus(**self._parse_payload(payload, is_erase=True))
+
+    def clear(self) -> None:
+        """Reset the drawing surface to its blank state."""
+
+        for row in self._grid:
+            for idx in range(len(row)):
+                row[idx] = 0.0
+        self._stylus_history.clear()
+
+    def iter_rows(self) -> Iterable[Iterable[float]]:
+        """Yield the grid rows – useful for snapshots in tests."""
+
+        for row in self._grid:
+            yield tuple(row)
+
+    def last_sample(self) -> StylusSample | None:
+        """Return the most recent stylus interaction, if any."""
+
+        return self._stylus_history[-1] if self._stylus_history else None
+
+    # ------------------------------------------------------------------
+    # Detection helpers
+    # ------------------------------------------------------------------
+    @classmethod
+    def detect(cls) -> Iterator[Self]:
+        """Expose a single virtual drawing pad instance."""
+
+        yield cls()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _parse_payload(self, data: Mapping[str, Any], *, is_erase: bool) -> dict[str, Any]:
+        if "x" not in data or "y" not in data:
+            raise ValueError("payload must contain 'x' and 'y'")
+
+        units = data.get("units", "relative")
+        x_norm = self._normalize_coordinate(float(data["x"]), units, axis="x")
+        y_norm = self._normalize_coordinate(float(data["y"]), units, axis="y")
+        radius = float(data.get("radius", 0.05))
+        radius_norm = self._normalize_distance(radius, units, axis="x")
+        pressure = float(data.get("pressure", 1.0))
+
+        return {
+            "sample": StylusSample(
+                x=x_norm,
+                y=y_norm,
+                pressure=pressure,
+                radius=radius_norm,
+                is_erase=is_erase,
+            )
+        }
+
+    def _apply_stylus(self, *, sample: StylusSample) -> None:
+        centre_x = self._to_index(sample.x)
+        centre_y = self._to_index(sample.y)
+        radius_cells = max(1, int(round(sample.radius * (self.resolution - 1))))
+        affected = self._iter_indices_within_radius(centre_x, centre_y, radius_cells)
+
+        for row_idx, col_idx in affected:
+            if sample.is_erase:
+                self._grid[row_idx][col_idx] = 0.0
+            else:
+                self._grid[row_idx][col_idx] = max(
+                    0.0, min(1.0, sample.pressure)
+                )
+
+        self._stylus_history.append(sample)
+
+    def _normalize_coordinate(self, value: float, units: str, *, axis: str) -> float:
+        if units == "relative":
+            normalized = value
+        elif units == "inches":
+            inches = self.width_inches if axis == "x" else self.height_inches
+            normalized = value / inches
+        else:
+            raise ValueError(f"Unsupported units: {units}")
+
+        return max(0.0, min(1.0, normalized))
+
+    def _normalize_distance(self, value: float, units: str, *, axis: str) -> float:
+        if units == "relative":
+            normalized = value
+        elif units == "inches":
+            inches = self.width_inches if axis == "x" else self.height_inches
+            normalized = value / inches
+        else:
+            raise ValueError(f"Unsupported units: {units}")
+
+        return max(0.0, normalized)
+
+    def _to_index(self, normalized: float) -> int:
+        return int(round(normalized * (self.resolution - 1)))
+
+    def _iter_indices_within_radius(
+        self, centre_x: int, centre_y: int, radius_cells: int
+    ) -> Iterable[tuple[int, int]]:
+        for row_idx in range(
+            max(0, centre_y - radius_cells), min(self.resolution, centre_y + radius_cells + 1)
+        ):
+            for col_idx in range(
+                max(0, centre_x - radius_cells),
+                min(self.resolution, centre_x + radius_cells + 1),
+            ):
+                if self._within_radius(centre_x, centre_y, col_idx, row_idx, radius_cells):
+                    yield (row_idx, col_idx)
+
+    @staticmethod
+    def _within_radius(
+        centre_x: int,
+        centre_y: int,
+        x: int,
+        y: int,
+        radius: int,
+    ) -> bool:
+        return (x - centre_x) ** 2 + (y - centre_y) ** 2 <= radius**2

--- a/tests/peripheral/test_drawing_pad.py
+++ b/tests/peripheral/test_drawing_pad.py
@@ -1,0 +1,62 @@
+import pytest
+
+from heart.peripheral.core import Input
+from heart.peripheral.drawing_pad import DrawingPad, StylusSample
+
+
+def test_defaults_match_spec():
+    pad = DrawingPad()
+    assert pad.width_inches == pytest.approx(6.0)
+    assert pad.height_inches == pytest.approx(6.0)
+    assert pad.resolution == 48
+
+
+def test_apply_stylus_updates_grid_and_history():
+    pad = DrawingPad(resolution=8)
+
+    pad.handle_input(
+        Input(
+            event_type="drawing_pad.stroke",
+            data={"x": 0.5, "y": 0.5, "pressure": 0.8, "radius": 0.2},
+        )
+    )
+
+    sample = pad.last_sample()
+    assert isinstance(sample, StylusSample)
+    assert not sample.is_erase
+    assert sample.pressure == pytest.approx(0.8)
+
+    # The centre cell should be filled with the provided pressure value.
+    grid = [list(row) for row in pad.iter_rows()]
+    centre_index = pad.resolution // 2
+    assert grid[centre_index][centre_index] == pytest.approx(0.8)
+
+
+def test_erase_clears_region():
+    pad = DrawingPad(resolution=8)
+    pad.apply_stylus(x=0.5, y=0.5, pressure=1.0, radius=0.3)
+
+    pad.handle_input(
+        Input(event_type="drawing_pad.erase", data={"x": 0.5, "y": 0.5, "radius": 0.3})
+    )
+
+    sample = pad.last_sample()
+    assert sample is not None and sample.is_erase
+
+    for row in pad.iter_rows():
+        for value in row:
+            assert value == pytest.approx(0.0)
+
+
+def test_units_in_inches_are_supported():
+    pad = DrawingPad(resolution=10)
+    pad.apply_stylus(x=3.0, y=3.0, units="inches")
+
+    # 3 inches is the midpoint on a 6 inch pad -> central cell should be non-zero
+    sample = pad.last_sample()
+    assert sample is not None
+
+    grid = [list(row) for row in pad.iter_rows()]
+    x_idx = round(sample.x * (pad.resolution - 1))
+    y_idx = round(sample.y * (pad.resolution - 1))
+    assert grid[y_idx][x_idx] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- add a virtual drawing pad peripheral with stylus and erase capabilities
- register the new pad with the peripheral manager for automatic detection
- exercise the drawing pad API with focused unit tests

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_690c94f5eff0832182e740b56988266a