### PR TITLE
Flatten peripheral metrics into dedicated classes

### DIFF
--- a/docs/planning/peripheral_metrics_suite.md
+++ b/docs/planning/peripheral_metrics_suite.md
@@ -1,0 +1,181 @@
+______________________________________________________________________
+
+## title: Peripheral Metrics Integration Plan
+
+# Problem Statement
+
+The current peripheral stack lacks a consolidated metrics subsystem that can
+surface core, spectral, and domain-specific statistics for incoming sensor
+streams. Without this layer we cannot detect bursts, oscillations, or failure
+signatures early enough to drive adaptive behaviours or maintenance alerts. We
+need a roadmap that enumerates every required metric, the data prerequisites,
+and the validation hooks so implementation can proceed without ambiguity.
+
+# Materials
+
+- Raspberry Pi 4 (8 GB) or equivalent host running the HEART peripheral stack.
+- BLE, USB, and analog sensor peripherals capable of emitting time-series
+  samples (force plates, microphones, IMUs, rotary encoders).
+- Access to the event bus APIs in `heart.peripheral.core.event_bus` and the
+  rolling window helpers in `heart.events.metrics`.
+- NumPy and SciPy runtime dependencies (already listed in `pyproject.toml`).
+- Benchmark capture scripts under `scripts/` to replay recorded sessions.
+- Diagram tooling (Mermaid via `mdformat` plugin or Excalidraw export) for
+  architecture visuals.
+
+# Opening Abstract
+
+This document defines the phased plan for building a unified peripheral metrics
+suite that emits the 20 standard and experimental analytics requested for the
+sensor pipeline. The plan sequences infrastructure upgrades (shared buffer,
+spectral transforms), implements the metrics in programmable batches, and wires
+them into the event bus for downstream consumers. Validation blends synthetic
+signal injection, regression snapshots, and performance profiling to guarantee
+we can sustain at least 120 Hz sampling without frame drops.
+
+# Success Criteria
+
+| Target Behaviour | Validation Signal | Owner |
+|---------------------------------------------------|----------------------------------------------------------------------------|-------|
+| Metrics buffers honour window and length policies | Unit tests under `tests/events/test_peripheral_metrics.py` exercise edge | @todo |
+|                                                   | windows via `EventWindow` fixtures.                                       |       |
+| Standard metrics emitted per update cycle         | Bus captures in `tests/events/test_metrics_bus.py` confirm 10/10 entries.| @todo |
+| Spectral features computed within 8 ms budget     | Benchmark harness `pytest -k metrics_benchmark` stays under threshold.   | @todo |
+| Domain-specific flags raise actionable alerts     | Integration test uses seeded IMU/log data to trigger Allan variance alert.| @todo |
+
+# Task Breakdown Checklists
+
+## Phase 1 – Infrastructure
+
+- [ ] Expose `compute_peripheral_metrics` in `src/heart/events/metrics.py` so any `EventWindow` can render snapshots.
+- [ ] Integrate percentile, histogram, and EWMA helpers leveraging
+  `heart.events.metrics.EventWindow` storage.
+- [ ] Add serialization schema for publishing snapshots onto the event bus.
+
+## Phase 2 – Standard Metrics
+
+- [ ] Implement event count, EPS, rolling sum/min/max, percentiles, histogram,
+  EWMA, inter-event interval stats, and threshold exceedance counters.
+- [ ] Validate against synthetic ramp/burst inputs to confirm expected outputs.
+- [ ] Document parameter knobs (window length, EWMA alpha, histogram bins).
+
+## Phase 3 – Experimental Metrics
+
+- [ ] Add z-score anomaly scoring, configurable complex event pattern detection,
+  zero-lag cross-correlation versus a reference stream, FFT dominant frequency,
+  and sample entropy calculators.
+- [ ] Provide fallback behaviour when insufficient samples are available.
+- [ ] Extend integration tests to cover dual-stream correlation scenarios.
+
+## Phase 4 – Domain Metrics
+
+- [ ] Implement Allan variance, Hurst exponent, crest factor, kurtosis, and
+  permutation entropy calculators with validation fixtures sourced from IMU and
+  vibration reference datasets.
+- [ ] Publish regression notebooks under `docs/research/` demonstrating metrics
+  stability on noisy inputs.
+- [ ] Create tuning checklist for choosing averaging times and embedding sizes.
+
+## Phase 5 – Spectral & Neuro Metrics
+
+- [ ] Add spectral centroid, flatness, roll-off, spectral entropy, spectral
+  kurtosis, envelope spectrum peak, order-tracked amplitudes, TKEO energy, and
+  Hjorth parameters.
+- [ ] Implement the Fano factor calculation for spike-train style event counts.
+- [ ] Benchmark FFT/analytic steps to ensure \<15 % CPU utilisation on Pi 4.
+
+## Phase 6 – Integration & Telemetry
+
+- [ ] Emit composite metric snapshots over the event bus with topic versioning.
+- [ ] Add CLI inspection command under `heart.x.cli` to stream live metrics.
+- [ ] Wire dashboards or log sinks to persist historical metric trends.
+
+# Narrative Walkthrough
+
+Phase 1 exposes the compute helper that consumes existing `EventWindow`
+policies. By wiring metrics directly into the established windowing layer we
+avoid duplicating buffer logic while keeping retention policies consistent for
+every downstream metric. Once in place, Phase 2 fleshes out the ten
+standard metrics that downstream consumers already expect. These are relatively
+lightweight calculations and will double as the first verification of buffer
+correctness.
+
+Phase 3 introduces experimental analytics that rely on more advanced signal
+processing primitives. This stage validates multi-stream handling (for
+cross-correlation) and ensures pattern detection can express finite state
+automata such as the Konami code for input devices. The entropy calculation
+exercises the shared buffer API to confirm we can fall back gracefully when
+window sizes shrink.
+
+Phase 4 shifts to domain-centric descriptors relevant to IMUs, vibration
+diagnostics, and financial-style persistence checks. These metrics are sensitive
+to sampling cadence and noise assumptions, so the plan calls for curated data
+sets and regression notebooks to capture expected behaviour. Completing this
+phase equips the stack to surface both mean-reverting and burst-heavy dynamics.
+
+Phase 5 layers on spectral heavy hitters. Implementing the FFT pipelines unlocks
+audio-style insights (centroid, flatness, roll-off) and bearing diagnostics via
+envelope spectra and spectral kurtosis. TKEO and Hjorth parameters bridge into
+neuroscience-style monitoring. The Fano factor rounds out the probability-space
+view by quantifying burstiness in discrete event counts. Performance profiling
+here keeps the computation budget under the render loop constraints.
+
+Phase 6 handles the final wiring, ensuring metrics travel over the event bus and
+are observable through CLI tooling and dashboards. By this point the suite is
+feature-complete; the integration work ensures instrumentation is usable in the
+field and remains maintainable via versioned payloads.
+
+# Visual Reference
+
+```mermaid
+flowchart LR
+    subgraph Sensors
+        A[Force Plate]
+        B[IMU]
+        C[Microphone]
+    end
+    subgraph Buffering
+        D[EventWindow Policies]
+        E[compute_peripheral_metrics]
+    end
+    subgraph Metrics
+        F[Standard]
+        G[Experimental]
+        H[Domain]
+        I[Spectral/Neuro]
+    end
+    subgraph Outputs
+        J[Event Bus Topics]
+        K[CLI Inspector]
+        L[Dashboards]
+    end
+
+    A & B & C --> D --> E --> F & G & H & I --> J --> K & L
+```
+
+# Risk Analysis
+
+| Risk | Probability | Impact | Mitigation | Early Signal |
+|----------------------------------------|-------------|--------|---------------------------------------------------------|-------------------------------------------|
+| Spectral calculations exceed CPU budget| Medium | High | Profile FFT length, cache windowed FFT plans, throttle | `pytest -k metrics_benchmark` regression |
+| Sparse data breaks entropy estimates | Medium | Medium | Add minimum-sample guards with NaN outputs | WARN logs about insufficient samples |
+| Cross-correlation drifts due to clock | Low | High | Resample streams onto shared timeline via interpolation | Diverging timestamps in debug traces |
+| Order tracking lacks RPM reference | Medium | Medium | Expose optional RPM input and skip metric when missing | Snapshot shows `None` order amplitudes |
+| Numerical instability in Allan variance| Low | Medium | Use double precision and validated SciPy routines | Unit tests failing on IMU fixture datasets |
+
+## Mitigation Checklist
+
+- [ ] Wire performance benchmarks into CI with failure thresholds.
+- [ ] Add log warnings when metrics fall back to `None` due to invalid inputs.
+- [ ] Include RPM/reference stream configuration in operator handbook.
+- [ ] Review SciPy/NumPy release notes before dependency upgrades.
+
+# Outcome Snapshot
+
+Once delivered, every peripheral capable of emitting scalar or vector samples
+will call `compute_peripheral_metrics` to publish structured snapshots
+bundles each frame. Consumers can query real-time event rates, detect spectral
+peaks, monitor anomaly scores, and triage domain-specific health indicators
+without bespoke glue code. The event bus topics provide a uniform contract so
+renderers, automation scripts, and remote dashboards can ingest analytics with a
+single subscription.

