### PR TITLE
Add virtual peripheral manager and gesture detectors to event bus

### DIFF
--- a/docs/planning/event_playlists.md
+++ b/docs/planning/event_playlists.md
@@ -1,0 +1,98 @@
+# Event Playlist Rollout Plan
+
+## Problem Statement
+
+Coordinate adoption of the event playlist scheduler and new virtual peripheral aggregators so timed behaviours and composite gestures migrate from ad-hoc timers to the shared event bus without destabilising existing peripherals.
+
+## Materials
+
+- `src/heart/peripheral/core/event_bus.py`
+- `tests/peripheral/test_event_bus.py`
+- Runtime logs capturing `event.playlist.*` emissions
+- Access to at least one configuration profile that exercises multiple peripherals
+
+## Opening Abstract
+
+The event playlist manager introduces a declarative way to express timed sequences of `Input` events, while virtual peripherals let us stitch multiple raw inputs into higher-level gestures (double taps, simultaneous presses, input codes) on the same bus. This plan sequences discovery, integration, and validation so applications can compose complex behaviours by wiring playlists and aggregators into their existing handlers. The rollout focuses on defining reusable playlists, layering gesture detectors that emit enriched events, teaching subsystems how to react to lifecycle emissions, and verifying that interrupts and composite detections behave predictably under load.
+
+## Success Criteria
+
+| Behaviour | Validation Signal | Owner |
+| --- | --- | --- |
+| Playlists trigger sequences deterministically | `tests/peripheral/test_event_bus.py::test_playlist_manual_start_runs_to_completion` passes and emits the expected telemetry payloads | Firmware/Runtime Team |
+| Interrupt events halt active playlists safely | `event.playlist.stopped` data shows `reason="interrupted"` with matching payload when `stop.sequence` is emitted in integration testing | Controls Team |
+| Applications consume playlist lifecycle data | Logging integration captures `event.playlist.created` and custom completion events for at least one production configuration | Runtime Operations |
+| Virtual peripherals emit enriched gestures | `tests/peripheral/test_event_bus.py::test_virtual_double_tap_emits_enriched_payload` and `::test_sequence_virtual_peripheral_detects_konami_code` produce the expected metadata envelopes | Input Systems Team |
+
+## Task Breakdown
+
+### Discovery
+
+- [ ] Catalogue existing timers in rendering and peripheral pipelines that can be replaced by event playlists.
+- [ ] Identify physical inputs that should emit composite gestures (double taps, simultaneous presses, command codes) and map them to virtual peripheral definitions.
+- [ ] Review `EventPlaylist`, `PlaylistStep`, `EventPlaylistManager`, and `VirtualPeripheralManager` APIs to confirm they cover timing and aggregation needs (offsets, repeats, interrupts, metadata, gesture windows).
+- [ ] Inspect `tests/peripheral/test_event_bus.py` to understand expected lifecycle emissions, completion semantics, and gesture metadata envelopes.
+
+### Implementation
+
+- [ ] Define reusable playlists for colour cycling, sensor sampling bursts, and notification banners in configuration modules.
+- [ ] Register double-tap, simultaneous, and sequence-based virtual peripherals with enriched metadata so downstream consumers can distinguish gesture types.
+- [ ] Replace direct timer usage with `EventBus.playlists.start()` calls, using completion events to trigger downstream transitions.
+- [ ] Wire virtual peripheral outputs into existing mode controllers to replace bespoke gesture parsing.
+- [ ] Register interrupt events (for example, user input or safety sensors) so long-running playlists can stop without lingering threads.
+- [ ] Persist playlist and virtual peripheral handles or definitions in configuration files to enable cross-process reuse.
+
+### Validation
+
+- [ ] Extend integration tests to subscribe to `event.playlist.created/emitted/stopped` and assert the payload schema.
+- [ ] Capture sample payloads from virtual peripherals (double tap, simultaneous detection, Konami sequence) and ensure metadata is preserved in logging pipelines.
+- [ ] Run hardware-in-the-loop sessions to confirm interrupts fire under physical input (switch rotation, emergency stop buttons) and that gesture windows respect physical timing.
+- [ ] Monitor CPU usage during concurrent playlist executions and active gesture detectors to ensure the scheduler thread model scales.
+- [ ] Review runtime logs for missing completion events, unexpected cancellation reasons, or gesture spam caused by noisy sensors.
+
+## Narrative Walkthrough
+
+Discovery starts with an audit of existing timing constructs—manual `time.sleep` loops, `threading.Timer` invocations, and update ticks baked into renderers. Each candidate is mapped to an `EventPlaylist` that describes offsets, repeat cadence, and metadata so observers can reason about the sequence. Once the API coverage is confirmed, configuration authors define playlists alongside existing mode registration code, storing the returned `PlaylistHandle` for reuse.
+
+Implementation replaces per-feature timers with event-driven launches. For example, the colour fade feature creates a `PlaylistStep` with a one-second interval and 60 repeats, then uses `EventBus.playlists.start()` when a mode change event lands. Interrupts wire safety signals—if a switch press or heart-rate anomaly occurs, the manager broadcasts `event.playlist.stopped` so renderers can abort gracefully. In parallel, teams author virtual peripherals: a button double tap combines two presses within 500 ms, a simultaneous detector watches for multi-sensor agreement inside 10 ms, and the Konami listener validates control sequences before emitting a higher-level `konami.activated` event. Metadata attached to both playlists and virtual peripherals allows dashboards to tag runs by feature, enabling richer diagnostics.
+
+Validation closes the loop with layered testing. Unit tests cover lifecycle behaviour, while integration tests assert that playlist telemetry reaches log pipelines. During hardware sessions, engineers trigger interrupts to confirm the manager cancels threads promptly and that completion events only fire on successful runs. Performance monitoring verifies that concurrent playlists do not starve the main loop.
+
+## Visual Reference
+
+| Time (s) | Event | Notes |
+| --- | --- | --- |
+| 0.0 | `event.playlist.created` (`playlist_id=abc123`) | Triggered by `start.sequence` input |
+| 0.0 | `color.update` repeat index 0 | `event.playlist.emitted` payload includes metadata |
+| 0.75 | `button.double_tap` | Virtual peripheral emits enriched payload referencing `virtual_peripheral.name` |
+| 1.0 | `color.update` repeat index 1 | Sequence continues with same playlist ID |
+| 3.2 | `stop.sequence` interrupt | Manager signals `runner.stop("interrupted")` |
+| 3.2 | `event.playlist.stopped` | `reason="interrupted"`, carries interrupt payload |
+
+| Window (ms) | Raw Inputs | Virtual Peripheral Output |
+| --- | --- | --- |
+| 5 | `sensor.trigger` from producer 1 and 2 | `sensor.combo` with `events` describing both sources |
+| 500 | `button.press` twice from producer 1 | `button.double_tap` with metadata `{gesture: double}` |
+| 800 | Ten `button.press` codes matching Konami sequence | `konami.activated` payload with `sequence` field |
+
+## Risk Analysis
+
+| Risk | Probability | Impact | Mitigation | Early Signals |
+| --- | --- | --- | --- | --- |
+| Playlists leak threads on cancellation | Medium | High | Use `EventPlaylistManager.join()` in shutdown paths and verify `_finalize_run()` always removes run IDs | `event.playlist.stopped` missing after interrupts |
+| Incorrect offsets cause drift between renderers and peripherals | Medium | Medium | Add configuration linting that validates offsets and repeat intervals before deployment | Telemetry shows unexpected `offset` values |
+| Excessive playlist or gesture metadata bloats state store | Low | Medium | Encourage storing lightweight identifiers and defer large payloads to downstream data stores | State snapshot shows large payload sizes |
+| Interrupt storms or gesture flapping starve normal event processing | Low | High | Rate-limit interrupt subscriptions, debounce gestures, or collapse redundant stop events in future revisions | Logs show rapid alternating `created`/`stopped` or gesture bursts |
+| Misconfigured gesture windows miss legitimate inputs | Medium | Medium | Exercise detectors in hardware loops and adjust `window`/`timeout` constants per device | QA sessions report missed combos despite correct input |
+
+### Mitigation Checklist
+
+- [ ] Add monitoring to alert when `event.playlist.stopped` is absent for more than 5 seconds after `created`.
+- [ ] Document recommended offset ranges and repetition limits for playlist authors.
+- [ ] Provide a guideline on metadata payload size (\<1KB) for runtime operators.
+- [ ] Prototype interrupt debouncing if hardware generates high-frequency stop signals.
+- [ ] Publish reference windows and timeout guidance for virtual peripheral authors, including physical input tolerances.
+
+## Outcome Snapshot
+
+When the plan completes, timed behaviours across renderers and peripherals launch via declarative playlists. Lifecycle events feed logging and analytics, interrupts terminate sequences cleanly, and gesture detectors emit higher-level events whenever users double tap, press in unison, or enter command codes. Teams share a consistent API for composing complex reactions without bespoke timers or ad-hoc input parsers.

