### PR TITLE
Add parameterized firmware IO driver tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,9 @@ Run `make test` to execute the Pytest suite located in the `tests/` directory. E
 
 When adding tests, it is reasonable to stub hardware- or framework-heavy dependencies so the core logic can be exercised in isolation.
 
+- Parameterize new Pytest cases when validating multiple input permutations (especially for driver behaviour) to keep coverage
+  clear and maintainable.
+
 ## Linting (Optional Pre-Check)
 
 Running `make check` is recommended to verify formatting and linting without applying fixes.

--- a/tests/firmware_io/conftest.py
+++ b/tests/firmware_io/conftest.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from helpers.time import DeterministicClock
+
+from heart.firmware_io import rotary_encoder
+
+
+@pytest.fixture
+def dummy_pull(monkeypatch: pytest.MonkeyPatch):
+    class DummyPull:
+        UP = "up"
+        DOWN = "down"
+
+    monkeypatch.setattr(rotary_encoder, "Pull", DummyPull)
+    return DummyPull
+
+
+@pytest.fixture
+def deterministic_clock() -> DeterministicClock:
+    return DeterministicClock()
+
+
+@pytest.fixture
+def rotary_components(dummy_pull):
+    encoder = SimpleNamespace(position=0)
+    switch = SimpleNamespace(value=False, pull=dummy_pull.DOWN)
+    return encoder, switch

--- a/tests/firmware_io/test_accel.py
+++ b/tests/firmware_io/test_accel.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+if "adafruit_lis2mdl" not in sys.modules:
+    lis2mdl = types.ModuleType("adafruit_lis2mdl")
+    lis2mdl.LIS2MDL = object
+    sys.modules["adafruit_lis2mdl"] = lis2mdl
+
+if "adafruit_lsm6ds" not in sys.modules:
+    lsm6ds = types.ModuleType("adafruit_lsm6ds")
+
+    class _FakeRate:
+        RATE_104_HZ = "RATE_104_HZ"
+        string = {"RATE_104_HZ": 0.0}
+
+    lsm6ds.Rate = _FakeRate
+    sys.modules["adafruit_lsm6ds"] = lsm6ds
+else:
+    lsm6ds = sys.modules["adafruit_lsm6ds"]
+
+if "adafruit_lsm6ds.ism330dhcx" not in sys.modules:
+    ism_module = types.ModuleType("adafruit_lsm6ds.ism330dhcx")
+    ism_module.ISM330DHCX = object
+    sys.modules["adafruit_lsm6ds.ism330dhcx"] = ism_module
+    setattr(lsm6ds, "ism330dhcx", ism_module)
+
+if "adafruit_lsm303_accel" not in sys.modules:
+    lsm303 = types.ModuleType("adafruit_lsm303_accel")
+    lsm303.LSM303_Accel = object
+    sys.modules["adafruit_lsm303_accel"] = lsm303
+
+from helpers.firmware_io import StubSensor
+
+from heart.firmware_io import accel, constants
+
+
+@pytest.mark.parametrize(
+    "sequence, expected",
+    [
+        (
+            [
+                {"accel": (0.0, 0.0, 0.0), "gyro": (0.0, 0.0, 0.0)},
+                {"accel": (0.05, 0.02, 0.0), "gyro": (0.05, 0.0, 0.0)},
+                {"accel": (0.3, 0.0, 0.0), "gyro": (0.12, 0.0, 0.0)},
+            ],
+            [
+                [
+                    accel.form_tuple_payload(constants.ACCELERATION, (0.0, 0.0, 0.0)),
+                    accel.form_tuple_payload(constants.GYROSCOPE, (0.0, 0.0, 0.0)),
+                ],
+                [],
+                [
+                    accel.form_tuple_payload(constants.ACCELERATION, (0.3, 0.0, 0.0)),
+                    accel.form_tuple_payload(constants.GYROSCOPE, (0.12, 0.0, 0.0)),
+                ],
+            ],
+        ),
+    ],
+)
+def test_sensor_reader_emits_payloads_when_values_change(sequence, expected) -> None:
+    sensor = StubSensor(acceleration=sequence[0]["accel"], gyro=sequence[0]["gyro"])
+    reader = accel.SensorReader([sensor], min_change=0.1)
+
+    captured: list[list[str]] = []
+    for step in sequence:
+        sensor.acceleration = step["accel"]
+        sensor.gyro = step["gyro"]
+        captured.append(list(reader.read()))
+
+    assert captured == expected
+
+
+@pytest.mark.parametrize(
+    "new, old, threshold, expected",
+    [
+        ((0.0, 0.0, 0.0), None, 0.1, True),
+        ((0.05, 0.0, 0.0), (0.0, 0.0, 0.0), 0.1, False),
+        ((0.2, 0.0, 0.0), (0.0, 0.0, 0.0), 0.1, True),
+    ],
+)
+def test_changed_enough_respects_threshold(new, old, threshold, expected) -> None:
+    reader = accel.SensorReader([])
+    assert reader._changed_enough(new, old, threshold) is expected
+
+
+@pytest.mark.parametrize(
+    "sensor_kwargs, expected_key",
+    [
+        ({"accelerometer_data_rate": "RATE_52_HZ"}, "RATE_52_HZ"),
+        ({}, "RATE_104_HZ"),
+    ],
+)
+def test_get_sample_rate_falls_back_to_default(monkeypatch, sensor_kwargs, expected_key) -> None:
+    class FakeRate:
+        RATE_104_HZ = "RATE_104_HZ"
+        string = {
+            "RATE_104_HZ": 9.6,
+            "RATE_52_HZ": 19.2,
+        }
+
+    monkeypatch.setattr(accel, "Rate", FakeRate)
+
+    sensor = SimpleNamespace(**sensor_kwargs)
+    reader = accel.SensorReader([])
+
+    assert reader.get_sample_rate(sensor) == FakeRate.string[expected_key]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        ((1.0, 2.0, 3.0),),
+        ((-0.1, 0.0, 9.81),),
+    ],
+)
+def test_form_tuple_payload_wraps_json_in_newlines(payload) -> None:
+    result = accel.form_tuple_payload(constants.ACCELERATION, payload[0])
+    assert result.startswith("\n") and result.endswith("\n")
+    parsed = json.loads(result.strip())
+    assert parsed == {
+        "event_type": constants.ACCELERATION,
+        "producer_id": 0,
+        "data": {
+            "value": {
+                "x": payload[0][0],
+                "y": payload[0][1],
+                "z": payload[0][2],
+            }
+        },
+    }

