### PR TITLE
Add missing runtime dependencies for peripherals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ dependencies = [
     "typer-slim",
     "PyOpenGL>=3.1.0",
     "moderngl",
+    "sounddevice",
+    "paho-mqtt",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add the sounddevice and paho-mqtt packages to the project dependencies so audio capture and MQTT sidecar features install correctly

## Testing
- `make test` *(fails: network access to PyPI is blocked in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f5e2c42b08321addb4efcf7b74661)