### PR TITLE
Implement IR sensor array peripheral and calibration tooling

### DIFF
--- a/docs/planning/ir_sensor_array_peripheral.md
+++ b/docs/planning/ir_sensor_array_peripheral.md
@@ -16,7 +16,7 @@ The Heart hardware stack needs an infrared (IR) sensor array peripheral capable 
 
 ### Discovery
 
-- [ ] Map the existing IR decoding flow in `drivers/` and document timing resolution limits in `docs/research/ir_sensor_array_positioning.md`.
+- [x] Map the existing IR decoding flow in `drivers/` and document timing resolution limits in `docs/research/ir_sensor_array_positioning.md`.
 - [ ] Benchmark wide-angle versus narrow field-of-view IR sensor packages; capture a comparison table with responsivity, latency, and ambient rejection metrics.
 - [ ] Prototype a four-sensor breadboard with synchronized capture, saving logic analyzer traces and timestamp alignment notes to the lab share.
 - [ ] Draft a communications spec for the peripheral-to-MCU interface (SPI vs. I²C + DMA) and solicit asynchronous feedback via architecture review notes.
@@ -26,9 +26,9 @@ The Heart hardware stack needs an infrared (IR) sensor array peripheral capable 
 
 - [ ] Design PCB v1 with radial IR sensor placement, precision clock distribution, and diagnostic headers; store KiCad sources alongside BOM revisions.
 - [ ] Implement the embedded driver module `src/hw/ir_array.rs` that streams timestamped interrupts into a double-buffered DMA queue with CRC tagging.
-- [ ] Extend the signal processing pipeline with a multilateration solver, confidence scoring, and unit tests using synthetic pulse fixtures.
+- [x] Extend the signal processing pipeline with a multilateration solver, confidence scoring, and unit tests using synthetic pulse fixtures.
 - [ ] Create an arrayed remote prototype with three IR LEDs at 120° offsets, each modulating distinct preamble sequences and payload slots.
-- [ ] Develop a calibration CLI (`scripts/ir_calibrate.py`) that records sweeps, solves for sensor offsets, and uploads results to the telemetry store.
+- [x] Develop a calibration CLI (`scripts/ir_calibrate.py`) that records sweeps, solves for sensor offsets, and uploads results to the telemetry store.
 
 ### Rollout
 

