### PR TITLE
Finish input event bus rollout

### DIFF
--- a/docs/api/input_bus.md
+++ b/docs/api/input_bus.md
@@ -1,0 +1,44 @@
+# Input Event Bus Developer Guide
+
+## Overview
+
+The input event bus is a synchronous in-process dispatcher for peripheral input.
+Peripherals normalise raw payloads into `heart.peripheral.core.Input` objects and
+emit them through `EventBus.emit()`. Subscribers receive events immediately and
+the shared `StateStore` captures the latest value for each `(event_type, producer_id)` pair.
+
+## Publishing events
+
+1. Inject or request an `EventBus` instance. `GameLoop` exposes the bus via
+   `GameLoop.event_bus` and propagates it to detected peripherals when
+   `ENABLE_INPUT_EVENT_BUS` is enabled.
+1. Compose payloads with the helpers in `heart.events.types`. For example,
+   `AccelerometerVector(x, y, z).to_input(producer_id=...)` yields a typed input.
+1. Call `event_bus.emit(input_event)` inside the peripheral once the payload is
+   validated. Exceptions raised by subscribers are logged and do not block
+   other handlers.
+
+### Lifecycle signalling
+
+Peripherals should emit lifecycle transitions so downstream systems can reason
+about availability. Use `HeartRateLifecycle`, `SwitchButton.long_press`, and
+similar helpers to encode `connected`, `suspected_disconnect`, `recovered`, and
+`disconnected` states. Maintain an internal status cache to avoid publishing
+unchanged lifecycle events.
+
+## Reading state snapshots
+
+`EventBus.state_store` tracks the most recent event per producer. Call
+`StateStore.get_latest(event_type, producer_id)` to read a single entry or
+`StateStore.snapshot()` to clone the entire store for deterministic inspection.
+`GameLoop.latest_input()` and `GameLoop.input_snapshot()` wrap these calls for
+renderers and controllers.
+
+## Testing
+
+- Use the concrete `EventBus` in unit tests and subscribe to the event types
+  under test to assert emitted payloads.
+- The helpers in `heart.events.types` return full `Input` instances, enabling
+  direct comparison in tests without constructing dictionaries manually.
+- `StateStore` objects are safe to share across threads; snapshots return
+  read-only `MappingProxyType` views so tests can verify immutability.

--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -24,6 +24,9 @@ from heart.peripheral.heart_rates import current_bpms
 from heart.utilities.env import Configuration
 from heart.utilities.logging import get_logger
 
+if TYPE_CHECKING:
+    from heart.peripheral.core import StateEntry, StateSnapshot
+
 
 def _load_cv2_module() -> ModuleType | None:
     module: ModuleType | None = None
@@ -342,6 +345,18 @@ class GameLoop:
     @property
     def event_bus(self) -> EventBus:
         return self._event_bus
+
+    def latest_input(
+        self, event_type: str, *, producer_id: int | None = None
+    ) -> "StateEntry" | None:
+        """Return the most recent :class:`Input` for ``event_type``."""
+
+        return self._event_bus.state_store.get_latest(event_type, producer_id)
+
+    def input_snapshot(self) -> "StateSnapshot":
+        """Capture a point-in-time snapshot of the input state store."""
+
+        return self._event_bus.state_store.snapshot()
 
     def start(self) -> None:
         logger.info("Starting GameLoop")

--- a/src/heart/events/__init__.py
+++ b/src/heart/events/__init__.py
@@ -1,0 +1,16 @@
+"""Typed helpers for composing input events."""
+
+from .types import (AccelerometerVector, HeartRateLifecycle,
+                    HeartRateMeasurement, InputEventPayload, MicrophoneLevel,
+                    PhoneTextMessage, SwitchButton, SwitchRotation)
+
+__all__ = [
+    "AccelerometerVector",
+    "HeartRateLifecycle",
+    "HeartRateMeasurement",
+    "InputEventPayload",
+    "MicrophoneLevel",
+    "PhoneTextMessage",
+    "SwitchButton",
+    "SwitchRotation",
+]

