### PR TITLE
Add compass peripheral and magnetometer events

### DIFF
--- a/drivers/sensor_bus/code.py
+++ b/drivers/sensor_bus/code.py
@@ -134,11 +134,11 @@ class SensorReader:
                     self._last_gyro = gyro
                     yield form_tuple_payload(constants.GYROSCOPE, gyro)
 
-            # if hasattr(sensor, "magnetic"):
-            #     mag = sensor.magnetic
-            #     if self._changed_enough(mag, self._last_mag, self.min_change):
-            #         self._last_mag = mag
-            #         yield form_tuple_payload(constants.MAGNETIC, mag)
+            if hasattr(sensor, "magnetic"):
+                mag = sensor.magnetic
+                if self._changed_enough(mag, self._last_mag, self.min_change):
+                    self._last_mag = mag
+                    yield form_tuple_payload(constants.MAGNETIC, mag)
 
     def _changed_enough(self, new: tuple, old: tuple | None, min_change: float) -> bool:
         """Return *True* if any axis differs by more than *min_change*."""

--- a/src/heart/events/types.py
+++ b/src/heart/events/types.py
@@ -176,6 +176,26 @@ class AccelerometerVector(InputEventPayload):
 
 
 @dataclass(frozen=True, slots=True)
+class MagnetometerVector(InputEventPayload):
+    """Three-axis magnetic field sample from the sensor bus."""
+
+    x: float
+    y: float
+    z: float
+
+    EVENT_TYPE: ClassVar[str] = "peripheral.magnetometer.vector"
+    event_type: str = EVENT_TYPE
+
+    def to_input(self, *, producer_id: int = 0, timestamp: datetime | None = None) -> Input:
+        return Input(
+            event_type=self.event_type,
+            data={"x": float(self.x), "y": float(self.y), "z": float(self.z)},
+            producer_id=producer_id,
+            timestamp=_normalize_timestamp(timestamp),
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class PhoneTextMessage(InputEventPayload):
     """Represents a BLE text payload received by the phone-text peripheral."""
 
@@ -195,6 +215,7 @@ class PhoneTextMessage(InputEventPayload):
 
 __all__ = [
     "AccelerometerVector",
+    "MagnetometerVector",
     "HeartRateLifecycle",
     "HeartRateMeasurement",
     "InputEventPayload",

--- a/src/heart/peripheral/compass.py
+++ b/src/heart/peripheral/compass.py
@@ -1,0 +1,119 @@
+"""Compass peripheral that derives heading from magnetometer vectors."""
+
+from __future__ import annotations
+
+import math
+import threading
+from collections import deque
+from collections.abc import Iterator
+from typing import Deque, Mapping, Self
+
+from heart.events.types import MagnetometerVector
+from heart.peripheral.core import Input, Peripheral
+from heart.peripheral.core.event_bus import EventBus
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+Vector3 = tuple[float, float, float]
+
+
+class Compass(Peripheral):
+    """Maintain a smoothed magnetic heading derived from sensor bus events."""
+
+    def __init__(
+        self,
+        *,
+        window_size: int = 5,
+        event_bus: EventBus | None = None,
+    ) -> None:
+        if window_size < 1:
+            raise ValueError("window_size must be at least one")
+
+        super().__init__()
+        self._window_size = window_size
+        self._history: Deque[Vector3] = deque(maxlen=window_size)
+        self._latest: Vector3 | None = None
+        self._lock = threading.Lock()
+
+        if event_bus is not None:
+            self.attach_event_bus(event_bus)
+
+    # ------------------------------------------------------------------
+    # Peripheral API
+    # ------------------------------------------------------------------
+    def run(self) -> None:  # pragma: no cover - no active loop required
+        """Compass reacts to event bus updates; no background loop needed."""
+
+    @classmethod
+    def detect(cls) -> Iterator[Self]:
+        """Always expose a single compass peripheral."""
+
+        yield cls()
+
+    # ------------------------------------------------------------------
+    # Event bus integration
+    # ------------------------------------------------------------------
+    def on_event_bus_attached(self, event_bus: EventBus) -> None:
+        self.subscribe_event(MagnetometerVector.EVENT_TYPE, self._handle_magnetometer)
+
+    def _handle_magnetometer(self, event: Input) -> None:
+        payload = event.data
+        if not isinstance(payload, Mapping):
+            logger.debug("Ignoring non-mapping magnetometer payload: %s", payload)
+            return
+
+        try:
+            vector = (
+                float(payload["x"]),
+                float(payload["y"]),
+                float(payload["z"]),
+            )
+        except (KeyError, TypeError, ValueError):
+            logger.debug("Magnetometer payload missing axis components: %s", payload)
+            return
+
+        with self._lock:
+            self._latest = vector
+            self._history.append(vector)
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+    def get_latest_vector(self) -> Vector3 | None:
+        """Return the most recent magnetic field sample."""
+
+        with self._lock:
+            return self._latest
+
+    def get_average_vector(self) -> Vector3 | None:
+        """Return the rolling average vector across the smoothing window."""
+
+        with self._lock:
+            if not self._history:
+                return None
+            count = len(self._history)
+            x = sum(vector[0] for vector in self._history) / count
+            y = sum(vector[1] for vector in self._history) / count
+            z = sum(vector[2] for vector in self._history) / count
+            return (x, y, z)
+
+    def get_heading_degrees(self) -> float | None:
+        """Return the smoothed magnetic heading in degrees clockwise from north."""
+
+        vector = self.get_average_vector()
+        if vector is None:
+            return None
+
+        x, y, _ = vector
+        if math.isclose(x, 0.0, abs_tol=1e-9) and math.isclose(y, 0.0, abs_tol=1e-9):
+            return None
+
+        heading = math.degrees(math.atan2(x, y))
+        if heading < 0:
+            heading += 360.0
+        return heading
+
+    @property
+    def window_size(self) -> int:
+        return self._window_size

--- a/src/heart/peripheral/core/__init__.py
+++ b/src/heart/peripheral/core/__init__.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 import abc
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Iterator, Mapping, Self
 
 if TYPE_CHECKING:  # pragma: no cover - import-time convenience
+    from .event_bus import EventBus, SubscriptionHandle
     from .state_store import StateEntry, StateSnapshot, StateStore
 
 __all__ = ["Input", "Peripheral", "StateEntry", "StateSnapshot", "StateStore"]
@@ -25,9 +29,18 @@ class Peripheral(abc.ABC):
 
     _logger = logging.getLogger(__name__)
 
+    def __init__(self) -> None:
+        self._event_bus: EventBus | None = None
+        self._event_bus_subscriptions: list[SubscriptionHandle] = []
+
     @abc.abstractmethod
     def run(self) -> None:
         """Start the peripheral's processing loop."""
+
+    @property
+    def event_bus(self) -> EventBus | None:
+        self._ensure_event_bus_storage()
+        return self._event_bus
 
     @classmethod
     def detect(cls) -> Iterator[Self]:
@@ -59,6 +72,106 @@ class Peripheral(abc.ABC):
             self._logger.debug(
                 "Ignoring malformed peripheral payload: %s", data, exc_info=True
             )
+
+    # ------------------------------------------------------------------
+    # Event bus integration
+    # ------------------------------------------------------------------
+    def attach_event_bus(self, event_bus: EventBus) -> None:
+        """Attach ``event_bus`` so the peripheral can participate in pub/sub."""
+
+        self._ensure_event_bus_storage()
+        if self._event_bus is event_bus:
+            return
+
+        if self._event_bus is not None:
+            self._unsubscribe_all()
+
+        self._event_bus = event_bus
+        self._event_bus_subscriptions = []
+        try:
+            self.on_event_bus_attached(event_bus)
+        except Exception:
+            self._logger.exception(
+                "Peripheral %s failed to attach to event bus", type(self).__name__
+            )
+
+    def detach_event_bus(self) -> None:
+        """Remove the current event bus, if any, and unsubscribe callbacks."""
+
+        self._ensure_event_bus_storage()
+        if self._event_bus is None:
+            return
+        self._unsubscribe_all()
+        self._event_bus = None
+
+    def on_event_bus_attached(self, event_bus: EventBus) -> None:  # noqa: D401
+        """Hook for subclasses to register event handlers."""
+
+    def subscribe_event(
+        self,
+        event_type: str | None,
+        callback: Callable[[Input], None],
+        *,
+        priority: int = 0,
+    ) -> SubscriptionHandle:
+        """Register ``callback`` for ``event_type`` and track the subscription."""
+
+        bus = self._require_event_bus()
+        handle = bus.subscribe(event_type, callback, priority=priority)
+        self._event_bus_subscriptions.append(handle)
+        return handle
+
+    def emit_input(self, input_event: Input) -> None:
+        """Publish ``input_event`` on the attached event bus, if present."""
+
+        bus = self.event_bus
+        if bus is None:
+            self._logger.debug(
+                "Peripheral %s dropped event %s due to missing bus",
+                type(self).__name__,
+                input_event.event_type,
+            )
+            return
+        bus.emit(input_event)
+
+    def emit_event(self, event_type: str, data: Any, *, producer_id: int = 0) -> None:
+        """Publish a payload as an :class:`Input` if an event bus is attached."""
+
+        bus = self.event_bus
+        if bus is None:
+            self._logger.debug(
+                "Peripheral %s dropped payload %s due to missing bus",
+                type(self).__name__,
+                event_type,
+            )
+            return
+        bus.emit(event_type, data, producer_id=producer_id)
+
+    def _ensure_event_bus_storage(self) -> None:
+        if not hasattr(self, "_event_bus_subscriptions"):
+            self._event_bus_subscriptions = []
+        if not hasattr(self, "_event_bus"):
+            self._event_bus = None
+
+    def _unsubscribe_all(self) -> None:
+        bus = self._event_bus
+        if bus is None:
+            self._event_bus_subscriptions = []
+            return
+        for handle in list(self._event_bus_subscriptions):
+            try:
+                bus.unsubscribe(handle)
+            except Exception:
+                self._logger.exception(
+                    "Failed to unsubscribe %s from event bus", handle.callback
+                )
+        self._event_bus_subscriptions = []
+
+    def _require_event_bus(self) -> EventBus:
+        bus = self.event_bus
+        if bus is None:
+            raise RuntimeError("Peripheral has no event bus attached")
+        return bus
 
 
 def __getattr__(name: str):

--- a/src/heart/peripheral/core/manager.py
+++ b/src/heart/peripheral/core/manager.py
@@ -2,6 +2,7 @@ import itertools
 import threading
 from typing import Iterable, Iterator
 
+from heart.peripheral.compass import Compass
 from heart.peripheral.core import Peripheral
 from heart.peripheral.core.event_bus import EventBus
 from heart.peripheral.drawing_pad import DrawingPad
@@ -112,7 +113,7 @@ class PeripheralManager:
         yield from itertools.chain(PhoneText.detect())
 
     def _detect_sensors(self) -> Iterator[Peripheral]:
-        yield from itertools.chain(Accelerometer.detect())
+        yield from itertools.chain(Accelerometer.detect(), Compass.detect())
 
     def _detect_gamepads(self) -> Iterator[Peripheral]:
         yield from itertools.chain(Gamepad.detect())

--- a/src/heart/peripheral/heart_rates.py
+++ b/src/heart/peripheral/heart_rates.py
@@ -62,6 +62,7 @@ class HeartRateManager(Peripheral):
     """Continuously scans for ANT+ HR straps and publishes measurements."""
 
     def __init__(self, *, event_bus: EventBus | None = None) -> None:
+        super().__init__()
         self._node: Optional[Node] = None
         self._scanner: Optional[Scanner] = None
         self._devices: List[HeartRate] = []
@@ -73,8 +74,10 @@ class HeartRateManager(Peripheral):
         )
         self._janitor.start()
 
-        self._event_bus = event_bus
         self._lifecycle_status: Dict[str, str] = {}
+
+        if event_bus is not None:
+            self.attach_event_bus(event_bus)
 
     # ---------- Peripheral framework ----------
 
@@ -85,7 +88,7 @@ class HeartRateManager(Peripheral):
     def attach_event_bus(self, event_bus: EventBus) -> None:
         """Attach the shared input event bus for publishing samples."""
 
-        self._event_bus = event_bus
+        super().attach_event_bus(event_bus)
 
     # ---------- Callbacks -----------------------------------------------------
 
@@ -173,7 +176,7 @@ class HeartRateManager(Peripheral):
     # ---------- Event bus helpers -------------------------------------------
 
     def _publish_measurement(self, device_id: str, data: HeartRateData) -> None:
-        event_bus = self._event_bus
+        event_bus = self.event_bus
         if event_bus is None:
             return
 
@@ -196,7 +199,7 @@ class HeartRateManager(Peripheral):
     def _emit_lifecycle(
         self, device_id: str, status: str, detail: Dict[str, float] | None = None
     ) -> None:
-        event_bus = self._event_bus
+        event_bus = self.event_bus
         if event_bus is None:
             return
 

--- a/src/heart/peripheral/phone_text.py
+++ b/src/heart/peripheral/phone_text.py
@@ -42,12 +42,14 @@ class PhoneText(Peripheral):
 
     def __init__(self, *, event_bus: EventBus | None = None, producer_id: int | None = None) -> None:
         """Create a new *PhoneText* peripheral."""
+        super().__init__()
         self._last_text: str | None = None  # full text as received
         self.new_text = False
         self._buffer = bytearray()  # assembly buffer for chunks
-        self._event_bus = event_bus
         self._producer_id = producer_id if producer_id is not None else id(self)
-        super().__init__()
+
+        if event_bus is not None:
+            self.attach_event_bus(event_bus)
 
     # ---------------------------------------------------------------------
     # Peripheral API
@@ -108,7 +110,7 @@ class PhoneText(Peripheral):
         return text
 
     def attach_event_bus(self, event_bus: EventBus) -> None:
-        self._event_bus = event_bus
+        super().attach_event_bus(event_bus)
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -140,7 +142,7 @@ class PhoneText(Peripheral):
             self._buffer.clear()
 
     def _emit_text_event(self, text: str) -> None:
-        event_bus = self._event_bus
+        event_bus = self.event_bus
         if event_bus is None:
             return
         message = PhoneTextMessage(text=text).to_input(producer_id=self._producer_id)

--- a/src/heart/peripheral/phyphox.py
+++ b/src/heart/peripheral/phyphox.py
@@ -9,6 +9,7 @@ from heart.peripheral.sensor import Acceleration
 
 class Phyphox(Peripheral):
     def __init__(self, url: str) -> None:
+        super().__init__()
         self.url = url
         self.acc_x: float | None = None
         self.acc_y: float | None = None

--- a/tests/peripheral/test_accelerometer_event_bus.py
+++ b/tests/peripheral/test_accelerometer_event_bus.py
@@ -1,6 +1,6 @@
 import pytest
 
-from heart.events.types import AccelerometerVector
+from heart.events.types import AccelerometerVector, MagnetometerVector
 from heart.peripheral.core.event_bus import EventBus
 from heart.peripheral.sensor import Accelerometer
 
@@ -29,3 +29,28 @@ def test_accelerometer_emits_vector(event_type: str) -> None:
     assert vector.x == pytest.approx(1.0)
     assert vector.y == pytest.approx(-2.5)
     assert vector.z == pytest.approx(0.5)
+
+
+def test_accelerometer_emits_magnetometer_vector() -> None:
+    bus = EventBus()
+    captured: list[MagnetometerVector] = []
+
+    def _capture(event):
+        captured.append(
+            MagnetometerVector(
+                x=event.data["x"], y=event.data["y"], z=event.data["z"]
+            )
+        )
+
+    bus.subscribe(MagnetometerVector.EVENT_TYPE, _capture)
+    accel = Accelerometer(port="/dev/null", baudrate=9600, event_bus=bus, producer_id=7)
+
+    accel._update_due_to_data(
+        {"event_type": "sensor.magnetic", "data": {"x": -30.0, "y": 12.0, "z": 4.0}}
+    )
+
+    assert captured
+    vector = captured[0]
+    assert vector.x == pytest.approx(-30.0)
+    assert vector.y == pytest.approx(12.0)
+    assert vector.z == pytest.approx(4.0)

--- a/tests/peripheral/test_compass.py
+++ b/tests/peripheral/test_compass.py
@@ -1,0 +1,49 @@
+import pytest
+
+from heart.events.types import MagnetometerVector
+from heart.peripheral.compass import Compass
+from heart.peripheral.core.event_bus import EventBus
+
+
+def _emit_vector(bus: EventBus, vector: MagnetometerVector) -> None:
+    bus.emit(vector.to_input(producer_id=0))
+
+
+def test_compass_tracks_latest_vector() -> None:
+    bus = EventBus()
+    compass = Compass(window_size=3)
+    compass.attach_event_bus(bus)
+
+    sample = MagnetometerVector(x=12.0, y=-5.0, z=1.5)
+    _emit_vector(bus, sample)
+
+    vector = compass.get_latest_vector()
+    assert vector is not None
+    assert vector[0] == pytest.approx(12.0)
+    assert vector[1] == pytest.approx(-5.0)
+    assert vector[2] == pytest.approx(1.5)
+
+
+def test_compass_heading_uses_smoothed_average() -> None:
+    bus = EventBus()
+    compass = Compass(window_size=2)
+    compass.attach_event_bus(bus)
+
+    _emit_vector(bus, MagnetometerVector(x=0.0, y=1.0, z=0.0))
+    assert compass.get_heading_degrees() == pytest.approx(0.0)
+
+    _emit_vector(bus, MagnetometerVector(x=1.0, y=0.0, z=0.0))
+    assert compass.get_heading_degrees() == pytest.approx(45.0)
+
+
+def test_compass_returns_none_for_empty_or_zero_vectors() -> None:
+    compass = Compass(window_size=4)
+
+    assert compass.get_heading_degrees() is None
+    assert compass.get_average_vector() is None
+
+    bus = EventBus()
+    compass.attach_event_bus(bus)
+    _emit_vector(bus, MagnetometerVector(x=0.0, y=0.0, z=0.0))
+
+    assert compass.get_heading_degrees() is None


### PR DESCRIPTION
## Summary
- re-enable LIS2MDL magnetometer payloads on the sensor bus and surface the readings as MagnetometerVector events
- extend the Peripheral event-bus plumbing so hardware readers can forward data and update existing peripherals to use the shared helpers
- add a Compass peripheral that smooths magnetic vectors, exposes heading helpers, and is covered by unit tests

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f5c004a3c83219b8bd09a8e0a2113)