--- a/scripts/ir_calibrate.py
+++ b/scripts/ir_calibrate.py
@@ -1,0 +1,186 @@
+"""CLI utilities for calibrating the IR sensor array peripheral."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import requests
+import typer
+
+from heart.peripheral.ir_sensor_array import SPEED_OF_LIGHT, radial_layout
+
+app = typer.Typer(help="Calibrate IR sensor arrays from captured sweep data.")
+
+
+@dataclass(slots=True)
+class CaptureRecord:
+    frame_id: int
+    sensor_index: int
+    timestamp: float
+    true_position: tuple[float, float, float]
+
+
+def _load_records(path: Path) -> list[CaptureRecord]:
+    text = path.read_text().strip()
+    if not text:
+        return []
+
+    try:
+        loaded = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(f"Failed to parse {path}: {exc}") from exc
+
+    if isinstance(loaded, dict) and "records" in loaded:
+        loaded = loaded["records"]
+
+    if not isinstance(loaded, list):
+        raise typer.BadParameter(f"Expected a list of records in {path}")
+
+    records: list[CaptureRecord] = []
+    for idx, entry in enumerate(loaded):
+        if not isinstance(entry, dict):
+            raise typer.BadParameter(f"Record {idx} is not a mapping")
+        try:
+            frame_id = int(entry["frame_id"])
+            sensor_index = int(entry["sensor_index"])
+            timestamp = float(entry["timestamp"])
+            true_position = tuple(float(v) for v in entry["true_position"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise typer.BadParameter(f"Malformed record at index {idx}: {exc}") from exc
+        if len(true_position) != 3:
+            raise typer.BadParameter(
+                f"Record {idx} true_position must have three coordinates"
+            )
+        records.append(
+            CaptureRecord(
+                frame_id=frame_id,
+                sensor_index=sensor_index,
+                timestamp=timestamp,
+                true_position=true_position,
+            )
+        )
+    return records
+
+
+def _resolve_layout(layout: str, layout_file: Path | None) -> np.ndarray:
+    if layout_file is not None:
+        data = json.loads(layout_file.read_text())
+        if not isinstance(data, (list, tuple)):
+            raise typer.BadParameter("Layout file must contain a list of positions")
+        return np.asarray(data, dtype=float)
+
+    layout = layout.lower()
+    if layout == "radial":
+        return np.asarray(radial_layout(), dtype=float)
+    raise typer.BadParameter(f"Unknown layout '{layout}'")
+
+
+def _group_by_frame(records: Iterable[CaptureRecord]) -> dict[int, dict[int, CaptureRecord]]:
+    frames: dict[int, dict[int, CaptureRecord]] = {}
+    for record in records:
+        frames.setdefault(record.frame_id, {})[record.sensor_index] = record
+    return frames
+
+
+def _compute_offsets(
+    frames: dict[int, dict[int, CaptureRecord]],
+    sensor_positions: np.ndarray,
+    *,
+    propagation_speed: float,
+) -> tuple[dict[int, float], dict[str, float]]:
+    offsets: dict[int, list[float]] = {}
+    residuals: list[float] = []
+    frames_used = 0
+
+    for frame_id, sensors in frames.items():
+        if len(sensors) != sensor_positions.shape[0]:
+            continue
+
+        true_position = None
+        for record in sensors.values():
+            true_position = record.true_position
+            break
+        assert true_position is not None
+        target = np.asarray(true_position, dtype=float)
+
+        for sensor_index, record in sensors.items():
+            sensor_pos = sensor_positions[sensor_index]
+            expected = np.linalg.norm(target - sensor_pos) / propagation_speed
+            offset = record.timestamp - expected
+            offsets.setdefault(sensor_index, []).append(offset)
+            residuals.append(offset)
+
+        frames_used += 1
+
+    collapsed = {
+        sensor: float(np.median(values))
+        for sensor, values in offsets.items()
+        if values
+    }
+
+    rmse = float(np.sqrt(np.mean(np.square(residuals)))) if residuals else 0.0
+    max_offset = float(max(abs(value) for value in residuals)) if residuals else 0.0
+
+    metrics = {
+        "frames_used": float(frames_used),
+        "rmse": rmse,
+        "max_offset": max_offset,
+    }
+    return collapsed, metrics
+
+
+@app.command()
+def calibrate(
+    data: Path = typer.Argument(..., help="Path to captured sweep data (JSON)."),
+    output: Path = typer.Option(
+        Path("ir_array_offsets.json"),
+        "--output",
+        "-o",
+        help="Destination for calibration offsets (JSON).",
+    ),
+    layout: str = typer.Option("radial", help="Built-in sensor layout to use."),
+    layout_file: Path | None = typer.Option(
+        None,
+        help="Optional path to custom sensor layout JSON overriding --layout.",
+    ),
+    propagation_speed: float = typer.Option(
+        SPEED_OF_LIGHT,
+        help="Propagation speed for the burst medium (m/s).",
+    ),
+    telemetry_url: str | None = typer.Option(
+        None,
+        help="Optional HTTP endpoint that receives the calibration payload.",
+    ),
+) -> None:
+    """Solve calibration offsets for each sensor channel."""
+
+    records = _load_records(data)
+    if not records:
+        raise typer.BadParameter("No records found in capture file")
+
+    sensor_positions = _resolve_layout(layout, layout_file)
+    frames = _group_by_frame(records)
+    offsets, metrics = _compute_offsets(
+        frames, sensor_positions, propagation_speed=propagation_speed
+    )
+
+    payload = {"offsets": offsets, "metrics": metrics}
+    output.write_text(json.dumps(payload, indent=2))
+    typer.echo(f"Wrote calibration to {output}")
+
+    if telemetry_url:
+        try:
+            response = requests.post(telemetry_url, json=payload, timeout=5)
+            response.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover - network
+            raise typer.BadParameter(f"Telemetry upload failed: {exc}") from exc
+        typer.echo(f"Uploaded calibration to {telemetry_url}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    app()
+

--- a/src/heart/peripheral/ir_sensor_array.py
+++ b/src/heart/peripheral/ir_sensor_array.py
@@ -1,0 +1,342 @@
+"""Infrared sensor array peripheral and positioning solver."""
+
+from __future__ import annotations
+
+import json
+import math
+import threading
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterator, Mapping, Sequence
+
+import numpy as np
+from scipy.optimize import least_squares
+
+from heart.peripheral.core import Input, Peripheral
+from heart.peripheral.core.event_bus import EventBus
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+SPEED_OF_LIGHT = 299_792_458.0  # metres per second
+
+
+@dataclass(slots=True)
+class IRSample:
+    """Single timestamped edge captured by a sensor in the array."""
+
+    frame_id: int
+    sensor_index: int
+    timestamp: float
+    level: int
+    duration_us: float
+
+
+@dataclass(slots=True)
+class IRDMAPacket:
+    """Chunk of captured IR samples transferred via DMA."""
+
+    buffer_id: int
+    samples: tuple[IRSample, ...]
+    crc: int
+    generated_at: datetime
+
+    def to_bytes(self) -> bytes:
+        payload = [
+            {
+                "frame_id": sample.frame_id,
+                "sensor_index": sample.sensor_index,
+                "timestamp": sample.timestamp,
+                "level": sample.level,
+                "duration_us": sample.duration_us,
+            }
+            for sample in self.samples
+        ]
+        return json.dumps(payload, separators=(",", ":")).encode("utf-8")
+
+
+class IRArrayDMAQueue:
+    """Double-buffered queue that simulates a DMA capture pipeline."""
+
+    def __init__(self, *, buffer_size: int = 64) -> None:
+        if buffer_size <= 0:
+            msg = "buffer_size must be positive"
+            raise ValueError(msg)
+        self.buffer_size = buffer_size
+        self._buffers: list[list[IRSample]] = [[], []]
+        self._active = 0
+        self._ready: deque[IRDMAPacket] = deque()
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Producer API
+    # ------------------------------------------------------------------
+    def push_sample(self, sample: IRSample) -> None:
+        """Append ``sample`` to the active DMA buffer."""
+
+        with self._lock:
+            buffer = self._buffers[self._active]
+            buffer.append(sample)
+            if len(buffer) >= self.buffer_size:
+                self._finalize_active_buffer_locked()
+
+    def flush(self) -> None:
+        """Force the active buffer to be emitted even if not full."""
+
+        with self._lock:
+            if self._buffers[self._active]:
+                self._finalize_active_buffer_locked()
+
+    # ------------------------------------------------------------------
+    # Consumer API
+    # ------------------------------------------------------------------
+    def pop(self) -> IRDMAPacket | None:
+        """Return the next ready packet, if any."""
+
+        with self._lock:
+            if not self._ready:
+                return None
+            return self._ready.popleft()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _finalize_active_buffer_locked(self) -> None:
+        buffer_id = self._active
+        samples = tuple(self._buffers[buffer_id])
+        self._buffers[buffer_id] = []
+        self._active = 1 - self._active
+
+        crc = self._crc_for_samples(samples)
+        packet = IRDMAPacket(
+            buffer_id=buffer_id,
+            samples=samples,
+            crc=crc,
+            generated_at=datetime.now(timezone.utc),
+        )
+        self._ready.append(packet)
+
+    @staticmethod
+    def _crc_for_samples(samples: tuple[IRSample, ...]) -> int:
+        crc = 0
+        for sample in samples:
+            crc ^= (sample.frame_id << 1) ^ (sample.sensor_index << 4)
+            crc ^= int(sample.timestamp * 1_000_000)
+            crc ^= sample.level << 8
+            crc ^= int(sample.duration_us)
+        return crc & 0xFFFFFFFF
+
+
+@dataclass(slots=True)
+class IRFrame:
+    """Collection of samples for a full frame across the sensor array."""
+
+    frame_id: int
+    samples: tuple[IRSample, ...]
+
+    @property
+    def arrival_times(self) -> list[float]:
+        return [sample.timestamp for sample in self.samples]
+
+    @property
+    def payload_bits(self) -> list[int]:
+        bits: list[int] = []
+        for sample in self.samples:
+            if sample.duration_us <= 0:
+                continue
+            # Assume the remote uses pulse-width modulation. Duration above
+            # 1000 microseconds is treated as a logical "1".
+            bits.append(1 if sample.duration_us >= 1000 else 0)
+        return bits
+
+
+class FrameAssembler:
+    """Aggregate samples by ``frame_id`` until each sensor has contributed."""
+
+    def __init__(self, *, sensor_count: int) -> None:
+        if sensor_count <= 1:
+            msg = "sensor_count must be greater than one"
+            raise ValueError(msg)
+        self.sensor_count = sensor_count
+        self._pending: dict[int, dict[int, IRSample]] = {}
+
+    def add(self, sample: IRSample) -> Iterator[IRFrame]:
+        bucket = self._pending.setdefault(sample.frame_id, {})
+        bucket[sample.sensor_index] = sample
+        if len(bucket) < self.sensor_count:
+            return iter(())
+
+        frame_samples = tuple(
+            bucket[index] for index in sorted(bucket)[: self.sensor_count]
+        )
+        del self._pending[sample.frame_id]
+        return iter((IRFrame(frame_id=sample.frame_id, samples=frame_samples),))
+
+
+class MultilaterationSolver:
+    """Estimate the origin of an IR burst using time-difference-of-arrival."""
+
+    def __init__(
+        self,
+        sensor_positions: Sequence[Sequence[float]],
+        *,
+        propagation_speed: float = SPEED_OF_LIGHT,
+        max_iterations: int = 12,
+        convergence_threshold: float = 1e-6,
+    ) -> None:
+        self.sensor_positions = np.asarray(sensor_positions, dtype=float)
+        if self.sensor_positions.ndim != 2 or self.sensor_positions.shape[1] != 3:
+            msg = "sensor_positions must be an (N,3) array"
+            raise ValueError(msg)
+        if self.sensor_positions.shape[0] < 3:
+            msg = "At least three sensors are required"
+            raise ValueError(msg)
+        self.propagation_speed = float(propagation_speed)
+        self.max_iterations = max_iterations
+        self.convergence_threshold = convergence_threshold
+
+    # ------------------------------------------------------------------
+    def solve(self, arrival_times: Sequence[float]) -> tuple[np.ndarray, float, float]:
+        """Return ``(position, confidence, rmse)`` for ``arrival_times``."""
+
+        times = np.asarray(arrival_times, dtype=float)
+        if times.shape[0] != self.sensor_positions.shape[0]:
+            msg = "arrival_times length must match number of sensors"
+            raise ValueError(msg)
+
+        point = np.mean(self.sensor_positions, axis=0)
+        emission_time = float(np.min(times)) - np.linalg.norm(
+            point - self.sensor_positions[0]
+        ) / self.propagation_speed
+
+        def objective(vector: np.ndarray) -> np.ndarray:
+            candidate_point = vector[:3]
+            candidate_emission = vector[3]
+            residuals = []
+            for sensor_pos, arrival in zip(
+                self.sensor_positions, times, strict=True
+            ):
+                distance = np.linalg.norm(candidate_point - sensor_pos)
+                residuals.append(
+                    distance
+                    - self.propagation_speed * (arrival - candidate_emission)
+                )
+            return np.asarray(residuals)
+
+        start = np.concatenate([point, [emission_time]])
+        result = least_squares(
+            objective,
+            start,
+            method="trf",
+            max_nfev=self.max_iterations * 100,
+            xtol=self.convergence_threshold,
+            ftol=self.convergence_threshold**2,
+            gtol=self.convergence_threshold,
+        )
+        if not result.success:
+            raise ValueError(f"Solver failed to converge: {result.message}")
+
+        point = result.x[:3]
+        emission_time = result.x[3]
+        final_residuals = objective(result.x)
+
+        rmse = float(math.sqrt(np.mean(np.square(final_residuals))))
+        confidence = float(1.0 / (1.0 + rmse * self.propagation_speed))
+        return point, confidence, rmse
+
+
+class IRSensorArray(Peripheral):
+    """Process DMA packets from an IR sensor array and emit pose estimates."""
+
+    EVENT_FRAME = "peripheral.ir_array.frame"
+
+    def __init__(
+        self,
+        *,
+        sensor_positions: Sequence[Sequence[float]],
+        event_bus: EventBus | None = None,
+        propagation_speed: float = SPEED_OF_LIGHT,
+    ) -> None:
+        self._assembler = FrameAssembler(sensor_count=len(sensor_positions))
+        self._solver = MultilaterationSolver(
+            sensor_positions, propagation_speed=propagation_speed
+        )
+        self._calibration_offsets: dict[int, float] = {}
+        self._event_bus = event_bus
+        self._producer_id = id(self)
+        super().__init__()
+
+    # ------------------------------------------------------------------
+    def attach_event_bus(self, event_bus: EventBus) -> None:
+        self._event_bus = event_bus
+
+    def apply_calibration(self, offsets: Mapping[int, float]) -> None:
+        self._calibration_offsets = dict(offsets)
+
+    # ------------------------------------------------------------------
+    def run(self) -> None:  # pragma: no cover - integration hook for hardware
+        logger.info("IRSensorArray run loop idle; use ingest_packet to feed data")
+
+    # ------------------------------------------------------------------
+    def ingest_packet(self, packet: IRDMAPacket) -> None:
+        """Validate ``packet`` and emit pose events for complete frames."""
+
+        expected_crc = IRArrayDMAQueue._crc_for_samples(packet.samples)
+        if expected_crc != packet.crc:
+            logger.warning(
+                "Dropping packet due to CRC mismatch (expected=%s, got=%s)",
+                expected_crc,
+                packet.crc,
+            )
+            return
+
+        for sample in packet.samples:
+            for frame in self._assembler.add(sample):
+                self._process_frame(frame, packet.generated_at)
+
+    # ------------------------------------------------------------------
+    def _process_frame(self, frame: IRFrame, generated_at: datetime) -> None:
+        calibrated_times = []
+        for sample in frame.samples:
+            offset = self._calibration_offsets.get(sample.sensor_index, 0.0)
+            calibrated_times.append(sample.timestamp - offset)
+
+        position, confidence, rmse = self._solver.solve(calibrated_times)
+        payload = {
+            "frame_id": frame.frame_id,
+            "bits": frame.payload_bits,
+            "confidence": confidence,
+            "rmse": rmse,
+            "position": position.tolist(),
+            "timestamp": generated_at.isoformat(),
+        }
+
+        if self._event_bus is not None:
+            self._event_bus.emit(
+                self.EVENT_FRAME,
+                data=payload,
+                producer_id=self._producer_id,
+            )
+
+        self.handle_input(
+            Input(
+                event_type=self.EVENT_FRAME,
+                data=payload,
+                producer_id=self._producer_id,
+            )
+        )
+
+
+def radial_layout(radius: float = 0.12) -> list[list[float]]:
+    """Return sensor positions for a square radial layout."""
+
+    half = radius / math.sqrt(2)
+    vertical = radius * 0.15
+    return [
+        [-half, 0.0, vertical],
+        [0.0, half, -vertical],
+        [half, 0.0, vertical],
+        [0.0, -half, -vertical],
+    ]
+

--- a/tests/peripheral/test_ir_sensor_array.py
+++ b/tests/peripheral/test_ir_sensor_array.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import numpy as np
+
+from heart.peripheral.core.event_bus import EventBus
+from heart.peripheral.ir_sensor_array import (SPEED_OF_LIGHT, IRArrayDMAQueue,
+                                              IRDMAPacket, IRSample,
+                                              IRSensorArray,
+                                              MultilaterationSolver,
+                                              radial_layout)
+
+
+def _make_packet(samples: list[IRSample]) -> IRDMAPacket:
+    queue = IRArrayDMAQueue(buffer_size=len(samples))
+    for sample in samples:
+        queue.push_sample(sample)
+    queue.flush()
+    packet = queue.pop()
+    assert packet is not None
+    return packet
+
+
+def test_dma_queue_emits_double_buffer_packets():
+    queue = IRArrayDMAQueue(buffer_size=2)
+
+    samples = [
+        IRSample(frame_id=1, sensor_index=0, timestamp=0.001, level=1, duration_us=500),
+        IRSample(frame_id=1, sensor_index=1, timestamp=0.0015, level=0, duration_us=750),
+        IRSample(frame_id=2, sensor_index=0, timestamp=0.002, level=1, duration_us=900),
+    ]
+
+    for sample in samples:
+        queue.push_sample(sample)
+
+    first = queue.pop()
+    assert first is not None
+    assert first.buffer_id == 0
+    assert first.samples == tuple(samples[:2])
+
+    queue.flush()
+    second = queue.pop()
+    assert second is not None
+    assert second.buffer_id == 1
+    assert second.samples == (samples[2],)
+
+
+def test_multilateration_solver_converges_on_known_point():
+    sensors = radial_layout(radius=0.2)
+    solver = MultilaterationSolver(sensors)
+    emitter = np.array([0.05, 0.03, 0.02])
+
+    arrival_times = []
+    for sensor in sensors:
+        sensor_vec = np.array(sensor)
+        distance = np.linalg.norm(emitter - sensor_vec)
+        arrival_times.append(distance / SPEED_OF_LIGHT)
+
+    position, confidence, rmse = solver.solve(arrival_times)
+
+    assert np.allclose(position, emitter, atol=1e-3)
+    assert confidence > 0.99
+    assert rmse < 1e-10
+
+
+def test_sensor_array_emits_frame_event():
+    sensors = radial_layout(radius=0.16)
+    bus = EventBus()
+    captured: list[dict] = []
+
+    bus.subscribe(IRSensorArray.EVENT_FRAME, lambda event: captured.append(event.data))
+
+    array = IRSensorArray(sensor_positions=sensors, event_bus=bus)
+
+    true_position = np.array([0.04, -0.02, 0.01])
+    offsets = {0: 2e-6, 1: -1e-6, 2: 3e-6, 3: -2e-6}
+    array.apply_calibration(offsets)
+
+    samples: list[IRSample] = []
+    for index, sensor in enumerate(sensors):
+        sensor_vec = np.array(sensor)
+        distance = np.linalg.norm(true_position - sensor_vec)
+        nominal = distance / SPEED_OF_LIGHT
+        observed = nominal + offsets[index]
+        duration = 1200 if index % 2 else 800
+        samples.append(
+            IRSample(
+                frame_id=42,
+                sensor_index=index,
+                timestamp=observed,
+                level=1,
+                duration_us=duration,
+            )
+        )
+
+    packet = _make_packet(samples)
+    array.ingest_packet(packet)
+
+    assert captured, "Expected event emission"
+    event = captured[0]
+    assert event["frame_id"] == 42
+    assert np.allclose(event["position"], true_position.tolist(), atol=1e-3)
+    assert event["confidence"] > 0.95
+    assert event["rmse"] < 1e-10
+    assert event["bits"] == [0, 1, 0, 1]
+


### PR DESCRIPTION
## Summary
- add an infrared sensor array peripheral with double-buffered DMA packets, multilateration solver, and radial layout helper
- provide a calibration CLI to compute per-sensor timing offsets and optionally upload results to telemetry
- document the positioning approach, update the implementation plan, and add unit tests covering the queue, solver, and event emission

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d703008cc8321a75d867f522595f2)