### PR TITLE
Handle missing adafruit_ble dependency

### DIFF
--- a/src/heart/firmware_io/bluetooth.py
+++ b/src/heart/firmware_io/bluetooth.py
@@ -1,10 +1,33 @@
-from adafruit_ble import BLERadio
-from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
-from adafruit_ble.services.nordic import UARTService
+from __future__ import annotations
 
-ble = BLERadio()
-uart = UARTService()
-advertisement = ProvideServicesAdvertisement(uart)
+import importlib
+
+if importlib.util.find_spec("adafruit_ble") is not None:
+    from adafruit_ble import BLERadio
+    from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
+    from adafruit_ble.services.nordic import UARTService
+else:
+    BLERadio = None  # type: ignore[assignment]
+    ProvideServicesAdvertisement = None  # type: ignore[assignment]
+    UARTService = None  # type: ignore[assignment]
+
+
+if BLERadio is not None and UARTService is not None and ProvideServicesAdvertisement is not None:
+    ble = BLERadio()
+    uart = UARTService()
+    advertisement = ProvideServicesAdvertisement(uart)
+else:
+    ble = None
+    uart = None
+    advertisement = None
+
+
+def _require_ble_dependencies() -> None:
+    if ble is None or uart is None:
+        raise ModuleNotFoundError(
+            "adafruit_ble is required to use heart.firmware_io.bluetooth. "
+            "Install the CircuitPython BLE libraries to enable Bluetooth communication."
+        )
 
 END_OF_MESSAGE_DELIMETER = "\n"
 ENCODING = "utf-8"
@@ -12,7 +35,14 @@ ENCODING = "utf-8"
 
 # TODO: AAddDd a bulk write command
 def send(messages: list[str]):
+    _require_ble_dependencies()
+
     if not ble.advertising:
+        if advertisement is None:
+            raise ModuleNotFoundError(
+                "ProvideServicesAdvertisement is unavailable. "
+                "Install the adafruit_ble package to advertise over BLE."
+            )
         ble.start_advertising(advertisement)
 
     if ble.connected:


### PR DESCRIPTION
## Summary
- guard the bluetooth firmware I/O module when the optional `adafruit_ble` package is unavailable
- provide informative errors and keep the tests able to monkeypatch BLE primitives

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f56f43b688321bd7b220eecd77eda)