### PR TITLE
Add ThreeDGlassesRenderer for LED anaglyph effect

### DIFF
--- a/docs/three_d_glasses_renderer.md
+++ b/docs/three_d_glasses_renderer.md
@@ -1,0 +1,42 @@
+# ThreeDGlassesRenderer
+
+## Overview
+
+`ThreeDGlassesRenderer` remaps static imagery into an LED-friendly
+anaglyph so that only red and blue subpixels are energised. The
+technique originates from a pairing session with Sri and Michael, and it
+is designed for displays that rely on LED glasses or similar colour
+filtering hardware.
+
+## How it works
+
+- The renderer loads one or more source images using
+  `heart.assets.loader.Loader` and scales them to the device window.
+- Each image receives a distinct `_ChannelProfile` that tweaks the
+  horizontal offset and balance between the red and blue channels.
+- `_apply_profile` converts the source frame to luma, shifts each colour
+  channel independently, and writes the result back into the rendering
+  surface with the green channel zeroed out.
+- Frames advance on a configurable cadence (default `650ms`) using the
+  renderer clock, so viewers perceive alternating depth cues when
+  looking through LED glasses.
+
+## Usage
+
+```python
+from heart.display.renderers.three_d_glasses import ThreeDGlassesRenderer
+
+renderer = ThreeDGlassesRenderer([
+    "gallery/left_panel.png",
+    "gallery/right_panel.png",
+])
+```
+
+Integrate the renderer into a program configuration the same way you
+would add any other `BaseRenderer` subclass.
+
+## Hardware notes
+
+Because only the red and blue subpixels are driven, brightness may be
+lower than a full-colour scene. Calibrate ambient lighting accordingly
+when preparing demos.