--- a/docs/research/event_playlists.md
+++ b/docs/research/event_playlists.md
@@ -1,0 +1,63 @@
+# Event Playlist Scheduler
+
+## Problem Statement
+
+Document the new event playlist feature and virtual peripheral aggregators so developers understand how timed sequences and composite gestures of `Input` events can be orchestrated through the core event bus.
+
+## Materials
+
+- `src/heart/peripheral/core/event_bus.py`
+- `tests/peripheral/test_event_bus.py`
+
+## Playlist Abstractions
+
+`EventPlaylist` encapsulates a named sequence of `PlaylistStep` descriptors. Each step declares the target event type, payload, producer, an absolute offset, and optional repetition with a fixed interval. The constructor normalises the immutable shape by coercing the step list to a tuple, the interrupt list to a `frozenset`, and metadata to a `MappingProxyType` for thread-safe read access. Offsets must be non-negative and repeating steps must provide a positive interval to guard against runaway schedulers.【F:src/heart/peripheral/core/event_bus.py†L24-L88】
+
+`PlaylistHandle` is an opaque identifier returned when a definition is registered. Handles remain stable even if the playlist is updated because the manager replaces trigger subscriptions in place. Consumers can store handles in configuration modules or runtime registries without leaking implementation details.【F:src/heart/peripheral/core/event_bus.py†L90-L148】【F:src/heart/peripheral/core/event_bus.py†L150-L197】
+
+## Execution Lifecycle
+
+`EventPlaylistManager` owns registration, trigger wiring, execution, and teardown. The manager hangs off `EventBus.playlists`, allowing existing systems to drive sequences through the shared bus rather than ad-hoc timers. Registration stores the definition before subscribing to its trigger to avoid races where a start event lands before the playlist exists. Updating a playlist reuses the original identifier, unsubscribes the old trigger, and rebinds the new trigger lambda that delegates to `start()`.【F:src/heart/peripheral/core/event_bus.py†L197-L269】
+
+Starting a playlist instantiates an internal `_PlaylistRunner` with a unique run identifier, caches it, and optionally wires interrupt subscriptions. Runners sort steps by offset and execute them on a dedicated daemon thread that honours stop events by checking a shared `threading.Event`. Each emission calls back into the manager so the bus can emit the real `Input`, record telemetry, and publish playlist control events. Once all scheduled steps finish (or a stop request fires), the runner notifies the manager to emit `event.playlist.stopped`, clean up interrupt subscriptions, and optionally send a caller-specified completion event that higher-level modes can observe.【F:src/heart/peripheral/core/event_bus.py†L100-L194】【F:src/heart/peripheral/core/event_bus.py†L269-L374】
+
+## Interrupt Handling
+
+Interrupt events are tracked per run. When a definition declares `interrupt_events`, the manager shares a high-priority subscription for each unique event type. The callback inspects the active runs mapped to that event and signals `runner.stop("interrupted")`. The runner then drops out of its scheduling loop, leading `_finalize_run()` to broadcast a stopped payload that includes the interrupt event metadata so downstream systems can correlate the stoppage.【F:src/heart/peripheral/core/event_bus.py†L297-L333】【F:src/heart/peripheral/core/event_bus.py†L333-L351】
+
+Manual cancellation is exposed through `EventPlaylistManager.stop(run_id)`, while `join()` lets synchronous code wait for completion—useful in tests. Active runs also maintain metadata and trigger context so instrumentation is consistent whether a playlist was started via an upstream event or direct call. Tests assert that manual runs emit three colour updates, publish playlist telemetry, and flag completion metadata, while triggered runs respond to a stop event and expose the triggering payload.【F:src/heart/peripheral/core/event_bus.py†L269-L374】【F:tests/peripheral/test_event_bus.py†L53-L144】
+
+## Observability
+
+Every playlist publishes three core lifecycle events:
+
+- `event.playlist.created` with the playlist metadata, trigger context, and normalised steps.
+- `event.playlist.emitted` after each dispatched `Input`, including the scheduled offset, repeat index, and event payload.
+- `event.playlist.stopped` upon completion, cancellation, or interruption, with the reason and optional interrupt payload.
+
+If a definition supplies `completion_event_type`, the manager emits that custom event when the run finishes successfully. These signals are stored in the shared `StateStore`, enabling downstream renderers or analytics tasks to observe playlists without bespoke plumbing.【F:src/heart/peripheral/core/event_bus.py†L314-L374】
+
+## Virtual Peripheral Manager
+
+Virtual peripherals extend the bus with aggregated gestures. `VirtualPeripheralDefinition` and `VirtualPeripheralHandle` mirror the playlist abstractions, storing immutable metadata and the factory used to construct a detector. Each definition registers to one or more event types and spawns a concrete `_VirtualPeripheral` instance with a `VirtualPeripheralContext`, giving detectors access to the bus, state store, a monotonic clock, and a helper that emits enriched events tagged with the originating virtual peripheral descriptor.【F:src/heart/peripheral/core/event_bus.py†L40-L143】【F:src/heart/peripheral/core/event_bus.py†L551-L653】
+
+`VirtualPeripheralManager` owns registration, updates, and teardown. During `_bind()` it subscribes to each source event type at the requested priority, routing inputs through `_route_event()` so detectors can synchronously process them. `remove()` unsubscribes and calls `shutdown()` on the detector, ensuring gesture-specific caches (for example, pending taps) are cleared. The bus exposes the manager through `EventBus.virtual_peripherals`, letting applications register detectors alongside playlists without wiring their own subscription scaffolding.【F:src/heart/peripheral/core/event_bus.py†L541-L650】【F:src/heart/peripheral/core/event_bus.py†L698-L712】
+
+## Gesture Aggregators
+
+Three reference detectors demonstrate how to compose higher-level gestures:
+
+- `_DoubleTapVirtualPeripheral` tracks the last press per producer and emits when the next press lands within the configured window, returning a payload that lists both raw inputs and the virtual peripheral metadata.【F:src/heart/peripheral/core/event_bus.py†L655-L690】
+- `_SimultaneousVirtualPeripheral` keeps a sliding deque of inputs per event type, collapsing them by producer and emitting once enough distinct sources fire within the window; afterwards it clears the bucket to avoid duplicate notifications.【F:src/heart/peripheral/core/event_bus.py†L692-L732】
+- `_SequenceVirtualPeripheral` steps through a series of `SequenceMatcher` predicates, maintaining per-producer progress and optional timeouts before emitting the completed sequence payload.【F:src/heart/peripheral/core/event_bus.py†L734-L779】
+
+Factory helpers—`double_tap_virtual_peripheral`, `simultaneous_virtual_peripheral`, and `sequence_virtual_peripheral`—package the detectors into reusable definitions. They expose parameters for window durations, output event types, names, and metadata so configuration modules can register gestures declaratively.【F:src/heart/peripheral/core/event_bus.py†L781-L831】
+
+The tests capture expected behaviour: the double-tap detector emits metadata-enriched payloads, the simultaneous detector requires distinct producers inside the 50 ms window, and the sequence detector recognises the Konami code. These assertions ensure the helper factories and manager integration behave as intended.【F:tests/peripheral/test_event_bus.py†L146-L213】
+
+## Future Work
+
+- Add persistence hooks so playlists can be described in configuration files and loaded at runtime.
+- Extend `_PlaylistRunner` to support dynamic tempo changes by listening to control events that adjust offsets mid-run.
+- Provide tooling for introspecting `list_definitions()` and visualising active runs in the debugging UI.
+- Surface built-in gesture definitions through configuration schemas so applications can declare complex inputs without bespoke factories.

