### PR TITLE
Remove mypy ignore overrides for event bus and switch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,13 +141,11 @@ follow_imports = "skip"
 
 [[tool.mypy.overrides]]
 module = [
-    "heart.peripheral.core.event_bus",
     "heart.peripheral.uwb",
     "heart.peripheral.heart_rates",
     "heart.peripheral.microphone",
     "heart.peripheral.ir_sensor_array",
     "heart.peripheral.bluetooth",
-    "heart.peripheral.switch",
     "heart.peripheral.sensor",
     "heart.peripheral.gamepad.gamepad",
     "heart.device.local",

--- a/src/heart/peripheral/core/event_bus.py
+++ b/src/heart/peripheral/core/event_bus.py
@@ -380,9 +380,13 @@ class EventPlaylistManager:
             self._playlists[playlist_id] = playlist
 
         if playlist.trigger_event_type is not None:
+
+            def handle_trigger(event: Input, playlist_id: str = playlist_id) -> None:
+                self.start(playlist_id, trigger_event=event)
+
             trigger_handle = self._bus.subscribe(
                 playlist.trigger_event_type,
-                lambda event, pid=playlist_id: self.start(pid, trigger_event=event),
+                handle_trigger,
                 priority=100,
             )
             with self._lock:
@@ -403,11 +407,13 @@ class EventPlaylistManager:
             self._bus.unsubscribe(previous_trigger)
 
         if playlist.trigger_event_type is not None:
+
+            def handle_trigger(event: Input, playlist_id: str = handle.playlist_id) -> None:
+                self.start(playlist_id, trigger_event=event)
+
             trigger_handle = self._bus.subscribe(
                 playlist.trigger_event_type,
-                lambda event, pid=handle.playlist_id: self.start(
-                    pid, trigger_event=event
-                ),
+                handle_trigger,
                 priority=100,
             )
 
@@ -455,9 +461,16 @@ class EventPlaylistManager:
                 runs = self._runs_by_interrupt[event_type]
                 runs.add(runner.run_id)
                 if event_type not in self._interrupt_subscribers:
+
+                    def handle_interrupt(
+                        event: Input,
+                        interrupt_type: str = event_type,
+                    ) -> None:
+                        self._handle_interrupt(interrupt_type, event)
+
                     self._interrupt_subscribers[event_type] = self._bus.subscribe(
                         event_type,
-                        lambda event, et=event_type: self._handle_interrupt(et, event),
+                        handle_interrupt,
                         priority=100,
                     )
 
@@ -553,7 +566,7 @@ class EventPlaylistManager:
                     if handle is not None:
                         self._bus.unsubscribe(handle)
 
-        payload = {
+        payload: dict[str, Any] = {
             "playlist_id": runner.run_id,
             "definition_id": runner.playlist_id,
             "playlist_name": runner.playlist.name,
@@ -572,7 +585,7 @@ class EventPlaylistManager:
         self._bus.emit(self.EVENT_STOPPED, data=payload)
 
         if reason == "completed" and runner.playlist.completion_event_type:
-            completion_payload = {
+            completion_payload: dict[str, Any] = {
                 "playlist_id": runner.run_id,
                 "definition_id": runner.playlist_id,
                 "playlist_name": runner.playlist.name,
@@ -680,9 +693,13 @@ class VirtualPeripheralManager:
         subscriptions: List[SubscriptionHandle] = []
 
         for event_type in definition.event_types:
+
+            def route_event(event: Input, peripheral_id: str = handle.peripheral_id) -> None:
+                self._route_event(peripheral_id, event)
+
             subscription = self._bus.subscribe(
                 event_type,
-                lambda event, pid=handle.peripheral_id: self._route_event(pid, event),
+                route_event,
                 priority=definition.priority,
             )
             subscriptions.append(subscription)

--- a/src/heart/peripheral/switch.py
+++ b/src/heart/peripheral/switch.py
@@ -202,8 +202,13 @@ class BluetoothSwitch(BaseSwitch):
         for switch in self.switches:
             switch.attach_event_bus(event_bus)
 
-    def update_due_to_data(self, data: dict[str, int]) -> None:
-        producer_id = data.get("producer_id", 0)
+    def update_due_to_data(self, data: Mapping[str, Any]) -> None:
+        producer_raw = data.get("producer_id", 0)
+        try:
+            producer_id = int(producer_raw)
+        except (TypeError, ValueError):
+            producer_id = 0
+
         self.switches[producer_id].update_due_to_data(data)
 
         # Update first producer as if it is the main switch


### PR DESCRIPTION
## Summary
- remove the mypy ignore override for the event bus and switch modules
- replace lambda callbacks with named helpers and annotate playlist payloads to satisfy type checking
- align `BluetoothSwitch.update_due_to_data` with the base signature while preserving producer routing

## Testing
- uv run mypy
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910a957eb608321b9d30f035f620ecf)