### PR TITLE
Enhance 3D glasses renderer effect

### DIFF
--- a/docs/three_d_glasses_renderer.md
+++ b/docs/three_d_glasses_renderer.md
@@ -3,7 +3,8 @@
 ## Overview
 
 `ThreeDGlassesRenderer` remaps static imagery into an LED-friendly
-anaglyph so that only red and blue subpixels are energised. The
+anaglyph so that the red lens sees a warm-tinted offset while the cyan
+lens receives a matching counterpart. The
 technique originates from a pairing session with Sri and Michael, and it
 is designed for displays that rely on LED glasses or similar colour
 filtering hardware.
@@ -13,10 +14,12 @@ filtering hardware.
 - The renderer loads one or more source images using
   `heart.assets.loader.Loader` and scales them to the device window.
 - Each image receives a distinct `_ChannelProfile` that tweaks the
-  horizontal offset and balance between the red and blue channels.
-- `_apply_profile` converts the source frame to luma, shifts each colour
-  channel independently, and writes the result back into the rendering
-  surface with the green channel zeroed out.
+  horizontal offset and balance between the red and cyan channels to
+  emphasise parallax cues on 64×64 content.
+- `_apply_profile` blends the source frame into warm (left-eye) and cool
+  (right-eye) views, shifts them in opposite directions, and writes the
+  result back into the rendering surface with the cyan tint duplicated
+  across green and blue.
 - Frames advance on a configurable cadence (default `650ms`) using the
   renderer clock, so viewers perceive alternating depth cues when
   looking through LED glasses.

--- a/tests/display/test_three_d_glasses_renderer.py
+++ b/tests/display/test_three_d_glasses_renderer.py
@@ -39,9 +39,10 @@ def test_generate_profiles_vary_shift_and_weights() -> None:
     profiles = ThreeDGlassesRenderer._generate_profiles(4)
 
     assert len(profiles) == 4
-    assert [profile.red_shift for profile in profiles] == [1, 2, 3, 1]
-    assert profiles[0].red_weight < profiles[-1].red_weight
-    assert profiles[0].blue_weight > profiles[-1].blue_weight
+    assert [profile.red_shift for profile in profiles] == [4, 6, 8, 5]
+    assert [profile.cyan_shift for profile in profiles] == [-4, -6, -8, -5]
+    assert profiles[0].red_gain < profiles[-1].red_gain
+    assert profiles[0].cyan_gain > profiles[-1].cyan_gain
 
 
 def test_process_applies_anaglyph_and_cycles(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -78,8 +79,11 @@ def test_process_applies_anaglyph_and_cycles(monkeypatch: pytest.MonkeyPatch) ->
     renderer.process(window, clock, manager, orientation)
     frame_two = pygame.surfarray.array3d(window).copy()
 
-    assert np.all(frame_one[..., 1] == 0)
-    assert np.all(frame_two[..., 1] == 0)
     assert np.any(frame_one[..., 0] > 0)
-    assert np.any(frame_two[..., 2] > 0)
+    assert np.any(frame_one[..., 1] > 0)
+    assert np.any(frame_one[..., 2] > 0)
+    assert np.any(frame_two[..., 0] > 0)
+    assert np.any(frame_two[..., 1] > 0)
+    assert np.all(frame_one[..., 1] == frame_one[..., 2])
+    assert np.all(frame_two[..., 1] == frame_two[..., 2])
     assert not np.array_equal(frame_one, frame_two)


### PR DESCRIPTION
## Summary
- intensify the ThreeDGlassesRenderer red/cyan profiles for clearer parallax
- clamp channel shifts for small frames and adjust tests to cover the new behaviour
- document the updated rendering approach in docs/three_d_glasses_renderer.md

## Testing
- make format
- make test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910d3c998788321bfc4d7181adbcd05)