### PR TITLE
Add KeyedMetric scaffold for keyed metrics

### DIFF
--- a/docs/events_metrics.md
+++ b/docs/events_metrics.md
@@ -1,0 +1,19 @@
+# Keyed metric conventions
+
+The helper classes in [`src/heart/events/metrics.py`](../src/heart/events/metrics.py)
+now expose a common scaffolding for keyed aggregates. Use
+`heart.events.metrics.KeyedMetric` when creating a new metric so the
+following behaviours remain consistent:
+
+- **`observe(key, ...)`** records data for the key without mutating prior
+  snapshots.
+- **`get(key)`** returns the latest aggregate value for a single key. Metrics
+  may return `None` when they have no observations.
+- **`snapshot()`** returns a fresh mapping that callers can mutate safely.
+- **`reset(key=None)`** clears the stored data for a key or, when omitted, every
+  key. Unknown keys are ignored so the method stays idempotent.
+
+`RollingAverageByKey` demonstrates how lightweight wrappers can delegate the
+heavy lifting to `RollingStatisticsByKey` while still complying with the
+interface. New metrics can follow the same pattern to reuse the rolling window
+utilities without exposing internal state.

--- a/src/heart/events/__init__.py
+++ b/src/heart/events/__init__.py
@@ -1,6 +1,6 @@
 """Typed helpers for composing input events and sensor metrics."""
 
-from .metrics import (CountByKey, EventSample, EventWindow,
+from .metrics import (CountByKey, EventSample, EventWindow, KeyedMetric,
                       LastEventsWithinTimeWindow, LastNEvents,
                       LastNEventsWithinTimeWindow, MaxAgePolicy,
                       MaxLengthPolicy, RollingAverageByKey, RollingMeanByKey,
@@ -18,6 +18,7 @@ __all__ = [
     "HeartRateLifecycle",
     "HeartRateMeasurement",
     "InputEventPayload",
+    "KeyedMetric",
     "LastEventsWithinTimeWindow",
     "LastNEvents",
     "LastNEventsWithinTimeWindow",

--- a/src/heart/peripheral/sensor.py
+++ b/src/heart/peripheral/sensor.py
@@ -2,7 +2,7 @@ import collections
 import json
 import time
 from dataclasses import dataclass
-from typing import Any, Iterator, Mapping, NoReturn, Self
+from typing import Any, Iterator, Mapping, NoReturn, Self, cast
 
 import serial
 


### PR DESCRIPTION
## Summary
- document the shared observe/get/snapshot/reset conventions for keyed metrics and introduce a `KeyedMetric` base class
- adapt counter and rolling statistics helpers to inherit the scaffold and expose the rolling-average wrapper as an example implementation
- cover the new behaviour with unit tests and contributor documentation

## Testing
- make format
- make test *(fails: existing force peripheral dataclass instantiation errors and LED matrix state store assertions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910a8d6f2408321be54df4e6d993a57)