### PR TITLE
Add SortedComposedRenderer for peripheral-driven ordering

### DIFF
--- a/docs/api/sorted_composed_renderer.md
+++ b/docs/api/sorted_composed_renderer.md
@@ -1,0 +1,40 @@
+# Sorted composed renderer
+
+`heart.navigation.SortedComposedRenderer` extends the existing composition
+behaviour to let a callback decide the ordering of child renderers for each
+frame. This keeps layering decisions close to runtime data such as peripheral
+input or telemetry.
+
+## Basic usage
+
+```python
+from heart.navigation import SortedComposedRenderer
+
+composer = SortedComposedRenderer(
+    renderers=[background, overlay, hud],
+    sorter=lambda renderers, _: sorted(renderers, key=lambda r: r.name),
+)
+```
+
+`SortedComposedRenderer` expects the sorter to return all renderers that were
+passed to the composer. Returning fewer or duplicate values raises a
+`ValueError`, protecting against accidental drops or repeats.
+
+## Peripheral-driven ordering
+
+`heart.navigation.switch_controlled_renderer_order` demonstrates how to wire the
+rotary switch into ordering decisions. It sorts renderers alphabetically, flips
+the stack when the button is pressed, and rotates the list using the current
+rotational offset.
+
+```python
+from heart.navigation import SortedComposedRenderer, switch_controlled_renderer_order
+
+composer = SortedComposedRenderer(
+    [alpha_renderer, beta_renderer, gamma_renderer],
+    sorter=switch_controlled_renderer_order,
+)
+```
+
+The `sorted_composer_demo` program configuration wires this renderer into the
+loop so the behaviour can be exercised directly with hardware.

--- a/src/heart/navigation.py
+++ b/src/heart/navigation.py
@@ -1,4 +1,5 @@
-from collections import defaultdict
+from collections import Counter, defaultdict, deque
+from collections.abc import Callable, Iterable
 
 import pygame
 
@@ -352,6 +353,94 @@ class ComposedRenderer(BaseRenderer):
         # TODO: This overlaps a bit with what the environment does
         for renderer in self.renderers:
             renderer._internal_process(window, clock, peripheral_manager, orientation)
+
+
+RendererSorter = Callable[[tuple[BaseRenderer, ...], PeripheralManager], Iterable[BaseRenderer]]
+
+
+class SortedComposedRenderer(ComposedRenderer):
+    """Compose renderers while dynamically reordering them.
+
+    ``SortedComposedRenderer`` works like :class:`ComposedRenderer` but delegates
+    ordering to a ``sorter`` callback. The callback receives the renderers as a
+    tuple and must return an iterable with the same renderers, potentially in a
+    different order. This makes it easy to express ordering strategies based on
+    runtime signals such as peripheral input.
+    """
+
+    def __init__(
+        self,
+        renderers: Iterable[BaseRenderer],
+        *,
+        sorter: RendererSorter,
+    ) -> None:
+        super().__init__(list(renderers))
+        self._sorter = sorter
+
+    def _ordered_renderers(
+        self, peripheral_manager: PeripheralManager
+    ) -> tuple[BaseRenderer, ...]:
+        unordered = tuple(self.renderers)
+        ordered = tuple(self._sorter(unordered, peripheral_manager))
+
+        if Counter(ordered) != Counter(unordered):
+            raise ValueError(
+                "Sorter must return an iterable containing the original renderers"
+            )
+
+        return ordered
+
+    def get_renderers(
+        self, peripheral_manager: PeripheralManager
+    ) -> list[BaseRenderer]:
+        result: list[BaseRenderer] = []
+        for renderer in self._ordered_renderers(peripheral_manager):
+            result.extend(renderer.get_renderers(peripheral_manager))
+        return result
+
+    def process(
+        self,
+        window: pygame.Surface,
+        clock: pygame.time.Clock,
+        peripheral_manager: PeripheralManager,
+        orientation: Orientation,
+    ) -> None:
+        for renderer in self._ordered_renderers(peripheral_manager):
+            renderer._internal_process(window, clock, peripheral_manager, orientation)
+
+
+def switch_controlled_renderer_order(
+    renderers: tuple[BaseRenderer, ...],
+    peripheral_manager: PeripheralManager,
+) -> tuple[BaseRenderer, ...]:
+    """Order renderers using the main switch's rotation and button state.
+
+    The renderers are alphabetised by name, rotated according to the current
+    rotary position since the last button press, and flipped when the button has
+    been pressed an odd number of times. Falling back to the original ordering
+    keeps the composition usable when the switch is unavailable.
+    """
+
+    if not renderers:
+        return renderers
+
+    try:
+        switch = peripheral_manager._deprecated_get_main_switch()
+    except Exception:
+        return renderers
+
+    ordered = sorted(renderers, key=lambda renderer: renderer.name.lower())
+
+    if switch.get_button_value() % 2 == 1:
+        ordered.reverse()
+
+    rotation = switch.get_rotation_since_last_button_press()
+    if rotation:
+        rotated = deque(ordered)
+        rotated.rotate(-rotation)
+        ordered = list(rotated)
+
+    return tuple(ordered)
 
 
 class MultiScene(BaseRenderer):