--- a/docs/three_d_glasses_renderer.md
+++ b/docs/three_d_glasses_renderer.md
@@ -35,6 +35,19 @@ renderer = ThreeDGlassesRenderer([
 Integrate the renderer into a program configuration the same way you
 would add any other `BaseRenderer` subclass.
 
+## Program configuration
+
+`heart/programs/configurations/three_d_glasses_demo.py` wires the
+renderer into the runtime with the stock `heart.png` assets. Launch it
+with:
+
+```bash
+totem run --configuration three_d_glasses_demo
+```
+
+The configuration adds a single mode so the demo starts immediately in
+the 3D view.
+
 ## Hardware notes
 
 Because only the red and blue subpixels are driven, brightness may be

--- a/src/heart/display/renderers/three_d_glasses.py
+++ b/src/heart/display/renderers/three_d_glasses.py
@@ -1,0 +1,169 @@
+"""Renderer for LED anaglyph imagery.
+
+This module implements a 3D glasses effect that remaps an image into
+per-channel (red / blue) components suitable for LED lenses. The
+technique was developed in collaboration with Sri and Michael.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+import pygame
+
+from heart.assets.loader import Loader
+from heart.device import Orientation
+from heart.display.renderers import BaseRenderer
+from heart.peripheral.core.manager import PeripheralManager
+
+
+@dataclass(frozen=True)
+class _ChannelProfile:
+    """Parameter bundle describing how to tint a specific frame."""
+
+    red_shift: int
+    blue_shift: int
+    red_weight: float
+    blue_weight: float
+
+
+class ThreeDGlassesRenderer(BaseRenderer):
+    """Render a sequence of images with a red/blue anaglyph effect."""
+
+    def __init__(
+        self,
+        image_files: Sequence[str],
+        *,
+        frame_duration_ms: int = 650,
+    ) -> None:
+        super().__init__()
+        if not image_files:
+            raise ValueError("ThreeDGlassesRenderer requires at least one image file")
+
+        self._image_files = list(image_files)
+        self._frame_duration_ms = frame_duration_ms
+
+        self._images: list[pygame.Surface] = []
+        self._image_arrays: list[np.ndarray] = []
+        self._profiles: list[_ChannelProfile] = []
+        self._effect_surface: pygame.Surface | None = None
+
+        self._current_index = 0
+        self._elapsed_ms = 0
+
+    @staticmethod
+    def _generate_profiles(count: int) -> list[_ChannelProfile]:
+        """Create per-image tint profiles with distinct red/blue balance."""
+
+        if count <= 0:
+            raise ValueError("Profile count must be positive")
+
+        profiles: list[_ChannelProfile] = []
+        # Cycle through gentle horizontal parallax values while varying colour balance
+        shift_pattern = (1, 2, 3)
+        denominator = max(count - 1, 1)
+
+        for index in range(count):
+            magnitude = shift_pattern[index % len(shift_pattern)]
+            ratio = index / denominator
+            red_weight = 0.55 + 0.35 * ratio
+            blue_weight = 0.95 - 0.35 * ratio
+            profiles.append(
+                _ChannelProfile(
+                    red_shift=magnitude,
+                    blue_shift=-magnitude,
+                    red_weight=red_weight,
+                    blue_weight=blue_weight,
+                )
+            )
+
+        return profiles
+
+    def initialize(
+        self,
+        window: pygame.Surface,
+        clock: pygame.time.Clock,
+        peripheral_manager: PeripheralManager,
+        orientation: Orientation,
+    ) -> None:
+        window_size = window.get_size()
+
+        self._images.clear()
+        self._image_arrays.clear()
+
+        for file_path in self._image_files:
+            surface = Loader.load(file_path).convert_alpha()
+            surface = pygame.transform.smoothscale(surface, window_size)
+            self._images.append(surface)
+
+            array = pygame.surfarray.array3d(surface).astype(np.float32) / 255.0
+            self._image_arrays.append(array)
+
+        self._profiles = self._generate_profiles(len(self._image_arrays))
+        self._effect_surface = pygame.Surface(window_size, pygame.SRCALPHA)
+
+        self._current_index = 0
+        self._elapsed_ms = 0
+
+        super().initialize(window, clock, peripheral_manager, orientation)
+
+    @staticmethod
+    def _shift_channel(channel: np.ndarray, shift: int) -> np.ndarray:
+        """Roll channel data horizontally while blanking the wrapped pixels."""
+
+        if shift == 0:
+            return channel
+
+        shifted = np.roll(channel, shift=shift, axis=0)
+        if shift > 0:
+            shifted[:shift, :] = 0.0
+        else:
+            shifted[shift:, :] = 0.0
+        return shifted
+
+    def _apply_profile(
+        self, base_array: np.ndarray, profile: _ChannelProfile
+    ) -> np.ndarray:
+        """Convert RGB input to a red/blue anaglyph frame."""
+
+        grayscale = (
+            base_array[..., 0] * 0.299
+            + base_array[..., 1] * 0.587
+            + base_array[..., 2] * 0.114
+        )
+
+        red = self._shift_channel(grayscale, profile.red_shift) * profile.red_weight
+        blue = self._shift_channel(grayscale, profile.blue_shift) * profile.blue_weight
+
+        frame = np.zeros_like(base_array)
+        frame[..., 0] = red
+        frame[..., 2] = blue
+
+        np.clip(frame, 0.0, 1.0, out=frame)
+        return (frame * 255).astype(np.uint8)
+
+    def process(
+        self,
+        window: pygame.Surface,
+        clock: pygame.time.Clock,
+        peripheral_manager: PeripheralManager,
+        orientation: Orientation,
+    ) -> None:
+        if not self._image_arrays:
+            return
+
+        self._elapsed_ms += clock.get_time()
+        if self._elapsed_ms >= self._frame_duration_ms:
+            self._elapsed_ms %= self._frame_duration_ms
+            self._current_index = (self._current_index + 1) % len(self._image_arrays)
+
+        profile = self._profiles[self._current_index]
+        base_array = self._image_arrays[self._current_index]
+
+        frame_array = self._apply_profile(base_array, profile)
+
+        assert self._effect_surface is not None
+        pygame.surfarray.blit_array(self._effect_surface, frame_array)
+        window.blit(self._effect_surface, (0, 0))

--- a/src/heart/peripheral/heart_rates.py
+++ b/src/heart/peripheral/heart_rates.py
@@ -12,7 +12,7 @@ from openant.devices.scanner import Scanner
 from openant.devices.utilities import auto_create_device
 from openant.easy.exception import AntException
 from openant.easy.node import Node
-from usb.core import NoBackendError  # type: ignore[import-untyped]
+from usb.core import NoBackendError
 
 from heart.events.types import HeartRateLifecycle, HeartRateMeasurement
 from heart.peripheral.core import Peripheral

--- a/src/heart/programs/configurations/three_d_glasses_demo.py
+++ b/src/heart/programs/configurations/three_d_glasses_demo.py
@@ -1,0 +1,19 @@
+from heart.display.renderers.three_d_glasses import ThreeDGlassesRenderer
+from heart.environment import GameLoop
+
+IMAGE_SEQUENCE = [
+    "heart.png",
+    "heart_16_big.png",
+]
+
+
+def configure(loop: GameLoop) -> None:
+    """Attach the ThreeDGlassesRenderer for manual testing."""
+
+    mode = loop.add_mode("3D Glasses Demo")
+    mode.add_renderer(
+        ThreeDGlassesRenderer(
+            list(IMAGE_SEQUENCE),
+            frame_duration_ms=650,
+        )
+    )

--- a/tests/display/test_three_d_glasses_renderer.py
+++ b/tests/display/test_three_d_glasses_renderer.py
@@ -1,0 +1,85 @@
+import os
+from collections import deque
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import numpy as np
+import pygame
+import pytest
+
+from heart.assets import loader as assets_loader
+from heart.device import Rectangle
+from heart.display.renderers.three_d_glasses import ThreeDGlassesRenderer
+from heart.peripheral.core.manager import PeripheralManager
+
+
+class _StubClock:
+    def __init__(self, *times: int) -> None:
+        self._times: deque[int] = deque(times)
+
+    def get_time(self) -> int:
+        if not self._times:
+            return 0
+        return self._times.popleft()
+
+
+@pytest.fixture(autouse=True)
+def init_pygame() -> None:
+    pygame.init()
+    yield
+    pygame.quit()
+
+
+def test_renderer_requires_images() -> None:
+    with pytest.raises(ValueError):
+        ThreeDGlassesRenderer([])
+
+
+def test_generate_profiles_vary_shift_and_weights() -> None:
+    profiles = ThreeDGlassesRenderer._generate_profiles(4)
+
+    assert len(profiles) == 4
+    assert [profile.red_shift for profile in profiles] == [1, 2, 3, 1]
+    assert profiles[0].red_weight < profiles[-1].red_weight
+    assert profiles[0].blue_weight > profiles[-1].blue_weight
+
+
+def test_process_applies_anaglyph_and_cycles(monkeypatch: pytest.MonkeyPatch) -> None:
+    window_size = (4, 4)
+    window = pygame.Surface(window_size, pygame.SRCALPHA)
+    orientation = Rectangle.with_layout(1, 1)
+    manager = PeripheralManager()
+
+    source_surfaces = [
+        pygame.Surface(window_size, pygame.SRCALPHA),
+        pygame.Surface(window_size, pygame.SRCALPHA),
+    ]
+    source_surfaces[0].fill((200, 120, 60, 255))
+    source_surfaces[1].fill((40, 220, 160, 255))
+
+    class _LoaderResult:
+        def __init__(self, surface: pygame.Surface) -> None:
+            self._surface = surface
+
+        def convert_alpha(self) -> pygame.Surface:
+            return self._surface
+
+    load_calls = iter(_LoaderResult(surface) for surface in source_surfaces)
+    monkeypatch.setattr(assets_loader.Loader, "load", lambda path: next(load_calls))
+
+    clock = _StubClock(0, 0, 150)
+    renderer = ThreeDGlassesRenderer(["one.png", "two.png"], frame_duration_ms=120)
+
+    renderer.initialize(window, clock, manager, orientation)
+
+    renderer.process(window, clock, manager, orientation)
+    frame_one = pygame.surfarray.array3d(window).copy()
+
+    renderer.process(window, clock, manager, orientation)
+    frame_two = pygame.surfarray.array3d(window).copy()
+
+    assert np.all(frame_one[..., 1] == 0)
+    assert np.all(frame_two[..., 1] == 0)
+    assert np.any(frame_one[..., 0] > 0)
+    assert np.any(frame_two[..., 2] > 0)
+    assert not np.array_equal(frame_one, frame_two)


### PR DESCRIPTION
## Summary
- add a ThreeDGlassesRenderer that remaps imagery into alternating red/blue LED-friendly frames inspired by Sri and Michael
- document the renderer pipeline and usage in docs/three_d_glasses_renderer.md
- remove an obsolete usb.core type ignore flagged during formatting

## Testing
- make format
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910c98db288832197015a140b655459)