### PR TITLE
Ensure CI runs make format before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,11 @@ jobs:
       - name: Install the project
         run: make install
 
-      - name: Run formatting checks
-        run: make check
+      - name: Run formatting
+        run: make format
+
+      - name: Ensure no formatting changes
+        run: git diff --exit-code
 
       - name: Run tests
         run: make test


### PR DESCRIPTION
## Summary
- update the CI workflow to execute `make format`
- ensure formatting leaves no diff before running tests

## Testing
- make format
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e1530fe788321812c6d6a4c5955eb)