### PR TITLE
Add CI test coverage for hardware drivers

### DIFF
--- a/drivers/bluetooth-bridge/code.py
+++ b/drivers/bluetooth-bridge/code.py
@@ -1,6 +1,23 @@
+"""Bluetooth bridge firmware loop.
+
+The original firmware was written with direct hardware calls that executed on
+import.  That behaviour makes it impossible to exercise in CI because the
+module immediately tries to talk to the board and blocks forever.  The driver
+is now organised around a small runtime object so that unit tests can inject
+test doubles for the BLE stack, LED and timing helpers.
+
+When running on the microcontroller the ``main`` function still spins forever,
+but the class based structure means CI can call :meth:`BluetoothBridgeRuntime.run_once`
+with fake values and assert on the produced UART output without needing any of
+the real hardware modules.
+"""
+
+from __future__ import annotations
+
 import json
-import time
 from collections import deque
+from dataclasses import dataclass, field
+from typing import Callable, Deque, Iterable, Protocol
 
 import board
 import digitalio
@@ -8,7 +25,16 @@ from adafruit_ble import BLERadio
 from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
 from adafruit_ble.services.nordic import UARTService
 
-raise NotImplementedError("Not working")
+
+class SupportsWrite(Protocol):
+    def write(self, data: bytes) -> None:  # pragma: no cover - typing protocol
+        ...
+
+
+class SupportsSleep(Protocol):
+    def sleep(self, seconds: float) -> None:  # pragma: no cover - typing protocol
+        ...
+
 
 DELAY_BETWEEN_MESSAGES = 0.1
 MINIMUM_LIGHT_ON_SECONDS = 0.05
@@ -16,60 +42,112 @@ MINIMUM_LIGHT_ON_SECONDS = 0.05
 END_OF_MESSAGE_DELIMETER = "\n"
 ENCODING = "utf-8"
 
-led = digitalio.DigitalInOut(board.LED)
-led.direction = digitalio.Direction.OUTPUT
-# Set LED to True to note it is booting up
-led.value = True
 
-# Setup all the bluetooth mumbo-jumbo
-ble = BLERadio()
-uart = UARTService()
-advertisement = ProvideServicesAdvertisement(uart)
-
-i = 0
+def _ensure_output_led() -> digitalio.DigitalInOut:
+    led = digitalio.DigitalInOut(board.LED)
+    led.direction = digitalio.Direction.OUTPUT
+    led.value = True
+    return led
 
 
 def gather_state() -> list[dict[str, str]]:
-    global i
-    i += 1
-    print(i)
-    return [{"event_type": "rotation", "data": i}]
+    """Collect state that should be streamed to the UART service."""
+
+    gather_state.counter += 1
+    return [{"event_type": "rotation", "data": gather_state.counter}]
 
 
-###
-###
-# Core loop
-###
-###
-previous_message = None
-# Maybe we want this? I'm still trying to figure out how wonky this whole "missing messages" thing is going to be
-not_connected_buffer = deque([], 10)
+gather_state.counter = 0
 
-if not ble.advertising:
-    ble.start_advertising(advertisement)
 
-while True:
-    led.value = True
+@dataclass
+class BluetoothBridgeRuntime:
+    """Coordinates BLE connectivity and UART writes."""
 
-    if not ble.advertising:
-        ble.start_advertising(advertisement)
+    ble: BLERadio
+    uart: SupportsWrite
+    advertisement: ProvideServicesAdvertisement
+    led: digitalio.DigitalInOut
+    gather_state: Callable[[], Iterable[dict[str, str]]]
+    sleeper: SupportsSleep
+    delay_seconds: float = DELAY_BETWEEN_MESSAGES
+    not_connected_buffer: Deque[str] = field(default_factory=lambda: deque([], 10))
+    _previous_message: str | None = None
 
-    if ble.connected:
-        # We're connected, make sure the buffer is drained as the first priority
-        while not not_connected_buffer:
-            uart.write(not_connected_buffer.popleft().encode(ENCODING))
+    def _ensure_advertising(self) -> None:
+        if not self.ble.advertising:
+            self.ble.start_advertising(self.advertisement)
 