--- a/tests/firmware_io/test_bluetooth.py
+++ b/tests/firmware_io/test_bluetooth.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+from helpers.firmware_io import StubBLE, StubUART
+
+from heart.firmware_io import bluetooth
+
+
+@pytest.mark.parametrize(
+    "connected, advertising, message, expected_starts, expected_writes",
+    [
+        (True, False, "ping", 1, [b"ping", bluetooth.END_OF_MESSAGE_DELIMETER.encode(bluetooth.ENCODING)]),
+        (True, True, "pong", 0, [b"pong", bluetooth.END_OF_MESSAGE_DELIMETER.encode(bluetooth.ENCODING)]),
+        (False, False, "idle", 1, []),
+    ],
+)
+def test_send_handles_advertising_and_buffer_flush(
+    monkeypatch, connected, advertising, message, expected_starts, expected_writes
+) -> None:
+    stub_ble = StubBLE(advertising=advertising, connected=connected)
+    stub_uart = StubUART()
+    advertisement = object()
+
+    monkeypatch.setattr(bluetooth, "ble", stub_ble)
+    monkeypatch.setattr(bluetooth, "uart", stub_uart)
+    monkeypatch.setattr(bluetooth, "advertisement", advertisement)
+
+    bluetooth.send([message])
+
+    assert len(stub_ble.started_advertising_with) == expected_starts
+    if expected_starts:
+        assert stub_ble.started_advertising_with[0] is advertisement
+
+    if expected_writes:
+        assert stub_uart.written == expected_writes
+    else:
+        assert stub_uart.written == []
+
+
+def test_send_encodes_multiple_messages(monkeypatch) -> None:
+    stub_ble = StubBLE(advertising=True, connected=True)
+    stub_uart = StubUART()
+
+    monkeypatch.setattr(bluetooth, "ble", stub_ble)
+    monkeypatch.setattr(bluetooth, "uart", stub_uart)
+
+    bluetooth.send(["one", "two"])
+
+    expected = [
+        b"one",
+        bluetooth.END_OF_MESSAGE_DELIMETER.encode(bluetooth.ENCODING),
+        b"two",
+        bluetooth.END_OF_MESSAGE_DELIMETER.encode(bluetooth.ENCODING),
+    ]
+    assert stub_uart.written == expected

