### PR TITLE
Add UWB zone tracking adapter

### DIFF
--- a/src/heart/peripheral/uwb.py
+++ b/src/heart/peripheral/uwb.py
@@ -1,0 +1,266 @@
+"""Helpers for translating UWB ranging data into automation events.
+
+The ``docs/planning/uwb_peripheral_rollout.md`` plan calls for an adapter that
+consumes raw ranging payloads and emits zone entry/exit events with hysteresis
+so downstream automations do not thrash when a tag hovers near a boundary.  The
+classes in this module implement that adapter on top of the existing
+``EventBus`` infrastructure.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+from heart.peripheral.core import Input
+from heart.peripheral.core.event_bus import EventBus, SubscriptionHandle
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+Vector3 = tuple[float, float, float]
+
+
+def _normalize_vector(value: Sequence[float]) -> Vector3:
+    components = [float(component) for component in value]
+    if len(components) == 2:
+        components.append(0.0)
+    if len(components) != 3:
+        raise ValueError("Vector must contain two or three components")
+    return (components[0], components[1], components[2])
+
+
+def _mapping_to_vector(mapping: Mapping[str, object]) -> Vector3:
+    try:
+        x = float(mapping.get("x", 0.0))
+        y = float(mapping.get("y", 0.0))
+        z_raw = mapping.get("z")
+        if z_raw is None:
+            z = 0.0
+        else:
+            z = float(z_raw)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive guard
+        raise ValueError("Position components must be numeric") from exc
+    return (x, y, z)
+
+
+@dataclass(slots=True, frozen=True)
+class UwbZoneDefinition:
+    """Description of a spatial zone used for automation triggers."""
+
+    zone_id: str
+    center: Vector3
+    enter_radius: float
+    exit_radius: float | None = None
+
+    def __post_init__(self) -> None:
+        if not self.zone_id:
+            raise ValueError("zone_id must be a non-empty string")
+        if self.enter_radius <= 0:
+            raise ValueError("enter_radius must be positive")
+        if self.exit_radius is not None and self.exit_radius < self.enter_radius:
+            raise ValueError("exit_radius must be greater than or equal to enter_radius")
+
+
+@dataclass(slots=True)
+class _Observation:
+    tag_id: str
+    position: Vector3
+    payload: Mapping[str, object]
+    producer_id: int
+
+
+class UwbZoneTracker:
+    """Translate UWB ranging events into zone entry/exit notifications."""
+
+    DEFAULT_EVENT_TYPE = "uwb.ranging_event"
+
+    def __init__(
+        self,
+        zones: Iterable[UwbZoneDefinition],
+        *,
+        event_type: str = DEFAULT_EVENT_TYPE,
+        exit_margin: float = 0.15,
+        event_bus: EventBus | None = None,
+        priority: int = 0,
+    ) -> None:
+        if exit_margin < 0:
+            raise ValueError("exit_margin must be non-negative")
+
+        self._zones: dict[str, UwbZoneDefinition] = {}
+        for zone in zones:
+            self._zones[zone.zone_id] = UwbZoneDefinition(
+                zone.zone_id,
+                _normalize_vector(zone.center),
+                zone.enter_radius,
+                zone.exit_radius,
+            )
+
+        self._event_type = event_type
+        self._exit_margin = exit_margin
+        self._event_bus: EventBus | None = None
+        self._priority = priority
+        self._subscription: SubscriptionHandle | None = None
+
+        self._memberships: MutableMapping[str, MutableMapping[str, bool]] = {}
+        self._last_positions: MutableMapping[str, Vector3] = {}
+
+        if event_bus is not None:
+            self.attach_event_bus(event_bus)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def attach_event_bus(self, event_bus: EventBus) -> None:
+        """Listen for ranging events on ``event_bus``."""
+
+        if self._subscription is not None and self._event_bus is not None:
+            self._event_bus.unsubscribe(self._subscription)
+
+        self._event_bus = event_bus
+        self._subscription = event_bus.subscribe(
+            self._event_type, self._handle_ranging_event, priority=self._priority
+        )
+
+    def detach_event_bus(self) -> None:
+        if self._subscription is None or self._event_bus is None:
+            return
+        self._event_bus.unsubscribe(self._subscription)
+        self._subscription = None
+        self._event_bus = None
+
+    def get_active_zones(self, tag_id: str) -> tuple[str, ...]:
+        """Return the zones currently occupied by ``tag_id``."""
+
+        membership = self._memberships.get(tag_id)
+        if not membership:
+            return ()
+        return tuple(sorted(zone_id for zone_id, inside in membership.items() if inside))
+
+    def get_last_position(self, tag_id: str) -> Vector3 | None:
+        return self._last_positions.get(tag_id)
+
+    # ------------------------------------------------------------------
+    # Event handling
+    # ------------------------------------------------------------------
+    def _handle_ranging_event(self, event: Input) -> None:
+        observation = self._parse_observation(event)
+        if observation is None:
+            return
+
+        self._last_positions[observation.tag_id] = observation.position
+        for zone in self._zones.values():
+            self._evaluate_zone(observation, zone)
+
+    def _parse_observation(self, event: Input) -> _Observation | None:
+        payload = event.data
+        if not isinstance(payload, Mapping):
+            logger.debug("Ignoring non-mapping UWB payload: %s", payload)
+            return None
+
+        tag_id = self._extract_tag_id(payload, event.producer_id)
+        position_raw = (
+            payload.get("position")
+            or payload.get("coordinates")
+            or payload.get("location")
+        )
+        if position_raw is None:
+            logger.debug("Ignoring UWB payload without coordinates: %s", payload)
+            return None
+
+        try:
+            if isinstance(position_raw, Mapping):
+                position = _mapping_to_vector(position_raw)
+            elif isinstance(position_raw, Sequence):
+                position = _normalize_vector(position_raw)
+            else:
+                raise TypeError
+        except (TypeError, ValueError):
+            logger.debug("Ignoring malformed UWB coordinates: %s", position_raw)
+            return None
+
+        return _Observation(
+            tag_id=tag_id,
+            position=position,
+            payload=payload,
+            producer_id=event.producer_id,
+        )
+
+    def _extract_tag_id(self, payload: Mapping[str, object], producer_id: int) -> str:
+        for key in ("tag_id", "device_id", "peripheral_id", "tracker_id", "anchor_id"):
+            value = payload.get(key)
+            if value is not None:
+                return str(value)
+        return str(producer_id)
+
+    def _evaluate_zone(self, observation: _Observation, zone: UwbZoneDefinition) -> None:
+        membership = self._memberships.setdefault(observation.tag_id, {})
+        inside = membership.get(zone.zone_id, False)
+        distance = self._distance(observation.position, zone.center)
+
+        exit_radius = (
+            zone.exit_radius
+            if zone.exit_radius is not None
+            else zone.enter_radius + self._exit_margin
+        )
+
+        if not inside and distance <= zone.enter_radius:
+            membership[zone.zone_id] = True
+            self._emit_zone_event(
+                "uwb.zone.entry", observation, zone, distance
+            )
+        elif inside and distance >= exit_radius:
+            membership[zone.zone_id] = False
+            self._emit_zone_event(
+                "uwb.zone.exit", observation, zone, distance
+            )
+
+    def _distance(self, a: Vector3, b: Vector3) -> float:
+        return math.dist(a, b)
+
+    def _emit_zone_event(
+        self,
+        event_type: str,
+        observation: _Observation,
+        zone: UwbZoneDefinition,
+        distance: float,
+    ) -> None:
+        if self._event_bus is None:
+            return
+
+        payload = {
+            "tag_id": observation.tag_id,
+            "zone_id": zone.zone_id,
+            "distance": distance,
+            "position": {
+                "x": observation.position[0],
+                "y": observation.position[1],
+                "z": observation.position[2],
+            },
+            "zone_center": {
+                "x": zone.center[0],
+                "y": zone.center[1],
+                "z": zone.center[2],
+            },
+            "enter_radius": zone.enter_radius,
+            "exit_radius": (
+                zone.exit_radius
+                if zone.exit_radius is not None
+                else zone.enter_radius + self._exit_margin
+            ),
+            "raw": observation.payload,
+        }
+
+        self._event_bus.emit(
+            Input(
+                event_type=event_type,
+                data=payload,
+                producer_id=observation.producer_id,
+            )
+        )
+
+
+__all__ = ["UwbZoneDefinition", "UwbZoneTracker"]
+

--- a/tests/peripheral/test_uwb_zone_tracker.py
+++ b/tests/peripheral/test_uwb_zone_tracker.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from collections import deque
+
+import pytest
+
+from heart.peripheral.core import Input
+from heart.peripheral.core.event_bus import EventBus
+from heart.peripheral.uwb import UwbZoneDefinition, UwbZoneTracker
+
+
+@pytest.fixture()
+def event_bus() -> EventBus:
+    return EventBus()
+
+
+def collect_events(event_bus: EventBus, event_type: str) -> deque[Input]:
+    captured: deque[Input] = deque()
+    event_bus.subscribe(event_type, lambda event: captured.append(event))
+    return captured
+
+
+def test_emits_entry_event_when_within_radius(event_bus: EventBus) -> None:
+    tracker = UwbZoneTracker(
+        [UwbZoneDefinition(zone_id="living", center=(0.0, 0.0, 0.0), enter_radius=1.0)],
+        event_bus=event_bus,
+    )
+
+    entries = collect_events(event_bus, "uwb.zone.entry")
+
+    event_bus.emit(
+        "uwb.ranging_event",
+        data={"tag_id": "tag-1", "position": {"x": 0.5, "y": 0.3}},
+        producer_id=7,
+    )
+
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.event_type == "uwb.zone.entry"
+    assert entry.producer_id == 7
+    assert entry.data["zone_id"] == "living"
+    assert pytest.approx(entry.data["distance"]) == pytest.approx(0.583095)
+    assert tracker.get_active_zones("tag-1") == ("living",)
+    assert tracker.get_last_position("tag-1") == (0.5, 0.3, 0.0)
+
+
+def test_hysteresis_prevents_spurious_exits(event_bus: EventBus) -> None:
+    tracker = UwbZoneTracker(
+        [
+            UwbZoneDefinition(
+                zone_id="kitchen",
+                center=(0.0, 0.0, 0.0),
+                enter_radius=1.0,
+                exit_radius=1.4,
+            )
+        ],
+        event_bus=event_bus,
+    )
+
+    entries = collect_events(event_bus, "uwb.zone.entry")
+    exits = collect_events(event_bus, "uwb.zone.exit")
+
+    # First sample enters the zone.
+    event_bus.emit(
+        "uwb.ranging_event",
+        data={"tag_id": "tag-2", "position": (0.2, 0.3)},
+        producer_id=3,
+    )
+    assert len(entries) == 1
+    assert len(exits) == 0
+
+    # Close to the boundary but still inside thanks to hysteresis.
+    event_bus.emit(
+        "uwb.ranging_event",
+        data={"tag_id": "tag-2", "position": {"x": 1.2, "y": 0.0}},
+        producer_id=3,
+    )
+    assert len(exits) == 0
+    assert tracker.get_active_zones("tag-2") == ("kitchen",)
+
+    # Far enough to cross the exit radius.
+    event_bus.emit(
+        "uwb.ranging_event",
+        data={"tag_id": "tag-2", "position": {"x": 1.5, "y": 0.0}},
+        producer_id=3,
+    )
+    assert len(exits) == 1
+    exit_event = exits[0]
+    assert exit_event.data["zone_id"] == "kitchen"
+    assert tracker.get_active_zones("tag-2") == ()
+
+
+def test_falls_back_to_producer_id_when_tag_missing(event_bus: EventBus) -> None:
+    tracker = UwbZoneTracker(
+        [UwbZoneDefinition(zone_id="office", center=(1.0, 1.0, 0.0), enter_radius=0.5)],
+        event_bus=event_bus,
+    )
+
+    entries = collect_events(event_bus, "uwb.zone.entry")
+
+    event_bus.emit(
+        "uwb.ranging_event",
+        data={"position": {"x": 1.1, "y": 1.1}},
+        producer_id=99,
+    )
+
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.data["tag_id"] == "99"
+    assert tracker.get_active_zones("99") == ("office",)
+


### PR DESCRIPTION
## Summary
- add a UwbZoneTracker that converts `uwb.ranging_event` payloads into zone entry/exit events with configurable hysteresis
- track per-tag positions and expose helpers so automations can query active zones
- cover the adapter with tests that exercise entry, hysteresis behaviour, and producer fallbacks

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d7073b8b88321ac8b4506fc5de165)