### PR TITLE
Ignore usb missing stubs for mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,13 +122,15 @@ module = [
     "pygame.*",
     "requests",
     "rgbmatrix",
-    "serial",
-    "serial.*",
-    "bluezero",
-    "bluezero.*",
-    "typer",
-    "toml",
-    "sounddevice",
+    "serial", 
+    "serial.*", 
+    "bluezero", 
+    "bluezero.*", 
+    "typer", 
+    "toml", 
+    "sounddevice", 
+    "usb", 
+    "usb.*", 
 ]
 ignore_missing_imports = true
 


### PR DESCRIPTION
## Summary
- add usb modules to the mypy ignore_missing_imports override so linting does not fail when usb.core stubs are unavailable

## Testing
- make format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910b08b7c288321a9ad5a8571884f25)