### PR TITLE
chore: drop __all__ exports and compact mypy output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ Use the tooling in this repository to manage environments. Prefer `uv` for Pytho
 
 Run `make format` before committing changes. This applies Ruff fixes, isort, Black, docformatter, and mdformat to Python sources and documentation. Documentation updates should avoid marketing language, state the technical problem in plain terms, and include a materials list when relevant.
 
+- Avoid declaring module-level `__all__` exports. Prefer explicit imports at call sites instead of curating export lists.
+
 ## Testing
 
 Run `make test` to execute the Pytest suite located in the `tests/` directory. Ensure all tests pass before submitting changes.

--- a/docs/devlog/2024_11_05_ToolingHygiene.md
+++ b/docs/devlog/2024_11_05_ToolingHygiene.md
@@ -1,0 +1,19 @@
+# Tooling hygiene adjustments
+
+## Summary
+
+- Configure `mypy` to emit compact, line-oriented diagnostics without color or context blocks by updating `pyproject.toml`.
+- Remove module-level `__all__` declarations across packages to favor explicit imports.
+
+## Impacted modules
+
+- `pyproject.toml`
+- `src/heart/events/*`
+- `src/heart/peripheral/*`
+- `src/heart/display/recorder.py`
+- `tests/events/test_metrics.py`
+- `tests/simulation/__init__.py`
+- `experimental/isolated_rendering/*`
+- `experimental/peripheral_sidecar/*`
+
+These adjustments align repository guidance with current linting expectations and simplify future tooling automation.

--- a/experimental/isolated_rendering/src/isolated_rendering/__init__.py
+++ b/experimental/isolated_rendering/src/isolated_rendering/__init__.py
@@ -1,5 +1,3 @@
 """Isolated rendering service for the heart LED matrix."""
 
-from .client import MatrixClient, send_image
-
-__all__ = ["MatrixClient", "send_image"]
+from .client import MatrixClient as MatrixClient, send_image as send_image

--- a/experimental/isolated_rendering/src/isolated_rendering/client.py
+++ b/experimental/isolated_rendering/src/isolated_rendering/client.py
@@ -1,3 +1,3 @@
-from heart.device.isolated_render import MatrixClient, send_image
+"""Compatibility re-export for isolated rendering helpers."""
 
-__all__ = ["MatrixClient", "send_image"]
+from heart.device.isolated_render import MatrixClient as MatrixClient, send_image as send_image

--- a/experimental/isolated_rendering/src/isolated_rendering/shared_memory.py
+++ b/experimental/isolated_rendering/src/isolated_rendering/shared_memory.py
@@ -227,10 +227,3 @@ class SharedMemoryWatcher:
             image = Image.frombytes(self._frame_buffer.mode, self._frame_buffer.size, payload)
             self._frame_buffer.update_image(image)
             self._last_version = version
-
-
-__all__ = [
-    "SharedMemoryError",
-    "SharedMemoryFrameWriter",
-    "SharedMemoryWatcher",
-]

--- a/experimental/peripheral_sidecar/src/peripheral_sidecar/__init__.py
+++ b/experimental/peripheral_sidecar/src/peripheral_sidecar/__init__.py
@@ -1,5 +1,3 @@
 """Service layer for sidecar processes and integrations."""
 