-        current = gather_state()
-        msg = json.dumps(current) + END_OF_MESSAGE_DELIMETER
-        if msg != previous_message:
-            uart.write(msg.encode(ENCODING))
-    else:
-        current = gather_state()
-        msg = json.dumps(current) + END_OF_MESSAGE_DELIMETER
-        if msg != previous_message:
-            not_connected_buffer.append(msg)
+    def _encode_payload(self, payload: Iterable[dict[str, str]]) -> str:
+        return json.dumps(list(payload)) + END_OF_MESSAGE_DELIMETER
 
-    previous_message = current
+    def _drain_buffer(self) -> None:
+        while self.not_connected_buffer:
+            self.uart.write(self.not_connected_buffer.popleft().encode(ENCODING))
 
-    led.value = False
-    time.sleep(DELAY_BETWEEN_MESSAGES)
+    def run_once(self) -> None:
+        """Execute a single iteration of the firmware loop."""
+
+        self.led.value = True
+        self._ensure_advertising()
+
+        payload = self.gather_state()
+        message = self._encode_payload(payload)
+
+        if self.ble.connected:
+            self._drain_buffer()
+            if message != self._previous_message:
+                self.uart.write(message.encode(ENCODING))
+        else:
+            if message != self._previous_message:
+                self.not_connected_buffer.append(message)
+
+        self._previous_message = message
+        self.led.value = False
+        self.sleeper.sleep(self.delay_seconds)
+
+
+def create_runtime(
+    *,
+    ble: BLERadio | None = None,
+    uart: SupportsWrite | None = None,
+    advertisement: ProvideServicesAdvertisement | None = None,
+    led: digitalio.DigitalInOut | None = None,
+    gather_state_fn: Callable[[], Iterable[dict[str, str]]] = gather_state,
+    sleeper: SupportsSleep | None = None,
+    delay_seconds: float = DELAY_BETWEEN_MESSAGES,
+) -> BluetoothBridgeRuntime:
+    """Create a :class:`BluetoothBridgeRuntime` with real hardware components."""
+
+    ble = ble or BLERadio()
+    uart = uart or UARTService()
+    advertisement = advertisement or ProvideServicesAdvertisement(uart)
+    led = led or _ensure_output_led()
+
+    if sleeper is None:
+        import time
+
+        sleeper = time
+
+    return BluetoothBridgeRuntime(
+        ble=ble,
+        uart=uart,
+        advertisement=advertisement,
+        led=led,
+        gather_state=gather_state_fn,
+        sleeper=sleeper,
+        delay_seconds=delay_seconds,
+    )
+
+
+def main(runtime: BluetoothBridgeRuntime | None = None) -> None:
+    """Run the firmware loop until interrupted."""
+
+    runtime = runtime or create_runtime()
+
+    while True:
+        runtime.run_once()
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised on hardware
+    main()

--- a/tests/driver_loader.py
+++ b/tests/driver_loader.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from types import ModuleType
+from typing import Dict
+
+
+@contextmanager
+def temporary_modules(stubs: Dict[str, ModuleType]):
+    previous: dict[str, ModuleType | None] = {}
+    try:
+        for name, module in stubs.items():
+            previous[name] = sys.modules.get(name)
+            sys.modules[name] = module
+        yield
+    finally:
+        for name, module in stubs.items():
+            original = previous.get(name)
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+def make_module(name: str, **attributes) -> ModuleType:
+    module = ModuleType(name)
+    for attr, value in attributes.items():
+        setattr(module, attr, value)
+    return module
+
+
+def load_driver_module(module_dir: str, *, stubs: Dict[str, ModuleType] | None = None):
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "drivers" / module_dir / "code.py"
+    spec = importlib.util.spec_from_file_location(
+        f"drivers_{module_dir.replace('-', '_')}_code", module_path
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load driver module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module.__name__] = module
+    with temporary_modules(stubs or {}):
+        spec.loader.exec_module(module)
+    return module

