### PR TITLE
Refine optional imports and tighten event window pruning

### DIFF
--- a/src/heart/events/metrics.py
+++ b/src/heart/events/metrics.py
@@ -52,7 +52,7 @@ class MaxAgePolicy(WindowPolicy[T]):
 
     def prune(self, samples: Deque[EventSample[T]], *, now: float) -> None:
         cutoff = now - self._window
-        while samples and samples[0].timestamp < cutoff:
+        while samples and samples[0].timestamp <= cutoff:
             samples.popleft()
 
 
@@ -176,7 +176,7 @@ class _RollingState:
     def _prune(self, *, now: float, maxlen: int | None, window: float | None) -> None:
         if window is not None:
             cutoff = now - window
-            while self.samples and self.samples[0].timestamp < cutoff:
+            while self.samples and self.samples[0].timestamp <= cutoff:
                 removed = self.samples.popleft()
                 self.sum -= removed.value
                 self.sum_sq -= removed.value * removed.value

--- a/src/heart/events/types.py
+++ b/src/heart/events/types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import (Any, ClassVar, Mapping, MutableMapping, Protocol,
                     runtime_checkable)
@@ -39,10 +39,14 @@ class SwitchButton(InputEventPayload):
     long_press: bool = False
     EVENT_TYPE_PRESS: ClassVar[str] = BUTTON_PRESS
     EVENT_TYPE_LONG_PRESS: ClassVar[str] = BUTTON_LONG_PRESS
+    event_type: str = field(init=False)
 
-    @property
-    def event_type(self) -> str:  # type: ignore[override]
-        return self.EVENT_TYPE_LONG_PRESS if self.long_press else self.EVENT_TYPE_PRESS
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "event_type",
+            self.EVENT_TYPE_LONG_PRESS if self.long_press else self.EVENT_TYPE_PRESS,
+        )
 
     def to_input(self, *, producer_id: int = 0, timestamp: datetime | None = None) -> Input:
         return Input(

--- a/src/heart/firmware_io/bluetooth.py
+++ b/src/heart/firmware_io/bluetooth.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
 import importlib
+from typing import Any
 
-if importlib.util.find_spec("adafruit_ble") is not None:
-    from adafruit_ble import BLERadio
-    from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
-    from adafruit_ble.services.nordic import UARTService
+BLERadio: type[Any] | None = None
+ProvideServicesAdvertisement: type[Any] | None = None
+UARTService: type[Any] | None = None
+
+try:
+    ble_module = importlib.import_module("adafruit_ble")
+    advertising_module = importlib.import_module("adafruit_ble.advertising.standard")
+    services_module = importlib.import_module("adafruit_ble.services.nordic")
+except ImportError:
+    pass
 else:
-    BLERadio = None  # type: ignore[assignment]
-    ProvideServicesAdvertisement = None  # type: ignore[assignment]
-    UARTService = None  # type: ignore[assignment]
+    BLERadio = getattr(ble_module, "BLERadio", None)
+    ProvideServicesAdvertisement = getattr(advertising_module, "ProvideServicesAdvertisement", None)
+    UARTService = getattr(services_module, "UARTService", None)
 
 
 if BLERadio is not None and UARTService is not None and ProvideServicesAdvertisement is not None:

--- a/src/heart/firmware_io/rotary_encoder.py
+++ b/src/heart/firmware_io/rotary_encoder.py
@@ -1,4 +1,5 @@
 import time
+from collections.abc import Callable
 
 from digitalio import Pull
 
@@ -21,16 +22,24 @@ def form_json(name: str, data: int, producer_id: int):
 
 
 class RotaryEncoderHandler:
-    def __init__(self, encoder, switch, index=0):
+    def __init__(
+        self,
+        encoder,
+        switch,
+        index=0,
+        *,
+        clock: Callable[[], float] | None = None,
+    ):
         self.last_position = None
         self.press_started_timestamp = None
         self.long_pressed_sent = False
         self.encoder = encoder
         self.switch = switch
         self.index = index
+        self._clock = clock or time.monotonic
 
     def _current_time(self):
-        return time.monotonic()
+        return self._clock()
 
     def _handle_switch(self):
         switch_is_pressed = self.switch.value

--- a/src/heart/peripheral/microphone.py
+++ b/src/heart/peripheral/microphone.py
@@ -6,7 +6,7 @@ import contextlib
 import threading
 import time
 from collections.abc import Iterator
-from typing import Any, Self
+from typing import Any, Self, cast
 
 import numpy as np
 
@@ -17,10 +17,11 @@ from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
 
+sd: Any | None
 try:  # pragma: no cover - import guarded for optional dependency
     import sounddevice as sd
 except Exception:  # pragma: no cover - module may be missing on CI
-    sd = None  # type: ignore[assignment]
+    sd = None
 
 
 class Microphone(Peripheral):
@@ -168,7 +169,7 @@ class Microphone(Peripheral):
             timestamp=timestamp,
         )
         payload = level.to_input(producer_id=self._producer_id)
-        self._latest_level = payload.data  # type: ignore[assignment]
+        self._latest_level = cast(dict[str, Any], payload.data)
 
         event_bus = self._event_bus
         if event_bus is not None:

--- a/src/heart/peripheral/sensor.py
+++ b/src/heart/peripheral/sensor.py
@@ -2,7 +2,7 @@ import collections
 import json
 import time
 from dataclasses import dataclass
-from typing import Any, Iterator, NoReturn, Self
+from typing import Any, Iterator, NoReturn, Self, cast
 
 import serial
 
@@ -136,7 +136,7 @@ class Accelerometer(Peripheral):
             return
 
         input_event = vector.to_input(producer_id=self._producer_id)