-from .mqtt_sidecar import PeripheralMQTTService
-
-__all__ = ["PeripheralMQTTService"]
+from .mqtt_sidecar import PeripheralMQTTService as PeripheralMQTTService

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,10 @@ packages = [
 warn_unused_configs = true
 warn_unused_ignores = true
 check_untyped_defs = true
+color_output = false
+error_summary = false
+show_error_context = false
+pretty = false
 
 [[tool.mypy.overrides]]
 module = [

--- a/src/heart/display/recorder.py
+++ b/src/heart/display/recorder.py
@@ -83,6 +83,3 @@ class ScreenRecorder:
             loop=0,
         )
         return path
-
-
-__all__ = ["ScreenRecorder"]

--- a/src/heart/display/renderers/internal/__init__.py
+++ b/src/heart/display/renderers/internal/__init__.py
@@ -1,5 +1,3 @@
 """Internal helpers for renderer performance features."""
 
-from .frame_accumulator import FrameAccumulator
-
-__all__ = ["FrameAccumulator"]
+from .frame_accumulator import FrameAccumulator as FrameAccumulator

--- a/src/heart/events/__init__.py
+++ b/src/heart/events/__init__.py
@@ -1,37 +1,25 @@
 """Typed helpers for composing input events and sensor metrics."""
 
-from .metrics import (CountByKey, EventSample, EventWindow, KeyedMetric,
-                      LastEventsWithinTimeWindow, LastNEvents,
-                      LastNEventsWithinTimeWindow, MaxAgePolicy,
-                      MaxLengthPolicy, RollingAverageByKey, RollingMeanByKey,
-                      RollingSnapshot, RollingStatisticsByKey,
-                      RollingStddevByKey, combine_windows)
-from .types import (AccelerometerVector, HeartRateLifecycle,
-                    HeartRateMeasurement, InputEventPayload, MicrophoneLevel,
-                    PhoneTextMessage, SwitchButton, SwitchRotation)
-
-__all__ = [
-    "AccelerometerVector",
-    "CountByKey",
-    "EventSample",
-    "EventWindow",
-    "HeartRateLifecycle",
-    "HeartRateMeasurement",
-    "InputEventPayload",
-    "KeyedMetric",
-    "LastEventsWithinTimeWindow",
-    "LastNEvents",
-    "LastNEventsWithinTimeWindow",
-    "MaxAgePolicy",
-    "MaxLengthPolicy",
-    "MicrophoneLevel",
-    "PhoneTextMessage",
-    "RollingAverageByKey",
-    "RollingMeanByKey",
-    "RollingSnapshot",
-    "RollingStatisticsByKey",
-    "RollingStddevByKey",
-    "SwitchButton",
-    "SwitchRotation",
-    "combine_windows",
-]
+from .metrics import CountByKey as CountByKey
+from .metrics import EventSample as EventSample
+from .metrics import EventWindow as EventWindow
+from .metrics import KeyedMetric as KeyedMetric
+from .metrics import LastEventsWithinTimeWindow as LastEventsWithinTimeWindow
+from .metrics import LastNEvents as LastNEvents
+from .metrics import LastNEventsWithinTimeWindow as LastNEventsWithinTimeWindow
+from .metrics import MaxAgePolicy as MaxAgePolicy
+from .metrics import MaxLengthPolicy as MaxLengthPolicy
+from .metrics import RollingAverageByKey as RollingAverageByKey
+from .metrics import RollingMeanByKey as RollingMeanByKey
+from .metrics import RollingSnapshot as RollingSnapshot
+from .metrics import RollingStatisticsByKey as RollingStatisticsByKey
+from .metrics import RollingStddevByKey as RollingStddevByKey
+from .metrics import combine_windows as combine_windows
+from .types import AccelerometerVector as AccelerometerVector
+from .types import HeartRateLifecycle as HeartRateLifecycle
+from .types import HeartRateMeasurement as HeartRateMeasurement
+from .types import InputEventPayload as InputEventPayload
+from .types import MicrophoneLevel as MicrophoneLevel
+from .types import PhoneTextMessage as PhoneTextMessage
+from .types import SwitchButton as SwitchButton
+from .types import SwitchRotation as SwitchRotation

--- a/src/heart/events/metrics.py
+++ b/src/heart/events/metrics.py
@@ -352,22 +352,3 @@ class RollingStddevByKey(KeyedMetric[K, float | None]):
 
     def reset(self, key: K | None = None) -> None:
         self._stats.reset(key)
-
-
-__all__ = [
-    "CountByKey",
-    "EventSample",
-    "EventWindow",
-    "KeyedMetric",
-    "LastEventsWithinTimeWindow",
-    "LastNEvents",
-    "LastNEventsWithinTimeWindow",
-    "MaxAgePolicy",
-    "MaxLengthPolicy",
-    "RollingAverageByKey",
-    "RollingMeanByKey",
-    "RollingSnapshot",
-    "RollingStatisticsByKey",
-    "RollingStddevByKey",
-    "combine_windows",
-]

--- a/src/heart/events/types.py
+++ b/src/heart/events/types.py
@@ -323,18 +323,3 @@ class DisplayFrame(InputEventPayload):
             producer_id=producer_id,
             timestamp=_normalize_timestamp(timestamp),
         )
-
-
-__all__ = [
-    "AccelerometerVector",
-    "DisplayFrame",
-    "MagnetometerVector",
-    "ForceMeasurement",
-    "HeartRateLifecycle",
-    "HeartRateMeasurement",
-    "InputEventPayload",
-    "MicrophoneLevel",
-    "PhoneTextMessage",
-    "SwitchButton",
-    "SwitchRotation",
-]

--- a/src/heart/peripheral/calibration.py
+++ b/src/heart/peripheral/calibration.py
@@ -12,8 +12,6 @@ from heart.peripheral.core.event_bus import (VirtualPeripheralContext,
                                              VirtualPeripheralDefinition,
                                              _VirtualPeripheral)
 
-__all__ = ["CalibrationProfile", "calibrated_virtual_peripheral"]
-
 LOGGER = logging.getLogger(__name__)
 
 

--- a/src/heart/peripheral/core/__init__.py
+++ b/src/heart/peripheral/core/__init__.py
@@ -8,10 +8,11 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Iterator, Mapping, Self
 
 if TYPE_CHECKING:  # pragma: no cover - import-time convenience