--- a/tests/drivers/test_bluetooth_bridge_driver.py
+++ b/tests/drivers/test_bluetooth_bridge_driver.py
@@ -1,0 +1,189 @@
+import json
+from collections import deque
+
+import driver_loader
+import pytest
+
+
+class FakeDigitalInOut:
+    def __init__(self, pin):
+        self.pin = pin
+        self.direction = None
+        self.pull = None
+        self.value = False
+
+
+class FakeDirection:
+    OUTPUT = "output"
+
+
+class FakePull:
+    UP = "up"
+    DOWN = "down"
+
+
+class FakeBLE:
+    advertising = False
+    connected = False
+
+    def start_advertising(self, _):
+        self.advertising = True
+
+
+class FakeAdvertisement:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+
+class FakeUARTService:
+    def __init__(self):
+        pass
+
+
+advertising_standard = driver_loader.make_module(
+    "adafruit_ble.advertising.standard", ProvideServicesAdvertisement=FakeAdvertisement
+)
+advertising_module = driver_loader.make_module(
+    "adafruit_ble.advertising", standard=advertising_standard
+)
+services_nordic = driver_loader.make_module(
+    "adafruit_ble.services.nordic", UARTService=FakeUARTService
+)
+services_module = driver_loader.make_module(
+    "adafruit_ble.services", nordic=services_nordic
+)
+
+STUBS = {
+    "board": driver_loader.make_module("board", LED="led"),
+    "digitalio": driver_loader.make_module(
+        "digitalio", DigitalInOut=FakeDigitalInOut, Direction=FakeDirection, Pull=FakePull
+    ),
+    "adafruit_ble": driver_loader.make_module(
+        "adafruit_ble",
+        BLERadio=FakeBLE,
+        advertising=advertising_module,
+        services=services_module,
+    ),
+    "adafruit_ble.advertising": advertising_module,
+    "adafruit_ble.advertising.standard": advertising_standard,
+    "adafruit_ble.services": services_module,
+    "adafruit_ble.services.nordic": services_nordic,
+}
+
+bluetooth_bridge = driver_loader.load_driver_module("bluetooth-bridge", stubs=STUBS)
+BluetoothBridgeRuntime = bluetooth_bridge.BluetoothBridgeRuntime
+END_OF_MESSAGE_DELIMETER = bluetooth_bridge.END_OF_MESSAGE_DELIMETER
+ENCODING = bluetooth_bridge.ENCODING
+
+
+class StubBLE:
+    def __init__(self):
+        self.connected = False
+        self.advertising = False
+        self.start_calls = []
+
+    def start_advertising(self, advertisement):
+        self.advertising = True
+        self.start_calls.append(advertisement)
+
+
+class StubUART:
+    def __init__(self):
+        self.writes = []
+
+    def write(self, payload: bytes) -> None:
+        self.writes.append(payload)
+
+
+class StubLED:
+    def __init__(self):
+        self.value = False
+
+
+class StubSleeper:
+    def __init__(self):
+        self.calls = []
+
+    def sleep(self, seconds: float) -> None:
+        self.calls.append(seconds)
+
+
+@pytest.fixture()
+def runtime_factory():
+    def _factory(payloads):
+        sequence = list(payloads)
+        index = {"value": 0}
+
+        def gather_state():
+            if index["value"] < len(sequence):
+                result = sequence[index["value"]]
+                index["value"] += 1
+            else:
+                result = sequence[-1]
+            return result
+
+        ble = StubBLE()
+        uart = StubUART()
+        led = StubLED()
+        sleeper = StubSleeper()
+        runtime = BluetoothBridgeRuntime(
+            ble=ble,
+            uart=uart,
+            advertisement=object(),
+            led=led,
+            gather_state=gather_state,
+            sleeper=sleeper,
+            delay_seconds=0,
+            not_connected_buffer=deque([], 5),
+        )
+        return runtime, ble, uart, led, sleeper
+
+    return _factory
+
+
+def _decode_payload(payload_bytes: bytes):
+    payload_str = payload_bytes.decode(ENCODING)
+    assert payload_str.endswith(END_OF_MESSAGE_DELIMETER)
+    return json.loads(payload_str[:-1])
+
+
+def test_runtime_buffers_and_flushes_messages(runtime_factory):
+    runtime, ble, uart, led, sleeper = runtime_factory(
+        [
+            [{"event_type": "rotation", "data": 1}],
+            [{"event_type": "rotation", "data": 2}],
+            [{"event_type": "rotation", "data": 2}],
+        ]
+    )
+
+    runtime.run_once()
+    assert ble.advertising is True
+    assert ble.start_calls
+    assert led.value is False
+    assert runtime.not_connected_buffer
+    assert uart.writes == []
+
+    ble.connected = True
+    runtime.run_once()
+    assert runtime.not_connected_buffer == deque([], 5)
+    assert [_decode_payload(data) for data in uart.writes] == [
+        [{"event_type": "rotation", "data": 1}],
+        [{"event_type": "rotation", "data": 2}],
+    ]
+    assert sleeper.calls == [0, 0]
+
+    runtime.run_once()
+    assert len(uart.writes) == 2
+
+
+def test_runtime_does_not_duplicate_buffer_entries(runtime_factory):
+    runtime, ble, uart, *_ = runtime_factory(
+        [[{"event_type": "rotation", "data": 99}]]
+    )
+
+    runtime.run_once()
+    runtime.run_once()
+    assert len(runtime.not_connected_buffer) == 1
+    stored = runtime.not_connected_buffer[0]
+    assert stored.endswith(END_OF_MESSAGE_DELIMETER)
+    assert json.loads(stored[:-1]) == [{"event_type": "rotation", "data": 99}]

