### PR TITLE
Register pytest timeout mark

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,9 @@ follow_imports = "skip"
 pythonpath = ["src"]
 testpaths = ["tests"]
 addopts = "-vv -n auto --dist=loadscope"
+markers = [
+    "timeout(duration): mark tests that should fail if they exceed the given duration",
+]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary
- register the pytest timeout marker so the integration test can use it without warnings

## Testing
- make format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e155435fc83219bcd8a70d0b204b7)