-    from .event_bus import EventBus, SubscriptionHandle
-    from .state_store import StateEntry, StateSnapshot, StateStore
-
-__all__ = ["Input", "Peripheral", "StateEntry", "StateSnapshot", "StateStore"]
+    from .event_bus import EventBus as EventBus
+    from .event_bus import SubscriptionHandle as SubscriptionHandle
+    from .state_store import StateEntry as StateEntry
+    from .state_store import StateSnapshot as StateSnapshot
+    from .state_store import StateStore as StateStore
 
 
 @dataclass(slots=True)

--- a/src/heart/peripheral/core/event_bus.py
+++ b/src/heart/peripheral/core/event_bus.py
@@ -20,25 +20,6 @@ from .state_store import StateStore
 
 _LOGGER = logging.getLogger(__name__)
 
-__all__ = [
-    "EventBus",
-    "EventPlaylist",
-    "EventPlaylistManager",
-    "PlaylistHandle",
-    "PlaylistStep",
-    "SequenceMatcher",
-    "SubscriptionHandle",
-    "VirtualPeripheralContext",
-    "VirtualPeripheralDefinition",
-    "VirtualPeripheralHandle",
-    "VirtualPeripheralManager",
-    "gated_mirror_virtual_peripheral",
-    "gated_playlist_virtual_peripheral",
-    "double_tap_virtual_peripheral",
-    "sequence_virtual_peripheral",
-    "simultaneous_virtual_peripheral",
-]
-
 
 EventCallback = Callable[[Input], None]
 GatePredicate = Callable[["VirtualPeripheralContext", Input], bool]

--- a/src/heart/peripheral/drawing_pad.py
+++ b/src/heart/peripheral/drawing_pad.py
@@ -23,8 +23,6 @@ from typing import Any, Iterator, Mapping, Self
 
 from heart.peripheral.core import Input, Peripheral
 
-__all__ = ["DrawingPad", "StylusSample"]
-
 
 @dataclass(slots=True)
 class StylusSample:

--- a/src/heart/peripheral/gamepad/__init__.py
+++ b/src/heart/peripheral/gamepad/__init__.py
@@ -1,3 +1,4 @@
-from .gamepad import Gamepad, GamepadIdentifier
+"""Convenience imports for the gamepad peripheral."""
 
-__all__ = ["Gamepad", "GamepadIdentifier"]
+from .gamepad import Gamepad as Gamepad
+from .gamepad import GamepadIdentifier as GamepadIdentifier

--- a/src/heart/peripheral/led_matrix.py
+++ b/src/heart/peripheral/led_matrix.py
@@ -10,12 +10,8 @@ from PIL import Image
 
 from heart.events.types import DisplayFrame
 from heart.peripheral.core import Peripheral
-from heart.peripheral.core.
-import EventBus
+from heart.peripheral.core.event_bus import EventBus
 from heart.utilities.logging import get_logger
-
-__all__ = ["LEDMatrixDisplay"]
-
 
 _LOGGER = get_logger(__name__)
 

--- a/src/heart/peripheral/uwb.py
+++ b/src/heart/peripheral/uwb.py
@@ -269,7 +269,3 @@ class UwbZoneTracker:
                 producer_id=observation.producer_id,
             )
         )
-
-
-__all__ = ["UwbZoneDefinition", "UwbZoneTracker"]
-

--- a/src/heart/x/__init__.py
+++ b/src/heart/x/__init__.py
@@ -1,5 +1,3 @@
 """Utility and experimental tooling for Totem hardware debugging."""
 
-from .cli import app
-
-__all__ = ["app"]
+from .cli import app as app

--- a/tests/events/test_metrics.py
+++ b/tests/events/test_metrics.py
@@ -24,5 +24,3 @@ _METRIC_MODULES: Final[tuple[str, ...]] = (
 
 for module_name in _METRIC_MODULES:
     import_module(module_name)
-
-__all__ = ("_METRIC_MODULES",)

--- a/tests/simulation/__init__.py
+++ b/tests/simulation/__init__.py
@@ -1,12 +1,7 @@
 """Simulation utilities for the IR sensor array peripheral."""
 
-from .ir_sensor_array_simulation import (IRArrayScenario, SimulationResult,
-                                         run_scenarios,
-                                         simulate_activation_geometry)
-
-__all__ = [
-    "IRArrayScenario",
-    "SimulationResult",
-    "simulate_activation_geometry",
-    "run_scenarios",
-]
+from .ir_sensor_array_simulation import IRArrayScenario as IRArrayScenario
+from .ir_sensor_array_simulation import SimulationResult as SimulationResult
+from .ir_sensor_array_simulation import run_scenarios as run_scenarios
+from .ir_sensor_array_simulation import \
+    simulate_activation_geometry as simulate_activation_geometry


### PR DESCRIPTION
## Summary
- remove module-level `__all__` declarations across runtime, tests, and experimental helpers while preserving convenient imports
- document the new export policy, including agent guidance and a devlog entry for the tooling update
- configure mypy to emit non-colored, context-free diagnostics to keep CI logs compact

## Testing
- make format
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910ac1b11988321928b4412b3bdd270)