-        self.acceleration_value = input_event.data  # type: ignore[assignment]
+        self.acceleration_value = cast(dict[str, float], input_event.data)
 
         self.x_distribution.add_value(vector.x)
         self.y_distribution.add_value(vector.y)

--- a/tests/events/metrics/test_last_event_windows.py
+++ b/tests/events/metrics/test_last_event_windows.py
@@ -22,7 +22,7 @@ def test_last_events_within_time_window_filters_by_age() -> None:
     window.append("event-1", timestamp=1.0)
     window.append("event-2", timestamp=3.1)
 
-    assert window.values() == ("event-1", "event-2")
+    assert window.values() == ("event-2",)
 
 
 def test_last_n_events_within_time_window_enforces_both_limits() -> None:

--- a/tests/events/metrics/test_rolling_statistics_by_key.py
+++ b/tests/events/metrics/test_rolling_statistics_by_key.py
@@ -40,8 +40,8 @@ def test_rolling_statistics_prunes_by_window_and_length() -> None:
     stats.observe("imu", 7.0, timestamp=9.0)
 
     snapshot = stats.snapshot()["imu"]
-    assert snapshot.count == 2
-    assert snapshot.mean == pytest.approx(6.0)
+    assert snapshot.count == 1
+    assert snapshot.mean == pytest.approx(7.0)
 
 
 def test_rolling_statistics_handles_missing_keys() -> None:

--- a/tests/events/test_metrics.py
+++ b/tests/events/test_metrics.py
@@ -6,8 +6,14 @@ This module remains so existing imports continue to resolve without change.
 
 from __future__ import annotations
 
+import sys
 from importlib import import_module
+from pathlib import Path
 from typing import Final
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
 
 _METRIC_MODULES: Final[tuple[str, ...]] = (
     "tests.events.metrics.test_count_by_key",

--- a/tests/firmware_io/test_rotary_encoder_handler.py
+++ b/tests/firmware_io/test_rotary_encoder_handler.py
@@ -59,9 +59,10 @@ def test_handle_emits_button_press_for_press_release_sequence(
 ) -> None:
     encoder = SimpleNamespace(position=12)
     switch = SimpleNamespace(value=released_value, pull=getattr(dummy_pull, pull_direction))
-    handler = rotary_encoder.RotaryEncoderHandler(encoder, switch, index=2)
+    handler = rotary_encoder.RotaryEncoderHandler(
+        encoder, switch, index=2, clock=deterministic_clock.monotonic
+    )
     handler.last_position = encoder.position
-    handler._current_time = deterministic_clock.monotonic  # type: ignore[method-assign]
 
     steps = [
         HandlerStep("baseline"),
@@ -92,9 +93,10 @@ def test_handle_emits_long_press_once_when_threshold_elapsed(
 ) -> None:
     encoder = SimpleNamespace(position=5)
     switch = SimpleNamespace(value=True, pull=dummy_pull.UP)
-    handler = rotary_encoder.RotaryEncoderHandler(encoder, switch, index=1)
+    handler = rotary_encoder.RotaryEncoderHandler(
+        encoder, switch, index=1, clock=deterministic_clock.monotonic
+    )
     handler.last_position = encoder.position
-    handler._current_time = deterministic_clock.monotonic  # type: ignore[method-assign]
 
     steps = [
         HandlerStep("baseline"),

--- a/tests/peripheral/test_event_bus.py
+++ b/tests/peripheral/test_event_bus.py
@@ -1,6 +1,6 @@
 import threading
 import time
-from typing import Any, Mapping
+from typing import Any, Mapping, cast
 
 import pytest
 
@@ -238,11 +238,11 @@ def test_virtual_peripheral_definitions_bind_resources() -> None:
     resources = bus.virtual_peripherals.list_definitions()[handle.peripheral_id].resources
     assert resources is not None
     with pytest.raises(TypeError):
-        resources["foo"] = 99  # type: ignore[index]
+        cast(dict[str, Any], resources)["foo"] = 99
 
     dummy_context = captured["context"]
     with pytest.raises(TypeError):
-        dummy_context.resources["foo"] = 5  # type: ignore[index]
+        cast(dict[str, Any], dummy_context.resources)["foo"] = 5
     with pytest.raises(KeyError):
         dummy_context.get_resource("missing")
 

--- a/tests/peripheral/test_state_store.py
+++ b/tests/peripheral/test_state_store.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import cast
 
 from heart.peripheral.core import Input, StateStore
 
@@ -32,7 +33,7 @@ def test_state_store_snapshot_is_immutable() -> None:
     assert 0 in bucket
 
     try:
-        bucket[1] = bucket[0]  # type: ignore[assignment]
+        cast(dict[int, Input], bucket)[1] = bucket[0]
     except TypeError:
         pass
     else:  # pragma: no cover - enforce immutability even if TypeError not raised
@@ -46,7 +47,7 @@ def test_get_all_returns_read_only_mapping() -> None:
     mapping = store.get_all("dial/rotate")
     assert 0 in mapping
     try:
-        mapping[1] = mapping[0]  # type: ignore[assignment]
+        cast(dict[int, Input], mapping)[1] = mapping[0]
     except TypeError:
         pass
     else:  # pragma: no cover


### PR DESCRIPTION
## Summary
- load optional firmware dependencies via `importlib` and add casts to eliminate redundant `type: ignore` comments
- inject a configurable clock into the rotary encoder handler and adjust peripherals to store typed payload snapshots
- make max-age pruning inclusive, update associated metrics tests, and ensure compatibility helpers add the project root to `sys.path`

## Testing
- make format
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f7307cd3883219e9946a48d78aa69)