### PR TITLE
Restore metrics test module and ensure Pillow availability

### DIFF
--- a/docs/planning/sensor_aggregate_metrics.md
+++ b/docs/planning/sensor_aggregate_metrics.md
@@ -1,0 +1,86 @@
+# Problem Statement
+
+The aggregate metrics pipeline for sensor peripherals lacks regression coverage and published targets, which makes it difficult to confirm that rolling windows, keyed statistics, and downstream dashboards behave consistently as we integrate new devices.
+
+# Materials
+
+- Python 3.11 toolchain with `uv` environment defined in `pyproject.toml`.
+- Access to the Heart repository, especially `src/heart/events/metrics.py` and `tests/events/metrics/`.
+- Local runtime capable of executing `make test` and `make format`.
+- Historical sensor traces stored in `drivers/` fixtures for offline validation.
+- Diagramming tool (Mermaid or Excalidraw) for sequence sketches.
+
+# Opening Abstract
+
+This plan extends regression coverage for the aggregate metrics helpers and defines a roadmap for collecting richer telemetry from accelerometer, gyroscope, heart-rate, infrared, UWB, and environmental sensors. By grounding every metric in rolling windows backed by deterministic tests, the team can ship sidecar aggregators and UI dashboards without re-implementing statistics logic in each component. The proposal sequences work so that we harden the Python primitives, align on a library of reusable aggregates, then wire metrics into orchestration layers and Grafana exports.
+
+# Success Criteria
+
+| Goal | Validation Signal | Owner |
+| --- | --- | --- |
+| Expand tests for `RollingStatisticsByKey` and related helpers | New pytest cases in `tests/events/metrics/` covering resets, window+length pruning, and policy composition | Application engineer |
+| Publish metrics catalog for all sensor families | Planning doc merged with enumerated aggregates, thresholds, and sampling guidance | Sensor lead |
+| Validate aggregator outputs on real traces | Replay logs through `scripts/peripheral/replay_events.py` and confirm metrics fall within documented thresholds | QA engineer |
+| Integrate aggregates into telemetry bus | `EventBus` emits derived metrics for accelerometer, IR, microphone, and UWB peripherals with schema notes | Runtime maintainer |
+
+# Task Breakdown
+
+## Discovery
+
+- [ ] Review existing usages of `RollingStatisticsByKey` within `experimental/peripheral_sidecar/`.
+- [ ] Audit Grafana dashboards to determine which aggregates already exist.
+- [ ] Collect sample traces from accelerometer, heart-rate, IR array, and UWB peripherals.
+
+## Implementation
+
+- [ ] Add targeted regression cases for resets, mixed pruning policies, and missing-key handling in `tests/events/metrics/`.
+- [ ] Introduce helper fixtures for ingesting sensor traces into rolling windows.
+- [ ] Wire aggregate emitters into accelerometer, heart-rate, microphone, IR array, and UWB pipelines.
+- [ ] Document metric schemas inline and export via `docs/runtime_overview.md`.
+
+## Validation
+
+- [ ] Run `make test` and ensure deterministic results on Linux and macOS runners.
+- [ ] Execute trace replays to confirm metric values align with catalog thresholds.
+- [ ] Update Grafana dashboards or CLI reporters to consume the new metrics.
+- [ ] Conduct code review focusing on numerical stability and timestamp handling.
+
+# Narrative Walkthrough
+
+We start with a focused test suite expansion to ensure the aggregate metrics helpers handle resets, sparse keys, and overlapping pruning policies. These utilities currently back the experimental sidecar aggregators, so coverage will prevent regressions when telemetry sources multiply. After the tests, we design a catalog that maps each sensor family to the aggregates we expect to compute. The catalog acts as the contract for downstream consumers, clarifying sampling windows, threshold logic, and naming conventions.
+
+Next, we augment the accelerometer, heart-rate, IR sensor array, microphone, and UWB modules to publish the documented aggregates. Where hardware is not yet streaming live data, replay scripts and recorded traces validate the behavior. Finally, the telemetry bus and dashboards are updated to consume the enriched events, ensuring observability teams receive consistent payloads regardless of the originating sensor.
+
+# Visual Reference
+
+| Sensor Family | Aggregate Metrics | Sampling Window | Notes |
+| --- | --- | --- | --- |
+| Accelerometer | magnitude RMS, jerk mean, jerk stddev, orientation change count, vibration percentile, zero-crossing rate, tilt dwell time, impact peak, sway ellipse area, motion energy | 5 s rolling window with 0.5 s stride | Derived from `AccelerometerVector` events; jerk computed from finite differences |
+| Gyroscope | angular velocity mean, angular velocity stddev, drift bias, yaw variance, pitch/roll RMS, spin rate histogram, stabilization confidence | 10 s window with 1 s stride | Combines bus events once gyroscope virtual peripheral lands |
+| Magnetometer | heading variance, hard-iron offset, soft-iron scaling stability, geomagnetic disturbance flag | 30 s window with 5 s stride | Requires calibration offsets stored per producer |
+| Heart-rate | beats-per-minute average, HRV RMSSD, tachycardia count, bradycardia minutes, signal quality index, perfusion index trend | 60 s window sliding every 5 s | Leverages `heart.peripheral.heart_rates` data frames |
+| IR Sensor Array | position RMSE, confidence mean, amplitude histogram, sensor dropout count, multipath suspicion score, ambient temperature delta, calibration drift | per-frame aggregation plus 15 s rolling summary | Mixes per-frame outputs from `IRSensorArray.EVENT_FRAME` |
+| UWB | range residual stddev, anchor availability, blink density, latency percentile, NLOS suspicion counter, spatial consistency score | 20 s window with 2 s stride | Consumes `uwb_ranging_event` logs |
+| Microphone | RMS level mean, peak level max, noise floor trend, clipping count, speech probability estimate, spectral centroid | 8 s window with 1 s stride | Extend `MicrophoneLevel` payloads with frequency features |
+| Environmental (temp, humidity, CO₂) | mean, rate of change, excursion duration, dew point deviation, alarm threshold breaches | 5 min window with 30 s stride | Aggregates future environmental peripherals |
+| Switch / Button | press frequency, long-press duration mean, rotation cumulative delta, inactivity streak length | 60 s window with event-driven updates | Derived from firmware input events |
+
+# Risk Analysis
+
+| Risk | Probability | Impact | Mitigation | Early Signal |
+| --- | --- | --- | --- | --- |
+| Timestamp drift between sensors causes inaccurate rolling windows | Medium | High | Normalize timestamps via `EventBus.monotonic()` and align on sync protocol | Divergent window counts across test runs |
+| Metric catalog diverges from emitted payloads | Medium | Medium | Enforce schema tests comparing docs to event outputs | Failing contract tests during CI |
+| Numerical instability for low-variance sensors | Low | Medium | Clamp variances to zero and add property-based tests | Negative variance observed in logs |
+| Performance regression from heavy aggregations | Low | High | Profile replay scripts and move expensive stats to native modules when needed | Increased CPU usage during sidecar benchmarks |
+
+## Mitigation Checklist
+
+- [ ] Implement timestamp normalization helper shared across peripherals.
+- [ ] Add contract tests comparing emitted aggregates to the catalog table.
+- [ ] Profile aggregator loops with representative traces and cache intermediate computations.
+- [ ] Schedule quarterly review of metric catalog with data science and firmware teams.
+
+# Outcome Snapshot
+
+After executing this plan, the aggregate metrics helpers expose deterministic behavior through regression tests, every sensor family publishes the agreed metrics with consistent naming, and monitoring tooling consumes the enriched payloads without additional glue code. Replay pipelines produce stable rollups, giving operators confidence that new peripherals will integrate into the observability stack with minimal risk.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "Pillow",
     "scipy",
     "mypy",
     "types-requests",

