### PR TITLE
Add screen recording test suite

### DIFF
--- a/src/heart/display/recorder.py
+++ b/src/heart/display/recorder.py
@@ -1,0 +1,88 @@
+"""Utilities for recording :class:`~heart.environment.GameLoop` output."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pygame
+from PIL import Image
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard
+    from heart.display.renderers import BaseRenderer
+    from heart.environment import GameLoop
+
+
+class ScreenRecorder:
+    """Record frames produced by a :class:`~heart.environment.GameLoop`.
+
+    The recorder advances the provided ``GameLoop`` through a sequence of
+    renderer batches, captures the resulting screen for each step, and writes an
+    animated GIF to ``output_path``.  GIF provides a simple, dependency-light
+    container that behaves like a video when inspected during development.
+    """
+
+    def __init__(self, loop: "GameLoop", *, fps: int = 30) -> None:
+        if fps <= 0:
+            raise ValueError("fps must be a positive integer")
+        self._loop = loop
+        self._fps = fps
+
+    @property
+    def fps(self) -> int:
+        """Frames per second used for the recorded animation."""
+
+        return self._fps
+
+    def record(
+        self,
+        inputs: Iterable[Sequence["BaseRenderer"] | list["BaseRenderer"]],
+        output_path: str | Path,
+    ) -> Path:
+        """Record the screen for each batch of ``inputs``.
+
+        Parameters
+        ----------
+        inputs:
+            Iterable of renderer sequences.  Each sequence represents the
+            renderers that should run for a single frame.
+        output_path:
+            Destination for the generated GIF.
+        """
+
+        path = Path(output_path)
+        frames: list[Image.Image] = []
+
+        for batch in inputs:
+            renderers = list(batch)
+            self._loop._one_loop(renderers)  # noqa: SLF001 - exercised via tests
+            screen = self._loop.screen
+            if screen is None:  # pragma: no cover - defensive guard
+                raise RuntimeError("GameLoop screen not initialized")
+
+            pixels = pygame.surfarray.array3d(screen).swapaxes(0, 1)
+            frame = Image.fromarray(pixels, mode="RGB").copy()
+            frames.append(frame)
+
+        if not frames:
+            raise ValueError("inputs must contain at least one frame")
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # GIF durations are stored in 10 ms increments. Round to the closest
+        # representable value while keeping a minimum non-zero duration.
+        duration_ms = max(int(round((1000 / self._fps) / 10.0) * 10), 10)
+
+        first, *rest = frames
+        first.save(
+            path,
+            save_all=True,
+            append_images=rest,
+            format="GIF",
+            duration=duration_ms,
+            loop=0,
+        )
+        return path
+
+
+__all__ = ["ScreenRecorder"]

--- a/tests/display/test_screen_recorder.py
+++ b/tests/display/test_screen_recorder.py
@@ -1,0 +1,77 @@
+import os
+from pathlib import Path
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import pytest
+from PIL import Image, ImageSequence
+
+from heart.display.recorder import ScreenRecorder
+from heart.display.renderers import BaseRenderer
+
+
+class SolidColorRenderer(BaseRenderer):
+    def __init__(self, color: tuple[int, int, int]) -> None:
+        super().__init__()
+        self._color = color
+
+    def process(self, window, clock, peripheral_manager, orientation) -> None:
+        window.fill(self._color)
+
+
+@pytest.fixture()
+def screen_recorder(loop) -> ScreenRecorder:
+    return ScreenRecorder(loop, fps=12)
+
+
+@pytest.mark.parametrize(
+    "colors",
+    [
+        [(255, 0, 0)],
+        [(0, 0, 0), (255, 255, 255), (0, 128, 255)],
+    ],
+)
+def test_screen_recorder_writes_expected_frames(
+    colors: list[tuple[int, int, int]], screen_recorder: ScreenRecorder, tmp_path: Path
+) -> None:
+    inputs = [[SolidColorRenderer(color)] for color in colors]
+
+    output_path = tmp_path / "capture.gif"
+    result_path = screen_recorder.record(inputs, output_path)
+
+    assert result_path.exists()
+
+    with Image.open(result_path) as image:
+        observed = [
+            frame.convert("RGB").getpixel((0, 0))
+            for frame in ImageSequence.Iterator(image)
+        ]
+
+    assert observed == colors
+
+
+def test_screen_recorder_sets_frame_duration(
+    screen_recorder: ScreenRecorder, tmp_path: Path
+) -> None:
+    inputs = [
+        [SolidColorRenderer((10, 20, 30))],
+        [SolidColorRenderer((30, 40, 50))],
+    ]
+    result_path = screen_recorder.record(inputs, tmp_path / "duration.gif")
+
+    with Image.open(result_path) as image:
+        durations = [
+            frame.info.get("duration")
+            for frame in ImageSequence.Iterator(image)
+        ]
+
+    expected_duration = max(
+        int(round((1000 / screen_recorder.fps) / 10.0) * 10),
+        10,
+    )
+    assert durations == [expected_duration] * len(inputs)
+
+
+def test_screen_recorder_requires_inputs(screen_recorder: ScreenRecorder, tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        screen_recorder.record([], tmp_path / "empty.gif")


### PR DESCRIPTION
## Summary
- add a `ScreenRecorder` helper that captures `GameLoop` output into an animated GIF
- cover the recorder with tests that validate captured frames, frame timing, and empty input handling

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d70175914832195e3eb09e14be552)