--- a/tests/drivers/test_lampe_controller_driver.py
+++ b/tests/drivers/test_lampe_controller_driver.py
@@ -1,0 +1,145 @@
+from driver_loader import load_driver_module, make_module
+
+
+class FakeDigitalInOut:
+    def __init__(self, pin):
+        self.pin = pin
+        self.direction = None
+        self.pull = None
+
+    def switch_to_input(self, pull):
+        self.pull = pull
+
+
+class FakeDirection:
+    OUTPUT = "output"
+
+
+class FakePull:
+    UP = "up"
+    DOWN = "down"
+
+
+class FakeI2C:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+
+class FakeSeesaw:
+    INPUT_PULLUP = "pullup"
+
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+
+class FakeIncrementalEncoder:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+
+class FakeDigitalIO:
+    def __init__(self, *_args, **_kwargs):
+        self.pull = None
+
+    def switch_to_input(self, pull):
+        self.pull = pull
+
+
+class FakeBLE:
+    advertising = False
+    connected = False
+
+    def start_advertising(self, _):
+        self.advertising = True
+
+
+class FakeAdvertisement:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+
+class FakeUARTService:
+    def __init__(self):
+        pass
+
+
+advertising_standard = make_module(
+    "adafruit_ble.advertising.standard", ProvideServicesAdvertisement=FakeAdvertisement
+)
+advertising_module = make_module("adafruit_ble.advertising", standard=advertising_standard)
+services_nordic = make_module("adafruit_ble.services.nordic", UARTService=FakeUARTService)
+services_module = make_module("adafruit_ble.services", nordic=services_nordic)
+
+adafruit_seesaw_module = make_module(
+    "adafruit_seesaw",
+    seesaw=make_module("adafruit_seesaw.seesaw", Seesaw=FakeSeesaw),
+    rotaryio=make_module("adafruit_seesaw.rotaryio", IncrementalEncoder=FakeIncrementalEncoder),
+    digitalio=make_module("adafruit_seesaw.digitalio", DigitalIO=FakeDigitalIO),
+)
+
+STUBS = {
+    "board": make_module("board", LED="led", SCL="scl", SDA="sda"),
+    "digitalio": make_module(
+        "digitalio", DigitalInOut=FakeDigitalInOut, Direction=FakeDirection, Pull=FakePull
+    ),
+    "busio": make_module("busio", I2C=FakeI2C),
+    "adafruit_seesaw": adafruit_seesaw_module,
+    "adafruit_seesaw.seesaw": adafruit_seesaw_module.seesaw,
+    "adafruit_seesaw.rotaryio": adafruit_seesaw_module.rotaryio,
+    "adafruit_seesaw.digitalio": adafruit_seesaw_module.digitalio,
+    "adafruit_ble": make_module(
+        "adafruit_ble",
+        BLERadio=FakeBLE,
+        advertising=advertising_module,
+        services=services_module,
+    ),
+    "adafruit_ble.advertising": advertising_module,
+    "adafruit_ble.advertising.standard": advertising_standard,
+    "adafruit_ble.services": services_module,
+    "adafruit_ble.services.nordic": services_nordic,
+}
+
+lampe_controller = load_driver_module("lampe-controller", stubs=STUBS)
+LampeControllerRuntime = lampe_controller.LampeControllerRuntime
+
+
+class StubSeesawController:
+    def __init__(self, batches):
+        self._batches = list(batches)
+
+    def handle(self):
+        if self._batches:
+            batch = self._batches.pop(0)
+        else:
+            batch = []
+        for event in batch:
+            yield event
+
+
+class StubSender:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, events):
+        self.calls.append(list(events))
+
+
+def test_runtime_sends_events_to_bluetooth():
+    controller = StubSeesawController([["a"], ["b", "c"]])
+    sender = StubSender()
+    runtime = LampeControllerRuntime(controller, sender)
+
+    runtime.run_once()
+    runtime.run_once()
+
+    assert sender.calls == [["a"], ["b", "c"]]
+
+
+def test_runtime_handles_empty_batches():
+    controller = StubSeesawController([[]])
+    sender = StubSender()
+    runtime = LampeControllerRuntime(controller, sender)
+
+    runtime.run_once()
+
+    assert sender.calls == [[]]

