### PR TITLE
Expand MIDI converter docs for bidirectional streaming

### DIFF
--- a/docs/planning/midi_peripheral_converter.md
+++ b/docs/planning/midi_peripheral_converter.md
@@ -1,0 +1,87 @@
+# MIDI Peripheral Converter Implementation Plan
+
+## Abstract
+
+We will deliver a converter that listens to the Heart peripheral event bus, renders MIDI messages across USB, DIN, and virtual transports, and ingests inbound MIDI streams back into the bus. The work targets creative coders and performers who want biometric and gestural inputs to influence external instruments while letting external controllers steer Heart automations without bespoke wiring. **Why now:** existing peripherals already emit normalized `Input` events through the shared `EventBus`, but no downstream consumer bridges those signals into an industry protocol, and operators rely on ad-hoc scripts to read MIDI back into Heart. Shipping the converter as a bidirectional bridge unlocks hardware integration pilots and human-in-the-loop performances that are currently blocked. 【F:src/heart/peripheral/core/event_bus.py†L22-L68】【F:src/heart/peripheral/core/manager.py†L20-L104】【F:src/heart/peripheral/core/__init__.py†L13-L56】
+
+## Success criteria
+
+| Target behaviour | Verification signal | Owner |
+| --- | --- | --- |
+| Converter streams MIDI CC and note events derived from accelerometer and switch peripherals with \<10 ms added latency | Automated integration test asserts message timestamps against monotonic clock while replaying recorded `Input` fixtures | Audio systems engineer |
+| Inbound MIDI messages generate normalized `Input` events that downstream subscribers handle without modification | Loopback test injects MIDI note/CC data and verifies event bus observers receive expected payloads | Automation engineer |
+| Configuration schema lets operators enable/disable converter, choose transport, select mapping profile, and define inbound routing without code changes | CLI smoke test loads YAML overrides and observes converter toggling and routing updates at runtime | Runtime maintainer |
+| Transport adapters recover from disconnects within 2 seconds without crashing the peripheral threads | Fault-injection test simulates USB removal and checks for automatic reconnection logs | Device reliability engineer |
+| Documentation provides mapping examples and troubleshooting guidance | Tech writer verifies new docs in `docs/research/` and `docs/planning/` plus runtime README updates | Developer experience lead |
+
+## Phase breakdown and checklists
+
+### Discovery
+
+- [ ] Confirm priority peripherals (switch, accelerometer, heart rate) with program stakeholders.
+- [ ] Audit `PeripheralManager` startup sequence to ensure converter can attach after detection completes. 【F:src/heart/peripheral/core/manager.py†L20-L118】
+- [ ] Benchmark `EventBus` publish frequency under combined peripheral load to estimate worst-case throughput. 【F:src/heart/peripheral/core/event_bus.py†L22-L68】
+- [ ] Evaluate candidate MIDI libraries (`mido`, `python-rtmidi`, ALSA bindings) for latency, licensing, duplex support, and deployment footprint.
+- [ ] Define initial mapping templates for CC, note, and pitch-bend conversions sourced from research note scenarios.
+- [ ] Inventory automation subsystems that should consume inbound MIDI events and capture their latency budgets.
+
+### Implementation
+
+- [ ] Introduce `MidiConverter` module under `heart/peripheral` with constructor accepting `EventBus` and configuration payload.
+- [ ] Provide wildcard and scoped subscription helpers that map to `EventBus.subscribe` without starving other listeners. 【F:src/heart/peripheral/core/event_bus.py†L22-L68】
+- [ ] Build mapping engine supporting scaling, smoothing, and stateful note gates using the bus `StateStore`.
+- [ ] Implement transport adapters: USB (via `python-rtmidi`), virtual port (using OS abstraction), and placeholder DIN (mocked until hardware lands).
+- [ ] Add inbound MIDI listener that parses bytes into `Input` events, tags their origin, and guards against feedback loops.
+- [ ] Wire configuration loader to extend `Configuration` schema so `heart manage` CLI can flip transports, profiles, and inbound routing tables. 【F:src/heart/peripheral/core/manager.py†L63-L107】
+- [ ] Register converter inside `PeripheralManager` startup path after all peripherals attach to ensure it hears every event and exposes inbound listeners. 【F:src/heart/peripheral/core/manager.py†L20-L118】
+- [ ] Add CLI diagnostics command that prints active mappings, transport status, and inbound routing state.
+
+### Validation
+
+- [ ] Unit tests cover mapping math, ensuring sensor ranges map into MIDI 0–127 and velocity envelopes behave deterministically.
+- [ ] Integration tests spin up fake bus, push fixture events, and assert serialized MIDI bytes for multiple profiles while injecting inbound MIDI to confirm normalized events.
+- [ ] Hardware-in-the-loop scenario uses loopback MIDI device to confirm latency budget, reconnection handling, and inbound control fidelity.
+- [ ] Reliability soak test runs continuous event replay plus MIDI controller sweeps for one hour and checks for missed events or crashes.
+
+## Narrative walkthrough
+
+We begin by clarifying scope with stakeholders to avoid over-engineering mappings that will not see immediate use. Discovery focuses on measuring existing event bus throughput, enumerating library dependencies, and confirming which automation surfaces expect inbound MIDI so we can set realistic latency targets for both directions. Benchmarking also reveals whether we need asynchronous queues from the outset.
+
+Implementation starts once we have a vetted library choice. We place the converter beside other peripherals so it can reuse configuration patterns and logging. The converter registers a wildcard subscription to the event bus, but also exposes profile-specific subscribers to minimize overhead when only a subset of events matter. Mapping logic lives in a dedicated component with deterministic scaling functions so QA can verify outputs without hardware. In parallel, the inbound listener normalizes MIDI into `Input` events, tags their origin, and observes backpressure metrics before publishing to the bus.
+
+Transport adapters abstract USB, virtual, and future DIN connections. We prioritize USB because it enables immediate desktop integration, while the DIN adapter ships as a stub that defers hardware signaling to follow-up work. Shared adapters expose bidirectional interfaces so the same transport handles output and input when hardware permits. Configuration hooks integrate with the existing `Configuration` helper so operators can toggle behaviours and define inbound routing without editing code. Finally, we add a CLI diagnostic command to surface which mappings are active, which inbound routes are enabled, and how transports are performing, assisting field debugging.
+
+Validation combines automated and manual checks. Unit tests exercise mapping math, note gate state machines, and inbound parser edge cases. Integration tests replay recorded `Input` fixtures, inspect emitted MIDI bytes, and feed in controller streams to ensure downstream subscribers receive normalized events. Hardware tests use loopback devices to measure end-to-end latency in both directions and confirm that disconnects are handled gracefully. A soak test ensures long-running sessions remain stable even when inbound controllers send dense data.
+
+## Visual reference
+
+| Component | Responsibility | Interfaces |
+| --- | --- | --- |
+| `MidiConverter` | Subscribes to `EventBus`, orchestrates mapping, transport, and inbound routing | Consumes `Input` events, depends on `StateStore`, emits MIDI packets, publishes MIDI-derived events |
+| Mapping engine | Applies templates, scaling, smoothing, and gating | Receives normalized events, returns MIDI message structs |
+| Transport adapters | Serialize MIDI messages, deliver to hardware/virtual endpoints, and receive input | Provide `open`, `send`, `receive`, `close` methods for USB, virtual, DIN |
+| Inbound listener | Parses MIDI input, deduplicates feedback, publishes events | Consumes raw MIDI bytes, emits `Input` instances |
+| Configuration layer | Loads profiles, transport selection, runtime toggles, and inbound routing | Extends `Configuration` schema, integrates with CLI |
+
+## Risk analysis
+
+| Risk | Probability | Impact | Mitigation strategy | Early warning signal |
+| --- | --- | --- | --- | --- |
+| MIDI library introduces heavy dependencies or fails on Raspberry Pi | Medium | High | Prototype with minimal wrappers; provide fallback pure-Python serializer | Installation errors or import failures during smoke test |
+| Event bus callback blocks peripheral threads, causing missed sensor data | Medium | High | Move MIDI serialization to worker thread with bounded queue | Log warnings about slow subscriber execution |
+| Transport disconnects overwhelm reconnection logic | Low | Medium | Add exponential backoff and watchdog timers for reconnect attempts | Repeated failure logs or queue growth metrics |
+| Mapping complexity confuses operators | Medium | Medium | Ship opinionated starter profiles and documentation with diagrams | Support tickets asking for configuration clarification |
+| Inbound MIDI floods saturate event bus consumers | Medium | Medium | Rate-limit inbound publishing, expose queue metrics, and allow per-route throttling | Observability dashboards show sustained inbound queue depth |
+| Hardware DIN output unavailable for initial release | High | Low | Publish stub adapter with clear TODO; plan follow-up hardware sprint | Planning review identifies missing hardware BOM |
+
+### Mitigation checklist
+
+- [ ] Implement queue depth metrics and log when subscriber processing exceeds 5 ms.
+- [ ] Wrap transport send operations in retry helpers with configurable backoff.
+- [ ] Write operator guide covering profile editing, transport selection, and inbound routing.
+- [ ] Document hardware dependencies and flag DIN adapter as experimental in release notes.
+- [ ] Add inbound throughput alerts that trigger when queue depth exceeds thresholds for 10 seconds.
+
+## Outcome snapshot
+
+After landing this work, any Heart deployment can translate peripheral activity into MIDI in under 10 ms without manual scripts while simultaneously reacting to inbound controller data. Operators toggle mappings and inbound routes through configuration files or CLI, and the system auto-recovers from transient transport failures. External synthesizers, DAWs, or lighting rigs respond to switches, accelerometers, and heart-rate data streamed by the existing peripheral stack, and performers can inject MIDI gestures that steer Heart automations. The bidirectional bridge creates a foundation for future creative programs and research experiments.

