### PR TITLE
Add Raspberry Pi GitHub Action

### DIFF
--- a/.github/workflows/raspi-tests.yml
+++ b/.github/workflows/raspi-tests.yml
@@ -1,0 +1,38 @@
+name: Raspberry Pi Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Run tests on Raspberry Pi architecture
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Enable QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Run test suite on aarch64
+        uses: uraimo/run-on-arch-action@v2
+        with:
+          arch: aarch64
+          distro: ubuntu22.04
+          githubToken: ${{ github.token }}
+          install: |
+            apt-get update
+            apt-get install -y curl build-essential python3 python3-pip python3-venv make
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+          run: |
+            export PATH="${HOME}/.local/bin:${PATH}"
+            uv sync --all-extras --group dev
+            make test


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs the test suite inside an arm64 environment that mimics a Raspberry Pi setup

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_690cafa6b2c083219751409724e41d80