### PR TITLE
Throttle render loop info logging

### DIFF
--- a/docs/logging_control.md
+++ b/docs/logging_control.md
@@ -1,0 +1,36 @@
+# Logging sample control
+
+The render loop and other high-frequency components now share a central
+controller that manages log sampling and verbosity overrides. The controller
+is exposed through `heart.utilities.logging_control.get_logging_controller()`
+and can be tuned with environment variables at runtime.
+
+## Default behaviour
+
+- The default sample interval is one second. When a call site uses the shared
+  controller, the first log entry is emitted at its requested level and any
+  additional entries within the one-second window fall back to `DEBUG` level.
+- Set `HEART_LOG_DEFAULT_INTERVAL=none` to disable the global throttle or to a
+  floating-point value (seconds) to choose a different cadence.
+
+## Per-key overrides
+
+The `HEART_LOG_RULES` variable accepts a comma-separated list of rules with the
+following shape:
+
+```
+<key>=<interval>[:<LEVEL>[:<FALLBACK>]]
+```
+
+- `<key>`: logical identifier supplied by the call site (e.g. `render.loop`).
+- `<interval>`: either `none` to disable sampling or the interval (seconds)
+  between primary log emissions.
+- `<LEVEL>`: optional log level name (e.g. `INFO`, `WARNING`) to force the
+  primary emission to a specific verbosity.
+- `<FALLBACK>`: optional level used when a log is suppressed by sampling.
+  Provide `none` to drop suppressed logs entirely.
+
+Example: `HEART_LOG_RULES="render.loop=0.5:INFO:DEBUG,ble.poll=none:WARNING:none"`.
+
+These settings allow tuning busy subsystems without editing source code while
+keeping structured extras intact for every emission.