--- a/tests/firmware_io/test_rotary_encoder_handler.py
+++ b/tests/firmware_io/test_rotary_encoder_handler.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from helpers.firmware_io import HandlerStep, run_handler_steps
+
+from heart.firmware_io import constants, rotary_encoder
+
+
+@pytest.mark.parametrize(
+    "index, steps, expected",
+    [
+        (
+            7,
+            [
+                HandlerStep("initial"),
+                HandlerStep("rotate-forward", position=4),
+                HandlerStep("steady"),
+            ],
+            [
+                ("initial", [rotary_encoder.form_json(constants.SWITCH_ROTATION, 0, 7)]),
+                ("rotate-forward", [rotary_encoder.form_json(constants.SWITCH_ROTATION, 4, 7)]),
+                ("steady", []),
+            ],
+        ),
+        (
+            5,
+            [
+                HandlerStep("initial"),
+                HandlerStep("rotate-negative", position=-3),
+                HandlerStep("repeat", position=-3),
+            ],
+            [
+                ("initial", [rotary_encoder.form_json(constants.SWITCH_ROTATION, 0, 5)]),
+                ("rotate-negative", [rotary_encoder.form_json(constants.SWITCH_ROTATION, -3, 5)]),
+                ("repeat", []),
+            ],
+        ),
+    ],
+)
+def test_handle_emits_rotation_events_when_position_changes(rotary_components, index, steps, expected) -> None:
+    encoder, switch = rotary_components
+    handler = rotary_encoder.RotaryEncoderHandler(encoder, switch, index=index)
+
+    timeline = run_handler_steps(handler, encoder, switch, steps)
+    assert timeline == expected
+
+
+@pytest.mark.parametrize(
+    "pull_direction, pressed_value, released_value",
+    [
+        ("DOWN", True, False),
+        ("UP", False, True),
+    ],
+)
+def test_handle_emits_button_press_for_press_release_sequence(
+    dummy_pull, deterministic_clock, pull_direction, pressed_value, released_value
+) -> None:
+    encoder = SimpleNamespace(position=12)
+    switch = SimpleNamespace(value=released_value, pull=getattr(dummy_pull, pull_direction))
+    handler = rotary_encoder.RotaryEncoderHandler(encoder, switch, index=2)
+    handler.last_position = encoder.position
+    handler._current_time = deterministic_clock.monotonic  # type: ignore[method-assign]
+
+    steps = [
+        HandlerStep("baseline"),
+        HandlerStep("press-start", switch_value=pressed_value),
+        HandlerStep("press-held", advance=0.2),
+        HandlerStep("release", switch_value=released_value, advance=0.1),
+    ]
+
+    timeline = run_handler_steps(handler, encoder, switch, steps, clock=deterministic_clock)
+    expected_press = rotary_encoder.form_json(constants.BUTTON_PRESS, 1, 2)
+    assert timeline == [
+        ("baseline", []),
+        ("press-start", []),
+        ("press-held", []),
+        ("release", [expected_press]),
+    ]
+
+
+@pytest.mark.parametrize(
+    "advance_sequence",
+    [
+        [rotary_encoder.LONG_PRESS_DURATION_SECONDS - 0.1, 0.2, 0.5],
+        [rotary_encoder.LONG_PRESS_DURATION_SECONDS, 0.3, 0.0],
+    ],
+)
+def test_handle_emits_long_press_once_when_threshold_elapsed(
+    dummy_pull, deterministic_clock, advance_sequence
+) -> None:
+    encoder = SimpleNamespace(position=5)
+    switch = SimpleNamespace(value=True, pull=dummy_pull.UP)
+    handler = rotary_encoder.RotaryEncoderHandler(encoder, switch, index=1)
+    handler.last_position = encoder.position
+    handler._current_time = deterministic_clock.monotonic  # type: ignore[method-assign]
+
+    steps = [
+        HandlerStep("baseline"),
+        HandlerStep("press-start", switch_value=False),
+        HandlerStep("pre-threshold", advance=advance_sequence[0]),
+        HandlerStep("long-press", advance=advance_sequence[1]),
+        HandlerStep("still-held", advance=advance_sequence[2]),
+        HandlerStep("release", switch_value=True),
+    ]
+
+    timeline = run_handler_steps(handler, encoder, switch, steps, clock=deterministic_clock)
+    expected_long_press = rotary_encoder.form_json(constants.BUTTON_LONG_PRESS, 1, 1)
+    labels = [
+        "baseline",
+        "press-start",
+        "pre-threshold",
+        "long-press",
+        "still-held",
+        "release",
+    ]
+    expected_timeline = [(label, []) for label in labels]
+    threshold = rotary_encoder.LONG_PRESS_DURATION_SECONDS
+    long_press_index = 2 if advance_sequence[0] >= threshold else 3
+    expected_timeline[long_press_index] = (
+        expected_timeline[long_press_index][0],
+        [expected_long_press],
+    )
+
+    assert timeline == expected_timeline
+    assert handler.press_started_timestamp is None
+    assert handler.long_pressed_sent is False
+
+
+def test_seesaw_streams_events_from_all_handlers(rotary_components) -> None:
+    encoder, switch = rotary_components
+    handler_a = rotary_encoder.RotaryEncoderHandler(encoder, switch, index=3)
+    handler_b = rotary_encoder.RotaryEncoderHandler(encoder, switch, index=4)
+
+    seesaw = rotary_encoder.Seesaw([handler_a, handler_b])
+
+    events = list(seesaw.handle())
+    expected = [
+        rotary_encoder.form_json(constants.SWITCH_ROTATION, 0, 3),
+        rotary_encoder.form_json(constants.SWITCH_ROTATION, 0, 4),
+    ]
+    assert events == expected

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Shared helpers for tests covering hardware drivers."""

--- a/tests/helpers/firmware_io.py
+++ b/tests/helpers/firmware_io.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence
+
+
+@dataclass(frozen=True)
+class HandlerStep:
+    """Represents a single call into a handler with optional state changes."""
+
+    label: str
+    position: int | None = None
+    switch_value: bool | None = None
+    advance: float = 0.0
+
+
+def run_handler_steps(handler, encoder, switch, steps: Sequence[HandlerStep], clock=None):
+    """Execute ``handler.handle`` over ``steps`` recording emitted events."""
+
+    timeline: List[tuple[str, list[str]]] = []
+    for step in steps:
+        if clock is not None and step.advance:
+            clock.advance(step.advance)
+        if step.position is not None:
+            encoder.position = step.position
+        if step.switch_value is not None:
+            switch.value = step.switch_value
+        timeline.append((step.label, list(handler.handle())))
+    return timeline
+
+
+class StubBLE:
+    def __init__(self, *, advertising: bool, connected: bool) -> None:
+        self.advertising = advertising
+        self.connected = connected
+        self.started_advertising_with: list[object] = []
+
+    def start_advertising(self, advertisement) -> None:
+        self.started_advertising_with.append(advertisement)
+        self.advertising = True
+
+
+class StubUART:
+    def __init__(self) -> None:
+        self.written: list[bytes] = []
+
+    def write(self, payload: bytes) -> None:
+        self.written.append(payload)
+
+
+class StubSensor:
+    def __init__(self, acceleration=None, gyro=None, magnetic=None) -> None:
+        self.acceleration = acceleration
+        self.gyro = gyro
+        self.magnetic = magnetic

--- a/tests/helpers/time.py
+++ b/tests/helpers/time.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+
+class DeterministicClock:
+    """Simple monotonic clock stub that advances when instructed."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self._now = start
+
+    def advance(self, delta: float) -> None:
+        self._now += delta
+
+    def monotonic(self) -> float:
+        return self._now


### PR DESCRIPTION
## Summary
- add shared helpers and fixtures to exercise firmware IO drivers with deterministic inputs
- expand rotary encoder coverage with parameterized rotation and button timelines
- add bluetooth and accelerometer driver tests while documenting the repository-wide parametrization requirement

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dfc3005808321a6c4862fe6a6ba0a)