### PR TITLE
Improve render loop logging context

### DIFF
--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -492,7 +492,16 @@ class GameLoop:
 
             duration_ms = (time.perf_counter_ns() - start_ns) / 1_000_000
             logger.info(
-                "render.loop",
+                (
+                    "render.loop renderer=%s duration_ms=%.2f queue_depth=%s "
+                    "display_mode=%s uses_opengl=%s initialized=%s"
+                ),
+                renderer.name,
+                duration_ms,
+                self._render_queue_depth,
+                renderer.device_display_mode.name,
+                renderer.device_display_mode == DeviceDisplayMode.OPENGL,
+                renderer.is_initialized(),
                 extra={
                     "renderer": renderer.name,
                     "duration_ms": duration_ms,

--- a/src/heart/peripheral/led_matrix.py
+++ b/src/heart/peripheral/led_matrix.py
@@ -10,8 +10,7 @@ from PIL import Image
 
 from heart.events.types import DisplayFrame
 from heart.peripheral.core import Peripheral
-from heart.peripheral.core.
-import EventBus
+from heart.peripheral.core.event_bus import EventBus
 from heart.utilities.logging import get_logger
 
 __all__ = ["LEDMatrixDisplay"]


### PR DESCRIPTION
## Summary
- emit a fully populated render loop log message so the console output is no longer blank
- keep the LED matrix EventBus import stable after formatting

## Testing
- make format
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910ad22245483218bcc25eeb8cc0a67)