--- a/src/heart/programs/configurations/sorted_composer_demo.py
+++ b/src/heart/programs/configurations/sorted_composer_demo.py
@@ -1,0 +1,39 @@
+from heart.display.color import Color
+from heart.display.renderers.text import TextRendering
+from heart.environment import GameLoop
+from heart.navigation import (SortedComposedRenderer,
+                              switch_controlled_renderer_order)
+
+
+def configure(loop: GameLoop) -> None:
+    """Showcase sorting a composed stack with the rotary switch."""
+
+    mode = loop.add_mode("Switch sorted stack")
+
+    layered_text = [
+        TextRendering(
+            text=["Layer A"],
+            font="Roboto",
+            font_size=24,
+            color=Color(255, 90, 90),
+            y_location=22,
+        ),
+        TextRendering(
+            text=["Layer B"],
+            font="Roboto",
+            font_size=24,
+            color=Color(90, 255, 120),
+            y_location=22,
+        ),
+        TextRendering(
+            text=["Layer C"],
+            font="Roboto",
+            font_size=24,
+            color=Color(120, 135, 255),
+            y_location=22,
+        ),
+    ]
+
+    mode.add_renderer(
+        SortedComposedRenderer(layered_text, sorter=switch_controlled_renderer_order)
+    )

--- a/tests/navigation/test_sorted_composed_renderer.py
+++ b/tests/navigation/test_sorted_composed_renderer.py
@@ -1,0 +1,81 @@
+import pytest
+
+from heart.display.renderers import BaseRenderer
+from heart.navigation import (SortedComposedRenderer,
+                              switch_controlled_renderer_order)
+
+
+class _StubRenderer(BaseRenderer):
+    def __init__(self, label: str) -> None:
+        super().__init__()
+        self.label = label
+
+    @property
+    def name(self) -> str:
+        return self.label
+
+    def get_renderers(self, peripheral_manager):  # pragma: no cover - trivial
+        return [self]
+
+
+class _StubSwitch:
+    def __init__(self, *, rotation: int = 0, button: int = 0) -> None:
+        self._rotation = rotation
+        self._button = button
+
+    def get_rotation_since_last_button_press(self) -> int:
+        return self._rotation
+
+    def get_button_value(self) -> int:
+        return self._button
+
+
+class _StubPeripheralManager:
+    def __init__(self, switch: _StubSwitch) -> None:
+        self._switch = switch
+
+    def _deprecated_get_main_switch(self) -> _StubSwitch:
+        return self._switch
+
+
+def test_sorted_composed_renderer_uses_sorter(manager) -> None:
+    renderers = [_StubRenderer(label) for label in ["beta", "alpha", "gamma"]]
+
+    composer = SortedComposedRenderer(
+        renderers, sorter=lambda rs, _: sorted(rs, key=lambda item: item.label)
+    )
+
+    ordered = composer.get_renderers(manager)
+    assert [renderer.label for renderer in ordered] == ["alpha", "beta", "gamma"]
+
+
+def test_sorted_composed_renderer_rejects_invalid_permutation(manager) -> None:
+    renderers = [_StubRenderer(label) for label in ["a", "b"]]
+
+    composer = SortedComposedRenderer(
+        renderers, sorter=lambda rs, _: rs[:-1]  # drop one renderer
+    )
+
+    with pytest.raises(ValueError):
+        composer.get_renderers(manager)
+
+
+@pytest.mark.parametrize(
+    "rotation,button,expected",
+    [
+        (0, 0, ["alpha", "beta", "gamma"]),
+        (1, 0, ["beta", "gamma", "alpha"]),
+        (2, 1, ["alpha", "gamma", "beta"]),
+    ],
+)
+def test_switch_controlled_renderer_order(rotation, button, expected) -> None:
+    renderers = tuple(
+        _StubRenderer(label) for label in ["gamma", "alpha", "beta"]
+    )
+    manager = _StubPeripheralManager(
+        _StubSwitch(rotation=rotation, button=button)
+    )
+
+    ordered = switch_controlled_renderer_order(renderers, manager)
+
+    assert [renderer.label for renderer in ordered] == expected


### PR DESCRIPTION
## Summary
- introduce `SortedComposedRenderer` to reorder composed renderers via a sorter callback
- add a switch-driven ordering helper, accompanying demo configuration, and API documentation
- cover the new behaviours with navigation unit tests

## Testing
- `make format` *(fails: mypy missing stubs for usb.core)*
- `make test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910b204c9b08321931fc1e3f3eaca38)