### PR TITLE
Organize planning project tracker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,4 +20,4 @@ Running `make check` is recommended to verify formatting and linting without app
 
 ## Documentation Guidelines
 
-Update `docs/code_flow.md` and re-render the diagram with `scripts/render_code_flow.py` whenever runtime architecture changes. Pair thoughtful implementations with a research note under `docs/research/` that cites the relevant source files. Plans under `docs/planning/` must follow the structure defined in their `AGENTS.md` file.
+Update `docs/code_flow.md` and re-render the diagram with `scripts/render_code_flow.py` whenever runtime architecture changes. Pair thoughtful implementations with a research note under `docs/research/` that cites the relevant source files. Plans under `docs/planning/` must follow the structure defined in their `AGENTS.md` file, and contributors should review the master project list in `docs/planning/README.md` before scoping new work.

--- a/docs/planning/Done/AGENTS.md
+++ b/docs/planning/Done/AGENTS.md
@@ -1,0 +1,3 @@
+# Archived Planning Instructions
+
+Plans stored in this directory should retain the structure defined in `../AGENTS.md` while clearly documenting their delivered status and referencing the production deployment where applicable.

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -1,23 +1,9 @@
-# Planning Overview
+# Planning Project Tracker
 
-## Problem Statement
+Consult this index before opening or updating plans. Each linked document must follow the structure defined in `AGENTS.md` so reviewers can quickly assess problem statements, materials, and validation strategy.
 
-Describe how planning documents in this directory should communicate technical proposals and implementation steps for the Heart project.
+## Planning
 
-## Materials
-
-- Planning templates and AGENTS guidance in this directory.
-- Access to related source modules for cross-referencing.
-
-## Technical Approach
-
-Each plan should open with a clear problem statement and materials list, follow the structure defined in `AGENTS.md`, and provide measurable criteria for success so contributors can execute work without ambiguity.
-
-This directory houses detailed plans covering runtime architecture changes, tooling upgrades, and peripheral integration strategies.
-
-## Master Project List
-
-### Planning
 - [ ] [Benchmarking Tooling](benchmarking_tooling.md)
 - [ ] [Bluetooth Cube Scene Pipeline](bluetooth_cube_scene_pipeline.md)
 - [ ] [Bluetooth Reverse Engineering](bluetooth_reverse_engineering.md)
@@ -27,10 +13,12 @@ This directory houses detailed plans covering runtime architecture changes, tool
 - [ ] [Multi-App Split](multi_app_split.md)
 - [ ] [UWB Peripheral Rollout](uwb_peripheral_rollout.md)
 
-### Active
+## Active
+
 - [ ] [Input Event Bus](input_event_bus.md)
 - [ ] [IR Sensor Array Peripheral](ir_sensor_array_peripheral.md)
 - [ ] [MIDI Peripheral Converter](midi_peripheral_converter.md)
 
-### Done
+## Done
+
 - [ ] Archive completed plans to [`docs/planning/Done/`](Done/)

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -14,3 +14,23 @@ Describe how planning documents in this directory should communicate technical p
 Each plan should open with a clear problem statement and materials list, follow the structure defined in `AGENTS.md`, and provide measurable criteria for success so contributors can execute work without ambiguity.
 
 This directory houses detailed plans covering runtime architecture changes, tooling upgrades, and peripheral integration strategies.
+
+## Master Project List
+
+### Planning
+- [ ] [Benchmarking Tooling](benchmarking_tooling.md)
+- [ ] [Bluetooth Cube Scene Pipeline](bluetooth_cube_scene_pipeline.md)
+- [ ] [Bluetooth Reverse Engineering](bluetooth_reverse_engineering.md)
+- [ ] [Direct Sensor Access](direct_sensor_access.md)
+- [ ] [Flow Toy Signal Interface](flow_toy_signal_interface.md)
+- [ ] [Light Dependent Resistor Peripheral](light_dependent_resistor_peripheral.md)
+- [ ] [Multi-App Split](multi_app_split.md)
+- [ ] [UWB Peripheral Rollout](uwb_peripheral_rollout.md)
+
+### Active
+- [ ] [Input Event Bus](input_event_bus.md)
+- [ ] [IR Sensor Array Peripheral](ir_sensor_array_peripheral.md)
+- [ ] [MIDI Peripheral Converter](midi_peripheral_converter.md)
+
+### Done
+- [ ] Archive completed plans to [`docs/planning/Done/`](Done/)


### PR DESCRIPTION
## Summary
- add a project checklist to docs/planning/README.md to highlight planning, active, and done workstreams
- update top-level AGENTS guidance to point contributors to the planning checklist before starting new efforts
- introduce a Done archive directory with instructions for maintaining completed plans

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dfbafd03c8321ba4eb1c04afb33ae)