--- a/src/heart/events/types.py
+++ b/src/heart/events/types.py
@@ -1,0 +1,205 @@
+"""Canonical payload helpers for peripherals emitting ``Input`` events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import (Any, ClassVar, Mapping, MutableMapping, Protocol,
+                    runtime_checkable)
+
+from heart.firmware_io.constants import (BUTTON_LONG_PRESS, BUTTON_PRESS,
+                                         SWITCH_ROTATION)
+from heart.peripheral.core import Input
+
+
+def _normalize_timestamp(timestamp: datetime | None) -> datetime:
+    if timestamp is None:
+        return datetime.now(timezone.utc)
+    if timestamp.tzinfo is None:
+        return timestamp.replace(tzinfo=timezone.utc)
+    return timestamp
+
+
+@runtime_checkable
+class InputEventPayload(Protocol):
+    """Protocol for payload helpers that can materialise :class:`Input`."""
+
+    event_type: str
+
+    def to_input(self, *, producer_id: int = 0, timestamp: datetime | None = None) -> Input:
+        """Render the payload as an :class:`Input` instance."""
+
+
+@dataclass(frozen=True, slots=True)
+class SwitchButton(InputEventPayload):
+    """Represents a discrete button press on a rotary switch."""
+
+    button: int
+    pressed: bool
+    long_press: bool = False
+    EVENT_TYPE_PRESS: ClassVar[str] = BUTTON_PRESS
+    EVENT_TYPE_LONG_PRESS: ClassVar[str] = BUTTON_LONG_PRESS
+
+    @property
+    def event_type(self) -> str:  # type: ignore[override]
+        return self.EVENT_TYPE_LONG_PRESS if self.long_press else self.EVENT_TYPE_PRESS
+
+    def to_input(self, *, producer_id: int = 0, timestamp: datetime | None = None) -> Input:
+        return Input(
+            event_type=self.event_type,
+            data={"button": self.button, "pressed": self.pressed},
+            producer_id=producer_id,
+            timestamp=_normalize_timestamp(timestamp),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SwitchRotation(InputEventPayload):
+    """Represents the absolute rotary encoder position of a switch."""
+
+    position: int
+
+    EVENT_TYPE: ClassVar[str] = SWITCH_ROTATION
+    event_type: str = EVENT_TYPE
+
+    def to_input(self, *, producer_id: int = 0, timestamp: datetime | None = None) -> Input:
+        return Input(
+            event_type=self.event_type,
+            data={"position": int(self.position)},
+            producer_id=producer_id,
+            timestamp=_normalize_timestamp(timestamp),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class MicrophoneLevel(InputEventPayload):
+    """Aggregated loudness metrics for a captured audio block."""
+
+    rms: float
+    peak: float
+    frames: int
+    samplerate: int
+    timestamp: float
+
+    EVENT_TYPE: ClassVar[str] = "peripheral.microphone.level"
+    event_type: str = EVENT_TYPE
+
+    def to_input(self, *, producer_id: int = 0, timestamp: datetime | None = None) -> Input:
+        payload = {
+            "rms": float(self.rms),
+            "peak": float(self.peak),
+            "frames": int(self.frames),
+            "samplerate": int(self.samplerate),
+            "timestamp": float(self.timestamp),
+        }
+        return Input(
+            event_type=self.event_type,
+            data=payload,
+            producer_id=producer_id,
+            timestamp=_normalize_timestamp(timestamp),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HeartRateMeasurement(InputEventPayload):
+    """Normalized payload for ANT+ strap heart rate samples."""
+
+    device_id: str
+    bpm: int
+    confidence: float | None = None
+    battery_level: float | None = None
+
+    EVENT_TYPE: ClassVar[str] = "peripheral.heart_rate.measurement"
+    event_type: str = EVENT_TYPE
+
+    def to_input(self, *, producer_id: int = 0, timestamp: datetime | None = None) -> Input:
+        payload: MutableMapping[str, Any] = {
+            "device_id": self.device_id,
+            "bpm": int(self.bpm),
+        }
+        if self.confidence is not None:
+            payload["confidence"] = float(self.confidence)
+        if self.battery_level is not None:
+            payload["battery_level"] = float(self.battery_level)
+        return Input(
+            event_type=self.event_type,
+            data=dict(payload),
+            producer_id=producer_id,
+            timestamp=_normalize_timestamp(timestamp),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HeartRateLifecycle(InputEventPayload):
+    """Lifecycle notification for ANT+ heart rate straps."""
+
+    status: str
+    device_id: str
+    detail: Mapping[str, Any] | None = None
+
+    EVENT_TYPE: ClassVar[str] = "peripheral.heart_rate.lifecycle"
+    event_type: str = EVENT_TYPE
+
+    def to_input(self, *, producer_id: int = 0, timestamp: datetime | None = None) -> Input:
+        payload: MutableMapping[str, Any] = {
+            "device_id": self.device_id,
+            "status": self.status,
+        }
+        if self.detail:
+            payload.update(dict(self.detail))
+        return Input(
+            event_type=self.event_type,
+            data=dict(payload),
+            producer_id=producer_id,
+            timestamp=_normalize_timestamp(timestamp),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AccelerometerVector(InputEventPayload):
+    """Three-axis acceleration sample from the IMU peripheral."""
+
+    x: float
+    y: float
+    z: float
+
+    EVENT_TYPE: ClassVar[str] = "peripheral.accelerometer.vector"
+    event_type: str = EVENT_TYPE
+
+    def to_input(self, *, producer_id: int = 0, timestamp: datetime | None = None) -> Input:
+        return Input(
+            event_type=self.event_type,
+            data={"x": float(self.x), "y": float(self.y), "z": float(self.z)},
+            producer_id=producer_id,
+            timestamp=_normalize_timestamp(timestamp),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PhoneTextMessage(InputEventPayload):
+    """Represents a BLE text payload received by the phone-text peripheral."""
+
+    text: str
+
+    EVENT_TYPE: ClassVar[str] = "peripheral.phone_text.message"
+    event_type: str = EVENT_TYPE
+
+    def to_input(self, *, producer_id: int = 0, timestamp: datetime | None = None) -> Input:
+        return Input(
+            event_type=self.event_type,
+            data={"text": self.text},
+            producer_id=producer_id,
+            timestamp=_normalize_timestamp(timestamp),
+        )
+
+
+__all__ = [
+    "AccelerometerVector",
+    "HeartRateLifecycle",
+    "HeartRateMeasurement",
+    "InputEventPayload",
+    "MicrophoneLevel",
+    "PhoneTextMessage",
+    "SwitchButton",
+    "SwitchRotation",
+]

--- a/src/heart/peripheral/heart_rates.py
+++ b/src/heart/peripheral/heart_rates.py
@@ -13,7 +13,9 @@ from openant.devices.utilities import auto_create_device
 from openant.easy.exception import AntException
 from openant.easy.node import Node
 
+from heart.events.types import HeartRateLifecycle, HeartRateMeasurement
 from heart.peripheral.core import Peripheral
+from heart.peripheral.core.event_bus import EventBus
 from heart.utilities.logging import get_logger
 
 RETRY_DELAY = 5
@@ -57,9 +59,9 @@ class _SafeList(list):
 
 
 class HeartRateManager(Peripheral):
-    """Continuously scans for ANT+ HR straps and maintains the global dicts."""
+    """Continuously scans for ANT+ HR straps and publishes measurements."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, event_bus: EventBus | None = None) -> None:
         self._node: Optional[Node] = None
         self._scanner: Optional[Scanner] = None
         self._devices: List[HeartRate] = []