--- a/docs/research/midi_peripheral_converter.md
+++ b/docs/research/midi_peripheral_converter.md
@@ -1,0 +1,115 @@
+# MIDI Peripheral Converter Research Note
+
+## Overview
+
+This note investigates how to translate data produced by Heart peripherals into MIDI-compatible output streams and, reciprocally, how to ingest MIDI into the peripheral event bus. The converter will monitor the `EventBus` used by `PeripheralManager`, emit MIDI messages over configurable transports (hardware DIN, USB MIDI, or virtual ports), and optionally subscribe to MIDI inputs so that Heart subsystems can react to external controllers. The goal is to leverage the existing normalized `Input` dataclass so that any peripheral that already publishes events can drive external synthesizers or DAWs without bespoke glue code, while external MIDI rigs can influence automations inside Heart without writing new peripherals. 【F:src/heart/peripheral/core/event_bus.py†L22-L68】【F:src/heart/peripheral/core/manager.py†L20-L104】【F:src/heart/peripheral/core/__init__.py†L13-L56】
+
+## Context
+
+Heart devices already orchestrate multiple peripherals—switches, accelerometers, heart-rate monitors, and phone bridges—through a shared manager and event bus abstraction. The bus synchronously dispatches events and maintains a state snapshot for observers, making it a natural tap point for MIDI conversion. Today, no component converts those inputs into an industry-standard music control protocol. Bridging to MIDI unlocks downstream creative coding, allows hardware synthesizers to respond to biometric or gestural signals, and supports experimental biofeedback performances.
+
+## Reference Architecture
+
+```
+┌─────────────────────────────┐        ┌──────────────────────────────┐
+│ PeripheralManager.detect()  │        │   MIDI Converter Runtime     │
+│  - Switch / Sensor threads  │        │  ┌────────────────────────┐  │
+│  - EventBus attachments     │───────▶│  │ EventBus Subscriber    │  │
+│  - Input(event_type, data)  │        │  └────────────┬───────────┘  │
+└─────────────────────────────┘        │               │              │
+                                       │        Mapping Engine        │
+                                       │   (profiles, scaling, LFOs)  │
+                                       │               │              │
+                                       │     MIDI Message Encoder     │
+                                       │         (Note/CC/SysEx)      │
+                                       │               │              │
+                                       │      Transport Adapters      │
+                                       │    (USB, DIN, Virtual Port)  │
+                                       └───────────────┴──────────────┘
+                                                       │
+                                                       │  MIDI In
+                                       ┌───────────────▼──────────────┐
+                                       │    MIDI Input Listener        │
+                                       │  (parses & publishes events)  │
+                                       └──────────────────────────────┘
+```
+
+The converter subscribes to the `EventBus`, enriches events with state history when necessary, evaluates mapping rules, and emits MIDI packets. Transport adapters abstract the physical or virtual output mediums. Symmetrically, a MIDI input listener attaches to the same transports, decodes inbound MIDI messages, and converts them into `Input` events so that other Heart components can act on external controllers.
+
+## Data Inputs and Normalization
+
+Peripherals already standardize payloads via the `Input` dataclass, which stores `event_type`, `data`, `producer_id`, and timestamps. Maintaining this format ensures compatibility with state snapshots and other subscribers. The converter should support two ingestion modes:
+
+1. **Direct subscription** – Register once for all events (wildcard subscription) and filter internally. This keeps registration code minimal and ensures future peripherals are automatically eligible.
+1. **Profile-scoped subscription** – Allow optional narrower subscriptions per mapping profile to reduce overhead when targeting specific event families (e.g., accelerometer axes only).
+
+## Mapping Semantics (Event → MIDI)
+
+Design goals for mapping engine:
+
+- **Event-to-Message Templates** – Each mapping rule defines source event types, target MIDI message class (note on/off, control change, pitch bend, SysEx), channel, and value derivation expressions.
+- **Stateful Interpretations** – Some conversions (e.g., note duration from button press) require tracking past events. Rely on the bus `StateStore` to retrieve last-seen data, avoiding redundant caches. 【F:src/heart/peripheral/core/event_bus.py†L22-L68】
+- **Scaling and Quantization** – Provide utilities to scale sensor ranges into MIDI 0–127 range or 14-bit pitch bend values. Include optional quantization tables (e.g., mapping heart rate to musical scale degrees).
+- **Temporal Modulation** – Introduce smoothing operators (moving average, exponential smoothing) and scheduled envelopes so jittery sensor data yields musically meaningful output.
+
+## MIDI Message Strategy
+
+Priority message types for initial release:
+
+1. **Control Change (CC)** – Map continuous sensor readings (accelerometer, heart rate variability) to CC values for synth parameter modulation.
+1. **Note Events** – Translate binary triggers (switches, gamepad buttons) into note on/off pairs with configurable pitch, velocity, and duration.
+1. **Pitch Bend and Aftertouch** – Offer expressive control for axes or microphone amplitude envelopes.
+1. **System Exclusive (SysEx)** – Reserve structure to push richer telemetry into compatible devices (e.g., sending full sensor state snapshots).
+
+Implementation should reuse existing Python MIDI libraries (e.g., `mido`, `python-rtmidi`) or wrap ALSA/JACK interfaces directly when running on Raspberry Pi. Evaluate dependency footprint versus in-house serialization; external libraries accelerate development but add packaging considerations for the Heart runtime environment.
+
+## MIDI Input Ingestion (MIDI → Event)
+
+Enabling MIDI ingestion requires a complementary mapping pipeline:
+
+- **Transport Listeners** – Reuse the output transports in input mode when possible (many libraries expose duplex ports). When hardware lacks bidirectional support (e.g., DIN-only output), allow separate input adapter registration.
+- **Message Normalization** – Translate MIDI primitives into `Input` events with clear `event_type` semantics (`midi.note_on`, `midi.cc`, etc.) and payloads that include channel, controller, velocity, and timestamps. Piggyback on the same `Input` dataclass so downstream consumers remain unaware of the MIDI origin. 【F:src/heart/peripheral/core/__init__.py†L13-L56】
+- **Profiled Routing** – Let operators declare routing tables that map inbound MIDI messages to existing virtual peripherals or automation hooks. For example, a control change can map to `VirtualSwitch` toggles or parameter adjustments in automation services.
+- **Feedback Loops** – Prevent infinite feedback by tagging events derived from MIDI and providing configuration to suppress re-broadcast of identical messages back out. Consider storing recent outbound hashes to detect loops.
+
+Input support extends the converter into a bridge that can host co-creative sessions: a DAW can trigger Heart light shows, while sensors continue to modulate synth parameters.
+
+## Transport Considerations
+
+- **USB MIDI (class-compliant)** – Likely the primary route; ensure the Heart device exposes endpoints recognized by host OS. Investigate `python-rtmidi` for cross-platform support.
+- **5-pin DIN** – For standalone synthesizers, integrate a microcontroller or HAT that provides UART-to-MIDI conversion. Need to confirm GPIO pin availability and electrical isolation.
+- **Virtual Ports** – For debugging on development machines, create virtual MIDI ports so DAWs can listen without additional hardware.
+
+Each transport adapter should share a common interface (`open()`, `send(message)`, `receive(callback)`, `close()`) to enable runtime selection. Receiving should forward raw MIDI bytes to the input listener, which performs parsing and publishes normalized events on the bus.
+
+## Performance and Reliability
+
+- **Thread Safety** – EventBus callbacks run synchronously, so heavy MIDI processing must be offloaded to a worker queue to avoid blocking other peripherals. Introduce a lock-free ring buffer or use `queue.Queue` with a dedicated sender thread.
+- **Backpressure** – If MIDI output falls behind, apply rate limiting or drop low-priority events to maintain responsiveness.
+- **Error Handling** – Wrap transport sends with retries and degrade gracefully when adapters disconnect (e.g., USB cable unplugged).
+- **Inbound Burst Control** – Throttle high-frequency MIDI input streams (e.g., dense controller data) and batch them into coarser event updates when downstream consumers cannot keep up. Extend metrics to observe inbound queue depth separately.
+
+## Configuration and UX
+
+Add configuration schema entries so operators can define mapping profiles via YAML or UI. Expose toggles to enable/disable converter, choose transport, adjust velocity scaling, and enable inbound MIDI routing with per-message mappings. Align configuration loading with existing `Configuration` helper used by the PeripheralManager. 【F:src/heart/peripheral/core/manager.py†L63-L107】
+
+## Validation Strategy
+
+- **Unit Tests** – Simulate `Input` events and assert generated MIDI bytes match expectations for multiple mapping scenarios.
+- **Integration Tests** – Spin up a fake EventBus, register converter, and ensure peripheral detection + event emission lead to expected transport calls. Mirror the flow for inbound MIDI by injecting byte streams into the transport listener and verifying normalized `Input` events on the bus.
+- **Hardware Loops** – Use loopback MIDI adapters or software synths (FluidSynth) to validate real-time responsiveness and absence of dropped events.
+
+## Open Questions
+
+1. **Dynamic Mapping Updates** – Should users be able to load new mappings at runtime? Requires hot-reloading and state migration.
+1. **Clock Synchronization** – Determine whether converter should emit MIDI clock or follow an external clock. Synchronization affects note quantization and arpeggiator behavior.
+1. **Security Considerations** – Evaluate whether exposing MIDI over network protocols (RTP-MIDI) introduces attack surface for control hijacking.
+1. **Inbound Message Arbitration** – Decide how conflicting inbound MIDI commands (e.g., multiple controllers targeting same automation) are resolved. Options include last-write-wins, priority weighting, or dedicated automation ownership.
+
+## Next Steps
+
+- Prototype wildcard EventBus subscription and confirm throughput under typical peripheral load.
+- Survey Python MIDI libraries for latency and deployment feasibility, including duplex (input/output) capabilities.
+- Draft configuration schema and CLI for toggling mappings and defining inbound routing.
+- Coordinate with hardware team about transport hardware feasibility, especially for DIN outputs and whether dedicated MIDI inputs are available.
+- Prototype inbound message parsing to confirm `Input` normalization covers common controllers.


### PR DESCRIPTION
## Summary
- extend the MIDI converter research note to cover inbound MIDI ingestion and bidirectional transport considerations
- update the implementation plan with new success criteria, tasks, risks, and outcomes for streaming MIDI back into the event bus

## Testing
- make format

------
https://chatgpt.com/codex/tasks/task_e_690c97a3bc9483218e46c1120694843b