### PR TITLE
Fix event bus integration for force and display peripherals

### DIFF
--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -682,22 +682,22 @@ class GameLoop:
         result: pygame.Surface | None = self._render_fn(override_renderer_variant)(
             renderers
         )
-        image = self.__finalize_rendering(result) if result else None
-        if image is not None:
-            pixel_bytes = image.tobytes()
+        render_image = self.__finalize_rendering(result) if result else None
+        if render_image is not None:
+            pixel_bytes = render_image.tobytes()
             surface = pygame.image.frombytes(
-                pixel_bytes, image.size, RGBA_IMAGE_FORMAT
+                pixel_bytes, render_image.size, RGBA_IMAGE_FORMAT
             )
             self.screen.blit(surface, (0, 0))
 
         if len(renderers) > 0:
             pygame.display.flip()
             # Convert screen to PIL Image
-            image = pygame.surfarray.array3d(self.screen)
-            image = np.transpose(image, (1, 0, 2))
-            image = Image.fromarray(image)
-            self.device.set_image(image)
-            self._display_peripheral.publish_image(image)
+            screen_array = pygame.surfarray.array3d(self.screen)
+            transposed_array = np.transpose(screen_array, (1, 0, 2))
+            pil_image = Image.fromarray(transposed_array)
+            self.device.set_image(pil_image)
+            self._display_peripheral.publish_image(pil_image)
 
     def _handle_events(self) -> None:
         try:

--- a/src/heart/events/types.py
+++ b/src/heart/events/types.py
@@ -201,6 +201,9 @@ class MagnetometerVector(InputEventPayload):
             producer_id=producer_id,
             timestamp=_normalize_timestamp(timestamp),
         )
+
+
+@dataclass(frozen=True, slots=True)
 class ForceMeasurement(InputEventPayload):
     """Normalized payload describing a tensile or magnetic force reading."""
 

--- a/src/heart/peripheral/force.py
+++ b/src/heart/peripheral/force.py
@@ -30,15 +30,16 @@ class ForcePeripheral(Peripheral):
         event_bus: EventBus | None = None,
         producer_id: int | None = None,
     ) -> None:
-        self._event_bus = event_bus
         self._producer_id = producer_id if producer_id is not None else id(self)
         super().__init__()
+        if event_bus is not None:
+            self.attach_event_bus(event_bus)
 
     def run(self) -> None:
         """No background loop is required for the force peripheral."""
 
     def attach_event_bus(self, event_bus: EventBus) -> None:
-        self._event_bus = event_bus
+        super().attach_event_bus(event_bus)
 
     def record_force(
         self,

--- a/src/heart/peripheral/led_matrix.py
+++ b/src/heart/peripheral/led_matrix.py
@@ -37,7 +37,6 @@ class LEDMatrixDisplay(Peripheral):
 
         self._width = width
         self._height = height
-        self._event_bus = event_bus
         self._producer_id = producer_id if producer_id is not None else id(self)
         self._frame_lock = threading.Lock()
         self._latest_frame: DisplayFrame | None = None
@@ -45,6 +44,8 @@ class LEDMatrixDisplay(Peripheral):
         self._stop = threading.Event()
 
         super().__init__()
+        if event_bus is not None:
+            self.attach_event_bus(event_bus)
 
     @property
     def width(self) -> int:
@@ -60,9 +61,6 @@ class LEDMatrixDisplay(Peripheral):
 
         with self._frame_lock:
             return self._latest_frame
-
-    def attach_event_bus(self, event_bus: EventBus) -> None:
-        self._event_bus = event_bus
 
     def publish_image(
         self,
@@ -87,7 +85,7 @@ class LEDMatrixDisplay(Peripheral):
             self._sequence += 1
             self._latest_frame = frame
 
-        event_bus = self._event_bus
+        event_bus = self.event_bus
         if event_bus is not None:
             try:
                 event_bus.emit(

--- a/src/heart/peripheral/sensor.py
+++ b/src/heart/peripheral/sensor.py
@@ -2,7 +2,7 @@ import collections
 import json
 import time
 from dataclasses import dataclass
-from typing import Any, Iterator, Mapping, NoReturn, Self
+from typing import Any, Iterator, Mapping, NoReturn, Self, cast
 
 import serial
 


### PR DESCRIPTION
## Summary
- add the missing typing import needed for the accelerometer sensor mypy check
- mark `ForceMeasurement` as a dataclass and ensure the force and LED display peripherals attach event buses via the base helper
- rename game loop intermediates to avoid conflicting types when exporting frames

## Testing
- make format
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910a6e02b3883218ca3fac4f0fed23f)