@@ -71,11 +73,19 @@ class HeartRateManager(Peripheral):
         )
         self._janitor.start()
 
+        self._event_bus = event_bus
+        self._lifecycle_status: Dict[str, str] = {}
+
     # ---------- Peripheral framework ----------
 
     @classmethod
     def detect(cls) -> Iterator["HeartRateManager"]:
         yield cls()
+
+    def attach_event_bus(self, event_bus: EventBus) -> None:
+        """Attach the shared input event bus for publishing samples."""
+
+        self._event_bus = event_bus
 
     # ---------- Callbacks -----------------------------------------------------
 
@@ -89,8 +99,7 @@ class HeartRateManager(Peripheral):
         except Exception as e:
             logger.error("Could not create HR device: %s", e)
 
-    @staticmethod
-    def _cb(hrm: HeartRate):
+    def _cb(self, hrm: HeartRate):
         def _inner(_pg, _name, data):
             if isinstance(data, HeartRateData):
                 device_id = f"{hrm.device_id:05X}"
@@ -101,6 +110,8 @@ class HeartRateManager(Peripheral):
                         battery_status[device_id] = data.battery_percentage * 100 / 256
 
                 logger.debug("HR %s BPM (device %s)", data.heart_rate, device_id)
+                self._mark_connected(device_id)
+                self._publish_measurement(device_id, data)
 
         return _inner
 
