### PR TITLE
Tighten mypy coverage for peripherals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,13 +141,11 @@ follow_imports = "skip"
 
 [[tool.mypy.overrides]]
 module = [
-    "heart.peripheral.core.event_bus",
     "heart.peripheral.uwb",
     "heart.peripheral.heart_rates",
     "heart.peripheral.microphone",
     "heart.peripheral.ir_sensor_array",
     "heart.peripheral.bluetooth",
-    "heart.peripheral.switch",
     "heart.peripheral.sensor",
     "heart.peripheral.gamepad.gamepad",
     "heart.device.local",

--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -682,22 +682,22 @@ class GameLoop:
         result: pygame.Surface | None = self._render_fn(override_renderer_variant)(
             renderers
         )
-        image = self.__finalize_rendering(result) if result else None
-        if image is not None:
-            pixel_bytes = image.tobytes()
+        finalized_image = self.__finalize_rendering(result) if result else None
+        if finalized_image is not None:
+            pixel_bytes = finalized_image.tobytes()
             surface = pygame.image.frombytes(
-                pixel_bytes, image.size, RGBA_IMAGE_FORMAT
+                pixel_bytes, finalized_image.size, RGBA_IMAGE_FORMAT
             )
             self.screen.blit(surface, (0, 0))
 
         if len(renderers) > 0:
             pygame.display.flip()
             # Convert screen to PIL Image
-            image = pygame.surfarray.array3d(self.screen)
-            image = np.transpose(image, (1, 0, 2))
-            image = Image.fromarray(image)
-            self.device.set_image(image)
-            self._display_peripheral.publish_image(image)
+            screen_array = pygame.surfarray.array3d(self.screen)
+            transposed_array = np.transpose(screen_array, (1, 0, 2))
+            pil_image = Image.fromarray(transposed_array)
+            self.device.set_image(pil_image)
+            self._display_peripheral.publish_image(pil_image)
 
     def _handle_events(self) -> None:
         try:

--- a/src/heart/events/types.py
+++ b/src/heart/events/types.py
@@ -201,6 +201,9 @@ class MagnetometerVector(InputEventPayload):
             producer_id=producer_id,
             timestamp=_normalize_timestamp(timestamp),
         )
+
+
+@dataclass(frozen=True, slots=True)
 class ForceMeasurement(InputEventPayload):
     """Normalized payload describing a tensile or magnetic force reading."""
 

--- a/src/heart/peripheral/core/event_bus.py
+++ b/src/heart/peripheral/core/event_bus.py
@@ -380,9 +380,12 @@ class EventPlaylistManager:
             self._playlists[playlist_id] = playlist
 
         if playlist.trigger_event_type is not None:
+            def _start_playlist(event: Input, *, _playlist_id: str = playlist_id) -> None:
+                self.start(_playlist_id, trigger_event=event)
+
             trigger_handle = self._bus.subscribe(
                 playlist.trigger_event_type,
-                lambda event, pid=playlist_id: self.start(pid, trigger_event=event),
+                _start_playlist,
                 priority=100,
             )
             with self._lock:
@@ -403,11 +406,12 @@ class EventPlaylistManager:
             self._bus.unsubscribe(previous_trigger)
 
         if playlist.trigger_event_type is not None:
+            def _start_playlist(event: Input, *, _playlist_id: str = handle.playlist_id) -> None:
+                self.start(_playlist_id, trigger_event=event)
+
             trigger_handle = self._bus.subscribe(
                 playlist.trigger_event_type,
-                lambda event, pid=handle.playlist_id: self.start(
-                    pid, trigger_event=event
-                ),
+                _start_playlist,
                 priority=100,
             )
 
@@ -455,9 +459,12 @@ class EventPlaylistManager:
                 runs = self._runs_by_interrupt[event_type]
                 runs.add(runner.run_id)
                 if event_type not in self._interrupt_subscribers:
+                    def _handle(event: Input, *, _event_type: str = event_type) -> None:
+                        self._handle_interrupt(_event_type, event)
+
                     self._interrupt_subscribers[event_type] = self._bus.subscribe(
                         event_type,
-                        lambda event, et=event_type: self._handle_interrupt(et, event),
+                        _handle,
                         priority=100,
                     )
 
@@ -553,7 +560,7 @@ class EventPlaylistManager:
                     if handle is not None:
                         self._bus.unsubscribe(handle)
 
