### PR TITLE
Fix LED matrix EventBus import path

### DIFF
--- a/src/heart/peripheral/led_matrix.py
+++ b/src/heart/peripheral/led_matrix.py
@@ -10,8 +10,7 @@ from PIL import Image
 
 from heart.events.types import DisplayFrame
 from heart.peripheral.core import Peripheral
-from heart.peripheral.core.
-import EventBus
+from heart.peripheral.core.event_bus import EventBus
 from heart.utilities.logging import get_logger
 
 __all__ = ["LEDMatrixDisplay"]


### PR DESCRIPTION
## Summary
- correct the LED matrix peripheral to import EventBus from the proper module

## Testing
- make format
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910acc66cf483218159bd67cbcd1fef)