@@ -123,6 +134,7 @@ class HeartRateManager(Peripheral):
                     logger.info(
                         "Pruned silent HR strap %s (>%ds idle)", dev_id, DEVICE_TIMEOUT
                     )
+                    self._mark_disconnect(dev_id, suspected=True)
 
     # ---------- ANT+ life-cycle ---------------------------------------------
 
@@ -157,6 +169,73 @@ class HeartRateManager(Peripheral):
                 if self._node:
                     self._node.stop()
                 self._devices.clear()
+
+    # ---------- Event bus helpers -------------------------------------------
+
+    def _publish_measurement(self, device_id: str, data: HeartRateData) -> None:
+        event_bus = self._event_bus
+        if event_bus is None:
+            return
+
+        battery = None
+        if hasattr(data, "battery_percentage"):
+            battery = data.battery_percentage * 100 / 256
+
+        measurement = HeartRateMeasurement(
+            device_id=device_id,
+            bpm=data.heart_rate,
+            confidence=1.0,
+            battery_level=battery,
+        ).to_input(producer_id=self._producer_for_device(device_id))
+
+        try:
+            event_bus.emit(measurement)
+        except Exception:
+            logger.exception("Failed to emit heart rate measurement for %s", device_id)
+
+    def _emit_lifecycle(
+        self, device_id: str, status: str, detail: Dict[str, float] | None = None
+    ) -> None:
+        event_bus = self._event_bus
+        if event_bus is None:
+            return
+
+        lifecycle = HeartRateLifecycle(
+            status=status,
+            device_id=device_id,
+            detail=detail,
+        ).to_input(producer_id=self._producer_for_device(device_id))
+
+        try:
+            event_bus.emit(lifecycle)
+        except Exception:
+            logger.exception("Failed to emit heart rate lifecycle event for %s", device_id)
+
+    def _mark_connected(self, device_id: str) -> None:
+        previous = self._lifecycle_status.get(device_id)
+        if previous is None:
+            self._lifecycle_status[device_id] = "connected"
+            self._emit_lifecycle(device_id, "connected")
+        elif previous == "suspected_disconnect":
+            self._lifecycle_status[device_id] = "connected"
+            self._emit_lifecycle(device_id, "recovered")
+
+    def _mark_disconnect(self, device_id: str, *, suspected: bool) -> None:
+        status = "suspected_disconnect" if suspected else "disconnected"
+        if self._lifecycle_status.get(device_id) == status:
+            return
+        self._lifecycle_status[device_id] = status
+        detail = None
+        if suspected:
+            detail = {"timeout_seconds": DEVICE_TIMEOUT}
+        self._emit_lifecycle(device_id, status, detail)
+
+    @staticmethod
+    def _producer_for_device(device_id: str) -> int:
+        try:
+            return int(device_id, 16)
+        except ValueError:
+            return abs(hash(device_id)) % (2**31)
 
     # ---------- Run loop -----------------------------------------------------
 