--- a/tests/events/metrics/test_count_by_key.py
+++ b/tests/events/metrics/test_count_by_key.py
@@ -1,0 +1,44 @@
+"""Unit tests for :class:`heart.events.metrics.CountByKey`."""
+
+from __future__ import annotations
+
+import pytest
+
+from heart.events.metrics import CountByKey
+
+
+@pytest.fixture()
+def counter() -> CountByKey[str]:
+    return CountByKey[str]()
+
+
+def test_count_by_key_increments_per_key(counter: CountByKey[str]) -> None:
+    counter.observe("sensor-1")
+    counter.observe("sensor-1", amount=2)
+    counter.observe("sensor-2")
+
+    assert counter.get("sensor-1") == 3
+    assert counter.get("sensor-2") == 1
+    assert counter.get("missing") == 0
+
+
+def test_count_by_key_snapshot_returns_copy(counter: CountByKey[str]) -> None:
+    counter.observe("sensor-1")
+
+    snapshot = counter.snapshot()
+    counter.observe("sensor-1")
+
+    assert snapshot == {"sensor-1": 1}
+    assert counter.snapshot() == {"sensor-1": 2}
+    assert snapshot is not counter.snapshot()
+
+
+def test_count_by_key_reset_clears_all_counts(counter: CountByKey[str]) -> None:
+    counter.observe("sensor-1")
+    counter.observe("sensor-2", amount=4)
+
+    counter.reset()
+
+    assert counter.snapshot() == {}
+    assert counter.get("sensor-1") == 0
+    assert counter.get("sensor-2") == 0

