### PR TITLE
Add registry-driven peripheral detection configuration

### DIFF
--- a/docs/peripheral_configurations.md
+++ b/docs/peripheral_configurations.md
@@ -1,0 +1,25 @@
+# Peripheral detection configurations
+
+Peripheral detection is now controlled through modules in
+`heart/peripheral/configurations`. Each module must expose a `configure`
+function that receives a `PeripheralManager` instance and returns a
+`PeripheralConfiguration`. The configuration contains the callable detectors that
+are executed during `PeripheralManager.detect()` and optional
+`VirtualPeripheralDefinition` objects that should be registered on the input
+`EventBus`.
+
+## Selecting a configuration
+
+`PeripheralManager` looks up the desired configuration from the
+`PERIPHERAL_CONFIGURATION` environment variable. When the variable is unset, the
+`default` configuration is used. Tests and tools can also inject a custom
+`PeripheralConfigurationRegistry` when constructing a manager, which makes it
+possible to provide bespoke detector sets without modifying global state.
+
+## Virtual peripherals
+
+Configurations may include virtual peripherals alongside physical detectors. The
+manager stores the declared definitions and registers them with the attached
+`EventBus.virtual_peripherals` coordinator whenever bus propagation is enabled.
+This allows virtual inputs—such as gesture recognisers or playlist triggers—to
+be declared next to the physical hardware detectors that they augment.

--- a/src/heart/peripheral/configuration.py
+++ b/src/heart/peripheral/configuration.py
@@ -1,0 +1,23 @@
+"""Configuration primitives for :class:`PeripheralManager`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, Sequence
+
+from heart.peripheral.core import Peripheral
+from heart.peripheral.core.event_bus import VirtualPeripheralDefinition
+
+DetectorFactory = Callable[[], Iterable[Peripheral]]
+
+
+@dataclass(frozen=True)
+class PeripheralConfiguration:
+    """Declarative description of a peripheral detection plan."""
+
+    detectors: Sequence[DetectorFactory]
+    virtual_peripherals: Sequence[VirtualPeripheralDefinition] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "detectors", tuple(self.detectors))
+        object.__setattr__(self, "virtual_peripherals", tuple(self.virtual_peripherals))

--- a/src/heart/peripheral/configurations/__init__.py
+++ b/src/heart/peripheral/configurations/__init__.py
@@ -1,0 +1,1 @@
+"""Peripheral detection configuration modules."""

--- a/src/heart/peripheral/configurations/default.py
+++ b/src/heart/peripheral/configurations/default.py
@@ -1,0 +1,24 @@
+"""Default peripheral detection configuration."""
+
+from __future__ import annotations
+
+from heart.peripheral.configuration import PeripheralConfiguration
+
+if False:  # pragma: no cover - typing aid
+    from heart.peripheral.core.manager import PeripheralManager
+
+
+def configure(manager: "PeripheralManager") -> PeripheralConfiguration:
+    """Return the default detection plan for ``manager``."""
+
+    detectors = (
+        manager._detect_switches,
+        manager._detect_sensors,
+        manager._detect_gamepads,
+        manager._detect_heart_rate_sensor,
+        manager._detect_phone_text,
+        manager._detect_microphones,
+        manager._detect_drawing_pads,
+        manager._detect_radios,
+    )
+    return PeripheralConfiguration(detectors=detectors)

--- a/src/heart/peripheral/registry.py
+++ b/src/heart/peripheral/registry.py
@@ -1,0 +1,35 @@
+"""Registry for peripheral detection configurations."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from functools import cached_property
+from typing import Callable
+
+from heart.peripheral.configuration import PeripheralConfiguration
+
+if False:  # pragma: no cover - for type checkers only
+    from heart.peripheral.core.manager import PeripheralManager
+
+ConfigurationFactory = Callable[["PeripheralManager"], PeripheralConfiguration]
+
+
+class PeripheralConfigurationRegistry:
+    """Discover available peripheral configuration modules."""
+
+    @cached_property
+    def registry(self) -> dict[str, ConfigurationFactory]:
+        registry: dict[str, ConfigurationFactory] = {}
+        configurations_dir = os.path.join(os.path.dirname(__file__), "configurations")
+        for filename in os.listdir(configurations_dir):
+            if not filename.endswith(".py") or filename == "__init__.py":
+                continue
+            module_name = f"heart.peripheral.configurations.{filename[:-3]}"
+            module = importlib.import_module(module_name)
+            if hasattr(module, "configure"):
+                registry[filename[:-3]] = getattr(module, "configure")
+        return registry
+
+    def get(self, name: str) -> ConfigurationFactory | None:
+        return self.registry.get(name)

--- a/src/heart/utilities/env.py
+++ b/src/heart/utilities/env.py
@@ -70,6 +70,10 @@ class Configuration:
         return _env_flag("ENABLE_INPUT_EVENT_BUS")
 
     @classmethod
+    def peripheral_configuration(cls) -> str:
+        return os.environ.get("PERIPHERAL_CONFIGURATION", "default")
+
+    @classmethod
     def isolated_renderer_socket(cls) -> str | None:
         socket_path = os.environ.get("ISOLATED_RENDER_SOCKET")
         if socket_path == "":

--- a/tests/peripheral/test_manager.py
+++ b/tests/peripheral/test_manager.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from heart.peripheral.configuration import PeripheralConfiguration
+from heart.peripheral.core import Peripheral
+from heart.peripheral.core.event_bus import (EventBus,
+                                             double_tap_virtual_peripheral)
+from heart.peripheral.core.manager import PeripheralManager
+
+
+class _StubPeripheral(Peripheral):
+    def run(self) -> None:  # pragma: no cover - nothing to execute
+        pass
+
+
+class _StubRegistry:
+    def __init__(self, configuration: PeripheralConfiguration) -> None:
+        self._configuration = configuration
+
+    def get(self, name: str):  # pragma: no cover - simple passthrough
+        return (lambda manager: self._configuration) if name == "test" else None
+
+
+def test_peripheral_manager_uses_configured_detectors() -> None:
+    captured: list[str] = []
+    sentinel = _StubPeripheral()
+
+    def detector():
+        captured.append("detector")
+        yield sentinel
+
+    virtual = double_tap_virtual_peripheral(
+        "input.event", output_event_type="output.event", name="virtual.test"
+    )
+
+    configuration = PeripheralConfiguration(
+        detectors=(detector,),
+        virtual_peripherals=(virtual,),
+    )
+
+    manager = PeripheralManager(
+        configuration="test",
+        configuration_registry=_StubRegistry(configuration),
+    )
+    bus = EventBus()
+    manager.attach_event_bus(bus)
+
+    manager.detect()
+
+    assert manager.peripherals == (sentinel,)
+    assert captured == ["detector"]
+
+    definitions = manager.virtual_peripheral_definitions
+    assert set(definitions) == {virtual.name}
+    assert definitions[virtual.name] is virtual
+
+    registered = bus.virtual_peripherals.list_definitions().values()
+    assert {definition.name for definition in registered} == {virtual.name}


### PR DESCRIPTION
## Summary
- externalize PeripheralManager detection ordering into configuration modules discoverable via a registry
- allow configurations to supply virtual peripheral definitions and select them with the PERIPHERAL_CONFIGURATION environment variable
- document the new workflow and cover it with a focused unit test

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910b0619cfc8321a8b87c8561c3464f)