--- a/src/heart/utilities/logging_control.py
+++ b/src/heart/utilities/logging_control.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import logging
+import os
+import re
+import threading
+import time
+from dataclasses import dataclass
+from functools import cache
+from typing import Callable, Sequence
+
+LOG_RULES_ENV_VAR = "HEART_LOG_RULES"
+DEFAULT_INTERVAL_ENV_VAR = "HEART_LOG_DEFAULT_INTERVAL"
+DEFAULT_FALLBACK_LEVEL = logging.DEBUG
+DEFAULT_INTERVAL_SECONDS = 1.0
+
+_RULE_PATTERN = re.compile(
+    r"^(?P<key>[^=]+)="
+    r"(?P<interval>none|\d+(?:\.\d+)?)"
+    r"(?::(?P<level>[A-Za-z]+))?"
+    r"(?::(?P<fallback>[A-Za-z]+|none))?$"
+)
+
+
+@dataclass(frozen=True)
+class LogRule:
+    """Configuration describing how frequently to emit a log statement."""
+
+    interval_seconds: float | None
+    level: int | None
+    fallback_level: int | None
+
+
+class LoggingController:
+    """Centralised control for log sampling and verbosity overrides."""
+
+    def __init__(
+        self,
+        *,
+        default_interval: float | None,
+        default_fallback_level: int | None,
+        rules: dict[str, LogRule],
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._default_interval = default_interval
+        self._default_fallback_level = default_fallback_level
+        self._rules = rules
+        self._monotonic = monotonic
+        self._lock = threading.Lock()
+        self._next_emit: dict[str, float] = {}
+
+    def _rule_for(self, key: str) -> LogRule:
+        if key in self._rules:
+            return self._rules[key]
+        return LogRule(
+            interval_seconds=self._default_interval,
+            level=None,
+            fallback_level=self._default_fallback_level,
+        )
+
+    def log(
+        self,
+        *,
+        key: str,
+        logger: logging.Logger,
+        level: int,
+        msg: str,
+        args: Sequence[object] | None = None,
+        extra: dict[str, object] | None = None,
+        fallback_level: int | None = None,
+    ) -> bool:
+        """
+        Emit a log statement honouring the configured sampling policy.
+
+        Returns ``True`` if the primary log level was emitted, ``False`` otherwise.
+        """
+
+        rule = self._rule_for(key)
+        primary_level = rule.level or level
+        suppressed_level = (
+            rule.fallback_level
+            if rule.fallback_level is not None
+            else fallback_level
+        )
+
+        interval = rule.interval_seconds
+        if interval is None:
+            logger.log(primary_level, msg, *(args or ()), extra=extra)
+            return True
+
+        now = self._monotonic()
+
+        with self._lock:
+            next_emit = self._next_emit.get(key, 0.0)
+            if now >= next_emit:
+                self._next_emit[key] = now + interval
+                logger.log(primary_level, msg, *(args or ()), extra=extra)
+                return True
+
+        if suppressed_level is not None:
+            logger.log(suppressed_level, msg, *(args or ()), extra=extra)
+        return False
+
+
+def _parse_level(name: str | None) -> int | None:
+    if not name:
+        return None
+    resolved = getattr(logging, name.upper(), None)
+    if isinstance(resolved, int):
+        return resolved
+    raise ValueError(f"Unknown log level {name!r}")
+
+
+def _parse_interval(value: str) -> float | None:
+    if value.lower() == "none":
+        return None
+    return float(value)
+
+
+def _parse_rules(raw_rules: str) -> dict[str, LogRule]:
+    rules: dict[str, LogRule] = {}
+    for chunk in filter(None, (part.strip() for part in raw_rules.split(","))):
+        match = _RULE_PATTERN.match(chunk)
+        if not match:
+            raise ValueError(
+                "Invalid HEART_LOG_RULES entry. Expected 'key=interval[:LEVEL[:FALLBACK]]'."
+            )
+        key = match.group("key").strip()
+        interval = _parse_interval(match.group("interval"))
+        level = _parse_level(match.group("level"))
+        fallback_raw = match.group("fallback")
+        fallback_level = (
+            None
+            if fallback_raw is None
+            else (None if fallback_raw.lower() == "none" else _parse_level(fallback_raw))
+        )
+        rules[key] = LogRule(interval, level, fallback_level)
+    return rules
+
+
+@cache
+def get_logging_controller() -> LoggingController:
+    """Return the shared logging controller instance."""
+
+    default_interval_raw = os.getenv(DEFAULT_INTERVAL_ENV_VAR)
+    default_interval = (
+        DEFAULT_INTERVAL_SECONDS
+        if default_interval_raw is None
+        else _parse_interval(default_interval_raw)
+    )
+
+    rules_raw = os.getenv(LOG_RULES_ENV_VAR, "")
+    rules = _parse_rules(rules_raw) if rules_raw else {}
+
+    return LoggingController(
+        default_interval=default_interval,
+        default_fallback_level=DEFAULT_FALLBACK_LEVEL,
+        rules=rules,
+    )

--- a/tests/utilities/test_logging_control.py
+++ b/tests/utilities/test_logging_control.py
@@ -1,0 +1,111 @@
+import logging
+
+import pytest
+
+from heart.utilities import logging_control
+
+
+class StubLogger:
+    def __init__(self) -> None:
+        self.records: list[tuple[int, str, tuple[object, ...], dict[str, object] | None]] = []
+
+    def log(
+        self,
+        level: int,
+        msg: str,
+        *args: object,
+        extra: dict[str, object] | None = None,
+    ) -> None:
+        self.records.append((level, msg, tuple(args), extra))
+
+
+def test_logging_controller_applies_interval() -> None:
+    monotonic_values = [0.0]
+
+    def monotonic() -> float:
+        return monotonic_values[0]
+
+    controller = logging_control.LoggingController(
+        default_interval=1.0,
+        default_fallback_level=logging.DEBUG,
+        rules={},
+        monotonic=monotonic,
+    )
+
+    logger = StubLogger()
+
+    emitted = controller.log(
+        key="render.loop",
+        logger=logger,
+        level=logging.INFO,
+        msg="render.loop",
+        args=("primary",),
+        fallback_level=logging.DEBUG,
+    )
+
+    assert emitted is True
+    assert logger.records[-1][0] == logging.INFO
+
+    emitted = controller.log(
+        key="render.loop",
+        logger=logger,
+        level=logging.INFO,
+        msg="render.loop",
+        args=("secondary",),
+        fallback_level=logging.DEBUG,
+    )
+
+    assert emitted is False
+    assert logger.records[-1][0] == logging.DEBUG
+
+    monotonic_values[0] = 1.0
+    emitted = controller.log(
+        key="render.loop",
+        logger=logger,
+        level=logging.INFO,
+        msg="render.loop",
+        args=("tertiary",),
+        fallback_level=logging.DEBUG,
+    )
+
+    assert emitted is True
+    assert logger.records[-1][0] == logging.INFO
+
+
+@pytest.fixture(autouse=True)
+def reset_logging_controller_cache() -> None:
+    logging_control.get_logging_controller.cache_clear()  # type: ignore[attr-defined]
+    yield
+    logging_control.get_logging_controller.cache_clear()  # type: ignore[attr-defined]
+
+
+def test_logging_controller_respects_rule_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HEART_LOG_RULES", "render.loop=none:WARNING:none")
+    controller = logging_control.get_logging_controller()
+
+    logger = StubLogger()
+
+    emitted = controller.log(
+        key="render.loop",
+        logger=logger,
+        level=logging.INFO,
+        msg="render.loop",
+        args=(),
+        fallback_level=logging.DEBUG,
+    )
+
+    assert emitted is True
+    assert logger.records[-1][0] == logging.WARNING
+
+    emitted = controller.log(
+        key="render.loop",
+        logger=logger,
+        level=logging.INFO,
+        msg="render.loop",
+        args=(),
+        fallback_level=logging.DEBUG,
+    )
+
+    assert emitted is True
+    assert len(logger.records) == 2
+    assert logger.records[-1][0] == logging.WARNING


### PR DESCRIPTION
## Summary
- add a render-loop log throttle so the info message only emits once per second
- fall back to debug-level logging for intermediate frames while preserving structured extras

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910d358c2548321bf6cea9fcb635589)