--- a/tests/events/metrics/test_event_window_policies.py
+++ b/tests/events/metrics/test_event_window_policies.py
@@ -1,0 +1,82 @@
+"""Tests covering :class:`EventWindow` and associated policies."""
+
+from __future__ import annotations
+
+import pytest
+
+from heart.events.metrics import (EventSample, EventWindow, MaxAgePolicy,
+                                  MaxLengthPolicy, combine_windows)
+
+
+def test_max_length_policy_requires_positive_count() -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        MaxLengthPolicy(count=0)
+
+
+def test_max_age_policy_requires_positive_window() -> None:
+    with pytest.raises(ValueError, match="positive duration"):
+        MaxAgePolicy(window=0.0)
+
+
+def test_event_window_applies_max_length_policy() -> None:
+    window = EventWindow[str](policies=(MaxLengthPolicy(count=2),))
+
+    window.append("a", timestamp=0.0)
+    window.append("b", timestamp=1.0)
+    window.append("c", timestamp=2.0)
+
+    assert window.values() == ("b", "c")
+
+
+def test_event_window_applies_max_age_policy() -> None:
+    window = EventWindow[str](policies=(MaxAgePolicy(window=1.5),))
+
+    window.append("a", timestamp=0.0)
+    window.append("b", timestamp=0.5)
+    window.append("c", timestamp=2.0)
+
+    assert window.values() == ("c",)
+
+
+def test_event_window_iterates_values_in_order() -> None:
+    window = EventWindow[str](policies=(MaxLengthPolicy(count=3),))
+    for index in range(3):
+        window.append(f"event-{index}", timestamp=float(index))
+
+    assert list(window) == ["event-0", "event-1", "event-2"]
+
+
+def test_event_window_samples_return_dataclasses() -> None:
+    window = EventWindow[str](policies=(MaxLengthPolicy(count=2),))
+    window.extend(["a", "b"], timestamp=1.0, step=0.25)
+
+    samples = window.samples()
+    assert samples == (
+        EventSample(value="a", timestamp=1.0),
+        EventSample(value="b", timestamp=1.25),
+    )
+
+
+def test_event_window_derive_appends_additional_policies() -> None:
+    base = EventWindow[str](policies=(MaxLengthPolicy(count=3),))
+    derived = base.derive(MaxAgePolicy(window=2.0))
+
+    timestamps = (0.0, 0.5, 1.0, 2.5, 3.0)
+    for index, ts in enumerate(timestamps):
+        derived.append(f"event-{index}", timestamp=ts)
+
+    assert derived.values() == ("event-3", "event-4")
+
+
+def test_combine_windows_merges_policies() -> None:
+    recent = EventWindow[str](policies=(MaxLengthPolicy(count=2),))
+    young = EventWindow[str](policies=(MaxAgePolicy(window=3.0),))
+
+    combined = combine_windows(recent, young)
+    helper = EventWindow[str](policies=(*recent.policies, *young.policies))
+
+    for timestamp, value in enumerate(("a", "b", "c", "d")):
+        combined.append(value, timestamp=float(timestamp))
+        helper.append(value, timestamp=float(timestamp))
+
+    assert combined.values() == helper.values()

