### PR TITLE
Refactor display resolution detection providers

### DIFF
--- a/docs/device_display_resolution.md
+++ b/docs/device_display_resolution.md
@@ -1,0 +1,19 @@
+# Display resolution detection
+
+The local device driver relies on platform-specific helpers to determine the host
+screen dimensions before scaling rendered frames.
+
+* `src/heart/device/local.py` defines three providers that implement
+  `DisplayResolutionProvider`:
+  * `MacDisplayResolutionProvider` parses `system_profiler SPDisplaysDataType`
+    output and extracts the primary display resolution.
+  * `XrandrDisplayResolutionProvider` inspects `xrandr --query` output to
+    support Linux and X11 forwarding scenarios.
+  * `FallbackDisplayResolutionProvider` emits the default 1920×1080 resolution
+    for platforms that do not expose a detection path.
+* `_get_display_resolution()` remains the module-level entry point, caching the
+  detected result via `functools.lru_cache` so other call sites can continue to
+  use the helper without change.
+
+All providers log their detection status and revert to the shared default of
+1920×1080 (16:9) when parsing fails or system utilities are unavailable.

--- a/src/heart/device/local.py
+++ b/src/heart/device/local.py
@@ -1,6 +1,7 @@
 import logging
 import platform
 import subprocess
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import cached_property, lru_cache
 from typing import Literal, cast
@@ -13,60 +14,107 @@ from heart.device import Device
 logger = logging.getLogger(__name__)
 
 
+class ResolutionDetectionError(RuntimeError):
+    """Raised when a display resolution provider cannot parse its output."""
+
+
+class DisplayResolutionProvider(ABC):
+    """Base class for retrieving the active display resolution."""
+
+    DEFAULT_RESOLUTION: tuple[int, int, float] = (1920, 1080, 16 / 9)
+
+    def get_resolution(self) -> tuple[int, int, float]:
+        try:
+            return self._detect_resolution()
+        except ResolutionDetectionError as error:
+            logger.warning(str(error))
+        except (FileNotFoundError, subprocess.CalledProcessError) as error:
+            logger.warning(self._command_failure_message(error))
+        return self.DEFAULT_RESOLUTION
+
+    @abstractmethod
+    def _detect_resolution(self) -> tuple[int, int, float]:
+        """Return the detected display resolution."""
+
+    def _command_failure_message(self, error: Exception) -> str:
+        return f"Could not detect display resolution: {error}. Using default resolution."
+
+
+class MacDisplayResolutionProvider(DisplayResolutionProvider):
+    """Detect the active display resolution on macOS hosts."""
+
+    def _detect_resolution(self) -> tuple[int, int, float]:
+        result = subprocess.run(
+            ["system_profiler", "SPDisplaysDataType"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        for line in result.stdout.splitlines():
+            if "Resolution" in line:
+                res = line.split(":")[1].strip()
+                parsable = res.replace(" x ", "x").split(" ")[0]
+                width, height = map(int, parsable.split("x"))
+                aspect_ratio = width / height
+                logger.info(f"Detected macOS display resolution: {width}x{height}")
+                return width, height, aspect_ratio
+
+        raise ResolutionDetectionError(
+            "Could not parse display resolution from system_profiler output."
+        )
+
+    def _command_failure_message(self, error: Exception) -> str:
+        return f"Could not run system_profiler: {error}. Using default resolution."
+
+
+class XrandrDisplayResolutionProvider(DisplayResolutionProvider):
+    """Detect the active display resolution via xrandr output."""
+
+    def _detect_resolution(self) -> tuple[int, int, float]:
+        result = subprocess.run(
+            ["xrandr", "--query"], capture_output=True, text=True, check=True
+        )
+
+        for line in result.stdout.splitlines():
+            if " current " in line:
+                res = line.split(" current ")[1].split(",")[0].strip()
+                width, height = map(int, res.split("x"))
+                aspect_ratio = width / height
+                logger.info(f"Detected Linux/X11 display resolution: {width}x{height}")
+                return width, height, aspect_ratio
+
+        raise ResolutionDetectionError(
+            "Could not parse display resolution from xrandr output."
+        )
+
+    def _command_failure_message(self, error: Exception) -> str:
+        return f"Could not run xrandr: {error}. Using default resolution."
+
+
+class FallbackDisplayResolutionProvider(DisplayResolutionProvider):
+    """Fallback provider when no platform specific implementation exists."""
+
+    def get_resolution(self) -> tuple[int, int, float]:
+        logger.info("Display resolution detection not supported. Using default resolution.")
+        return self.DEFAULT_RESOLUTION
+
+    def _detect_resolution(self) -> tuple[int, int, float]:
+        return self.DEFAULT_RESOLUTION
+
+
+def _display_resolution_provider() -> DisplayResolutionProvider:
+    system = platform.system()
+    if system == "Darwin":
+        return MacDisplayResolutionProvider()
+    if system == "Linux":
+        return XrandrDisplayResolutionProvider()
+    return FallbackDisplayResolutionProvider()
+
+
 @lru_cache(maxsize=1)
 def _get_display_resolution() -> tuple[int, int, float]:
-    if platform.system() == "Darwin":  # Check if running on macOS
-        try:
-            result = subprocess.run(
-                ["system_profiler", "SPDisplaysDataType"],
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-
-            # find the line with the resolution
-            for line in result.stdout.splitlines():
-                if "Resolution" in line:
-                    res = line.split(":")[1].strip()
-                    parsable = res.replace(" x ", "x").split(" ")[0]
-                    width, height = map(int, parsable.split("x"))
-                    aspect_ratio = width / height
-                    logger.info(f"Detected macOS display resolution: {width}x{height}")
-                    return width, height, aspect_ratio
-            logger.warning(
-                "Could not parse display resolution from system_profiler output."
-            )
-            return 1920, 1080, 16 / 9  # Default if parsing fails
-        except (FileNotFoundError, subprocess.CalledProcessError) as e:
-            logger.warning(
-                f"Could not run system_profiler: {e}. Using default resolution."
-            )
-            return 1920, 1080, 16 / 9  # Default resolution
-    else:
-        # Attempt to use xrandr on Linux/other systems
-        # This is used to do X11 forwarding on Pi
-        try:
-            result = subprocess.run(
-                ["xrandr", "--query"], capture_output=True, text=True, check=True
-            )
-            for line in result.stdout.splitlines():
-                if " current " in line:
-                    res = line.split(" current ")[1].split(",")[0].strip()
-                    width, height = map(int, res.split("x"))
-                    aspect_ratio = width / height
-                    logger.info(
-                        f"Detected Linux/X11 display resolution: {width}x{height}"
-                    )
-                    return width, height, aspect_ratio
-            logger.warning("Could not parse display resolution from xrandr output.")
-            return 1920, 1080, 16 / 9  # Default if parsing fails
-        except (FileNotFoundError, subprocess.CalledProcessError) as e:
-            logger.warning(f"Could not run xrandr: {e}. Using default resolution.")
-            return (
-                1920,
-                1080,
-                16 / 9,
-            )  # Default resolution for non-macOS if xrandr fails
+    return _display_resolution_provider().get_resolution()
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- replace `_get_display_resolution` logic with platform-specific providers while keeping the cached helper
- add documentation for the display resolution detection workflow

## Testing
- make format *(fails: src/heart/peripheral/led_matrix.py contains invalid syntax prior to this change)*
- make test *(fails: src/heart/peripheral/led_matrix.py contains invalid syntax prior to this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910ada533b8832195666568f50f725a)