### PR TITLE
Add single LED mirror peripheral for LED matrix output

### DIFF
--- a/docs/code_flow.md
+++ b/docs/code_flow.md
@@ -56,6 +56,8 @@ flowchart LR
         Capture["Frame Capture\n(share surface)"]
         DeviceBridge["Device Bridge"]
         LedMatrix["LEDMatrix Driver\n(rgbmatrix)"]
+        AverageMirror["AverageColorLED Peripheral"]
+        SingleLED["Single LED Device"]
     end
 
     CLI --> Registry --> Configurer --> Loop
@@ -65,6 +67,7 @@ flowchart LR
     AppRouter --> ModeServices --> FrameComposer --> DisplaySvc
     DisplaySvc --> LocalScreen
     DisplaySvc --> Capture --> DeviceBridge --> LedMatrix
+    Capture --> AverageMirror --> SingleLED
 
     Loop --> PeripheralMgr
     PeripheralMgr --> Switch --> AppRouter
@@ -76,7 +79,7 @@ flowchart LR
     class CLI,Registry,Configurer,ModeServices,FrameComposer service;
     class Loop,AppRouter orchestrator;
     class PeripheralMgr,Switch,Gamepad,Sensors,HeartRate,PhoneText input;
-    class DisplaySvc,LocalScreen,Capture,DeviceBridge,LedMatrix output;
+    class DisplaySvc,LocalScreen,Capture,DeviceBridge,LedMatrix,AverageMirror,SingleLED output;
 ```
 
 ## Rendering Procedure

--- a/docs/dual_output_renderer.md
+++ b/docs/dual_output_renderer.md
@@ -1,0 +1,39 @@
+# Dual Output Renderer Example
+
+## Overview
+
+This example demonstrates how a single `GameLoop` fan-outs its rendered frame
+to both the primary LED matrix and a secondary 1×1 LED device. The mirror LED
+derives its colour from the average hue of the matrix frame, allowing a small
+indicator to reflect the aggregate brightness of the main scene.
+
+## Components
+
+- `heart.device.single_led.SingleLEDDevice` – in-memory device representing a
+  single addressable LED pixel.
+- `heart.peripheral.average_color_led.AverageColorLED` – peripheral that
+  subscribes to the LED matrix display frames and updates the single LED with
+  the average colour.
+- `heart.programs.configurations.dual_output_demo` – configuration that wires
+  the mirror peripheral into the default render loop.
+
+## Running the configuration
+
+```bash
+totem run --configuration dual_output_demo
+```
+
+The CLI bootstraps the primary `GameLoop`, renders the configured colour
+through the matrix drivers, and publishes each frame to the
+`LEDMatrixDisplay` peripheral. `AverageColorLED` listens for these frame events
+and renders the average colour to the single LED device. In a hardware setup
+this secondary device can drive a dedicated indicator LED or any controller
+that accepts 1×1 RGB frames.
+
+## Testing
+
+The Pytest suite includes targeted coverage in
+`tests/peripheral/test_average_color_led.py` ensuring the mirror peripheral
+tracks only the intended producer and correctly computes the mean colour from
+mixed frames. `tests/test_environment.py` additionally validates that multiple
+`GameLoop` instances can coexist when coordinating multi-device output.

--- a/src/heart/device/single_led.py
+++ b/src/heart/device/single_led.py
@@ -1,0 +1,48 @@
+"""Simple in-memory device modelling a single 1x1 LED pixel."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from PIL import Image
+
+from heart.device import Device, Orientation, Rectangle
+
+
+class SingleLEDDevice(Device):
+    """Device implementation that records the colour of a single LED."""
+
+    def __init__(self, orientation: Orientation | None = None) -> None:
+        super().__init__(
+            orientation=orientation or Rectangle.with_layout(columns=1, rows=1)
+        )
+        self._last_image: Image.Image | None = None
+
+    def individual_display_size(self) -> tuple[int, int]:
+        return (1, 1)
+
+    def set_image(self, image: Image.Image) -> None:
+        if image.size != self.full_display_size():
+            raise ValueError(
+                "SingleLEDDevice expects a 1x1 image; "
+                f"received {image.size!r}"
+            )
+        if image.mode != "RGB":
+            image = image.convert("RGB")
+        self._last_image = image.copy()
+
+    @property
+    def last_image(self) -> Image.Image | None:
+        """Return the most recently rendered image, if any."""
+
+        return self._last_image.copy() if self._last_image is not None else None
+
+    @property
+    def last_color(self) -> tuple[int, int, int] | None:
+        """Return the most recently rendered colour as an RGB tuple."""
+
+        if self._last_image is None:
+            return None
+        pixel = cast(tuple[int, int, int], self._last_image.getpixel((0, 0)))
+        return (int(pixel[0]), int(pixel[1]), int(pixel[2]))
+

--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -763,10 +763,13 @@ class GameLoop:
         self.__dim_display()
 
     def __set_singleton(self) -> None:
-        if self.get_game_loop() is not None:
-            raise Exception("An active GameLoop exists already, please re-use that one")
-
-        GameLoop.set_game_loop(self)
+        active_loop = self.get_game_loop()
+        if active_loop is None:
+            GameLoop.set_game_loop(self)
+        elif active_loop is not self:
+            logger.debug(
+                "GameLoop initialized alongside existing instance; keeping original active"
+            )
 
     def _initialize_screen(self) -> None:
         pygame.init()

--- a/src/heart/peripheral/average_color_led.py
+++ b/src/heart/peripheral/average_color_led.py
@@ -1,0 +1,69 @@
+"""Peripheral that mirrors an LED matrix onto a single LED device."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable, cast
+
+from PIL import Image, ImageStat
+
+from heart.device import Device
+from heart.events.types import DisplayFrame
+from heart.peripheral.core import Input, Peripheral
+from heart.peripheral.led_matrix import LEDMatrixDisplay
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard
+    from heart.peripheral.core.event_bus import EventBus
+
+
+def _rgb_mean(image: Image.Image) -> tuple[int, int, int]:
+    stat = ImageStat.Stat(image.convert("RGB"))
+    mean = tuple(int(round(channel)) for channel in stat.mean[:3])
+    return cast(tuple[int, int, int], mean)
+
+
+@dataclass(slots=True)
+class _FrameHandler:
+    source_display_id: int
+    update_device: Callable[[tuple[int, int, int]], None]
+
+    def __call__(self, input_event: Input) -> None:
+        payload = input_event.data
+        if (
+            not isinstance(payload, DisplayFrame)
+            or input_event.producer_id != self.source_display_id
+        ):
+            return
+        colour = _rgb_mean(payload.to_image())
+        self.update_device(colour)
+
+
+class AverageColorLED(Peripheral):
+    """Mirror the average matrix colour onto a single LED device."""
+
+    def __init__(
+        self,
+        *,
+        device: Device,
+        source_display: LEDMatrixDisplay,
+    ) -> None:
+        super().__init__()
+        self._device = device
+        self._frame_handler = _FrameHandler(
+            source_display_id=source_display.producer_id,
+            update_device=self._update_device,
+        )
+        if source_display.event_bus is not None:
+            self.attach_event_bus(source_display.event_bus)
+
+    def on_event_bus_attached(self, event_bus: "EventBus") -> None:
+        super().on_event_bus_attached(event_bus)
+        self.subscribe_event(DisplayFrame.EVENT_TYPE, self._frame_handler)
+
+    def _update_device(self, colour: tuple[int, int, int]) -> None:
+        image = Image.new("RGB", self._device.full_display_size(), colour)
+        self._device.set_image(image)
+
+    def run(self) -> None:  # pragma: no cover - passive peripheral
+        return None
+

--- a/src/heart/peripheral/heart_rates.py
+++ b/src/heart/peripheral/heart_rates.py
@@ -12,7 +12,7 @@ from openant.devices.scanner import Scanner
 from openant.devices.utilities import auto_create_device
 from openant.easy.exception import AntException
 from openant.easy.node import Node
-from usb.core import NoBackendError
+from usb.core import NoBackendError  # type: ignore[import-untyped]
 
 from heart.events.types import HeartRateLifecycle, HeartRateMeasurement
 from heart.peripheral.core import Peripheral

--- a/src/heart/peripheral/led_matrix.py
+++ b/src/heart/peripheral/led_matrix.py
@@ -53,6 +53,12 @@ class LEDMatrixDisplay(Peripheral):
         return self._height
 
     @property
+    def producer_id(self) -> int:
+        """Return the producer identifier used for emitted frames."""
+
+        return self._producer_id
+
+    @property
     def latest_frame(self) -> DisplayFrame | None:
         """Return the most recently published frame, if any."""
 

--- a/src/heart/programs/configurations/dual_output_demo.py
+++ b/src/heart/programs/configurations/dual_output_demo.py
@@ -1,0 +1,19 @@
+"""Configuration demonstrating LED matrix mirroring to a single LED."""
+
+from heart.device.single_led import SingleLEDDevice
+from heart.display.color import Color
+from heart.display.renderers.color import RenderColor
+from heart.environment import GameLoop
+from heart.peripheral.average_color_led import AverageColorLED
+
+
+def configure(loop: GameLoop) -> None:
+    mode = loop.add_mode("Dual Output Demo")
+    mode.add_renderer(RenderColor(color=Color(32, 96, 224)))
+
+    single_led = SingleLEDDevice()
+    average_led = AverageColorLED(
+        device=single_led,
+        source_display=loop.display_peripheral,
+    )
+    loop.peripheral_manager.register(average_led)

--- a/tests/peripheral/test_average_color_led.py
+++ b/tests/peripheral/test_average_color_led.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from PIL import Image
+
+from heart.device.single_led import SingleLEDDevice
+from heart.events.types import DisplayFrame
+from heart.peripheral.average_color_led import AverageColorLED
+
+
+def _register_average(loop) -> tuple[SingleLEDDevice, AverageColorLED]:
+    single_led = SingleLEDDevice()
+    average_led = AverageColorLED(
+        device=single_led,
+        source_display=loop.display_peripheral,
+    )
+    loop.peripheral_manager.register(average_led)
+    return single_led, average_led
+
+
+def test_average_led_tracks_latest_frame(loop) -> None:
+    single_led, _ = _register_average(loop)
+    image = Image.new("RGB", loop.device.full_display_size(), (255, 0, 0))
+
+    loop.display_peripheral.publish_image(image)
+
+    assert single_led.last_color == (255, 0, 0)
+
+
+def test_average_led_computes_mean_colour(loop) -> None:
+    single_led, _ = _register_average(loop)
+    width, height = loop.device.full_display_size()
+    image = Image.new("RGB", (width, height))
+    image.paste((255, 0, 0), (0, 0, width // 2, height))
+    image.paste((0, 0, 255), (width // 2, 0, width, height))
+
+    loop.display_peripheral.publish_image(image)
+
+    assert single_led.last_color == (128, 0, 128)
+
+
+def test_average_led_ignores_other_displays(loop) -> None:
+    single_led, _ = _register_average(loop)
+    width, height = loop.device.full_display_size()
+    alien_frame = DisplayFrame.from_image(
+        Image.new("RGB", (width, height), (0, 255, 0)),
+        frame_id=99,
+    )
+
+    loop.event_bus.emit(alien_frame.to_input(producer_id=999))
+
+    assert single_led.last_color is None
+
+    loop.display_peripheral.publish_image(
+        Image.new("RGB", (width, height), (0, 255, 0))
+    )
+
+    assert single_led.last_color == (0, 255, 0)

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,3 +1,4 @@
+import os
 import types
 
 import pygame
@@ -7,6 +8,8 @@ from pytest_benchmark.fixture import BenchmarkFixture
 from heart.display.renderers.pixels import RandomPixel
 from heart.environment import GameLoop, RendererVariant
 from heart.peripheral.core import events
+from heart.peripheral.core.manager import PeripheralManager
+from tests.conftest import FakeFixtureDevice
 
 
 @pytest.mark.parametrize("num_renderers", [1, 5, 10, 25, 50, 100, 1000])
@@ -102,3 +105,21 @@ def test_handle_events_supports_missing_event_payload(loop: GameLoop, monkeypatc
             "pygame_event_name": pygame.event.event_name(pygame.NOEVENT),
         }
     ]
+
+
+def test_multiple_game_loops_can_coexist(orientation) -> None:
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
+    manager_one = PeripheralManager()
+    device_one = FakeFixtureDevice(orientation=orientation)
+    loop_one = GameLoop(device=device_one, peripheral_manager=manager_one)
+    loop_one._initialize_screen()
+
+    manager_two = PeripheralManager()
+    device_two = FakeFixtureDevice(orientation=orientation)
+    loop_two = GameLoop(device=device_two, peripheral_manager=manager_two)
+    loop_two._initialize_screen()
+
+    assert loop_one.device is device_one
+    assert loop_two.device is device_two
+
+    pygame.quit()


### PR DESCRIPTION
## Summary
- allow more than one GameLoop to initialize without raising so auxiliary display loops can coexist
- add a SingleLEDDevice and AverageColorLED peripheral that mirror LED matrix frames onto a 1×1 LED
- document the dual-output example, add a configuration hook, and cover the behaviour with targeted tests

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910b1a0df0c8321a041dbaf42f3b2e0)