### PR TITLE
Handle missing USB backend in heart rate peripheral

### DIFF
--- a/src/heart/peripheral/heart_rates.py
+++ b/src/heart/peripheral/heart_rates.py
@@ -12,6 +12,7 @@ from openant.devices.scanner import Scanner
 from openant.devices.utilities import auto_create_device
 from openant.easy.exception import AntException
 from openant.easy.node import Node
+from usb.core import NoBackendError
 
 from heart.events.types import HeartRateLifecycle, HeartRateMeasurement
 from heart.peripheral.core import Peripheral
@@ -249,6 +250,11 @@ class HeartRateManager(Peripheral):
                     self._ant_cycle()
                 except DriverNotFound:
                     logger.error("ANT driver not found - skipping HeartRateManager")
+                    return
+                except NoBackendError:
+                    logger.error(
+                        "USB backend not available - skipping HeartRateManager"
+                    )
                     return
                 except (AntException, OSError, RuntimeError) as e:
                     logger.error("ANT error: %s – retrying in %d s", e, RETRY_DELAY)


### PR DESCRIPTION
## Summary
- catch usb.core.NoBackendError when starting the ANT+ node so the heart rate peripheral exits cleanly when the USB backend is unavailable
- log the missing backend condition instead of allowing the peripheral thread to crash

## Testing
- make test *(fails: existing SyntaxError in src/heart/peripheral/led_matrix.py during import)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910ad4839c88321bb9e8b7894d1e727)