--- a/tests/peripheral/test_event_bus.py
+++ b/tests/peripheral/test_event_bus.py
@@ -1,7 +1,16 @@
+import threading
+import time
+
 import pytest
 
 from heart.peripheral.core import Input
-from heart.peripheral.core.event_bus import EventBus
+from heart.peripheral.core.event_bus import (EventBus, EventPlaylist,
+                                             EventPlaylistManager,
+                                             PlaylistHandle, PlaylistStep,
+                                             SequenceMatcher,
+                                             double_tap_virtual_peripheral,
+                                             sequence_virtual_peripheral,
+                                             simultaneous_virtual_peripheral)
 
 
 def test_emit_orders_callbacks_by_priority_then_fifo():
@@ -63,3 +72,243 @@ def test_emit_updates_state_store_before_callbacks():
     bus.emit("button", data={"pressed": True}, producer_id=2)
 
     assert observed == [2]
+
+
+def test_playlist_manual_start_runs_to_completion() -> None:
+    bus = EventBus()
+    emitted_values: list[int] = []
+    playlist_events: list[dict] = []
+    stops: list[dict] = []
+    completions: list[dict] = []
+
+    bus.subscribe(
+        "color.update",
+        lambda event: emitted_values.append(event.data["value"]),
+    )
+    bus.subscribe(
+        EventPlaylistManager.EVENT_EMITTED,
+        lambda event: playlist_events.append(event.data),
+    )
+    bus.subscribe(
+        EventPlaylistManager.EVENT_STOPPED,
+        lambda event: stops.append(event.data),
+    )
+
+    playlist = EventPlaylist(
+        name="cycle",
+        steps=[
+            PlaylistStep(
+                event_type="color.update",
+                data={"value": 7},
+                offset=0.0,
+                repeat=3,
+                interval=0.01,
+                producer_id=5,
+            )
+        ],
+        completion_event_type="color.cycle.complete",
+        metadata={"mode": "test"},
+    )
+    handle: PlaylistHandle = bus.playlists.register(playlist)
+
+    bus.subscribe(
+        "color.cycle.complete",
+        lambda event: completions.append(event.data),
+    )
+
+    run_id = bus.playlists.start(handle)
+    assert bus.playlists.join(run_id, timeout=1.0)
+
+    assert emitted_values == [7, 7, 7]
+    assert [item["repeat_index"] for item in playlist_events] == [0, 1, 2]
+    assert all(item["data"] == {"value": 7} for item in playlist_events)
+    assert stops and stops[0]["reason"] == "completed"
+    assert stops[0]["playlist_metadata"] == {"mode": "test"}
+    assert completions and completions[0]["playlist_id"] == run_id
+    assert completions[0]["playlist_metadata"] == {"mode": "test"}
+
+
+def test_playlist_trigger_interrupted_by_event() -> None:
+    bus = EventBus()
+    created_events: list[dict] = []
+    emitted_events: list[dict] = []
+    stop_events: list[dict] = []
+
+    created_ready = threading.Event()
+    emitted_twice = threading.Event()
+
+    bus.subscribe(
+        EventPlaylistManager.EVENT_CREATED,
+        lambda event: (created_events.append(event.data), created_ready.set()),
+    )
+    bus.subscribe(
+        EventPlaylistManager.EVENT_EMITTED,
+        lambda event: (
+            emitted_events.append(event.data),
+            emitted_twice.set()
+            if len(emitted_events) >= 2
+            else None,
+        ),
+    )
+    bus.subscribe(
+        EventPlaylistManager.EVENT_STOPPED,
+        lambda event: stop_events.append(event.data),
+    )
+
+    playlist = EventPlaylist(
+        name="interruptible",
+        steps=[
+            PlaylistStep(
+                event_type="color.update",
+                data={"value": 1},
+                offset=0.0,
+                repeat=10,
+                interval=0.05,
+            )
+        ],
+        trigger_event_type="start.sequence",
+        interrupt_events=("stop.sequence",),
+        metadata={"mode": "interrupt"},
+    )
+    bus.playlists.register(playlist)
+
+    bus.emit("start.sequence", data={"begin": True})
+    assert created_ready.wait(timeout=1.0)
+    run_id = created_events[0]["playlist_id"]
+
+    # Wait for at least two emissions before interrupting.
+    assert emitted_twice.wait(timeout=1.0)
+    bus.emit("stop.sequence", data={"reason": "test"})
+
+    assert bus.playlists.join(run_id, timeout=1.0)
+
+    assert stop_events and stop_events[0]["reason"] == "interrupted"
+    interrupt_data = stop_events[0]["interrupt_event"]
+    assert interrupt_data["event_type"] == "stop.sequence"
+    assert interrupt_data["data"] == {"reason": "test"}
+    assert created_events[0]["trigger_event"]["data"] == {"begin": True}
+    assert created_events[0]["playlist_metadata"] == {"mode": "interrupt"}
+    assert emitted_events
+    assert len(emitted_events) < 10
+
+
+def test_virtual_double_tap_emits_enriched_payload() -> None:
+    bus = EventBus()
+    captured: list[dict] = []
+
+    definition = double_tap_virtual_peripheral(
+        "button.press",
+        output_event_type="button.double_tap",
+        window=0.5,
+        metadata={"gesture": "double"},
+    )
+    bus.virtual_peripherals.register(definition)
+
+    bus.subscribe(
+        "button.double_tap",
+        lambda event: captured.append(event.data),
+    )
+
+    bus.emit("button.press", data={"state": "down"}, producer_id=1)
+    bus.emit("button.press", data={"state": "down"}, producer_id=1)
+
+    assert captured
+    payload = captured[0]
+    assert payload["virtual_peripheral"]["name"] == definition.name
+    assert payload["virtual_peripheral"]["metadata"] == {"gesture": "double"}
+    assert [item["data"] for item in payload["events"]] == [
+        {"state": "down"},
+        {"state": "down"},
+    ]
+
+    captured.clear()
+    time.sleep(0.6)
+    bus.emit("button.press", data={"state": "down"}, producer_id=1)
+    time.sleep(0.6)
+    bus.emit("button.press", data={"state": "down"}, producer_id=1)
+    assert not captured
+
+
+def test_virtual_simultaneous_detector_requires_distinct_producers() -> None:
+    bus = EventBus()
+    detected: list[dict] = []
+
+    bus.virtual_peripherals.register(
+        simultaneous_virtual_peripheral(
+            "sensor.trigger",
+            output_event_type="sensor.combo",
+            window=0.05,
+            required_sources=2,
+        )
+    )
+
+    bus.subscribe("sensor.combo", lambda event: detected.append(event.data))
+
+    bus.emit("sensor.trigger", data={"value": 1}, producer_id=1)
+    time.sleep(0.005)
+    bus.emit("sensor.trigger", data={"value": 2}, producer_id=2)
+
+    assert detected
+    payload = detected[0]
+    producers = {item["producer_id"] for item in payload["events"]}
+    assert producers == {1, 2}
+
+    detected.clear()
+    time.sleep(0.06)
+    bus.emit("sensor.trigger", data={"value": 3}, producer_id=1)
+    bus.emit("sensor.trigger", data={"value": 4}, producer_id=1)
+    assert not detected
+
+
+def test_sequence_virtual_peripheral_detects_konami_code() -> None:
+    bus = EventBus()
+    detected: list[dict] = []
+
+    konami = [
+        "up",
+        "up",
+        "down",
+        "down",
+        "left",
+        "right",
+        "left",
+        "right",
+        "b",
+        "a",
+    ]
+
+    matchers = [
+        SequenceMatcher(
+            "button.press",
+            predicate=lambda event, expected=direction: event.data["code"]
+            == expected,
+        )
+        for direction in konami
+    ]
+
+    definition = sequence_virtual_peripheral(
+        name="konami.listener",
+        matchers=matchers,
+        output_event_type="konami.activated",
+        timeout=1.0,
+        metadata={"combo": "konami"},
+    )
+    bus.virtual_peripherals.register(definition)
+
+    bus.subscribe(
+        "konami.activated",
+        lambda event: detected.append(event.data),
+    )
+
+    bus.emit("button.press", data={"code": "up"}, producer_id=7)
+    bus.emit("button.press", data={"code": "left"}, producer_id=7)
+    assert not detected
+
+    for direction in konami:
+        bus.emit("button.press", data={"code": direction}, producer_id=7)
+
+    assert detected
+    payload = detected[0]
+    assert payload["virtual_peripheral"]["name"] == "konami.listener"
+    assert payload["virtual_peripheral"]["metadata"] == {"combo": "konami"}
+    assert [item["data"]["code"] for item in payload["sequence"]] == konami


### PR DESCRIPTION
## Summary
- extend the event bus with virtual peripheral definitions, context, and manager support for registering aggregated gesture detectors
- provide reusable double tap, simultaneous, and sequence helper factories with tests covering the emitted metadata payloads
- update the planning and research docs to outline the playlist plus virtual peripheral rollout and architecture

## Testing
- `make test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e05f50b2c83219c4cb638795af9af)