### PR TITLE
Handle pygame events without payload dictionaries

### DIFF
--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -4,6 +4,7 @@ import enum
 import importlib
 import time
 from collections import OrderedDict
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from types import ModuleType
 from typing import TYPE_CHECKING
@@ -709,7 +710,18 @@ class GameLoop:
         return f"pygame/{slug}"
 
     def _resolve_event_payload(self, event: pygame.event.Event) -> dict[str, object]:
-        payload = dict(getattr(event, "dict", {}))
+        raw_payload = getattr(event, "dict", None)
+
+        if isinstance(raw_payload, Mapping):
+            payload: dict[str, object] = dict(raw_payload)
+        elif raw_payload is None:
+            payload = {}
+        else:
+            try:
+                payload = dict(raw_payload)
+            except TypeError:
+                payload = {"value": raw_payload}
+
         payload["pygame_type"] = event.type
         payload["pygame_event_name"] = pygame.event.event_name(event.type)
         return payload

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -82,3 +82,23 @@ def test_handle_events_emits_custom_system_event(loop: GameLoop, monkeypatch) ->
 
     assert calls == {"quit": 1, "init": 1}
     assert captured == [joystick_reset]
+
+
+def test_handle_events_supports_missing_event_payload(loop: GameLoop, monkeypatch) -> None:
+    captured: list[dict[str, object]] = []
+
+    loop.event_bus.subscribe(
+        "pygame/noevent", lambda evt: captured.append(evt.data)
+    )
+
+    fake_event = types.SimpleNamespace(type=pygame.NOEVENT, dict=None)
+    monkeypatch.setattr(pygame.event, "get", lambda: [fake_event])
+
+    loop._handle_events()
+
+    assert captured == [
+        {
+            "pygame_type": pygame.NOEVENT,
+            "pygame_event_name": pygame.event.event_name(pygame.NOEVENT),
+        }
+    ]


### PR DESCRIPTION
## Summary
- gracefully normalize pygame events that provide no payload dictionary
- add a regression test covering events without payload data on the GameLoop event bus

## Testing
- make format
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ec6fe9afc8321a8589b924d0f23eb)