### PR TITLE
Clarify planning review requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,4 +23,4 @@ Running `make check` is recommended to verify formatting and linting without app
 
 ## Documentation Guidelines
 
-Update `docs/code_flow.md` and re-render the diagram with `scripts/render_code_flow.py` whenever runtime architecture changes. Pair thoughtful implementations with a research note under `docs/research/` that cites the relevant source files. Plans under `docs/planning/` must follow the structure defined in their `AGENTS.md` file, and contributors should review the master project list in `docs/planning/README.md` before scoping new work.
+Update `docs/code_flow.md` and re-render the diagram with `scripts/render_code_flow.py` whenever runtime architecture changes. Pair thoughtful implementations with a research note under `docs/research/` that cites the relevant source files. Plans under `docs/planning/` must follow the structure defined in their `AGENTS.md` file, and contributors should review the master project list in `docs/planning/README.md` before scoping new work. Before implementing a proposal, check `docs/planning/` for related higher-level plans and review any relevant documents.


### PR DESCRIPTION
## Summary
- update the root AGENTS.md documentation guidelines to require reviewing docs/planning for related higher-level plans before implementation

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910a8170d1c8321a14d931e02dcf132)