--- a/tests/peripheral/test_accelerometer_event_bus.py
+++ b/tests/peripheral/test_accelerometer_event_bus.py
@@ -1,0 +1,31 @@
+import pytest
+
+from heart.events.types import AccelerometerVector
+from heart.peripheral.core.event_bus import EventBus
+from heart.peripheral.sensor import Accelerometer
+
+
+@pytest.mark.parametrize("event_type", ["acceleration", "sensor.acceleration"])
+def test_accelerometer_emits_vector(event_type: str) -> None:
+    bus = EventBus()
+    captured: list[AccelerometerVector] = []
+
+    def _capture(event):
+        captured.append(
+            AccelerometerVector(
+                x=event.data["x"], y=event.data["y"], z=event.data["z"]
+            )
+        )
+
+    bus.subscribe(AccelerometerVector.EVENT_TYPE, _capture)
+    accel = Accelerometer(port="/dev/null", baudrate=9600, event_bus=bus, producer_id=7)
+
+    accel._update_due_to_data(
+        {"event_type": event_type, "data": {"x": 1.0, "y": -2.5, "z": 0.5}}
+    )
+
+    assert captured
+    vector = captured[0]
+    assert vector.x == pytest.approx(1.0)
+    assert vector.y == pytest.approx(-2.5)
+    assert vector.z == pytest.approx(0.5)

--- a/tests/peripheral/test_heart_rate_event_bus.py
+++ b/tests/peripheral/test_heart_rate_event_bus.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+
+from heart.events.types import HeartRateLifecycle, HeartRateMeasurement
+from heart.peripheral.core.event_bus import EventBus
+from heart.peripheral.heart_rates import HeartRateManager
+
+
+def test_heart_rate_manager_emits_measurements_and_lifecycle():
+    bus = EventBus()
+    measurements = []
+    lifecycle = []
+
+    bus.subscribe(HeartRateMeasurement.EVENT_TYPE, measurements.append)
+    bus.subscribe(HeartRateLifecycle.EVENT_TYPE, lifecycle.append)
+
+    manager = HeartRateManager(event_bus=bus)
+
+    sample = SimpleNamespace(heart_rate=72, battery_percentage=128)
+
+    manager._mark_connected("0A001")
+    manager._publish_measurement("0A001", sample)
+    manager._mark_disconnect("0A001", suspected=True)
+
+    assert measurements
+    measurement = measurements[0]
+    assert measurement.data["device_id"] == "0A001"
+    assert measurement.data["bpm"] == 72
+    assert measurement.producer_id == int("0A001", 16)
+
+    statuses = [event.data["status"] for event in lifecycle]
+    assert "connected" in statuses
+    assert "suspected_disconnect" in statuses

--- a/tests/peripheral/test_phone_text_event_bus.py
+++ b/tests/peripheral/test_phone_text_event_bus.py
@@ -1,0 +1,19 @@
+from heart.events.types import PhoneTextMessage
+from heart.peripheral.core.event_bus import EventBus
+from heart.peripheral.phone_text import PhoneText
+
+
+def test_phone_text_emits_message_event():
+    bus = EventBus()
+    captured: list[str] = []
+
+    bus.subscribe(
+        PhoneTextMessage.EVENT_TYPE, lambda event: captured.append(event.data["text"])
+    )
+
+    phone = PhoneText(event_bus=bus, producer_id=3)
+
+    phone._on_write(b"hello world\0", None)
+
+    assert captured == ["hello world"]
+    assert phone.pop_text() == "hello world"


### PR DESCRIPTION
## Summary
- add typed input payload helpers plus developer documentation for the event bus
- wire heart rate, accelerometer, phone text, and microphone peripherals into the shared bus with lifecycle/state-store integration
- expose state snapshots on the game loop, add structured logging, and extend the planning checklist alongside new regression tests

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dfbd573188321ac2da02ccbc36f93)