--- a/tests/drivers/test_rotary_encoder_driver.py
+++ b/tests/drivers/test_rotary_encoder_driver.py
@@ -1,0 +1,86 @@
+import importlib
+
+from driver_loader import load_driver_module, make_module, temporary_modules
+
+
+class FakeDigitalInOut:
+    def __init__(self, pin):
+        self.pin = pin
+        self.direction = None
+        self.pull = None
+
+
+class FakeDirection:
+    INPUT = "input"
+
+
+class FakePull:
+    UP = "up"
+    DOWN = "down"
+
+
+digitalio_stub = make_module(
+    "digitalio", DigitalInOut=FakeDigitalInOut, Direction=FakeDirection, Pull=FakePull
+)
+
+with temporary_modules({"digitalio": digitalio_stub}):
+    rotary_encoder = importlib.import_module("heart.firmware_io.rotary_encoder")
+
+
+class StubRotaryModule:
+    class IncrementalEncoder:
+        def __init__(self, *, pin_a, pin_b):
+            self.pin_a = pin_a
+            self.pin_b = pin_b
+            self.position = 0
+
+
+STUBS = {
+    "board": make_module("board", ROTA="rota", ROTB="rotb", SWITCH="switch"),
+    "rotaryio": make_module("rotaryio", IncrementalEncoder=StubRotaryModule.IncrementalEncoder),
+    "digitalio": digitalio_stub,
+}
+
+rotary_driver = load_driver_module("rotary_encoder", stubs=STUBS)
+create_handler = rotary_driver.create_handler
+read_events = rotary_driver.read_events
+
+
+class StubDigitalInOut:
+    instances = []
+
+    def __init__(self, pin):
+        self.pin = pin
+        self.direction = None
+        self.pull = None
+        StubDigitalInOut.instances.append(self)
+
+
+class StubHandler:
+    def __init__(self, events):
+        self._events = events
+
+    def handle(self):
+        yield from self._events
+
+
+def test_create_handler_uses_injected_modules():
+    StubDigitalInOut.instances.clear()
+    handler = create_handler(
+        board_module=make_module("board", ROTA="rota", ROTB="rotb", SWITCH="switch"),
+        rotary_module=StubRotaryModule,
+        digital_in_out_cls=StubDigitalInOut,
+        direction=FakeDirection,
+        pull=FakePull,
+    )
+
+    assert isinstance(handler, rotary_encoder.RotaryEncoderHandler)
+    assert len(StubDigitalInOut.instances) == 1
+    created_switch = StubDigitalInOut.instances[0]
+    assert created_switch.direction == FakeDirection.INPUT
+    assert created_switch.pull == FakePull.DOWN
+
+
+def test_read_events_returns_handler_values():
+    handler = StubHandler(["event1", "event2"])
+    assert read_events(handler) == ["event1", "event2"]

