### PR TITLE
Ensure tests helpers are importable during pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,7 @@ module = [
 follow_imports = "skip"
 
 [tool.pytest.ini_options]
-pythonpath = ["src"]
+pythonpath = ["src", "tests"]
 testpaths = ["tests"]
 addopts = "-vv -n auto --dist=loadscope"
 


### PR DESCRIPTION
## Summary
- add the tests directory to pytest's configured python path so helper modules can be imported without manual path tweaks

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e04b15f9c83218e9a5f698bfab91d)