--- a/src/heart/events/metrics.py
+++ b/src/heart/events/metrics.py
@@ -6,7 +6,12 @@ import math
 import time
 from collections import Counter, defaultdict, deque
 from dataclasses import dataclass
-from typing import Deque, Dict, Generic, Iterable, Iterator, Mapping, TypeVar
+from typing import (Deque, Dict, Generic, Iterable, Iterator, Mapping,
+                    Sequence, TypeVar)
+
+import numpy as np
+from scipy.signal import hilbert  # type: ignore[import-untyped]
+from scipy.stats import kurtosis  # type: ignore[import-untyped]
 
 T = TypeVar("T")
 K = TypeVar("K")
@@ -288,19 +293,787 @@ class RollingStddevByKey(Generic[K]):
         self._stats.reset(key)
 
 
+@dataclass(slots=True)
+class EventCountMetric:
+    """Number of events captured within the window."""
+
+    count: int
+
+
+@dataclass(slots=True)
+class EventRateMetric:
+    """Event rate expressed in events per second."""
+
+    rate: float | None
+
+
+@dataclass(slots=True)
+class RollingSumMetric:
+    """Rolling sum of samples."""
+
+    total: float | None
+
+
+@dataclass(slots=True)
+class RollingMinMetric:
+    """Rolling minimum of samples."""
+
+    value: float | None
+
+
+@dataclass(slots=True)
+class RollingMaxMetric:
+    """Rolling maximum of samples."""
+
+    value: float | None
+
+
+@dataclass(slots=True)
+class PercentilesMetric:
+    """Percentile values computed from the window."""
+
+    values: Mapping[str, float]
+
+
+@dataclass(slots=True)
+class HistogramMetric:
+    """Histogram counts and associated bin edges."""
+
+    counts: tuple[float, ...]
+    bin_edges: tuple[float, ...]
+
+
+@dataclass(slots=True)
+class EWMAMetric:
+    """Exponentially weighted moving average."""
+
+    value: float | None
+
+
+@dataclass(slots=True)
+class InterEventIntervalMetric:
+    """Descriptive statistics for inter-event intervals."""
+
+    minimum: float | None
+    maximum: float | None
+    mean: float | None
+    stddev: float | None
+
+
+@dataclass(slots=True)
+class ThresholdExceedanceMetric:
+    """Count of samples outside provided thresholds."""
+
+    count: int | None
+
+
+@dataclass(slots=True)
+class ZScoreMetric:
+    """Z-score of the most recent sample against the window."""
+
+    score: float | None
+
+
+@dataclass(slots=True)
+class PatternDetectionMetric:
+    """Count of pattern occurrences within the window."""
+
+    occurrences: int | None
+
+
+@dataclass(slots=True)
+class CrossCorrelationMetric:
+    """Cross-correlation coefficient with a reference window."""
+
+    coefficient: float | None
+
+
+@dataclass(slots=True)
+class DominantFrequencyMetric:
+    """Dominant frequency detected via FFT."""
+
+    frequency_hz: float | None
+
+
+@dataclass(slots=True)
+class SampleEntropyMetric:
+    """Sample entropy of the window."""
+
+    entropy: float | None
+
+
+@dataclass(slots=True)
+class AllanVarianceMetric:
+    """Allan variance describing stability over averaging time."""
+
+    variance: float | None
+
+
+@dataclass(slots=True)
+class HurstExponentMetric:
+    """Hurst exponent indicating persistence or mean reversion."""
+
+    exponent: float | None
+
+
+@dataclass(slots=True)
+class CrestFactorMetric:
+    """Crest factor describing peak-to-RMS ratio."""
+
+    value: float | None
+
+
+@dataclass(slots=True)
+class KurtosisMetric:
+    """Kurtosis capturing tail heaviness of the distribution."""
+
+    value: float | None
+
+
+@dataclass(slots=True)
+class PermutationEntropyMetric:
+    """Permutation entropy measuring ordinal complexity."""
+
+    entropy: float | None
+
+
+@dataclass(slots=True)
+class SpectralCentroidMetric:
+    """Spectral centroid of the power spectrum."""
+
+    frequency_hz: float | None
+
+
+@dataclass(slots=True)
+class SpectralFlatnessMetric:
+    """Spectral flatness describing tonality vs. noisiness."""
+
+    flatness: float | None
+
+
+@dataclass(slots=True)
+class SpectralRolloffMetric:
+    """Spectral roll-off frequency for the requested percentile."""
+
+    frequency_hz: float | None
+
+
+@dataclass(slots=True)
+class SpectralEntropyMetric:
+    """Spectral entropy of the power distribution."""
+
+    entropy: float | None
+
+
+@dataclass(slots=True)
+class SpectralKurtosisMetric:
+    """Spectral kurtosis emphasising impulsive behaviour."""
+
+    kurtosis: float | None
+
+
+@dataclass(slots=True)
+class EnvelopeSpectrumPeakMetric:
+    """Peak frequency of the envelope spectrum."""
+
+    frequency_hz: float | None
+
+
+@dataclass(slots=True)
+class OrderTrackedAmplitudeMetric:
+    """Order-tracked amplitudes keyed by harmonic order."""
+
+    amplitudes: Mapping[int, float] | None
+
+
+@dataclass(slots=True)
+class TeagerKaiserEnergyMetric:
+    """Teager–Kaiser energy of the signal."""
+
+    energy: float | None
+
+
+@dataclass(slots=True)
+class HjorthParametersMetric:
+    """Hjorth parameters (activity, mobility, complexity)."""
+
+    parameters: Mapping[str, float] | None
+
+
+@dataclass(slots=True)
+class FanoFactorMetric:
+    """Fano factor quantifying dispersion of event counts."""
+
+    factor: float | None
+
+
+@dataclass(slots=True)
+class PeripheralMetricsSnapshot:
+    """Snapshot of every peripheral metric."""
+
+    event_count: EventCountMetric
+    event_rate: EventRateMetric
+    rolling_sum: RollingSumMetric
+    rolling_min: RollingMinMetric
+    rolling_max: RollingMaxMetric
+    percentiles: PercentilesMetric
+    histogram: HistogramMetric
+    ewma: EWMAMetric
+    inter_event_intervals: InterEventIntervalMetric
+    threshold_exceedance: ThresholdExceedanceMetric
+    z_score: ZScoreMetric
+    pattern_detection: PatternDetectionMetric
+    cross_correlation: CrossCorrelationMetric
+    dominant_frequency: DominantFrequencyMetric
+    sample_entropy: SampleEntropyMetric
+    allan_variance: AllanVarianceMetric
+    hurst_exponent: HurstExponentMetric
+    crest_factor: CrestFactorMetric
+    kurtosis: KurtosisMetric
+    permutation_entropy: PermutationEntropyMetric
+    spectral_centroid: SpectralCentroidMetric
+    spectral_flatness: SpectralFlatnessMetric
+    spectral_rolloff: SpectralRolloffMetric
+    spectral_entropy: SpectralEntropyMetric
+    spectral_kurtosis: SpectralKurtosisMetric
+    envelope_spectrum_peak: EnvelopeSpectrumPeakMetric
+    order_tracked_amplitude: OrderTrackedAmplitudeMetric
+    tkeo_energy: TeagerKaiserEnergyMetric
+    hjorth_parameters: HjorthParametersMetric
+    fano_factor: FanoFactorMetric
+
+
+def compute_peripheral_metrics(
+    samples: Sequence[EventSample[float]],
+    *,
+    histogram_bins: int = 20,
+    percentiles: Sequence[float] = (50, 90, 99),
+    ewma_alpha: float = 0.3,
+    thresholds: tuple[float, float] | None = None,
+    pattern: Sequence[float] | None = None,
+    pattern_tolerance: float = 1e-3,
+    reference_samples: Sequence[EventSample[float]] | None = None,
+    rolloff_percent: float = 0.95,
+    orders: Sequence[int] = (1,),
+    order_reference_hz: float | None = None,
+    sample_rate: float | None = None,
+) -> PeripheralMetricsSnapshot:
+    """Compute the requested metrics using existing window helpers."""
+
+    values, timestamps = _extract_arrays(samples)
+    reference_values: np.ndarray | None
+    reference_timestamps: np.ndarray | None
+    if reference_samples is not None:
+        reference_values, reference_timestamps = _extract_arrays(reference_samples)
+    else:
+        reference_values = None
+        reference_timestamps = None
+
+    standard = _compute_standard_metrics(
+        values,
+        timestamps=timestamps,
+        histogram_bins=histogram_bins,
+        percentiles=percentiles,
+        ewma_alpha=ewma_alpha,
+        thresholds=thresholds,
+    )
+    experimental = _compute_experimental_metrics(
+        values,
+        timestamps=timestamps,
+        reference_values=reference_values,
+        reference_timestamps=reference_timestamps,
+        pattern=pattern,
+        pattern_tolerance=pattern_tolerance,
+        sample_rate=sample_rate,
+    )
+    domain = _compute_domain_metrics(values, sample_rate=sample_rate)
+    spectral = _compute_spectral_metrics(
+        values,
+        sample_rate=sample_rate,
+        rolloff_percent=rolloff_percent,
+        orders=orders,
+        order_reference_hz=order_reference_hz,
+    )
+    snapshot_kwargs: dict[str, object] = {}
+    snapshot_kwargs.update(standard)
+    snapshot_kwargs.update(experimental)
+    snapshot_kwargs.update(domain)
+    snapshot_kwargs.update(spectral)
+    return PeripheralMetricsSnapshot(**snapshot_kwargs)
+
+
+def _extract_arrays(
+    samples: Sequence[EventSample[float]],
+) -> tuple[np.ndarray, np.ndarray]:
+    if not samples:
+        return np.asarray([]), np.asarray([])
+    values = np.fromiter((sample.value for sample in samples), dtype=float)
+    timestamps = np.fromiter((sample.timestamp for sample in samples), dtype=float)
+    return values, timestamps
+
+
+def _compute_standard_metrics(
+    values: np.ndarray,
+    *,
+    timestamps: np.ndarray,
+    histogram_bins: int,
+    percentiles: Sequence[float],
+    ewma_alpha: float,
+    thresholds: tuple[float, float] | None,
+) -> dict[str, object]:
+    event_count = int(values.size)
+    duration = float(timestamps[-1] - timestamps[0]) if timestamps.size > 1 else 0.0
+    event_rate_value = event_count / duration if duration > 0 else None
+
+    rolling_sum_value = float(np.sum(values)) if event_count else None
+    rolling_min_value = float(np.min(values)) if event_count else None
+    rolling_max_value = float(np.max(values)) if event_count else None
+    percentile_values = (
+        {f"p{int(p)}": float(np.percentile(values, p)) for p in percentiles}
+        if event_count
+        else {}
+    )
+    if histogram_bins > 0 and event_count > 0:
+        counts, bin_edges = np.histogram(values, bins=histogram_bins)
+        histogram_metric = HistogramMetric(
+            counts=tuple(float(count) for count in counts),
+            bin_edges=tuple(float(edge) for edge in bin_edges),
+        )
+    else:
+        histogram_metric = HistogramMetric(counts=(), bin_edges=())
+
+    ewma_value = _compute_ewma(values, alpha=ewma_alpha)
+    inter_event = _compute_inter_event_intervals(timestamps)
+    threshold_count = _count_threshold_exceedances(values, thresholds)
+
+    return {
+        "event_count": EventCountMetric(count=event_count),
+        "event_rate": EventRateMetric(rate=event_rate_value),
+        "rolling_sum": RollingSumMetric(total=rolling_sum_value),
+        "rolling_min": RollingMinMetric(value=rolling_min_value),
+        "rolling_max": RollingMaxMetric(value=rolling_max_value),
+        "percentiles": PercentilesMetric(values=percentile_values),
+        "histogram": histogram_metric,
+        "ewma": EWMAMetric(value=ewma_value),
+        "inter_event_intervals": inter_event,
+        "threshold_exceedance": ThresholdExceedanceMetric(count=threshold_count),
+    }
+
+
+def _compute_experimental_metrics(
+    values: np.ndarray,
+    *,
+    timestamps: np.ndarray,
+    reference_values: np.ndarray | None,
+    reference_timestamps: np.ndarray | None,
+    pattern: Sequence[float] | None,
+    pattern_tolerance: float,
+    sample_rate: float | None,
+) -> dict[str, object]:
+    if values.size == 0:
+        z_score = None
+    else:
+        mean = float(np.mean(values))
+        std = float(np.std(values, ddof=0))
+        z_score = float((values[-1] - mean) / std) if std > 0 else None
+
+    pattern_count = _count_pattern_occurrences(values, pattern, pattern_tolerance)
+
+    cross_correlation = None
+    if reference_values is not None and reference_timestamps is not None:
+        cross_correlation = _compute_cross_correlation(
+            values, reference_values, timestamps, reference_timestamps
+        )
+
+    dominant_frequency = _compute_dominant_frequency(values, sample_rate)
+    sample_entropy = _sample_entropy(values)
+
+    return {
+        "z_score": ZScoreMetric(score=z_score),
+        "pattern_detection": PatternDetectionMetric(occurrences=pattern_count),
+        "cross_correlation": CrossCorrelationMetric(coefficient=cross_correlation),
+        "dominant_frequency": DominantFrequencyMetric(frequency_hz=dominant_frequency),
+        "sample_entropy": SampleEntropyMetric(entropy=sample_entropy),
+    }
+
+
+def _compute_domain_metrics(
+    values: np.ndarray,
+    *,
+    sample_rate: float | None,
+) -> dict[str, object]:
+    allan = _allan_variance(values, sample_rate)
+    hurst = _hurst_exponent(values)
+    crest = _crest_factor(values)
+    kurt = float(kurtosis(values, fisher=True, bias=False)) if values.size > 3 else None
+    perm_entropy = _permutation_entropy(values)
+    return {
+        "allan_variance": AllanVarianceMetric(variance=allan),
+        "hurst_exponent": HurstExponentMetric(exponent=hurst),
+        "crest_factor": CrestFactorMetric(value=crest),
+        "kurtosis": KurtosisMetric(value=kurt),
+        "permutation_entropy": PermutationEntropyMetric(entropy=perm_entropy),
+    }
+
+
+def _compute_spectral_metrics(
+    values: np.ndarray,
+    *,
+    sample_rate: float | None,
+    rolloff_percent: float,
+    orders: Sequence[int],
+    order_reference_hz: float | None,
+) -> dict[str, object]:
+    if values.size == 0:
+        spectrum = np.asarray([])
+        freqs = np.asarray([])
+    else:
+        spectrum, freqs = _power_spectrum(values, sample_rate)
+
+    centroid = _spectral_centroid(freqs, spectrum)
+    flatness = _spectral_flatness(spectrum)
+    rolloff = _spectral_rolloff(freqs, spectrum, rolloff_percent)
+    entropy = _spectral_entropy(spectrum)
+    spec_kurtosis = _spectral_kurtosis(spectrum)
+    envelope_peak = _envelope_spectrum_peak(values, sample_rate)
+    orders_map = _order_tracked_amplitudes(
+        spectrum,
+        freqs,
+        orders,
+        order_reference_hz,
+    )
+    tkeo = _tkeo_energy(values)
+    hjorth = _hjorth_parameters(values)
+    fano = _fano_factor(values)
+
+    return {
+        "spectral_centroid": SpectralCentroidMetric(frequency_hz=centroid),
+        "spectral_flatness": SpectralFlatnessMetric(flatness=flatness),
+        "spectral_rolloff": SpectralRolloffMetric(frequency_hz=rolloff),
+        "spectral_entropy": SpectralEntropyMetric(entropy=entropy),
+        "spectral_kurtosis": SpectralKurtosisMetric(kurtosis=spec_kurtosis),
+        "envelope_spectrum_peak": EnvelopeSpectrumPeakMetric(
+            frequency_hz=envelope_peak
+        ),
+        "order_tracked_amplitude": OrderTrackedAmplitudeMetric(amplitudes=orders_map),
+        "tkeo_energy": TeagerKaiserEnergyMetric(energy=tkeo),
+        "hjorth_parameters": HjorthParametersMetric(parameters=hjorth),
+        "fano_factor": FanoFactorMetric(factor=fano),
+    }
+
+
+def _compute_ewma(values: np.ndarray, *, alpha: float) -> float | None:
+    if values.size == 0:
+        return None
+    alpha = float(np.clip(alpha, 0.0, 1.0))
+    if alpha == 0:
+        return float(values[-1])
+    ewma = values[0]
+    for value in values[1:]:
+        ewma = alpha * value + (1 - alpha) * ewma
+    return float(ewma)
+
+
+def _compute_inter_event_intervals(timestamps: np.ndarray) -> InterEventIntervalMetric:
+    if timestamps.size < 2:
+        return InterEventIntervalMetric(None, None, None, None)
+    deltas = np.diff(timestamps)
+    return InterEventIntervalMetric(
+        minimum=float(np.min(deltas)),
+        maximum=float(np.max(deltas)),
+        mean=float(np.mean(deltas)),
+        stddev=float(np.std(deltas, ddof=0)),
+    )
+
+
+def _count_threshold_exceedances(
+    values: np.ndarray, thresholds: tuple[float, float] | None
+) -> int | None:
+    if thresholds is None:
+        return None
+    lower, upper = thresholds
+    exceedances = np.logical_or(values < lower, values > upper)
+    return int(np.count_nonzero(exceedances))
+
+
+def _count_pattern_occurrences(
+    values: np.ndarray,
+    pattern: Sequence[float] | None,
+    tolerance: float,
+) -> int | None:
+    if pattern is None or len(pattern) == 0:
+        return None
+    pattern_arr = np.asarray(pattern, dtype=float)
+    if values.size < pattern_arr.size:
+        return 0
+
+    count = 0
+    for start in range(values.size - pattern_arr.size + 1):
+        window = values[start : start + pattern_arr.size]
+        if np.all(np.abs(window - pattern_arr) <= tolerance):
+            count += 1
+    return count
+
+
+def _compute_cross_correlation(
+    primary: np.ndarray,
+    reference: np.ndarray,
+    primary_timestamps: np.ndarray,
+    reference_timestamps: np.ndarray,
+) -> float | None:
+    if primary.size == 0 or reference.size == 0:
+        return None
+    primary_mean = primary - np.mean(primary)
+    reference_mean = reference - np.mean(reference)
+    correlation = np.correlate(primary_mean, reference_mean, mode="valid")
+    denom = np.linalg.norm(primary_mean) * np.linalg.norm(reference_mean)
+    if denom == 0:
+        return None
+    return float(correlation[0] / denom)
+
+
+def _compute_dominant_frequency(values: np.ndarray, sample_rate: float | None) -> float | None:
+    if values.size == 0 or sample_rate is None or sample_rate <= 0:
+        return None
+    spectrum = np.abs(np.fft.rfft(values))
+    freqs = np.fft.rfftfreq(values.size, d=1.0 / sample_rate)
+    max_index = np.argmax(spectrum[1:]) + 1 if spectrum.size > 1 else 0
+    return float(freqs[max_index])
+
+
+def _sample_entropy(values: np.ndarray, m: int = 2, r: float | None = None) -> float | None:
+    if values.size <= m + 1:
+        return None
+    if r is None:
+        r = 0.2 * np.std(values, ddof=0)
+    if r == 0:
+        return None
+    count = 0
+    template_count = 0
+    limit = values.size - m
+    for i in range(limit):
+        template = values[i : i + m]
+        for j in range(i + 1, limit):
+            window = values[j : j + m]
+            if np.max(np.abs(template - window)) <= r:
+                template_count += 1
+                if abs(values[i + m] - values[j + m]) <= r:
+                    count += 1
+    if template_count == 0 or count == 0:
+        return 0.0
+    return float(-np.log(count / template_count))
+
+
+def _allan_variance(values: np.ndarray, sample_rate: float | None) -> float | None:
+    if values.size < 2 or sample_rate is None or sample_rate <= 0:
+        return None
+    taus = np.array([1, 2, 4, 8]) / sample_rate
+    variances = []
+    for tau in taus:
+        m = int(round(tau * sample_rate))
+        if m < 1 or 2 * m >= values.size:
+            continue
+        averaged = np.array([np.mean(values[i : i + m]) for i in range(0, values.size - m + 1)])
+        diff = np.diff(averaged)
+        if diff.size == 0:
+            continue
+        variances.append(0.5 * np.mean(diff**2))
+    if not variances:
+        return None
+    return float(np.mean(variances))
+
+
+def _hurst_exponent(values: np.ndarray) -> float | None:
+    if values.size < 20:
+        return None
+    cumulative = np.cumsum(values - np.mean(values))
+    ranges = np.max(cumulative) - np.min(cumulative)
+    std = np.std(values, ddof=0)
+    if std == 0 or ranges == 0:
+        return None
+    return float(np.log(ranges / std) / np.log(values.size))
+
+
+def _crest_factor(values: np.ndarray) -> float | None:
+    if values.size == 0:
+        return None
+    rms = np.sqrt(np.mean(values**2))
+    if rms == 0:
+        return None
+    peak = np.max(np.abs(values))
+    return float(peak / rms)
+
+
+def _permutation_entropy(values: np.ndarray, order: int = 3) -> float | None:
+    if values.size < order:
+        return None
+    patterns = {}
+    for i in range(values.size - order + 1):
+        pattern = tuple(np.argsort(values[i : i + order]))
+        patterns[pattern] = patterns.get(pattern, 0) + 1
+    counts = np.array(list(patterns.values()), dtype=float)
+    probabilities = counts / np.sum(counts)
+    return float(-np.sum(probabilities * np.log(probabilities)))
+
+
+def _power_spectrum(values: np.ndarray, sample_rate: float | None) -> tuple[np.ndarray, np.ndarray]:
+    if sample_rate is None or sample_rate <= 0:
+        sample_rate = 1.0
+    spectrum = np.abs(np.fft.rfft(values)) ** 2
+    freqs = np.fft.rfftfreq(values.size, d=1.0 / sample_rate)
+    return spectrum, freqs
+
+
+def _spectral_centroid(freqs: np.ndarray, spectrum: np.ndarray) -> float | None:
+    if spectrum.size == 0 or np.sum(spectrum) == 0:
+        return None
+    return float(np.sum(freqs * spectrum) / np.sum(spectrum))
+
+
+def _spectral_flatness(spectrum: np.ndarray) -> float | None:
+    if spectrum.size == 0:
+        return None
+    geometric_mean = np.exp(np.mean(np.log(np.maximum(spectrum, 1e-12))))
+    arithmetic_mean = np.mean(spectrum)
+    if arithmetic_mean == 0:
+        return None
+    return float(geometric_mean / arithmetic_mean)
+
+
+def _spectral_rolloff(
+    freqs: np.ndarray,
+    spectrum: np.ndarray,
+    rolloff_percent: float,
+) -> float | None:
+    if spectrum.size == 0:
+        return None
+    cumulative = np.cumsum(spectrum)
+    target = rolloff_percent * cumulative[-1]
+    index = np.searchsorted(cumulative, target)
+    index = min(index, freqs.size - 1)
+    return float(freqs[index])
+
+
+def _spectral_entropy(spectrum: np.ndarray) -> float | None:
+    if spectrum.size == 0:
+        return None
+    norm = np.sum(spectrum)
+    if norm == 0:
+        return None
+    probabilities = spectrum / norm
+    return float(-np.sum(probabilities * np.log(probabilities + 1e-12)))
+
+
+def _spectral_kurtosis(spectrum: np.ndarray) -> float | None:
+    if spectrum.size < 4:
+        return None
+    centered = spectrum - np.mean(spectrum)
+    variance = np.mean(centered**2)
+    if variance == 0:
+        return None
+    return float(np.mean(centered**4) / (variance**2))
+
+
+def _envelope_spectrum_peak(values: np.ndarray, sample_rate: float | None) -> float | None:
+    if sample_rate is None or sample_rate <= 0:
+        return None
+    analytic_signal = hilbert(values)
+    envelope = np.abs(analytic_signal)
+    spectrum = np.abs(np.fft.rfft(envelope))
+    freqs = np.fft.rfftfreq(envelope.size, d=1.0 / sample_rate)
+    peak_index = int(np.argmax(spectrum))
+    return float(freqs[peak_index])
+
+
+def _order_tracked_amplitudes(
+    spectrum: np.ndarray,
+    freqs: np.ndarray,
+    orders: Sequence[int],
+    reference_hz: float | None,
+) -> Mapping[int, float] | None:
+    if reference_hz is None or reference_hz <= 0 or not orders:
+        return None
+    amplitudes: dict[int, float] = {}
+    for order in orders:
+        target_freq = order * reference_hz
+        index = int(np.argmin(np.abs(freqs - target_freq)))
+        amplitudes[order] = float(spectrum[index]) if index < spectrum.size else 0.0
+    return amplitudes
+
+
+def _tkeo_energy(values: np.ndarray) -> float | None:
+    if values.size < 3:
+        return None
+    energy = values[1:-1] ** 2 - values[:-2] * values[2:]
+    return float(np.mean(energy))
+
+
+def _hjorth_parameters(values: np.ndarray) -> Mapping[str, float] | None:
+    if values.size < 3:
+        return None
+    activity = float(np.var(values))
+    diff = np.diff(values)
+    diff2 = np.diff(diff)
+    mobility = float(np.sqrt(np.var(diff) / activity)) if activity > 0 else 0.0
+    complexity = float(np.sqrt(np.var(diff2) / np.var(diff))) if np.var(diff) > 0 else 0.0
+    return {"activity": activity, "mobility": mobility, "complexity": complexity}
+
+
+def _fano_factor(values: np.ndarray) -> float | None:
+    if values.size == 0:
+        return None
+    mean = float(np.mean(values))
+    if abs(mean) < 1e-12:
+        return None
+    variance = float(np.var(values))
+    return variance / mean
+
+
 __all__ = [
+    "AllanVarianceMetric",
     "CountByKey",
+    "CrestFactorMetric",
+    "CrossCorrelationMetric",
+    "DominantFrequencyMetric",
+    "EnvelopeSpectrumPeakMetric",
+    "EventCountMetric",
+    "EventRateMetric",
     "EventSample",
     "EventWindow",
+    "EWMAMetric",
+    "FanoFactorMetric",
+    "HistogramMetric",
+    "HjorthParametersMetric",
+    "HurstExponentMetric",
+    "InterEventIntervalMetric",
+    "KurtosisMetric",
     "LastEventsWithinTimeWindow",
     "LastNEvents",
     "LastNEventsWithinTimeWindow",
     "MaxAgePolicy",
     "MaxLengthPolicy",
+    "OrderTrackedAmplitudeMetric",
+    "PatternDetectionMetric",
+    "PeripheralMetricsSnapshot",
+    "PercentilesMetric",
+    "PermutationEntropyMetric",
     "RollingAverageByKey",
+    "RollingMaxMetric",
     "RollingMeanByKey",
+    "RollingMinMetric",
     "RollingSnapshot",
     "RollingStatisticsByKey",
     "RollingStddevByKey",
+    "RollingSumMetric",
+    "SampleEntropyMetric",
+    "SpectralCentroidMetric",
+    "SpectralEntropyMetric",
+    "SpectralFlatnessMetric",
+    "SpectralKurtosisMetric",
+    "SpectralRolloffMetric",
+    "TeagerKaiserEnergyMetric",
+    "ThresholdExceedanceMetric",
+    "ZScoreMetric",
     "combine_windows",
+    "compute_peripheral_metrics",
 ]

