### PR TITLE
Add force peripheral for tensile and magnetic readings

### DIFF
--- a/src/heart/peripheral/force.py
+++ b/src/heart/peripheral/force.py
@@ -1,0 +1,117 @@
+"""Force sensor peripheral emitting normalized measurement events."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal, Mapping, cast
+
+from heart.events.types import ForceMeasurement
+from heart.peripheral.core import Input, Peripheral
+from heart.peripheral.core.event_bus import EventBus
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+ForceKind = Literal["tensile", "magnetic"]
+
+
+class ForcePeripheral(Peripheral):
+    """Peripheral that converts force readings into bus events.
+
+    The peripheral accepts normalized measurements describing either a tensile
+    or magnetic force.  For each reading it emits a
+    :class:`~heart.peripheral.core.Input` event using the
+    :class:`~heart.events.types.ForceMeasurement` helper.
+    """
+
+    def __init__(
+        self,
+        *,
+        event_bus: EventBus | None = None,
+        producer_id: int | None = None,
+    ) -> None:
+        self._event_bus = event_bus
+        self._producer_id = producer_id if producer_id is not None else id(self)
+        super().__init__()
+
+    def run(self) -> None:
+        """No background loop is required for the force peripheral."""
+
+    def attach_event_bus(self, event_bus: EventBus) -> None:
+        self._event_bus = event_bus
+
+    def record_force(
+        self,
+        *,
+        force_type: ForceKind,
+        magnitude: float,
+        unit: str | None = None,
+        timestamp: datetime | None = None,
+    ) -> Input:
+        """Emit an event describing a single force reading.
+
+        Parameters
+        ----------
+        force_type:
+            Whether the force reading represents tensile or magnetic force.
+        magnitude:
+            Force magnitude parsed from the sensor.
+        unit:
+            Optional unit string.  Defaults to ``ForceMeasurement.DEFAULT_UNIT``
+            when omitted.
+        timestamp:
+            Optional timestamp to use for the resulting event.
+        """
+
+        measurement = ForceMeasurement(
+            magnitude=magnitude,
+            force_type=force_type,
+            unit=unit or ForceMeasurement.DEFAULT_UNIT,
+        )
+        event = measurement.to_input(
+            producer_id=self._producer_id, timestamp=timestamp
+        )
+        self._emit(event)
+        return event
+
+    def update_due_to_data(self, data: Mapping[str, Any]) -> None:
+        """Accept raw payloads and emit a normalized measurement event."""
+
+        event_type = data.get("event_type")
+        if event_type and event_type != ForceMeasurement.EVENT_TYPE:
+            return
+
+        payload: Any = data.get("data", data)
+        if not isinstance(payload, Mapping):
+            logger.debug("Ignoring malformed force payload: %s", payload)
+            return
+
+        try:
+            force_type = str(payload["force_type"]).lower()
+            magnitude = float(payload["magnitude"])
+        except (KeyError, TypeError, ValueError):
+            logger.debug("Force payload missing required fields: %s", payload)
+            return
+
+        unit_obj = payload.get("unit")
+        unit = str(unit_obj) if unit_obj is not None else None
+
+        try:
+            normalized_type = cast(ForceKind, force_type)
+            self.record_force(
+                force_type=normalized_type, magnitude=magnitude, unit=unit
+            )
+        except ValueError:
+            logger.debug("Rejected invalid force payload: %s", payload)
+
+    def handle_input(self, input: Input) -> None:  # pragma: no cover - no-op hook
+        return
+
+    def _emit(self, event: Input) -> None:
+        event_bus = self._event_bus
+        if event_bus is None:
+            return
+        try:
+            event_bus.emit(event)
+        except Exception:
+            logger.exception("Failed to emit force measurement event")

--- a/tests/peripheral/test_force_event_bus.py
+++ b/tests/peripheral/test_force_event_bus.py
@@ -1,0 +1,66 @@
+import pytest
+
+from heart.events.types import ForceMeasurement
+from heart.peripheral.core.event_bus import EventBus
+from heart.peripheral.force import ForcePeripheral
+
+
+def test_force_peripheral_emits_event() -> None:
+    bus = EventBus()
+    captured = []
+
+    def _capture(event):
+        captured.append(event)
+
+    bus.subscribe(ForceMeasurement.EVENT_TYPE, _capture)
+    peripheral = ForcePeripheral(event_bus=bus, producer_id=42)
+
+    event = peripheral.record_force(force_type="tensile", magnitude=12.5, unit="N")
+
+    assert captured
+    emitted = captured[0]
+    assert emitted is event
+    assert emitted.event_type == ForceMeasurement.EVENT_TYPE
+    assert emitted.data["type"] == "tensile"
+    assert emitted.data["magnitude"] == pytest.approx(12.5)
+    assert emitted.data["unit"] == "N"
+    assert emitted.producer_id == 42
+
+
+def test_force_peripheral_normalizes_payload() -> None:
+    bus = EventBus()
+    captured = []
+
+    bus.subscribe(ForceMeasurement.EVENT_TYPE, captured.append)
+    peripheral = ForcePeripheral(event_bus=bus, producer_id=7)
+
+    peripheral.update_due_to_data(
+        {
+            "event_type": ForceMeasurement.EVENT_TYPE,
+            "data": {"force_type": "MAGNETIC", "magnitude": "3.5", "unit": "mT"},
+        }
+    )
+
+    assert captured
+    event = captured[0]
+    assert event.data["type"] == "magnetic"
+    assert event.data["magnitude"] == pytest.approx(3.5)
+    assert event.data["unit"] == "mT"
+    assert event.producer_id == 7
+
+
+def test_force_peripheral_rejects_invalid_payload() -> None:
+    bus = EventBus()
+    captured = []
+
+    bus.subscribe(ForceMeasurement.EVENT_TYPE, captured.append)
+    peripheral = ForcePeripheral(event_bus=bus)
+
+    peripheral.update_due_to_data({"data": {"force_type": "gravity", "magnitude": 9.81}})
+
+    assert not captured
+
+
+def test_force_measurement_validates_type() -> None:
+    with pytest.raises(ValueError):
+        ForceMeasurement(magnitude=1.0, force_type="gravity")


### PR DESCRIPTION
## Summary
- add a `ForceMeasurement` payload helper that normalizes tensile and magnetic data
- implement a `ForcePeripheral` that emits events for tensile and magnetic readings
- exercise the new peripheral behaviour with force-specific unit tests

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f62a354b88321b874198951add410)