-        payload = {
+        payload: dict[str, Any] = {
             "playlist_id": runner.run_id,
             "definition_id": runner.playlist_id,
             "playlist_name": runner.playlist.name,
@@ -572,7 +579,7 @@ class EventPlaylistManager:
         self._bus.emit(self.EVENT_STOPPED, data=payload)
 
         if reason == "completed" and runner.playlist.completion_event_type:
-            completion_payload = {
+            completion_payload: dict[str, Any] = {
                 "playlist_id": runner.run_id,
                 "definition_id": runner.playlist_id,
                 "playlist_name": runner.playlist.name,
@@ -680,9 +687,12 @@ class VirtualPeripheralManager:
         subscriptions: List[SubscriptionHandle] = []
 
         for event_type in definition.event_types:
+            def _route(event: Input, *, _peripheral_id: str = handle.peripheral_id) -> None:
+                self._route_event(_peripheral_id, event)
+
             subscription = self._bus.subscribe(
                 event_type,
-                lambda event, pid=handle.peripheral_id: self._route_event(pid, event),
+                _route,
                 priority=definition.priority,
             )
             subscriptions.append(subscription)

--- a/src/heart/peripheral/led_matrix.py
+++ b/src/heart/peripheral/led_matrix.py
@@ -37,7 +37,6 @@ class LEDMatrixDisplay(Peripheral):
 
         self._width = width
         self._height = height
-        self._event_bus = event_bus
         self._producer_id = producer_id if producer_id is not None else id(self)
         self._frame_lock = threading.Lock()
         self._latest_frame: DisplayFrame | None = None
@@ -45,6 +44,9 @@ class LEDMatrixDisplay(Peripheral):
         self._stop = threading.Event()
 
         super().__init__()
+
+        if event_bus is not None:
+            self.attach_event_bus(event_bus)
 
     @property
     def width(self) -> int:
@@ -62,7 +64,7 @@ class LEDMatrixDisplay(Peripheral):
             return self._latest_frame
 
     def attach_event_bus(self, event_bus: EventBus) -> None:
-        self._event_bus = event_bus
+        super().attach_event_bus(event_bus)
 
     def publish_image(
         self,
@@ -87,17 +89,14 @@ class LEDMatrixDisplay(Peripheral):
             self._sequence += 1
             self._latest_frame = frame
 
-        event_bus = self._event_bus
-        if event_bus is not None:
-            try:
-                event_bus.emit(
-                    frame.to_input(
-                        producer_id=self._producer_id,
-                        timestamp=timestamp,
-                    )
-                )
-            except Exception:  # pragma: no cover - defensive logging only
-                _LOGGER.exception("Failed to emit LED matrix frame update")
+        try:
+            input_event = frame.to_input(
+                producer_id=self._producer_id,
+                timestamp=timestamp,
+            )
+            self.emit_input(input_event)
+        except Exception:  # pragma: no cover - defensive logging only
+            _LOGGER.exception("Failed to emit LED matrix frame update")
         return frame
 
     def run(self) -> None:  # noqa: D401 - signature defined by base class

--- a/src/heart/peripheral/sensor.py
+++ b/src/heart/peripheral/sensor.py
@@ -2,7 +2,7 @@ import collections
 import json
 import time
 from dataclasses import dataclass
-from typing import Any, Iterator, Mapping, NoReturn, Self
+from typing import Any, Iterator, Mapping, NoReturn, Self, cast
 
 import serial
 

--- a/src/heart/peripheral/switch.py
+++ b/src/heart/peripheral/switch.py
@@ -202,9 +202,17 @@ class BluetoothSwitch(BaseSwitch):
         for switch in self.switches:
             switch.attach_event_bus(event_bus)
 
-    def update_due_to_data(self, data: dict[str, int]) -> None:
-        producer_id = data.get("producer_id", 0)
-        self.switches[producer_id].update_due_to_data(data)
+    def update_due_to_data(self, data: Mapping[str, Any]) -> None:
+        payload = dict(data)
+        producer_raw = payload.get("producer_id", 0)
+        try:
+            producer_id = int(producer_raw)
+        except (TypeError, ValueError):
+            logger.debug("Switch payload has invalid producer_id: %s", producer_raw)
+            producer_id = 0
+        payload["producer_id"] = producer_id
+
+        self.switches[producer_id].update_due_to_data(payload)
 
         # Update first producer as if it is the main switch
         if producer_id == 0:


### PR DESCRIPTION
## Summary
- remove the mypy ignore blanket from the switch and event bus modules and fix the resulting type issues
- align the switch, force, and LED matrix peripherals with the core Peripheral API so they emit typed events through the shared bus
- tidy up rendering and payload helpers to keep mypy happy now that the modules are fully checked

## Testing
- `make format`
- `make test`
- `uv run mypy`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910a5138f348321bf89ad412a2014d6)