--- a/tests/events/metrics/test_last_event_windows.py
+++ b/tests/events/metrics/test_last_event_windows.py
@@ -1,0 +1,45 @@
+"""Tests for high-level event window helpers."""
+
+from __future__ import annotations
+
+from heart.events.metrics import (LastEventsWithinTimeWindow, LastNEvents,
+                                  LastNEventsWithinTimeWindow)
+
+
+def test_last_n_events_retains_recent_entries() -> None:
+    window = LastNEvents[str](count=3)
+
+    for index in range(5):
+        window.append(f"event-{index}", timestamp=float(index))
+
+    assert window.values() == ("event-2", "event-3", "event-4")
+
+
+def test_last_events_within_time_window_filters_by_age() -> None:
+    window = LastEventsWithinTimeWindow[str](window=2.0)
+
+    window.append("event-0", timestamp=0.0)
+    window.append("event-1", timestamp=1.0)
+    window.append("event-2", timestamp=3.1)
+
+    assert window.values() == ("event-1", "event-2")
+
+
+def test_last_n_events_within_time_window_enforces_both_limits() -> None:
+    window = LastNEventsWithinTimeWindow[str](count=2, window=3.0)
+
+    window.append("event-0", timestamp=0.0)
+    window.append("event-1", timestamp=1.0)
+    window.append("event-2", timestamp=2.0)
+    window.append("event-3", timestamp=6.0)
+
+    assert window.values() == ("event-3",)
+
+
+def test_last_n_events_within_time_window_limits_count() -> None:
+    window = LastNEventsWithinTimeWindow[str](count=2, window=5.0)
+
+    for index in range(4):
+        window.append(f"event-{index}", timestamp=float(index))
+
+    assert window.values() == ("event-2", "event-3")

