### PR TITLE
Remove formatting diff guard from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,5 @@ jobs:
       - name: Run mypy
         run: uv run mypy --config-file pyproject.toml
 
-      - name: Ensure no formatting changes
-        run: git diff --exit-code
-
       - name: Run tests
         run: make test


### PR DESCRIPTION
## Summary
- remove the "Ensure no formatting changes" step from the CI workflow

## Testing
- make format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f7603957483219777e2b89b00ad0f)