### PR TITLE
Add LED matrix peripheral to publish rendered frames

### DIFF
--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -22,6 +22,7 @@ from heart.peripheral.core import events
 from heart.peripheral.core.event_bus import EventBus
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.heart_rates import current_bpms
+from heart.peripheral.led_matrix import LEDMatrixDisplay
 from heart.utilities.env import Configuration
 from heart.utilities.logging import get_logger
 
@@ -266,6 +267,7 @@ class GameLoop:
         render_variant: RendererVariant = RendererVariant.ITERATIVE,
         *,
         event_bus: EventBus | None = None,
+        display_peripheral: LEDMatrixDisplay | None = None,
     ) -> None:
         self.initalized = False
         self.device = device
@@ -315,6 +317,14 @@ class GameLoop:
             self._event_bus, propagate=propagate_bus
         )
 
+        width, height = self.device.full_display_size()
+        self._display_peripheral = display_peripheral or LEDMatrixDisplay(
+            width=width,
+            height=height,
+        )
+        self._display_peripheral.attach_event_bus(self._event_bus)
+        self.peripheral_manager.register(self._display_peripheral)
+
         pygame.display.set_mode(
             (
                 device.full_display_size()[0] * device.scale_factor,
@@ -348,6 +358,10 @@ class GameLoop:
     @property
     def event_bus(self) -> EventBus:
         return self._event_bus
+
+    @property
+    def display_peripheral(self) -> LEDMatrixDisplay:
+        return self._display_peripheral
 
     def latest_input(
         self, event_type: str, *, producer_id: int | None = None
@@ -674,6 +688,7 @@ class GameLoop:
             image = np.transpose(image, (1, 0, 2))
             image = Image.fromarray(image)
             self.device.set_image(image)
+            self._display_peripheral.publish_image(image)
 
     def _handle_events(self) -> None:
         try:

--- a/src/heart/events/types.py
+++ b/src/heart/events/types.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import (Any, ClassVar, Mapping, MutableMapping, Protocol,
-                    runtime_checkable)
+from types import MappingProxyType
+from typing import (TYPE_CHECKING, Any, ClassVar, Mapping, MutableMapping,
+                    Protocol, runtime_checkable)
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checking only
+    from PIL import Image
 
 from heart.firmware_io.constants import (BUTTON_LONG_PRESS, BUTTON_PRESS,
                                          SWITCH_ROTATION)
@@ -193,8 +197,66 @@ class PhoneTextMessage(InputEventPayload):
         )
 
 
+@dataclass(frozen=True, slots=True)
+class DisplayFrame(InputEventPayload):
+    """Raw image payload emitted by the LED matrix peripheral."""
+
+    frame_id: int
+    width: int
+    height: int
+    mode: str
+    data: bytes
+    metadata: Mapping[str, Any] | None = None
+
+    EVENT_TYPE: ClassVar[str] = "peripheral.display.frame"
+    event_type: str = EVENT_TYPE
+
+    def __post_init__(self) -> None:
+        if self.width <= 0 or self.height <= 0:
+            raise ValueError("DisplayFrame dimensions must be positive")
+        if self.metadata is not None and not isinstance(self.metadata, Mapping):
+            raise TypeError("DisplayFrame metadata must be a mapping when provided")
+        if self.metadata is not None:
+            object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
+
+    @classmethod
+    def from_image(
+        cls,
+        image: Image.Image,
+        *,
+        frame_id: int,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> "DisplayFrame":
+        from PIL import Image
+
+        if not isinstance(image, Image.Image):
+            raise TypeError("image must be a PIL.Image.Image instance")
+        return cls(
+            frame_id=frame_id,
+            width=image.width,
+            height=image.height,
+            mode=image.mode,
+            data=image.tobytes(),
+            metadata=metadata,
+        )
+
+    def to_image(self) -> Image.Image:
+        from PIL import Image
+
+        return Image.frombytes(self.mode, (self.width, self.height), self.data)
+
+    def to_input(self, *, producer_id: int = 0, timestamp: datetime | None = None) -> Input:
+        return Input(
+            event_type=self.event_type,
+            data=self,
+            producer_id=producer_id,
+            timestamp=_normalize_timestamp(timestamp),
+        )
+
+
 __all__ = [
     "AccelerometerVector",
+    "DisplayFrame",
     "HeartRateLifecycle",
     "HeartRateMeasurement",
     "InputEventPayload",

--- a/src/heart/peripheral/core/manager.py
+++ b/src/heart/peripheral/core/manager.py
@@ -7,6 +7,7 @@ from heart.peripheral.core.event_bus import EventBus
 from heart.peripheral.drawing_pad import DrawingPad
 from heart.peripheral.gamepad import Gamepad
 from heart.peripheral.heart_rates import HeartRateManager
+from heart.peripheral.led_matrix import LEDMatrixDisplay
 from heart.peripheral.microphone import Microphone
 from heart.peripheral.phone_text import PhoneText
 from heart.peripheral.phyphox import Phyphox
@@ -59,6 +60,11 @@ class PeripheralManager:
     def detect(self) -> None:
         for peripheral in self._iter_detected_peripherals():
             self._register_peripheral(peripheral)
+
+    def register(self, peripheral: Peripheral) -> None:
+        """Manually register ``peripheral`` with the manager."""
+
+        self._register_peripheral(peripheral)
 
     def _iter_detected_peripherals(self) -> Iterable[Peripheral]:
         yield from itertools.chain(
@@ -130,6 +136,12 @@ class PeripheralManager:
         self._peripherals.append(peripheral)
         if self._event_bus is not None and self._propagate_event_bus:
             self._attach_event_bus(peripheral, self._event_bus)
+
+    def get_led_matrix_display(self) -> LEDMatrixDisplay:
+        for peripheral in self._peripherals:
+            if isinstance(peripheral, LEDMatrixDisplay):
+                return peripheral
+        raise ValueError("No LEDMatrixDisplay peripheral registered")
 
     def _attach_event_bus(self, peripheral: Peripheral, event_bus: EventBus) -> None:
         attach = getattr(peripheral, "attach_event_bus", None)

--- a/src/heart/peripheral/led_matrix.py
+++ b/src/heart/peripheral/led_matrix.py
@@ -1,0 +1,113 @@
+"""Peripheral exposing the current LED matrix frame via the event bus."""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime
+from typing import Any, Mapping
+
+from PIL import Image
+
+from heart.events.types import DisplayFrame
+from heart.peripheral.core import Peripheral
+from heart.peripheral.core.event_bus import EventBus
+from heart.utilities.logging import get_logger
+
+__all__ = ["LEDMatrixDisplay"]
+
+
+_LOGGER = get_logger(__name__)
+
+
+class LEDMatrixDisplay(Peripheral):
+    """Virtual peripheral representing the rendered LED matrix image."""
+
+    EVENT_FRAME = DisplayFrame.EVENT_TYPE
+
+    def __init__(
+        self,
+        *,
+        width: int,
+        height: int,
+        event_bus: EventBus | None = None,
+        producer_id: int | None = None,
+    ) -> None:
+        if width <= 0 or height <= 0:
+            raise ValueError("Display dimensions must be positive")
+
+        self._width = width
+        self._height = height
+        self._event_bus = event_bus
+        self._producer_id = producer_id if producer_id is not None else id(self)
+        self._frame_lock = threading.Lock()
+        self._latest_frame: DisplayFrame | None = None
+        self._sequence = 0
+        self._stop = threading.Event()
+
+        super().__init__()
+
+    @property
+    def width(self) -> int:
+        return self._width
+
+    @property
+    def height(self) -> int:
+        return self._height
+
+    @property
+    def latest_frame(self) -> DisplayFrame | None:
+        """Return the most recently published frame, if any."""
+
+        with self._frame_lock:
+            return self._latest_frame
+
+    def attach_event_bus(self, event_bus: EventBus) -> None:
+        self._event_bus = event_bus
+
+    def publish_image(
+        self,
+        image: Image.Image,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+        timestamp: datetime | None = None,
+    ) -> DisplayFrame:
+        """Record ``image`` as the latest frame and emit it on the event bus."""
+
+        if image.size != (self._width, self._height):
+            raise ValueError(
+                "Image dimensions do not match configured display size"
+            )
+
+        with self._frame_lock:
+            frame = DisplayFrame.from_image(
+                image,
+                frame_id=self._sequence,
+                metadata=metadata,
+            )
+            self._sequence += 1
+            self._latest_frame = frame
+
+        event_bus = self._event_bus
+        if event_bus is not None:
+            try:
+                event_bus.emit(
+                    frame.to_input(
+                        producer_id=self._producer_id,
+                        timestamp=timestamp,
+                    )
+                )
+            except Exception:  # pragma: no cover - defensive logging only
+                _LOGGER.exception("Failed to emit LED matrix frame update")
+        return frame
+
+    def run(self) -> None:  # noqa: D401 - signature defined by base class
+        """Idle loop to satisfy the :class:`Peripheral` contract."""
+
+        while not self._stop.wait(timeout=60.0):
+            continue
+
+    def stop(self) -> None:
+        """Signal the background thread to exit."""
+
+        self._stop.set()
+

--- a/tests/peripheral/test_led_matrix_display.py
+++ b/tests/peripheral/test_led_matrix_display.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import numpy as np
+from PIL import Image
+
+from heart.events.types import DisplayFrame
+from heart.peripheral.core.event_bus import EventBus
+from heart.peripheral.led_matrix import LEDMatrixDisplay
+
+
+def _solid_image(width: int, height: int, *, value: int) -> Image.Image:
+    array = np.full((height, width, 3), value, dtype=np.uint8)
+    return Image.fromarray(array, mode="RGB")
+
+
+def test_publish_image_emits_event_and_updates_state_store() -> None:
+    bus = EventBus()
+    peripheral = LEDMatrixDisplay(width=4, height=2, event_bus=bus)
+
+    image = _solid_image(4, 2, value=128)
+    peripheral.publish_image(
+        image, timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc)
+    )
+
+    latest = peripheral.latest_frame
+    assert latest is not None
+    assert latest.frame_id == 0
+    assert latest.width == 4 and latest.height == 2
+    assert latest.mode == "RGB"
+    assert latest.data == image.tobytes()
+    reconstructed = latest.to_image()
+    assert reconstructed.tobytes() == image.tobytes()
+
+    state_entry = bus.state_store.get_latest(DisplayFrame.EVENT_TYPE)
+    assert state_entry is not None
+    assert isinstance(state_entry.data, DisplayFrame)
+    assert state_entry.data.data == image.tobytes()
+
+
+def test_publish_image_increments_frame_id(monkeypatch) -> None:
+    bus = EventBus()
+    peripheral = LEDMatrixDisplay(width=2, height=2, event_bus=bus)
+    image = _solid_image(2, 2, value=64)
+
+    first = peripheral.publish_image(image)
+    second = peripheral.publish_image(image)
+
+    assert first.frame_id == 0
+    assert second.frame_id == 1
+    assert bus.state_store.get_latest(DisplayFrame.EVENT_TYPE).data.frame_id == 1
+
+
+def test_publish_image_validates_dimensions() -> None:
+    peripheral = LEDMatrixDisplay(width=2, height=2)
+    image = _solid_image(3, 2, value=10)
+
+    try:
+        peripheral.publish_image(image)
+    except ValueError as exc:
+        assert "dimensions" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("ValueError expected when dimensions do not match")


### PR DESCRIPTION
## Summary
- add a DisplayFrame payload and LEDMatrixDisplay peripheral that publishes the current rendered frame to the event bus
- register the display peripheral with the game loop so each rendered image is captured in the state store
- expose helpers and tests so sensors can inspect the latest LED matrix frame data

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f62234d3083219542ea940b7b3aaf)