--- a/tests/events/metrics/test_rolling_statistics_by_key.py
+++ b/tests/events/metrics/test_rolling_statistics_by_key.py
@@ -1,0 +1,102 @@
+"""Tests for rolling statistics helpers grouped by key."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from heart.events.metrics import (RollingAverageByKey, RollingMeanByKey,
+                                  RollingStatisticsByKey, RollingStddevByKey)
+
+
+def test_rolling_statistics_tracks_multiple_keys() -> None:
+    stats = RollingStatisticsByKey[str](maxlen=3)
+
+    stats.observe("imu", 1.0, timestamp=0.0)
+    stats.observe("imu", 3.0, timestamp=1.0)
+    stats.observe("imu", 5.0, timestamp=2.0)
+    stats.observe("imu", 7.0, timestamp=3.0)
+    stats.observe("heart", 60.0, timestamp=3.0)
+    stats.observe("heart", 70.0, timestamp=4.0)
+
+    imu = stats.snapshot()["imu"]
+    heart = stats.snapshot()["heart"]
+
+    assert imu.count == 3
+    assert imu.mean == pytest.approx(5.0)
+    assert imu.stddev == pytest.approx(math.sqrt(8 / 3))
+    assert heart.count == 2
+    assert heart.mean == pytest.approx(65.0)
+    assert heart.stddev == pytest.approx(5.0)
+
+
+def test_rolling_statistics_prunes_by_window_and_length() -> None:
+    stats = RollingStatisticsByKey[str](maxlen=3, window=5.0)
+
+    stats.observe("imu", 1.0, timestamp=0.0)
+    stats.observe("imu", 3.0, timestamp=1.0)
+    stats.observe("imu", 5.0, timestamp=2.0)
+    stats.observe("imu", 7.0, timestamp=9.0)
+
+    snapshot = stats.snapshot()["imu"]
+    assert snapshot.count == 2
+    assert snapshot.mean == pytest.approx(6.0)
+
+
+def test_rolling_statistics_handles_missing_keys() -> None:
+    stats = RollingStatisticsByKey[str]()
+
+    assert stats.mean("missing") is None
+    assert stats.stddev("missing") is None
+    assert stats.count("missing") == 0
+
+
+def test_rolling_statistics_reset_scopes() -> None:
+    stats = RollingStatisticsByKey[str]()
+
+    stats.observe("imu", 1.0, timestamp=0.0)
+    stats.observe("imu", 3.0, timestamp=1.0)
+    stats.observe("heart", 60.0, timestamp=1.0)
+
+    stats.reset("imu")
+    assert "imu" not in stats.snapshot()
+    assert "heart" in stats.snapshot()
+
+    stats.reset()
+    assert stats.snapshot() == {}
+
+
+def test_rolling_average_and_stddev_wrappers() -> None:
+    averages = RollingAverageByKey[str](maxlen=2)
+    deviations = RollingStddevByKey[str](maxlen=2)
+
+    averages.observe("imu", 5.0, timestamp=0.0)
+    deviations.observe("imu", 5.0, timestamp=0.0)
+    averages.observe("imu", 9.0, timestamp=1.0)
+    deviations.observe("imu", 9.0, timestamp=1.0)
+
+    assert averages.get("imu") == pytest.approx(7.0)
+    assert deviations.get("imu") == pytest.approx(2.0)
+    assert averages.snapshot()["imu"] == pytest.approx(7.0)
+    assert deviations.snapshot()["imu"] == pytest.approx(2.0)
+
+
+def test_rolling_statistics_requires_positive_parameters() -> None:
+    with pytest.raises(ValueError):
+        RollingStatisticsByKey[str](maxlen=0)
+
+    with pytest.raises(ValueError):
+        RollingStatisticsByKey[str](window=0.0)
+
+
+def test_rolling_mean_alias_matches_average() -> None:
+    averages = RollingAverageByKey[str](maxlen=3)
+    alias = RollingMeanByKey[str](maxlen=3)
+
+    for timestamp, value in enumerate((2.0, 4.0, 6.0)):
+        averages.observe("imu", value, timestamp=float(timestamp))
+        alias.observe("imu", value, timestamp=float(timestamp))
+
+    assert averages.get("imu") == alias.get("imu")
+    assert averages.snapshot() == alias.snapshot()

--- a/tests/events/test_metrics.py
+++ b/tests/events/test_metrics.py
@@ -1,115 +1,22 @@
-"""Unit tests for sensor metric aggregations."""
+"""Compatibility wrapper for sensor metric aggregation tests.
+
+Pytest now collects the dedicated modules under :mod:`tests.events.metrics`.
+This module remains so existing imports continue to resolve without change.
+"""
 
 from __future__ import annotations
 
-import math
+from importlib import import_module
+from typing import Final
 
-import pytest
+_METRIC_MODULES: Final[tuple[str, ...]] = (
+    "tests.events.metrics.test_count_by_key",
+    "tests.events.metrics.test_event_window_policies",
+    "tests.events.metrics.test_last_event_windows",
+    "tests.events.metrics.test_rolling_statistics_by_key",
+)
 
-from heart.events.metrics import (CountByKey, EventWindow,
-                                  LastEventsWithinTimeWindow, LastNEvents,
-                                  LastNEventsWithinTimeWindow,
-                                  RollingAverageByKey, RollingStatisticsByKey,
-                                  RollingStddevByKey, combine_windows)
+for module_name in _METRIC_MODULES:
+    import_module(module_name)
 
-
-def test_count_by_key() -> None:
-    counter = CountByKey[str]()
-    counter.observe("sensor-1")
-    counter.observe("sensor-1", amount=2)
-    counter.observe("sensor-2")
-
-    assert counter.get("sensor-1") == 3
-    assert counter.get("sensor-2") == 1
-    assert counter.get("missing") == 0
-
-
-def test_rolling_statistics_by_key_maxlen() -> None:
-    stats = RollingStatisticsByKey[str](maxlen=3)
-
-    stats.observe("imu", 1.0, timestamp=0.0)
-    stats.observe("imu", 2.0, timestamp=1.0)
-    stats.observe("imu", 3.0, timestamp=2.0)
-    stats.observe("imu", 4.0, timestamp=3.0)
-
-    snapshot = stats.snapshot()["imu"]
-    assert snapshot.count == 3
-    assert snapshot.mean == pytest.approx(3.0)
-    assert snapshot.stddev == pytest.approx(math.sqrt(2 / 3))
-
-
-def test_rolling_statistics_by_key_time_window() -> None:
-    stats = RollingStatisticsByKey[str](window=5.0)
-
-    stats.observe("imu", 1.0, timestamp=0.0)
-    stats.observe("imu", 3.0, timestamp=1.0)
-    stats.observe("imu", 5.0, timestamp=6.0)
-
-    snapshot = stats.snapshot()["imu"]
-    assert snapshot.count == 2
-    assert snapshot.mean == pytest.approx(4.0)
-    assert snapshot.stddev == pytest.approx(1.0)
-
-
-def test_rolling_average_and_stddev_by_key() -> None:
-    averages = RollingAverageByKey[str](maxlen=2)
-    stddevs = RollingStddevByKey[str](maxlen=2)
-
-    averages.observe("imu", 5.0, timestamp=0.0)
-    stddevs.observe("imu", 5.0, timestamp=0.0)
-    averages.observe("imu", 9.0, timestamp=1.0)
-    stddevs.observe("imu", 9.0, timestamp=1.0)
-
-    assert averages.get("imu") == pytest.approx(7.0)
-    assert stddevs.get("imu") == pytest.approx(2.0)
-
-
-def test_last_n_events() -> None:
-    window = LastNEvents[str](count=3)
-
-    for index in range(5):
-        window.append(f"event-{index}", timestamp=float(index))
-
-    assert window.values() == ("event-2", "event-3", "event-4")
-
-
-def test_last_events_within_time_window() -> None:
-    window = LastEventsWithinTimeWindow[str](window=2.0)
-
-    window.append("event-0", timestamp=0.0)
-    window.append("event-1", timestamp=1.0)
-    window.append("event-2", timestamp=4.0)
-
-    assert window.values() == ("event-2",)
-
-
-def test_last_n_events_within_time_window() -> None:
-    window = LastNEventsWithinTimeWindow[str](count=2, window=3.0)
-
-    window.append("event-0", timestamp=0.0)
-    window.append("event-1", timestamp=1.0)
-    window.append("event-2", timestamp=2.0)
-    window.append("event-3", timestamp=6.0)
-
-    assert window.values() == ("event-3",)
-
-
-def test_composed_window_matches_helper() -> None:
-    last_n = LastNEvents[str](count=2)
-    within_window = LastEventsWithinTimeWindow[str](window=3.0)
-
-    composed = combine_windows(last_n, within_window)
-    helper = LastNEventsWithinTimeWindow[str](count=2, window=3.0)
-
-    for timestamp, event in enumerate(("a", "b", "c", "d")):
-        composed.append(event, timestamp=float(timestamp))
-        helper.append(event, timestamp=float(timestamp))
-
-    assert composed.values() == helper.values()
-
-
-def test_event_window_extend() -> None:
-    window: EventWindow[int] = LastNEvents(count=4)
-    window.extend([1, 2, 3, 4], timestamp=0.0, step=0.5)
-
-    assert window.values() == (1, 2, 3, 4)
+__all__ = ("_METRIC_MODULES",)


### PR DESCRIPTION
## Summary
- restore `tests/events/test_metrics.py` as a compatibility entry point that imports the focused metrics suites
- add Pillow to the development dependency group so the pytest environment always installs the imaging dependency

## Testing
- make format *(fails: unable to download pillow due to network restrictions)*
- uv run pytest tests/events/metrics *(fails: unable to fetch dependencies due to network restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f5c40bea0832195a28ded09cde973)