--- a/tests/drivers/test_sensor_bus_driver.py
+++ b/tests/drivers/test_sensor_bus_driver.py
@@ -1,0 +1,134 @@
+import json
+
+from driver_loader import load_driver_module, make_module
+
+from heart.firmware_io import constants
+
+
+class FakeRate:
+    RATE_104_HZ = "104"
+    RATE_208_HZ = "208"
+    string = {RATE_104_HZ: 104.0, RATE_208_HZ: 208.0}
+
+
+STUBS = {
+    "board": make_module("board"),
+    "adafruit_lis2mdl": make_module("adafruit_lis2mdl", LIS2MDL=object),
+    "adafruit_lsm6ds": make_module("adafruit_lsm6ds", Rate=FakeRate),
+    "adafruit_lsm6ds.ism330dhcx": make_module(
+        "adafruit_lsm6ds.ism330dhcx", ISM330DHCX=object
+    ),
+    "adafruit_lsm303_accel": make_module("adafruit_lsm303_accel", LSM303_Accel=object),
+}
+
+sensor_bus = load_driver_module("sensor_bus", stubs=STUBS)
+
+
+class StubAccelerationSensor:
+    def __init__(self, acceleration):
+        self._values = list(acceleration)
+        self._index = 0
+        self.current = self._values[0]
+
+    def step(self):
+        if self._index + 1 < len(self._values):
+            self._index += 1
+        self.current = self._values[self._index]
+
+    @property
+    def acceleration(self):
+        return self.current
+
+
+class StubGyroSensor:
+    def __init__(self, gyro):
+        self._values = list(gyro)
+        self._index = 0
+        self.current = self._values[0]
+
+    def step(self):
+        if self._index + 1 < len(self._values):
+            self._index += 1
+        self.current = self._values[self._index]
+
+    @property
+    def gyro(self):
+        return self.current
+
+
+def test_form_tuple_payload_returns_json():
+    payload = sensor_bus.form_tuple_payload("rotation", (1.0, 2.0, 3.0))
+    assert payload.startswith("\n")
+    decoded = json.loads(payload.strip())
+    assert decoded == {"event_type": "rotation", "data": {"x": 1.0, "y": 2.0, "z": 3.0}}
+
+
+def test_get_sample_rate_prefers_sensor_value():
+    class Stub:
+        accelerometer_data_rate = sensor_bus.Rate.RATE_208_HZ
+
+    assert sensor_bus.get_sample_rate(Stub()) == sensor_bus.Rate.string[Stub.accelerometer_data_rate]
+
+
+def test_get_sample_rate_defaults_when_missing():
+    class Stub:
+        pass
+
+    assert sensor_bus.get_sample_rate(Stub()) == sensor_bus.Rate.string[sensor_bus.Rate.RATE_104_HZ]
+
+
+def test_connect_to_sensors_skips_failures(monkeypatch):
+    created = []
+
+    class GoodSensor:
+        def __init__(self, i2c):
+            created.append((self.__class__.__name__, i2c))
+
+    class BadSensor:
+        def __init__(self, i2c):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(sensor_bus, "LSM303_Accel", GoodSensor)
+    monkeypatch.setattr(sensor_bus, "LIS2MDL", BadSensor)
+    monkeypatch.setattr(sensor_bus, "ISM330DHCX", GoodSensor)
+
+    sensors = sensor_bus.connect_to_sensors("i2c-bus")
+    assert len(sensors) == 2
+    assert created == [("GoodSensor", "i2c-bus"), ("GoodSensor", "i2c-bus")]
+
+
+def test_sensor_reader_emits_when_change_exceeds_threshold():
+    accel_sensor = StubAccelerationSensor(
+        acceleration=[
+            (0.0, 0.0, 0.0),
+            (0.05, 0.0, 0.05),
+            (0.05, 0.0, 0.25),
+            (0.05, 0.0, 0.25),
+        ],
+    )
+    gyro_sensor = StubGyroSensor(
+        gyro=[
+            (0.0, 0.0, 0.0),
+            (0.0, 0.0, 0.05),
+            (0.0, 0.0, 0.3),
+            (0.0, 0.0, 0.3),
+        ]
+    )
+    reader = sensor_bus.SensorReader([accel_sensor, gyro_sensor], min_change=0.1)
+
+    first = list(reader.read())
+    accel_sensor.step()
+    gyro_sensor.step()
+    second = list(reader.read())
+    accel_sensor.step()
+    gyro_sensor.step()
+    third = list(reader.read())
+
+    assert constants.ACCELERATION in first[0]
+    assert constants.GYROSCOPE in first[1]
+    assert second == []
+    assert len(third) == 2
+    accel_payload = json.loads(third[0].strip())
+    gyro_payload = json.loads(third[1].strip())
+    assert accel_payload["event_type"] == constants.ACCELERATION
+    assert gyro_payload["event_type"] == constants.GYROSCOPE


### PR DESCRIPTION
## Summary
- refactor driver modules to expose testable runtimes and handlers instead of running hardware setup on import
- add a driver loader helper that installs temporary hardware stubs for pytest
- add pytest coverage for the Bluetooth bridge, lampe controller, rotary encoder, and sensor bus drivers

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_690cb0765acc8321afdb48f3d10cb75b