--- a/tests/events/test_peripheral_metrics.py
+++ b/tests/events/test_peripheral_metrics.py
@@ -1,0 +1,108 @@
+from typing import Iterable
+
+import numpy as np
+import pytest
+
+from heart.events.metrics import EventSample, compute_peripheral_metrics
+
+
+def _samples(values: Iterable[float], *, start: float = 0.0, step: float = 1.0):
+    return [
+        EventSample(value=float(value), timestamp=start + index * step)
+        for index, value in enumerate(values)
+    ]
+
+
+def test_compute_peripheral_metrics_standard_fields() -> None:
+    samples = _samples([1.0, 2.0, 3.0, 4.0], step=0.5)
+    snapshot = compute_peripheral_metrics(
+        samples,
+        histogram_bins=2,
+        percentiles=(50, 75),
+        ewma_alpha=1.0,
+        thresholds=(0.0, 3.0),
+    )
+
+    assert snapshot.event_count.count == 4
+    assert snapshot.event_rate.rate == pytest.approx(4 / 1.5)
+    assert snapshot.rolling_sum.total == pytest.approx(10.0)
+    assert snapshot.rolling_min.value == pytest.approx(1.0)
+    assert snapshot.rolling_max.value == pytest.approx(4.0)
+    assert snapshot.percentiles.values["p50"] == pytest.approx(2.5)
+    assert "p75" in snapshot.percentiles.values
+    histogram = snapshot.histogram
+    assert histogram.counts
+    assert sum(histogram.counts) == pytest.approx(4.0)
+    assert snapshot.ewma.value == pytest.approx(4.0)
+
+    intervals = snapshot.inter_event_intervals
+    assert intervals.minimum == pytest.approx(0.5)
+    assert intervals.maximum == pytest.approx(0.5)
+    assert intervals.mean == pytest.approx(0.5)
+    assert intervals.stddev == pytest.approx(0.0)
+
+    assert snapshot.threshold_exceedance.count == 1
+
+
+def test_compute_peripheral_metrics_experimental_fields() -> None:
+    values = [0.0, 1.0, 0.0, -1.0, 0.0]
+    samples = _samples(values, step=0.1)
+    reference = _samples(values, step=0.1)
+
+    snapshot = compute_peripheral_metrics(
+        samples,
+        reference_samples=reference,
+        pattern=(0.0, 1.0, 0.0),
+        pattern_tolerance=1e-6,
+        sample_rate=10.0,
+    )
+
+    assert snapshot.pattern_detection.occurrences == 1
+    assert snapshot.cross_correlation.coefficient == pytest.approx(1.0)
+    assert snapshot.dominant_frequency.frequency_hz == pytest.approx(2.0, rel=0.1)
+    assert snapshot.sample_entropy.entropy is not None
+
+
+def test_compute_peripheral_metrics_domain_and_spectral_fields() -> None:
+    sample_rate = 100.0
+    duration = 1.0
+    t = np.arange(0.0, duration, 1.0 / sample_rate)
+    freq = 5.0
+    waveform = np.sin(2 * np.pi * freq * t)
+    samples = _samples(waveform, step=1.0 / sample_rate)
+
+    snapshot = compute_peripheral_metrics(
+        samples,
+        sample_rate=sample_rate,
+        rolloff_percent=0.9,
+        orders=(1, 2),
+        order_reference_hz=freq,
+    )
+
+    assert snapshot.allan_variance.variance is not None
+    assert snapshot.hurst_exponent.exponent is not None
+    assert snapshot.crest_factor.value == pytest.approx(1.414, rel=0.05)
+    assert snapshot.kurtosis.value is not None
+    assert snapshot.permutation_entropy.entropy is not None
+
+    assert snapshot.spectral_centroid.frequency_hz == pytest.approx(freq, rel=0.1)
+    assert snapshot.spectral_flatness.flatness is not None
+    assert snapshot.spectral_rolloff.frequency_hz is not None
+    assert snapshot.spectral_entropy.entropy is not None
+    assert snapshot.spectral_kurtosis.kurtosis is not None
+    assert snapshot.envelope_spectrum_peak.frequency_hz == pytest.approx(0.0, abs=1e-6)
+    assert snapshot.order_tracked_amplitude.amplitudes is not None
+    assert snapshot.order_tracked_amplitude.amplitudes[1] == pytest.approx(
+        snapshot.order_tracked_amplitude.amplitudes[1]
+    )
+    assert snapshot.tkeo_energy.energy is not None
+    assert snapshot.hjorth_parameters.parameters is not None
+    assert snapshot.fano_factor.factor is None
+
+
+def test_compute_peripheral_metrics_handles_empty_samples() -> None:
+    snapshot = compute_peripheral_metrics(())
+    assert snapshot.event_count.count == 0
+    assert snapshot.z_score.score is None
+    assert snapshot.crest_factor.value is None
+    assert snapshot.spectral_entropy.entropy is None


### PR DESCRIPTION
## Summary
- replace the grouped peripheral metric containers with dedicated dataclasses for each metric
- update `compute_peripheral_metrics` to assemble the flattened snapshot and harden crest factor handling for empty windows
- refresh the regression tests to assert the new metric accessors

## Testing
- make format
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f6edc518483218381ba041a27aeba)