### PR TITLE
Group tests into descriptive classes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,11 @@ When adding tests, it is reasonable to stub hardware- or framework-heavy depende
 
 - Parameterize new Pytest cases when validating multiple input permutations (especially for driver behaviour) to keep coverage
   clear and maintainable.
+- Write tests with precise assertions and include a short docstring at the top of every test function that explains the behaviour
+  being validated. Each test docstring must mention both the specific behaviour under test and why that behaviour matters at a
+  higher level (e.g., performance, resilience, integration, documentation value). Group related tests into descriptive `pytest`
+  classes and give every class a docstring that states the shared focus and broader value of the grouped scenarios so readers can
+  immediately understand the collection's intent.
 
 ## Linting (Optional Pre-Check)
 

--- a/tests/display/test_screen_recorder.py
+++ b/tests/display/test_screen_recorder.py
@@ -24,54 +24,64 @@ def screen_recorder(loop) -> ScreenRecorder:
     return ScreenRecorder(loop, fps=12)
 
 
-@pytest.mark.parametrize(
-    "colors",
-    [
-        [(255, 0, 0)],
-        [(0, 0, 0), (255, 255, 255), (0, 128, 255)],
-    ],
-)
-def test_screen_recorder_writes_expected_frames(
-    colors: list[tuple[int, int, int]], screen_recorder: ScreenRecorder, tmp_path: Path
-) -> None:
-    inputs = [[SolidColorRenderer(color)] for color in colors]
+class TestDisplayScreenRecorder:
+    """Group Display Screen Recorder tests so display screen recorder behaviour stays reliable. This preserves confidence in display screen recorder for end-to-end scenarios."""
 
-    output_path = tmp_path / "capture.gif"
-    result_path = screen_recorder.record(inputs, output_path)
-
-    assert result_path.exists()
-
-    with Image.open(result_path) as image:
-        observed = [
-            frame.convert("RGB").getpixel((0, 0))
-            for frame in ImageSequence.Iterator(image)
-        ]
-
-    assert observed == colors
-
-
-def test_screen_recorder_sets_frame_duration(
-    screen_recorder: ScreenRecorder, tmp_path: Path
-) -> None:
-    inputs = [
-        [SolidColorRenderer((10, 20, 30))],
-        [SolidColorRenderer((30, 40, 50))],
-    ]
-    result_path = screen_recorder.record(inputs, tmp_path / "duration.gif")
-
-    with Image.open(result_path) as image:
-        durations = [
-            frame.info.get("duration")
-            for frame in ImageSequence.Iterator(image)
-        ]
-
-    expected_duration = max(
-        int(round((1000 / screen_recorder.fps) / 10.0) * 10),
-        10,
+    @pytest.mark.parametrize(
+        "colors",
+        [
+            [(255, 0, 0)],
+            [(0, 0, 0), (255, 255, 255), (0, 128, 255)],
+        ],
     )
-    assert durations == [expected_duration] * len(inputs)
+    def test_screen_recorder_writes_expected_frames(
+        self,
+        colors: list[tuple[int, int, int]], screen_recorder: ScreenRecorder, tmp_path: Path
+    ) -> None:
+        """Verify that ScreenRecorder emits a GIF whose frames match the provided renderer colours. This demonstrates capture fidelity so visual regressions are caught when renderers change."""
+        inputs = [[SolidColorRenderer(color)] for color in colors]
+
+        output_path = tmp_path / "capture.gif"
+        result_path = screen_recorder.record(inputs, output_path)
+
+        assert result_path.exists()
+
+        with Image.open(result_path) as image:
+            observed = [
+                frame.convert("RGB").getpixel((0, 0))
+                for frame in ImageSequence.Iterator(image)
+            ]
+
+        assert observed == colors
 
 
-def test_screen_recorder_requires_inputs(screen_recorder: ScreenRecorder, tmp_path: Path) -> None:
-    with pytest.raises(ValueError):
-        screen_recorder.record([], tmp_path / "empty.gif")
+
+    def test_screen_recorder_sets_frame_duration(
+        self,
+        screen_recorder: ScreenRecorder, tmp_path: Path
+    ) -> None:
+        """Verify that ScreenRecorder records frames using the expected millisecond duration. This keeps playback timing accurate so exported recordings feel consistent."""
+        inputs = [
+            [SolidColorRenderer((10, 20, 30))],
+            [SolidColorRenderer((30, 40, 50))],
+        ]
+        result_path = screen_recorder.record(inputs, tmp_path / "duration.gif")
+
+        with Image.open(result_path) as image:
+            durations = [
+                frame.info.get("duration")
+                for frame in ImageSequence.Iterator(image)
+            ]
+
+        expected_duration = max(
+            int(round((1000 / screen_recorder.fps) / 10.0) * 10),
+            10,
+        )
+        assert durations == [expected_duration] * len(inputs)
+
+
+
+    def test_screen_recorder_requires_inputs(self, screen_recorder: ScreenRecorder, tmp_path: Path) -> None:
+        """Verify that ScreenRecorder raises an error when recording with no renderer frames. This prevents silent failures when capture pipelines are misconfigured."""
+        with pytest.raises(ValueError):
+            screen_recorder.record([], tmp_path / "empty.gif")

--- a/tests/display/test_three_d_glasses_renderer.py
+++ b/tests/display/test_three_d_glasses_renderer.py
@@ -30,56 +30,64 @@ def init_pygame() -> None:
     pygame.quit()
 
 
-def test_renderer_requires_images() -> None:
-    with pytest.raises(ValueError):
-        ThreeDGlassesRenderer([])
+class TestDisplayThreeDGlassesRenderer:
+    """Group Display Three D Glasses Renderer tests so display three d glasses renderer behaviour stays reliable. This preserves confidence in display three d glasses renderer for end-to-end scenarios."""
+
+    def test_renderer_requires_images(self) -> None:
+        """Verify that ThreeDGlassesRenderer rejects initialization without input image paths. This avoids runtime crashes by catching configuration errors when wiring assets."""
+        with pytest.raises(ValueError):
+            ThreeDGlassesRenderer([])
 
 
-def test_generate_profiles_vary_shift_and_weights() -> None:
-    profiles = ThreeDGlassesRenderer._generate_profiles(4)
 
-    assert len(profiles) == 4
-    assert [profile.red_shift for profile in profiles] == [1, 2, 3, 1]
-    assert profiles[0].red_weight < profiles[-1].red_weight
-    assert profiles[0].blue_weight > profiles[-1].blue_weight
+    def test_generate_profiles_vary_shift_and_weights(self) -> None:
+        """Verify that _generate_profiles returns profiles with distinct colour shifts and weights. This underpins depth perception accuracy so 3D rendering preserves the intended effect."""
+        profiles = ThreeDGlassesRenderer._generate_profiles(4)
+
+        assert len(profiles) == 4
+        assert [profile.red_shift for profile in profiles] == [1, 2, 3, 1]
+        assert profiles[0].red_weight < profiles[-1].red_weight
+        assert profiles[0].blue_weight > profiles[-1].blue_weight
 
 
-def test_process_applies_anaglyph_and_cycles(monkeypatch: pytest.MonkeyPatch) -> None:
-    window_size = (4, 4)
-    window = pygame.Surface(window_size, pygame.SRCALPHA)
-    orientation = Rectangle.with_layout(1, 1)
-    manager = PeripheralManager()
 
-    source_surfaces = [
-        pygame.Surface(window_size, pygame.SRCALPHA),
-        pygame.Surface(window_size, pygame.SRCALPHA),
-    ]
-    source_surfaces[0].fill((200, 120, 60, 255))
-    source_surfaces[1].fill((40, 220, 160, 255))
+    def test_process_applies_anaglyph_and_cycles(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify that process builds alternating anaglyph frames and advances once the frame duration elapses. This protects motion smoothness so the glasses experience remains comfortable."""
+        window_size = (4, 4)
+        window = pygame.Surface(window_size, pygame.SRCALPHA)
+        orientation = Rectangle.with_layout(1, 1)
+        manager = PeripheralManager()
 
-    class _LoaderResult:
-        def __init__(self, surface: pygame.Surface) -> None:
-            self._surface = surface
+        source_surfaces = [
+            pygame.Surface(window_size, pygame.SRCALPHA),
+            pygame.Surface(window_size, pygame.SRCALPHA),
+        ]
+        source_surfaces[0].fill((200, 120, 60, 255))
+        source_surfaces[1].fill((40, 220, 160, 255))
 
-        def convert_alpha(self) -> pygame.Surface:
-            return self._surface
+        class _LoaderResult:
+            def __init__(self, surface: pygame.Surface) -> None:
+                self._surface = surface
 
-    load_calls = iter(_LoaderResult(surface) for surface in source_surfaces)
-    monkeypatch.setattr(assets_loader.Loader, "load", lambda path: next(load_calls))
+            def convert_alpha(self) -> pygame.Surface:
+                return self._surface
 
-    clock = _StubClock(0, 0, 150)
-    renderer = ThreeDGlassesRenderer(["one.png", "two.png"], frame_duration_ms=120)
+        load_calls = iter(_LoaderResult(surface) for surface in source_surfaces)
+        monkeypatch.setattr(assets_loader.Loader, "load", lambda path: next(load_calls))
 
-    renderer.initialize(window, clock, manager, orientation)
+        clock = _StubClock(0, 0, 150)
+        renderer = ThreeDGlassesRenderer(["one.png", "two.png"], frame_duration_ms=120)
 
-    renderer.process(window, clock, manager, orientation)
-    frame_one = pygame.surfarray.array3d(window).copy()
+        renderer.initialize(window, clock, manager, orientation)
 
-    renderer.process(window, clock, manager, orientation)
-    frame_two = pygame.surfarray.array3d(window).copy()
+        renderer.process(window, clock, manager, orientation)
+        frame_one = pygame.surfarray.array3d(window).copy()
 
-    assert np.all(frame_one[..., 1] == 0)
-    assert np.all(frame_two[..., 1] == 0)
-    assert np.any(frame_one[..., 0] > 0)
-    assert np.any(frame_two[..., 2] > 0)
-    assert not np.array_equal(frame_one, frame_two)
+        renderer.process(window, clock, manager, orientation)
+        frame_two = pygame.surfarray.array3d(window).copy()
+
+        assert np.all(frame_one[..., 1] == 0)
+        assert np.all(frame_two[..., 1] == 0)
+        assert np.any(frame_one[..., 0] > 0)
+        assert np.any(frame_two[..., 2] > 0)
+        assert not np.array_equal(frame_one, frame_two)

--- a/tests/drivers/test_rotary_encoder_driver.py
+++ b/tests/drivers/test_rotary_encoder_driver.py
@@ -74,36 +74,44 @@ class StubHandler:
         yield from self._events
 
 
-def test_create_handler_uses_injected_modules(rotary_driver):
-    StubDigitalInOut.instances.clear()
-    handler = rotary_driver.create_handler(
-        board_module=make_module("board", ROTA="rota", ROTB="rotb", SWITCH="switch"),
-        rotary_module=StubRotaryModule,
-        digital_in_out_cls=StubDigitalInOut,
-        direction=FakeDirection,
-        pull=FakePull,
-    )
+class TestDriversRotaryEncoderDriver:
+    """Group Drivers Rotary Encoder Driver tests so drivers rotary encoder driver behaviour stays reliable. This preserves confidence in drivers rotary encoder driver for end-to-end scenarios."""
 
-    assert isinstance(handler, rotary_encoder.RotaryEncoderHandler)
-    assert len(StubDigitalInOut.instances) == 1
-    created_switch = StubDigitalInOut.instances[0]
-    assert created_switch.direction == FakeDirection.INPUT
-    assert created_switch.pull == FakePull.DOWN
+    def test_create_handler_uses_injected_modules(self, rotary_driver):
+        """Verify that create_handler uses the provided modules to configure the rotary encoder handler. This keeps hardware abstraction swappable so deployments can tailor pin assignments."""
+        StubDigitalInOut.instances.clear()
+        handler = rotary_driver.create_handler(
+            board_module=make_module("board", ROTA="rota", ROTB="rotb", SWITCH="switch"),
+            rotary_module=StubRotaryModule,
+            digital_in_out_cls=StubDigitalInOut,
+            direction=FakeDirection,
+            pull=FakePull,
+        )
+
+        assert isinstance(handler, rotary_encoder.RotaryEncoderHandler)
+        assert len(StubDigitalInOut.instances) == 1
+        created_switch = StubDigitalInOut.instances[0]
+        assert created_switch.direction == FakeDirection.INPUT
+        assert created_switch.pull == FakePull.DOWN
 
 
-def test_read_events_returns_handler_values(rotary_driver):
-    handler = StubHandler(["event1", "event2"])
-    assert rotary_driver.read_events(handler) == ["event1", "event2"]
+
+    def test_read_events_returns_handler_values(self, rotary_driver):
+        """Verify that read_events returns the events produced by the handler iterable. This ensures driver plumbing forwards physical interactions without modification."""
+        handler = StubHandler(["event1", "event2"])
+        assert rotary_driver.read_events(handler) == ["event1", "event2"]
 
 
-def test_rotary_driver_emits_identity_payload(rotary_driver):
-    stream = io.StringIO("Identify\n")
-    outputs: list[str] = []
 
-    handled = rotary_driver.respond_to_identify_query(stdin=stream, print_fn=outputs.append)
+    def test_rotary_driver_emits_identity_payload(self, rotary_driver):
+        """Verify that respond_to_identify_query prints the rotary encoder driver identity payload. This aids device discovery so orchestration tools can label encoder modules."""
+        stream = io.StringIO("Identify\n")
+        outputs: list[str] = []
 
-    assert handled is True
-    payload = json.loads(outputs[0])
-    assert payload["event_type"] == constants.DEVICE_IDENTIFY
-    assert payload["data"]["device_name"] == rotary_driver.IDENTITY.device_name
-    assert payload["data"]["device_id"] == "rotary-encoder-test-id"
+        handled = rotary_driver.respond_to_identify_query(stdin=stream, print_fn=outputs.append)
+
+        assert handled is True
+        payload = json.loads(outputs[0])
+        assert payload["event_type"] == constants.DEVICE_IDENTIFY
+        assert payload["data"]["device_name"] == rotary_driver.IDENTITY.device_name
+        assert payload["data"]["device_id"] == "rotary-encoder-test-id"

--- a/tests/drivers/test_sensor_bus_driver.py
+++ b/tests/drivers/test_sensor_bus_driver.py
@@ -65,93 +65,107 @@ class StubGyroSensor:
         return self.current
 
 
-def test_form_tuple_payload_returns_json(sensor_bus):
-    payload = sensor_bus.form_tuple_payload("rotation", (1.0, 2.0, 3.0))
-    assert payload.startswith("\n")
-    decoded = json.loads(payload.strip())
-    assert decoded == {"event_type": "rotation", "data": {"x": 1.0, "y": 2.0, "z": 3.0}}
+class TestDriversSensorBusDriver:
+    """Group Drivers Sensor Bus Driver tests so drivers sensor bus driver behaviour stays reliable. This preserves confidence in drivers sensor bus driver for end-to-end scenarios."""
+
+    def test_form_tuple_payload_returns_json(self, sensor_bus):
+        """Verify that form_tuple_payload encodes sensor tuples into the expected JSON string. This keeps bus messages compatible with consumers that parse structured telemetry."""
+        payload = sensor_bus.form_tuple_payload("rotation", (1.0, 2.0, 3.0))
+        assert payload.startswith("\n")
+        decoded = json.loads(payload.strip())
+        assert decoded == {"event_type": "rotation", "data": {"x": 1.0, "y": 2.0, "z": 3.0}}
 
 
-def test_get_sample_rate_prefers_sensor_value(sensor_bus):
-    class Stub:
-        accelerometer_data_rate = sensor_bus.Rate.RATE_208_HZ
 
-    assert sensor_bus.get_sample_rate(Stub()) == sensor_bus.Rate.string[Stub.accelerometer_data_rate]
+    def test_get_sample_rate_prefers_sensor_value(self, sensor_bus):
+        """Verify that get_sample_rate honours the accelerometer's configured data rate when it is provided. This preserves calibration intent so sampling frequency matches device capabilities."""
+        class Stub:
+            accelerometer_data_rate = sensor_bus.Rate.RATE_208_HZ
 
-
-def test_get_sample_rate_defaults_when_missing(sensor_bus):
-    class Stub:
-        pass
-
-    assert sensor_bus.get_sample_rate(Stub()) == sensor_bus.Rate.string[sensor_bus.Rate.RATE_104_HZ]
+        assert sensor_bus.get_sample_rate(Stub()) == sensor_bus.Rate.string[Stub.accelerometer_data_rate]
 
 
-def test_connect_to_sensors_skips_failures(monkeypatch, sensor_bus):
-    created = []
 
-    class GoodSensor:
-        def __init__(self, i2c):
-            created.append((self.__class__.__name__, i2c))
+    def test_get_sample_rate_defaults_when_missing(self, sensor_bus):
+        """Verify that get_sample_rate falls back to the default rate when the sensor defines no preference. This ensures predictable behaviour when hardware lacks metadata."""
+        class Stub:
+            pass
 
-    class BadSensor:
-        def __init__(self, i2c):
-            raise RuntimeError("boom")
-
-    monkeypatch.setattr(sensor_bus, "LSM303_Accel", GoodSensor)
-    monkeypatch.setattr(sensor_bus, "LIS2MDL", BadSensor)
-    monkeypatch.setattr(sensor_bus, "ISM330DHCX", GoodSensor)
-
-    sensors = sensor_bus.connect_to_sensors("i2c-bus")
-    assert len(sensors) == 2
-    assert created == [("GoodSensor", "i2c-bus"), ("GoodSensor", "i2c-bus")]
+        assert sensor_bus.get_sample_rate(Stub()) == sensor_bus.Rate.string[sensor_bus.Rate.RATE_104_HZ]
 
 
-def test_sensor_reader_emits_when_change_exceeds_threshold(sensor_bus):
-    accel_sensor = StubAccelerationSensor(
-        acceleration=[
-            (0.0, 0.0, 0.0),
-            (0.05, 0.0, 0.05),
-            (0.05, 0.0, 0.25),
-            (0.05, 0.0, 0.25),
-        ],
-    )
-    gyro_sensor = StubGyroSensor(
-        gyro=[
-            (0.0, 0.0, 0.0),
-            (0.0, 0.0, 0.05),
-            (0.0, 0.0, 0.3),
-            (0.0, 0.0, 0.3),
-        ]
-    )
-    reader = sensor_bus.SensorReader([accel_sensor, gyro_sensor], min_change=0.1)
 
-    first = list(reader.read())
-    accel_sensor.step()
-    gyro_sensor.step()
-    second = list(reader.read())
-    accel_sensor.step()
-    gyro_sensor.step()
-    third = list(reader.read())
+    def test_connect_to_sensors_skips_failures(self, monkeypatch, sensor_bus):
+        """Verify that connect_to_sensors ignores constructors that fail and returns only the working sensors. This keeps initialization resilient so one bad component does not break the stack."""
+        created = []
 
-    assert constants.ACCELERATION in first[0]
-    assert constants.GYROSCOPE in first[1]
-    assert second == []
-    assert len(third) == 2
-    accel_payload = json.loads(third[0].strip())
-    gyro_payload = json.loads(third[1].strip())
-    assert accel_payload["event_type"] == constants.ACCELERATION
-    assert gyro_payload["event_type"] == constants.GYROSCOPE
+        class GoodSensor:
+            def __init__(self, i2c):
+                created.append((self.__class__.__name__, i2c))
+
+        class BadSensor:
+            def __init__(self, i2c):
+                raise RuntimeError("boom")
+
+        monkeypatch.setattr(sensor_bus, "LSM303_Accel", GoodSensor)
+        monkeypatch.setattr(sensor_bus, "LIS2MDL", BadSensor)
+        monkeypatch.setattr(sensor_bus, "ISM330DHCX", GoodSensor)
+
+        sensors = sensor_bus.connect_to_sensors("i2c-bus")
+        assert len(sensors) == 2
+        assert created == [("GoodSensor", "i2c-bus"), ("GoodSensor", "i2c-bus")]
 
 
-def test_respond_to_identify_query_emits_identity_payload(sensor_bus):
-    stream = io.StringIO("Identify\n")
-    outputs: list[str] = []
 
-    handled = sensor_bus.respond_to_identify_query(stdin=stream, print_fn=outputs.append)
+    def test_sensor_reader_emits_when_change_exceeds_threshold(self, sensor_bus):
+        """Verify that SensorReader yields events only when the change exceeds the configured threshold. This filters out sensor noise so downstream analytics highlight meaningful movement."""
+        accel_sensor = StubAccelerationSensor(
+            acceleration=[
+                (0.0, 0.0, 0.0),
+                (0.05, 0.0, 0.05),
+                (0.05, 0.0, 0.25),
+                (0.05, 0.0, 0.25),
+            ],
+        )
+        gyro_sensor = StubGyroSensor(
+            gyro=[
+                (0.0, 0.0, 0.0),
+                (0.0, 0.0, 0.05),
+                (0.0, 0.0, 0.3),
+                (0.0, 0.0, 0.3),
+            ]
+        )
+        reader = sensor_bus.SensorReader([accel_sensor, gyro_sensor], min_change=0.1)
 
-    assert handled is True
-    assert outputs
-    payload = json.loads(outputs[0])
-    assert payload["event_type"] == constants.DEVICE_IDENTIFY
-    assert payload["data"]["device_name"] == sensor_bus.IDENTITY.device_name
-    assert payload["data"]["device_id"] == "sensor-bus-test-id"
+        first = list(reader.read())
+        accel_sensor.step()
+        gyro_sensor.step()
+        second = list(reader.read())
+        accel_sensor.step()
+        gyro_sensor.step()
+        third = list(reader.read())
+
+        assert constants.ACCELERATION in first[0]
+        assert constants.GYROSCOPE in first[1]
+        assert second == []
+        assert len(third) == 2
+        accel_payload = json.loads(third[0].strip())
+        gyro_payload = json.loads(third[1].strip())
+        assert accel_payload["event_type"] == constants.ACCELERATION
+        assert gyro_payload["event_type"] == constants.GYROSCOPE
+
+
+
+    def test_respond_to_identify_query_emits_identity_payload(self, sensor_bus):
+        """Verify that respond_to_identify_query prints the sensor bus identity payload. This lets maintenance tooling track which sensor assemblies are connected."""
+        stream = io.StringIO("Identify\n")
+        outputs: list[str] = []
+
+        handled = sensor_bus.respond_to_identify_query(stdin=stream, print_fn=outputs.append)
+
+        assert handled is True
+        assert outputs
+        payload = json.loads(outputs[0])
+        assert payload["event_type"] == constants.DEVICE_IDENTIFY
+        assert payload["data"]["device_name"] == sensor_bus.IDENTITY.device_name
+        assert payload["data"]["device_id"] == "sensor-bus-test-id"

--- a/tests/events/metrics/test_advanced_metrics.py
+++ b/tests/events/metrics/test_advanced_metrics.py
@@ -7,43 +7,53 @@ from heart.events.metrics import (InterArrivalMetric, MomentMetric,
                                   PercentileMetric, RollingExtrema)
 
 
-def test_rolling_extrema_respects_maxlen() -> None:
-    metric: RollingExtrema[str] = RollingExtrema(maxlen=2)
-    metric.observe("loop", 10.0, timestamp=0.0)
-    metric.observe("loop", 5.0, timestamp=1.0)
-    metric.observe("loop", 8.0, timestamp=2.0)
-    snapshot = metric.get("loop")
-    assert snapshot == {"min": 5.0, "max": 8.0}
+class TestEventsMetricsAdvancedMetrics:
+    """Group Events Metrics Advanced Metrics tests so events metrics advanced metrics behaviour stays reliable. This preserves confidence in events metrics advanced metrics for end-to-end scenarios."""
+
+    def test_rolling_extrema_respects_maxlen(self) -> None:
+        """Verify that RollingExtrema evicts older samples once the maximum window length is reached. This keeps memory bounded so real-time analytics stay performant."""
+        metric: RollingExtrema[str] = RollingExtrema(maxlen=2)
+        metric.observe("loop", 10.0, timestamp=0.0)
+        metric.observe("loop", 5.0, timestamp=1.0)
+        metric.observe("loop", 8.0, timestamp=2.0)
+        snapshot = metric.get("loop")
+        assert snapshot == {"min": 5.0, "max": 8.0}
 
 
-def test_percentile_metric_matches_numpy() -> None:
-    samples = [1.0, 2.0, 3.0, 4.0, 5.0]
-    metric: PercentileMetric[str] = PercentileMetric((50.0, 90.0))
-    for index, sample in enumerate(samples):
-        metric.observe("sensor", sample, timestamp=float(index))
-    snapshot = metric.get("sensor")
-    expected = np.percentile(np.array(samples), (50.0, 90.0), method="linear")
-    assert snapshot["p50"] == expected[0]
-    assert snapshot["p90"] == expected[1]
+
+    def test_percentile_metric_matches_numpy(self) -> None:
+        """Verify that PercentileMetric reports the same percentile estimates as NumPy's linear interpolation. This validates our calculation pipeline against a trusted reference to avoid statistical drift."""
+        samples = [1.0, 2.0, 3.0, 4.0, 5.0]
+        metric: PercentileMetric[str] = PercentileMetric((50.0, 90.0))
+        for index, sample in enumerate(samples):
+            metric.observe("sensor", sample, timestamp=float(index))
+        snapshot = metric.get("sensor")
+        expected = np.percentile(np.array(samples), (50.0, 90.0), method="linear")
+        assert snapshot["p50"] == expected[0]
+        assert snapshot["p90"] == expected[1]
 
 
-def test_interarrival_metric_limits_window() -> None:
-    metric: InterArrivalMetric[str] = InterArrivalMetric(maxlen=2)
-    metric.observe("imu", timestamp=0.0)
-    metric.observe("imu", timestamp=0.1)
-    metric.observe("imu", timestamp=0.25)
-    metric.observe("imu", timestamp=0.4)
-    snapshot = metric.get("imu")
-    assert snapshot["interval_ms"] == pytest.approx((150.0, 150.0))
+
+    def test_interarrival_metric_limits_window(self) -> None:
+        """Verify that InterArrivalMetric keeps only the latest arrival intervals within the configured window size. This keeps latency reporting focused on current behaviour for alerting accuracy."""
+        metric: InterArrivalMetric[str] = InterArrivalMetric(maxlen=2)
+        metric.observe("imu", timestamp=0.0)
+        metric.observe("imu", timestamp=0.1)
+        metric.observe("imu", timestamp=0.25)
+        metric.observe("imu", timestamp=0.4)
+        snapshot = metric.get("imu")
+        assert snapshot["interval_ms"] == pytest.approx((150.0, 150.0))
 
 
-def test_moment_metric_normalises_kurtosis() -> None:
-    samples = [1.0, 2.0, 3.0, 4.0]
-    metric: MomentMetric[str] = MomentMetric(order=4, label="kurtosis", normalise=True)
-    for index, sample in enumerate(samples):
-        metric.observe("channel", sample, timestamp=float(index))
-    snapshot = metric.get("channel")
-    array = np.array(samples)
-    centred = array - array.mean()
-    expected = float(np.mean(np.power(centred, 4)) / (np.std(array) ** 4))
-    assert snapshot["kurtosis"] == expected
+
+    def test_moment_metric_normalises_kurtosis(self) -> None:
+        """Verify that MomentMetric returns a normalised kurtosis value when normalisation is enabled. This ensures comparisons across channels remain meaningful when data scales differ."""
+        samples = [1.0, 2.0, 3.0, 4.0]
+        metric: MomentMetric[str] = MomentMetric(order=4, label="kurtosis", normalise=True)
+        for index, sample in enumerate(samples):
+            metric.observe("channel", sample, timestamp=float(index))
+        snapshot = metric.get("channel")
+        array = np.array(samples)
+        centred = array - array.mean()
+        expected = float(np.mean(np.power(centred, 4)) / (np.std(array) ** 4))
+        assert snapshot["kurtosis"] == expected

--- a/tests/events/metrics/test_count_by_key.py
+++ b/tests/events/metrics/test_count_by_key.py
@@ -12,33 +12,41 @@ def counter() -> CountByKey[str]:
     return CountByKey[str]()
 
 
-def test_count_by_key_increments_per_key(counter: CountByKey[str]) -> None:
-    counter.observe("sensor-1")
-    counter.observe("sensor-1", amount=2)
-    counter.observe("sensor-2")
+class TestEventsMetricsCountByKey:
+    """Group Events Metrics Count By Key tests so events metrics count by key behaviour stays reliable. This preserves confidence in events metrics count by key for end-to-end scenarios."""
 
-    assert counter.get("sensor-1") == 3
-    assert counter.get("sensor-2") == 1
-    assert counter.get("missing") == 0
+    def test_count_by_key_increments_per_key(self, counter: CountByKey[str]) -> None:
+        """Verify that CountByKey accumulates counts independently for each key. This ensures multi-device metrics stay isolated so one sensor cannot skew another's totals."""
+        counter.observe("sensor-1")
+        counter.observe("sensor-1", amount=2)
+        counter.observe("sensor-2")
 
-
-def test_count_by_key_snapshot_returns_copy(counter: CountByKey[str]) -> None:
-    counter.observe("sensor-1")
-
-    snapshot = counter.snapshot()
-    counter.observe("sensor-1")
-
-    assert snapshot == {"sensor-1": 1}
-    assert counter.snapshot() == {"sensor-1": 2}
-    assert snapshot is not counter.snapshot()
+        assert counter.get("sensor-1") == 3
+        assert counter.get("sensor-2") == 1
+        assert counter.get("missing") == 0
 
 
-def test_count_by_key_reset_clears_all_counts(counter: CountByKey[str]) -> None:
-    counter.observe("sensor-1")
-    counter.observe("sensor-2", amount=4)
 
-    counter.reset()
+    def test_count_by_key_snapshot_returns_copy(self, counter: CountByKey[str]) -> None:
+        """Verify that snapshot returns a detached copy unaffected by later updates. This prevents monitoring dashboards from mutating shared state when rendering statistics."""
+        counter.observe("sensor-1")
 
-    assert counter.snapshot() == {}
-    assert counter.get("sensor-1") == 0
-    assert counter.get("sensor-2") == 0
+        snapshot = counter.snapshot()
+        counter.observe("sensor-1")
+
+        assert snapshot == {"sensor-1": 1}
+        assert counter.snapshot() == {"sensor-1": 2}
+        assert snapshot is not counter.snapshot()
+
+
+
+    def test_count_by_key_reset_clears_all_counts(self, counter: CountByKey[str]) -> None:
+        """Verify that reset clears every tracked count and zeros subsequent lookups. This supports periodic reporting cycles where counters must start fresh."""
+        counter.observe("sensor-1")
+        counter.observe("sensor-2", amount=4)
+
+        counter.reset()
+
+        assert counter.snapshot() == {}
+        assert counter.get("sensor-1") == 0
+        assert counter.get("sensor-2") == 0

--- a/tests/events/metrics/test_event_window_policies.py
+++ b/tests/events/metrics/test_event_window_policies.py
@@ -8,75 +8,93 @@ from heart.events.metrics import (EventSample, EventWindow, MaxAgePolicy,
                                   MaxLengthPolicy, combine_windows)
 
 
-def test_max_length_policy_requires_positive_count() -> None:
-    with pytest.raises(ValueError, match="positive integer"):
-        MaxLengthPolicy(count=0)
+class TestEventsMetricsEventWindowPolicies:
+    """Group Events Metrics Event Window Policies tests so events metrics event window policies behaviour stays reliable. This preserves confidence in events metrics event window policies for end-to-end scenarios."""
+
+    def test_max_length_policy_requires_positive_count(self) -> None:
+        """Verify that MaxLengthPolicy raises when constructed with a non-positive count. This protects against misconfiguration that would otherwise produce unbounded buffers."""
+        with pytest.raises(ValueError, match="positive integer"):
+            MaxLengthPolicy(count=0)
 
 
-def test_max_age_policy_requires_positive_window() -> None:
-    with pytest.raises(ValueError, match="positive duration"):
-        MaxAgePolicy(window=0.0)
+
+    def test_max_age_policy_requires_positive_window(self) -> None:
+        """Verify that MaxAgePolicy raises when the configured window duration is not positive. This prevents nonsensical windows that could hide stale telemetry."""
+        with pytest.raises(ValueError, match="positive duration"):
+            MaxAgePolicy(window=0.0)
 
 
-def test_event_window_applies_max_length_policy() -> None:
-    window = EventWindow[str](policies=(MaxLengthPolicy(count=2),))
 
-    window.append("a", timestamp=0.0)
-    window.append("b", timestamp=1.0)
-    window.append("c", timestamp=2.0)
+    def test_event_window_applies_max_length_policy(self) -> None:
+        """Verify that EventWindow discards oldest entries to honour the max-length policy. This keeps memory usage predictable during spikes in event volume."""
+        window = EventWindow[str](policies=(MaxLengthPolicy(count=2),))
 
-    assert window.values() == ("b", "c")
+        window.append("a", timestamp=0.0)
+        window.append("b", timestamp=1.0)
+        window.append("c", timestamp=2.0)
 
-
-def test_event_window_applies_max_age_policy() -> None:
-    window = EventWindow[str](policies=(MaxAgePolicy(window=1.5),))
-
-    window.append("a", timestamp=0.0)
-    window.append("b", timestamp=0.5)
-    window.append("c", timestamp=2.0)
-
-    assert window.values() == ("c",)
+        assert window.values() == ("b", "c")
 
 
-def test_event_window_iterates_values_in_order() -> None:
-    window = EventWindow[str](policies=(MaxLengthPolicy(count=3),))
-    for index in range(3):
-        window.append(f"event-{index}", timestamp=float(index))
 
-    assert list(window) == ["event-0", "event-1", "event-2"]
+    def test_event_window_applies_max_age_policy(self) -> None:
+        """Verify that EventWindow excludes entries older than the configured age window. This ensures time-based analyses focus on the freshest data."""
+        window = EventWindow[str](policies=(MaxAgePolicy(window=1.5),))
 
+        window.append("a", timestamp=0.0)
+        window.append("b", timestamp=0.5)
+        window.append("c", timestamp=2.0)
 
-def test_event_window_samples_return_dataclasses() -> None:
-    window = EventWindow[str](policies=(MaxLengthPolicy(count=2),))
-    window.extend(["a", "b"], timestamp=1.0, step=0.25)
-
-    samples = window.samples()
-    assert samples == (
-        EventSample(value="a", timestamp=1.0),
-        EventSample(value="b", timestamp=1.25),
-    )
+        assert window.values() == ("c",)
 
 
-def test_event_window_derive_appends_additional_policies() -> None:
-    base = EventWindow[str](policies=(MaxLengthPolicy(count=3),))
-    derived = base.derive(MaxAgePolicy(window=2.0))
 
-    timestamps = (0.0, 0.5, 1.0, 2.5, 3.0)
-    for index, ts in enumerate(timestamps):
-        derived.append(f"event-{index}", timestamp=ts)
+    def test_event_window_iterates_values_in_order(self) -> None:
+        """Verify that iterating an EventWindow yields values in the order they were appended. This preserves chronological semantics for consumers that assume FIFO ordering."""
+        window = EventWindow[str](policies=(MaxLengthPolicy(count=3),))
+        for index in range(3):
+            window.append(f"event-{index}", timestamp=float(index))
 
-    assert derived.values() == ("event-3", "event-4")
+        assert list(window) == ["event-0", "event-1", "event-2"]
 
 
-def test_combine_windows_merges_policies() -> None:
-    recent = EventWindow[str](policies=(MaxLengthPolicy(count=2),))
-    young = EventWindow[str](policies=(MaxAgePolicy(window=3.0),))
 
-    combined = combine_windows(recent, young)
-    helper = EventWindow[str](policies=(*recent.policies, *young.policies))
+    def test_event_window_samples_return_dataclasses(self) -> None:
+        """Verify that EventWindow.samples returns EventSample objects with derived timestamps. This provides structured records so downstream consumers can reconstruct event timing."""
+        window = EventWindow[str](policies=(MaxLengthPolicy(count=2),))
+        window.extend(["a", "b"], timestamp=1.0, step=0.25)
 
-    for timestamp, value in enumerate(("a", "b", "c", "d")):
-        combined.append(value, timestamp=float(timestamp))
-        helper.append(value, timestamp=float(timestamp))
+        samples = window.samples()
+        assert samples == (
+            EventSample(value="a", timestamp=1.0),
+            EventSample(value="b", timestamp=1.25),
+        )
 
-    assert combined.values() == helper.values()
+
+
+    def test_event_window_derive_appends_additional_policies(self) -> None:
+        """Verify that derive creates a new window evaluating the original and added policies together. This makes policy composition predictable for complex retention strategies."""
+        base = EventWindow[str](policies=(MaxLengthPolicy(count=3),))
+        derived = base.derive(MaxAgePolicy(window=2.0))
+
+        timestamps = (0.0, 0.5, 1.0, 2.5, 3.0)
+        for index, ts in enumerate(timestamps):
+            derived.append(f"event-{index}", timestamp=ts)
+
+        assert derived.values() == ("event-3", "event-4")
+
+
+
+    def test_combine_windows_merges_policies(self) -> None:
+        """Verify that combine_windows produces a window enforcing the policies from both inputs. This ensures merged analytics honour all constraints when aggregating sources."""
+        recent = EventWindow[str](policies=(MaxLengthPolicy(count=2),))
+        young = EventWindow[str](policies=(MaxAgePolicy(window=3.0),))
+
+        combined = combine_windows(recent, young)
+        helper = EventWindow[str](policies=(*recent.policies, *young.policies))
+
+        for timestamp, value in enumerate(("a", "b", "c", "d")):
+            combined.append(value, timestamp=float(timestamp))
+            helper.append(value, timestamp=float(timestamp))
+
+        assert combined.values() == helper.values()

--- a/tests/events/metrics/test_keyed_metric_contract.py
+++ b/tests/events/metrics/test_keyed_metric_contract.py
@@ -7,47 +7,53 @@ import pytest
 from heart.events.metrics import CountByKey, KeyedMetric, RollingAverageByKey
 
 
-def test_count_by_key_obeys_keyed_metric_contract() -> None:
-    metric: KeyedMetric[str, int] = CountByKey[str]()
+class TestEventsMetricsKeyedMetricContract:
+    """Group Events Metrics Keyed Metric Contract tests so events metrics keyed metric contract behaviour stays reliable. This preserves confidence in events metrics keyed metric contract for end-to-end scenarios."""
 
-    assert isinstance(metric, KeyedMetric)
+    def test_count_by_key_obeys_keyed_metric_contract(self) -> None:
+        """Verify that CountByKey satisfies the KeyedMetric contract for observation, snapshot, and reset. This ensures the base interface remains backward compatible for metric implementations."""
+        metric: KeyedMetric[str, int] = CountByKey[str]()
 
-    metric.observe("imu", amount=2)
-    metric.observe("imu", amount=3)
+        assert isinstance(metric, KeyedMetric)
 
-    assert metric.get("imu") == 5
+        metric.observe("imu", amount=2)
+        metric.observe("imu", amount=3)
 
-    snapshot = metric.snapshot()
-    snapshot["imu"] = 0
+        assert metric.get("imu") == 5
 
-    assert metric.get("imu") == 5
+        snapshot = metric.snapshot()
+        snapshot["imu"] = 0
 
-    metric.reset("imu")
-    assert metric.get("imu") == 0
+        assert metric.get("imu") == 5
 
-    metric.observe("imu", amount=7)
-    metric.reset()
+        metric.reset("imu")
+        assert metric.get("imu") == 0
 
-    assert metric.get("imu") == 0
+        metric.observe("imu", amount=7)
+        metric.reset()
+
+        assert metric.get("imu") == 0
 
 
-def test_rolling_average_keyed_metric_example() -> None:
-    metric: KeyedMetric[str, float | None] = RollingAverageByKey[str](maxlen=2)
 
-    metric.observe("imu", 5.0, timestamp=0.0)
-    metric.observe("imu", 7.0, timestamp=1.0)
+    def test_rolling_average_keyed_metric_example(self) -> None:
+        """Verify that RollingAverageByKey exercises the KeyedMetric workflow for averaging values. This demonstrates how temporal metrics can rely on the shared lifecycle to stay consistent."""
+        metric: KeyedMetric[str, float | None] = RollingAverageByKey[str](maxlen=2)
 
-    assert metric.get("imu") == pytest.approx(6.0)
+        metric.observe("imu", 5.0, timestamp=0.0)
+        metric.observe("imu", 7.0, timestamp=1.0)
 
-    snapshot = metric.snapshot()
-    snapshot["imu"] = None
+        assert metric.get("imu") == pytest.approx(6.0)
 
-    assert metric.get("imu") == pytest.approx(6.0)
+        snapshot = metric.snapshot()
+        snapshot["imu"] = None
 
-    metric.reset("imu")
-    assert metric.get("imu") is None
+        assert metric.get("imu") == pytest.approx(6.0)
 
-    metric.observe("imu", 9.0, timestamp=2.0)
-    metric.reset()
+        metric.reset("imu")
+        assert metric.get("imu") is None
 
-    assert metric.get("imu") is None
+        metric.observe("imu", 9.0, timestamp=2.0)
+        metric.reset()
+
+        assert metric.get("imu") is None

--- a/tests/events/metrics/test_last_event_windows.py
+++ b/tests/events/metrics/test_last_event_windows.py
@@ -6,40 +6,50 @@ from heart.events.metrics import (LastEventsWithinTimeWindow, LastNEvents,
                                   LastNEventsWithinTimeWindow)
 
 
-def test_last_n_events_retains_recent_entries() -> None:
-    window = LastNEvents[str](count=3)
+class TestEventsMetricsLastEventWindows:
+    """Group Events Metrics Last Event Windows tests so events metrics last event windows behaviour stays reliable. This preserves confidence in events metrics last event windows for end-to-end scenarios."""
 
-    for index in range(5):
-        window.append(f"event-{index}", timestamp=float(index))
+    def test_last_n_events_retains_recent_entries(self) -> None:
+        """Verify that LastNEvents keeps only the most recent events up to the configured count. This ensures bounded memory usage while surfacing the freshest samples."""
+        window = LastNEvents[str](count=3)
 
-    assert window.values() == ("event-2", "event-3", "event-4")
+        for index in range(5):
+            window.append(f"event-{index}", timestamp=float(index))
 
-
-def test_last_events_within_time_window_filters_by_age() -> None:
-    window = LastEventsWithinTimeWindow[str](window=2.0)
-
-    window.append("event-0", timestamp=0.0)
-    window.append("event-1", timestamp=1.0)
-    window.append("event-2", timestamp=3.1)
-
-    assert window.values() == ("event-2",)
+        assert window.values() == ("event-2", "event-3", "event-4")
 
 
-def test_last_n_events_within_time_window_enforces_both_limits() -> None:
-    window = LastNEventsWithinTimeWindow[str](count=2, window=3.0)
 
-    window.append("event-0", timestamp=0.0)
-    window.append("event-1", timestamp=1.0)
-    window.append("event-2", timestamp=2.0)
-    window.append("event-3", timestamp=6.0)
+    def test_last_events_within_time_window_filters_by_age(self) -> None:
+        """Verify that LastEventsWithinTimeWindow filters out events older than the allowed window. This keeps time-based dashboards aligned with current system behaviour."""
+        window = LastEventsWithinTimeWindow[str](window=2.0)
 
-    assert window.values() == ("event-3",)
+        window.append("event-0", timestamp=0.0)
+        window.append("event-1", timestamp=1.0)
+        window.append("event-2", timestamp=3.1)
+
+        assert window.values() == ("event-2",)
 
 
-def test_last_n_events_within_time_window_limits_count() -> None:
-    window = LastNEventsWithinTimeWindow[str](count=2, window=5.0)
 
-    for index in range(4):
-        window.append(f"event-{index}", timestamp=float(index))
+    def test_last_n_events_within_time_window_enforces_both_limits(self) -> None:
+        """Verify that LastNEventsWithinTimeWindow prunes by both age and count limits. This demonstrates hybrid retention for scenarios needing both freshness and bounded storage."""
+        window = LastNEventsWithinTimeWindow[str](count=2, window=3.0)
 
-    assert window.values() == ("event-2", "event-3")
+        window.append("event-0", timestamp=0.0)
+        window.append("event-1", timestamp=1.0)
+        window.append("event-2", timestamp=2.0)
+        window.append("event-3", timestamp=6.0)
+
+        assert window.values() == ("event-3",)
+
+
+
+    def test_last_n_events_within_time_window_limits_count(self) -> None:
+        """Verify that LastNEventsWithinTimeWindow trims to the latest N events when all are timely. This confirms consistent behaviour when data arrives within SLA windows."""
+        window = LastNEventsWithinTimeWindow[str](count=2, window=5.0)
+
+        for index in range(4):
+            window.append(f"event-{index}", timestamp=float(index))
+
+        assert window.values() == ("event-2", "event-3")

--- a/tests/events/metrics/test_rolling_statistics_by_key.py
+++ b/tests/events/metrics/test_rolling_statistics_by_key.py
@@ -10,93 +10,109 @@ from heart.events.metrics import (RollingAverageByKey, RollingMeanByKey,
                                   RollingStatisticsByKey, RollingStddevByKey)
 
 
-def test_rolling_statistics_tracks_multiple_keys() -> None:
-    stats = RollingStatisticsByKey[str](maxlen=3)
+class TestEventsMetricsRollingStatisticsByKey:
+    """Group Events Metrics Rolling Statistics By Key tests so events metrics rolling statistics by key behaviour stays reliable. This preserves confidence in events metrics rolling statistics by key for end-to-end scenarios."""
 
-    stats.observe("imu", 1.0, timestamp=0.0)
-    stats.observe("imu", 3.0, timestamp=1.0)
-    stats.observe("imu", 5.0, timestamp=2.0)
-    stats.observe("imu", 7.0, timestamp=3.0)
-    stats.observe("heart", 60.0, timestamp=3.0)
-    stats.observe("heart", 70.0, timestamp=4.0)
+    def test_rolling_statistics_tracks_multiple_keys(self) -> None:
+        """Verify that RollingStatisticsByKey maintains independent statistics for each key. This preserves signal separation so anomalies on one channel do not pollute others."""
+        stats = RollingStatisticsByKey[str](maxlen=3)
 
-    imu = stats.snapshot()["imu"]
-    heart = stats.snapshot()["heart"]
+        stats.observe("imu", 1.0, timestamp=0.0)
+        stats.observe("imu", 3.0, timestamp=1.0)
+        stats.observe("imu", 5.0, timestamp=2.0)
+        stats.observe("imu", 7.0, timestamp=3.0)
+        stats.observe("heart", 60.0, timestamp=3.0)
+        stats.observe("heart", 70.0, timestamp=4.0)
 
-    assert imu.count == 3
-    assert imu.mean == pytest.approx(5.0)
-    assert imu.stddev == pytest.approx(math.sqrt(8 / 3))
-    assert heart.count == 2
-    assert heart.mean == pytest.approx(65.0)
-    assert heart.stddev == pytest.approx(5.0)
+        imu = stats.snapshot()["imu"]
+        heart = stats.snapshot()["heart"]
 
-
-def test_rolling_statistics_prunes_by_window_and_length() -> None:
-    stats = RollingStatisticsByKey[str](maxlen=3, window=5.0)
-
-    stats.observe("imu", 1.0, timestamp=0.0)
-    stats.observe("imu", 3.0, timestamp=1.0)
-    stats.observe("imu", 5.0, timestamp=2.0)
-    stats.observe("imu", 7.0, timestamp=9.0)
-
-    snapshot = stats.snapshot()["imu"]
-    assert snapshot.count == 1
-    assert snapshot.mean == pytest.approx(7.0)
+        assert imu.count == 3
+        assert imu.mean == pytest.approx(5.0)
+        assert imu.stddev == pytest.approx(math.sqrt(8 / 3))
+        assert heart.count == 2
+        assert heart.mean == pytest.approx(65.0)
+        assert heart.stddev == pytest.approx(5.0)
 
 
-def test_rolling_statistics_handles_missing_keys() -> None:
-    stats = RollingStatisticsByKey[str]()
 
-    assert stats.mean("missing") is None
-    assert stats.stddev("missing") is None
-    assert stats.count("missing") == 0
+    def test_rolling_statistics_prunes_by_window_and_length(self) -> None:
+        """Verify that RollingStatisticsByKey prunes samples when either the count or window limit is exceeded. This demonstrates bounded historical storage to support long-running services."""
+        stats = RollingStatisticsByKey[str](maxlen=3, window=5.0)
 
+        stats.observe("imu", 1.0, timestamp=0.0)
+        stats.observe("imu", 3.0, timestamp=1.0)
+        stats.observe("imu", 5.0, timestamp=2.0)
+        stats.observe("imu", 7.0, timestamp=9.0)
 
-def test_rolling_statistics_reset_scopes() -> None:
-    stats = RollingStatisticsByKey[str]()
-
-    stats.observe("imu", 1.0, timestamp=0.0)
-    stats.observe("imu", 3.0, timestamp=1.0)
-    stats.observe("heart", 60.0, timestamp=1.0)
-
-    stats.reset("imu")
-    assert "imu" not in stats.snapshot()
-    assert "heart" in stats.snapshot()
-
-    stats.reset()
-    assert stats.snapshot() == {}
+        snapshot = stats.snapshot()["imu"]
+        assert snapshot.count == 1
+        assert snapshot.mean == pytest.approx(7.0)
 
 
-def test_rolling_average_and_stddev_wrappers() -> None:
-    averages = RollingAverageByKey[str](maxlen=2)
-    deviations = RollingStddevByKey[str](maxlen=2)
 
-    averages.observe("imu", 5.0, timestamp=0.0)
-    deviations.observe("imu", 5.0, timestamp=0.0)
-    averages.observe("imu", 9.0, timestamp=1.0)
-    deviations.observe("imu", 9.0, timestamp=1.0)
+    def test_rolling_statistics_handles_missing_keys(self) -> None:
+        """Verify that RollingStatisticsByKey returns empty results for keys with no samples. This prevents callers from misinterpreting stale values when data has not arrived."""
+        stats = RollingStatisticsByKey[str]()
 
-    assert averages.get("imu") == pytest.approx(7.0)
-    assert deviations.get("imu") == pytest.approx(2.0)
-    assert averages.snapshot()["imu"] == pytest.approx(7.0)
-    assert deviations.snapshot()["imu"] == pytest.approx(2.0)
+        assert stats.mean("missing") is None
+        assert stats.stddev("missing") is None
+        assert stats.count("missing") == 0
 
 
-def test_rolling_statistics_requires_positive_parameters() -> None:
-    with pytest.raises(ValueError):
-        RollingStatisticsByKey[str](maxlen=0)
 
-    with pytest.raises(ValueError):
-        RollingStatisticsByKey[str](window=0.0)
+    def test_rolling_statistics_reset_scopes(self) -> None:
+        """Verify that RollingStatisticsByKey can reset a single key or the entire metric. This supports maintenance workflows where metrics must be cleared after calibration."""
+        stats = RollingStatisticsByKey[str]()
+
+        stats.observe("imu", 1.0, timestamp=0.0)
+        stats.observe("imu", 3.0, timestamp=1.0)
+        stats.observe("heart", 60.0, timestamp=1.0)
+
+        stats.reset("imu")
+        assert "imu" not in stats.snapshot()
+        assert "heart" in stats.snapshot()
+
+        stats.reset()
+        assert stats.snapshot() == {}
 
 
-def test_rolling_mean_alias_matches_average() -> None:
-    averages = RollingAverageByKey[str](maxlen=3)
-    alias = RollingMeanByKey[str](maxlen=3)
 
-    for timestamp, value in enumerate((2.0, 4.0, 6.0)):
-        averages.observe("imu", value, timestamp=float(timestamp))
-        alias.observe("imu", value, timestamp=float(timestamp))
+    def test_rolling_average_and_stddev_wrappers(self) -> None:
+        """Verify that RollingAverageByKey and RollingStddevByKey expose the underlying statistics helpers. This guards the shims against regressions so downstream call sites remain stable."""
+        averages = RollingAverageByKey[str](maxlen=2)
+        deviations = RollingStddevByKey[str](maxlen=2)
 
-    assert averages.get("imu") == alias.get("imu")
-    assert averages.snapshot() == alias.snapshot()
+        averages.observe("imu", 5.0, timestamp=0.0)
+        deviations.observe("imu", 5.0, timestamp=0.0)
+        averages.observe("imu", 9.0, timestamp=1.0)
+        deviations.observe("imu", 9.0, timestamp=1.0)
+
+        assert averages.get("imu") == pytest.approx(7.0)
+        assert deviations.get("imu") == pytest.approx(2.0)
+        assert averages.snapshot()["imu"] == pytest.approx(7.0)
+        assert deviations.snapshot()["imu"] == pytest.approx(2.0)
+
+
+
+    def test_rolling_statistics_requires_positive_parameters(self) -> None:
+        """Verify that RollingStatisticsByKey rejects non-positive window or length arguments. This avoids accidental division errors and runaway buffers from invalid input."""
+        with pytest.raises(ValueError):
+            RollingStatisticsByKey[str](maxlen=0)
+
+        with pytest.raises(ValueError):
+            RollingStatisticsByKey[str](window=0.0)
+
+
+
+    def test_rolling_mean_alias_matches_average(self) -> None:
+        """Verify that RollingMeanByKey produces identical values to RollingAverageByKey. This keeps the alias trustworthy so teams can use their preferred terminology without behaviour changes."""
+        averages = RollingAverageByKey[str](maxlen=3)
+        alias = RollingMeanByKey[str](maxlen=3)
+
+        for timestamp, value in enumerate((2.0, 4.0, 6.0)):
+            averages.observe("imu", value, timestamp=float(timestamp))
+            alias.observe("imu", value, timestamp=float(timestamp))
+
+        assert averages.get("imu") == alias.get("imu")
+        assert averages.snapshot() == alias.snapshot()

--- a/tests/firmware_io/test_accel.py
+++ b/tests/firmware_io/test_accel.py
@@ -40,97 +40,107 @@ from helpers.firmware_io import StubSensor
 from heart.firmware_io import accel, constants
 
 
-@pytest.mark.parametrize(
-    "sequence, expected",
-    [
-        (
-            [
-                {"accel": (0.0, 0.0, 0.0), "gyro": (0.0, 0.0, 0.0)},
-                {"accel": (0.05, 0.02, 0.0), "gyro": (0.05, 0.0, 0.0)},
-                {"accel": (0.3, 0.0, 0.0), "gyro": (0.12, 0.0, 0.0)},
-            ],
-            [
+class TestFirmwareIoAccel:
+    """Group Firmware Io Accel tests so firmware io accel behaviour stays reliable. This preserves confidence in firmware io accel for end-to-end scenarios."""
+
+    @pytest.mark.parametrize(
+        "sequence, expected",
+        [
+            (
                 [
-                    accel.form_tuple_payload(constants.ACCELERATION, (0.0, 0.0, 0.0)),
-                    accel.form_tuple_payload(constants.GYROSCOPE, (0.0, 0.0, 0.0)),
+                    {"accel": (0.0, 0.0, 0.0), "gyro": (0.0, 0.0, 0.0)},
+                    {"accel": (0.05, 0.02, 0.0), "gyro": (0.05, 0.0, 0.0)},
+                    {"accel": (0.3, 0.0, 0.0), "gyro": (0.12, 0.0, 0.0)},
                 ],
-                [],
                 [
-                    accel.form_tuple_payload(constants.ACCELERATION, (0.3, 0.0, 0.0)),
-                    accel.form_tuple_payload(constants.GYROSCOPE, (0.12, 0.0, 0.0)),
+                    [
+                        accel.form_tuple_payload(constants.ACCELERATION, (0.0, 0.0, 0.0)),
+                        accel.form_tuple_payload(constants.GYROSCOPE, (0.0, 0.0, 0.0)),
+                    ],
+                    [],
+                    [
+                        accel.form_tuple_payload(constants.ACCELERATION, (0.3, 0.0, 0.0)),
+                        accel.form_tuple_payload(constants.GYROSCOPE, (0.12, 0.0, 0.0)),
+                    ],
                 ],
-            ],
-        ),
-    ],
-)
-def test_sensor_reader_emits_payloads_when_values_change(sequence, expected) -> None:
-    sensor = StubSensor(acceleration=sequence[0]["accel"], gyro=sequence[0]["gyro"])
-    reader = accel.SensorReader([sensor], min_change=0.1)
+            ),
+        ],
+    )
+    def test_sensor_reader_emits_payloads_when_values_change(self, sequence, expected) -> None:
+        """Verify that SensorReader emits payloads only when readings change beyond the configured threshold. This keeps telemetry focused on meaningful motion so links stay bandwidth-efficient."""
+        sensor = StubSensor(acceleration=sequence[0]["accel"], gyro=sequence[0]["gyro"])
+        reader = accel.SensorReader([sensor], min_change=0.1)
 
-    captured: list[list[str]] = []
-    for step in sequence:
-        sensor.acceleration = step["accel"]
-        sensor.gyro = step["gyro"]
-        captured.append(list(reader.read()))
+        captured: list[list[str]] = []
+        for step in sequence:
+            sensor.acceleration = step["accel"]
+            sensor.gyro = step["gyro"]
+            captured.append(list(reader.read()))
 
-    assert captured == expected
-
-
-@pytest.mark.parametrize(
-    "new, old, threshold, expected",
-    [
-        ((0.0, 0.0, 0.0), None, 0.1, True),
-        ((0.05, 0.0, 0.0), (0.0, 0.0, 0.0), 0.1, False),
-        ((0.2, 0.0, 0.0), (0.0, 0.0, 0.0), 0.1, True),
-    ],
-)
-def test_changed_enough_respects_threshold(new, old, threshold, expected) -> None:
-    reader = accel.SensorReader([])
-    assert reader._changed_enough(new, old, threshold) is expected
+        assert captured == expected
 
 
-@pytest.mark.parametrize(
-    "sensor_kwargs, expected_key",
-    [
-        ({"accelerometer_data_rate": "RATE_52_HZ"}, "RATE_52_HZ"),
-        ({}, "RATE_104_HZ"),
-    ],
-)
-def test_get_sample_rate_falls_back_to_default(monkeypatch, sensor_kwargs, expected_key) -> None:
-    class FakeRate:
-        RATE_104_HZ = "RATE_104_HZ"
-        string = {
-            "RATE_104_HZ": 9.6,
-            "RATE_52_HZ": 19.2,
-        }
 
-    monkeypatch.setattr(accel, "Rate", FakeRate)
-
-    sensor = SimpleNamespace(**sensor_kwargs)
-    reader = accel.SensorReader([])
-
-    assert reader.get_sample_rate(sensor) == FakeRate.string[expected_key]
+    @pytest.mark.parametrize(
+        "new, old, threshold, expected",
+        [
+            ((0.0, 0.0, 0.0), None, 0.1, True),
+            ((0.05, 0.0, 0.0), (0.0, 0.0, 0.0), 0.1, False),
+            ((0.2, 0.0, 0.0), (0.0, 0.0, 0.0), 0.1, True),
+        ],
+    )
+    def test_changed_enough_respects_threshold(self, new, old, threshold, expected) -> None:
+        """Verify that SensorReader._changed_enough applies the magnitude threshold when comparing tuples. This ensures the helper enforces noise rejection consistently across the driver."""
+        reader = accel.SensorReader([])
+        assert reader._changed_enough(new, old, threshold) is expected
 
 
-@pytest.mark.parametrize(
-    "payload",
-    [
-        ((1.0, 2.0, 3.0),),
-        ((-0.1, 0.0, 9.81),),
-    ],
-)
-def test_form_tuple_payload_wraps_json_in_newlines(payload) -> None:
-    result = accel.form_tuple_payload(constants.ACCELERATION, payload[0])
-    assert result.startswith("\n") and result.endswith("\n")
-    parsed = json.loads(result.strip())
-    assert parsed == {
-        "event_type": constants.ACCELERATION,
-        "producer_id": 0,
-        "data": {
-            "value": {
-                "x": payload[0][0],
-                "y": payload[0][1],
-                "z": payload[0][2],
+
+    @pytest.mark.parametrize(
+        "sensor_kwargs, expected_key",
+        [
+            ({"accelerometer_data_rate": "RATE_52_HZ"}, "RATE_52_HZ"),
+            ({}, "RATE_104_HZ"),
+        ],
+    )
+    def test_get_sample_rate_falls_back_to_default(self, monkeypatch, sensor_kwargs, expected_key) -> None:
+        """Verify that SensorReader.get_sample_rate honours sensor overrides and falls back to the default rate. This keeps sampling frequency predictable so downstream filters stay tuned."""
+        class FakeRate:
+            RATE_104_HZ = "RATE_104_HZ"
+            string = {
+                "RATE_104_HZ": 9.6,
+                "RATE_52_HZ": 19.2,
             }
-        },
-    }
+
+        monkeypatch.setattr(accel, "Rate", FakeRate)
+
+        sensor = SimpleNamespace(**sensor_kwargs)
+        reader = accel.SensorReader([])
+
+        assert reader.get_sample_rate(sensor) == FakeRate.string[expected_key]
+
+
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            ((1.0, 2.0, 3.0),),
+            ((-0.1, 0.0, 9.81),),
+        ],
+    )
+    def test_form_tuple_payload_wraps_json_in_newlines(self, payload) -> None:
+        """Verify that form_tuple_payload wraps the JSON payload in newlines and encodes axis values. This guarantees compatibility with serial consumers expecting newline-delimited telemetry."""
+        result = accel.form_tuple_payload(constants.ACCELERATION, payload[0])
+        assert result.startswith("\n") and result.endswith("\n")
+        parsed = json.loads(result.strip())
+        assert parsed == {
+            "event_type": constants.ACCELERATION,
+            "producer_id": 0,
+            "data": {
+                "value": {
+                    "x": payload[0][0],
+                    "y": payload[0][1],
+                    "z": payload[0][2],
+                }
+            },
+        }

--- a/tests/firmware_io/test_bluetooth.py
+++ b/tests/firmware_io/test_bluetooth.py
@@ -6,50 +6,57 @@ from helpers.firmware_io import StubBLE, StubUART
 from heart.firmware_io import bluetooth
 
 
-@pytest.mark.parametrize(
-    "connected, advertising, message, expected_starts, expected_writes",
-    [
-        (True, False, "ping", 1, [b"ping", bluetooth.END_OF_MESSAGE_DELIMETER.encode(bluetooth.ENCODING)]),
-        (True, True, "pong", 0, [b"pong", bluetooth.END_OF_MESSAGE_DELIMETER.encode(bluetooth.ENCODING)]),
-        (False, False, "idle", 1, []),
-    ],
-)
-def test_send_handles_advertising_and_buffer_flush(
-    monkeypatch, connected, advertising, message, expected_starts, expected_writes
-) -> None:
-    stub_ble = StubBLE(advertising=advertising, connected=connected)
-    stub_uart = StubUART()
-    advertisement = object()
+class TestFirmwareIoBluetooth:
+    """Group Firmware Io Bluetooth tests so firmware io bluetooth behaviour stays reliable. This preserves confidence in firmware io bluetooth for end-to-end scenarios."""
 
-    monkeypatch.setattr(bluetooth, "ble", stub_ble)
-    monkeypatch.setattr(bluetooth, "uart", stub_uart)
-    monkeypatch.setattr(bluetooth, "advertisement", advertisement)
+    @pytest.mark.parametrize(
+        "connected, advertising, message, expected_starts, expected_writes",
+        [
+            (True, False, "ping", 1, [b"ping", bluetooth.END_OF_MESSAGE_DELIMETER.encode(bluetooth.ENCODING)]),
+            (True, True, "pong", 0, [b"pong", bluetooth.END_OF_MESSAGE_DELIMETER.encode(bluetooth.ENCODING)]),
+            (False, False, "idle", 1, []),
+        ],
+    )
+    def test_send_handles_advertising_and_buffer_flush(
+        self,
+        monkeypatch, connected, advertising, message, expected_starts, expected_writes
+    ) -> None:
+        """Verify that bluetooth.send manages advertising and flushes buffered messages after connecting. This keeps wireless telemetry flowing even when the link drops momentarily."""
+        stub_ble = StubBLE(advertising=advertising, connected=connected)
+        stub_uart = StubUART()
+        advertisement = object()
 
-    bluetooth.send([message])
+        monkeypatch.setattr(bluetooth, "ble", stub_ble)
+        monkeypatch.setattr(bluetooth, "uart", stub_uart)
+        monkeypatch.setattr(bluetooth, "advertisement", advertisement)
 
-    assert len(stub_ble.started_advertising_with) == expected_starts
-    if expected_starts:
-        assert stub_ble.started_advertising_with[0] is advertisement
+        bluetooth.send([message])
 
-    if expected_writes:
-        assert stub_uart.written == expected_writes
-    else:
-        assert stub_uart.written == []
+        assert len(stub_ble.started_advertising_with) == expected_starts
+        if expected_starts:
+            assert stub_ble.started_advertising_with[0] is advertisement
+
+        if expected_writes:
+            assert stub_uart.written == expected_writes
+        else:
+            assert stub_uart.written == []
 
 
-def test_send_encodes_multiple_messages(monkeypatch) -> None:
-    stub_ble = StubBLE(advertising=True, connected=True)
-    stub_uart = StubUART()
 
-    monkeypatch.setattr(bluetooth, "ble", stub_ble)
-    monkeypatch.setattr(bluetooth, "uart", stub_uart)
+    def test_send_encodes_multiple_messages(self, monkeypatch) -> None:
+        """Verify that bluetooth.send encodes each message with the expected delimiter sequence. This ensures protocol compatibility with microcontroller firmware consuming the stream."""
+        stub_ble = StubBLE(advertising=True, connected=True)
+        stub_uart = StubUART()
 
-    bluetooth.send(["one", "two"])
+        monkeypatch.setattr(bluetooth, "ble", stub_ble)
+        monkeypatch.setattr(bluetooth, "uart", stub_uart)
 
-    expected = [
-        b"one",
-        bluetooth.END_OF_MESSAGE_DELIMETER.encode(bluetooth.ENCODING),
-        b"two",
-        bluetooth.END_OF_MESSAGE_DELIMETER.encode(bluetooth.ENCODING),
-    ]
-    assert stub_uart.written == expected
+        bluetooth.send(["one", "two"])
+
+        expected = [
+            b"one",
+            bluetooth.END_OF_MESSAGE_DELIMETER.encode(bluetooth.ENCODING),
+            b"two",
+            bluetooth.END_OF_MESSAGE_DELIMETER.encode(bluetooth.ENCODING),
+        ]
+        assert stub_uart.written == expected

--- a/tests/firmware_io/test_rotary_encoder_handler.py
+++ b/tests/firmware_io/test_rotary_encoder_handler.py
@@ -8,138 +8,150 @@ from helpers.firmware_io import HandlerStep, run_handler_steps
 from heart.firmware_io import constants, rotary_encoder
 
 
-@pytest.mark.parametrize(
-    "index, steps, expected",
-    [
-        (
-            7,
-            [
-                HandlerStep("initial"),
-                HandlerStep("rotate-forward", position=4),
-                HandlerStep("steady"),
-            ],
-            [
-                ("initial", [rotary_encoder.form_json(constants.SWITCH_ROTATION, 0, 7)]),
-                ("rotate-forward", [rotary_encoder.form_json(constants.SWITCH_ROTATION, 4, 7)]),
-                ("steady", []),
-            ],
-        ),
-        (
-            5,
-            [
-                HandlerStep("initial"),
-                HandlerStep("rotate-negative", position=-3),
-                HandlerStep("repeat", position=-3),
-            ],
-            [
-                ("initial", [rotary_encoder.form_json(constants.SWITCH_ROTATION, 0, 5)]),
-                ("rotate-negative", [rotary_encoder.form_json(constants.SWITCH_ROTATION, -3, 5)]),
-                ("repeat", []),
-            ],
-        ),
-    ],
-)
-def test_handle_emits_rotation_events_when_position_changes(rotary_components, index, steps, expected) -> None:
-    encoder, switch = rotary_components
-    handler = rotary_encoder.RotaryEncoderHandler(encoder, switch, index=index)
+class TestFirmwareIoRotaryEncoderHandler:
+    """Group Firmware Io Rotary Encoder Handler tests so firmware io rotary encoder handler behaviour stays reliable. This preserves confidence in firmware io rotary encoder handler for end-to-end scenarios."""
 
-    timeline = run_handler_steps(handler, encoder, switch, steps)
-    assert timeline == expected
-
-
-@pytest.mark.parametrize(
-    "pull_direction, pressed_value, released_value",
-    [
-        ("DOWN", True, False),
-        ("UP", False, True),
-    ],
-)
-def test_handle_emits_button_press_for_press_release_sequence(
-    dummy_pull, deterministic_clock, pull_direction, pressed_value, released_value
-) -> None:
-    encoder = SimpleNamespace(position=12)
-    switch = SimpleNamespace(value=released_value, pull=getattr(dummy_pull, pull_direction))
-    handler = rotary_encoder.RotaryEncoderHandler(
-        encoder, switch, index=2, clock=deterministic_clock.monotonic
+    @pytest.mark.parametrize(
+        "index, steps, expected",
+        [
+            (
+                7,
+                [
+                    HandlerStep("initial"),
+                    HandlerStep("rotate-forward", position=4),
+                    HandlerStep("steady"),
+                ],
+                [
+                    ("initial", [rotary_encoder.form_json(constants.SWITCH_ROTATION, 0, 7)]),
+                    ("rotate-forward", [rotary_encoder.form_json(constants.SWITCH_ROTATION, 4, 7)]),
+                    ("steady", []),
+                ],
+            ),
+            (
+                5,
+                [
+                    HandlerStep("initial"),
+                    HandlerStep("rotate-negative", position=-3),
+                    HandlerStep("repeat", position=-3),
+                ],
+                [
+                    ("initial", [rotary_encoder.form_json(constants.SWITCH_ROTATION, 0, 5)]),
+                    ("rotate-negative", [rotary_encoder.form_json(constants.SWITCH_ROTATION, -3, 5)]),
+                    ("repeat", []),
+                ],
+            ),
+        ],
     )
-    handler.last_position = encoder.position
+    def test_handle_emits_rotation_events_when_position_changes(self, rotary_components, index, steps, expected) -> None:
+        """Verify that RotaryEncoderHandler emits rotation events when the encoder position changes. This confirms motion gestures are surfaced for navigation controls."""
+        encoder, switch = rotary_components
+        handler = rotary_encoder.RotaryEncoderHandler(encoder, switch, index=index)
 
-    steps = [
-        HandlerStep("baseline"),
-        HandlerStep("press-start", switch_value=pressed_value),
-        HandlerStep("press-held", advance=0.2),
-        HandlerStep("release", switch_value=released_value, advance=0.1),
-    ]
-
-    timeline = run_handler_steps(handler, encoder, switch, steps, clock=deterministic_clock)
-    expected_press = rotary_encoder.form_json(constants.BUTTON_PRESS, 1, 2)
-    assert timeline == [
-        ("baseline", []),
-        ("press-start", []),
-        ("press-held", []),
-        ("release", [expected_press]),
-    ]
+        timeline = run_handler_steps(handler, encoder, switch, steps)
+        assert timeline == expected
 
 
-@pytest.mark.parametrize(
-    "advance_sequence",
-    [
-        [rotary_encoder.LONG_PRESS_DURATION_SECONDS - 0.1, 0.2, 0.5],
-        [rotary_encoder.LONG_PRESS_DURATION_SECONDS, 0.3, 0.0],
-    ],
-)
-def test_handle_emits_long_press_once_when_threshold_elapsed(
-    dummy_pull, deterministic_clock, advance_sequence
-) -> None:
-    encoder = SimpleNamespace(position=5)
-    switch = SimpleNamespace(value=True, pull=dummy_pull.UP)
-    handler = rotary_encoder.RotaryEncoderHandler(
-        encoder, switch, index=1, clock=deterministic_clock.monotonic
+
+    @pytest.mark.parametrize(
+        "pull_direction, pressed_value, released_value",
+        [
+            ("DOWN", True, False),
+            ("UP", False, True),
+        ],
     )
-    handler.last_position = encoder.position
+    def test_handle_emits_button_press_for_press_release_sequence(
+        self,
+        dummy_pull, deterministic_clock, pull_direction, pressed_value, released_value
+    ) -> None:
+        """Verify that RotaryEncoderHandler emits a button press when a press-release sequence completes. This links physical button feedback to UI actions relying on taps."""
+        encoder = SimpleNamespace(position=12)
+        switch = SimpleNamespace(value=released_value, pull=getattr(dummy_pull, pull_direction))
+        handler = rotary_encoder.RotaryEncoderHandler(
+            encoder, switch, index=2, clock=deterministic_clock.monotonic
+        )
+        handler.last_position = encoder.position
 
-    steps = [
-        HandlerStep("baseline"),
-        HandlerStep("press-start", switch_value=False),
-        HandlerStep("pre-threshold", advance=advance_sequence[0]),
-        HandlerStep("long-press", advance=advance_sequence[1]),
-        HandlerStep("still-held", advance=advance_sequence[2]),
-        HandlerStep("release", switch_value=True),
-    ]
+        steps = [
+            HandlerStep("baseline"),
+            HandlerStep("press-start", switch_value=pressed_value),
+            HandlerStep("press-held", advance=0.2),
+            HandlerStep("release", switch_value=released_value, advance=0.1),
+        ]
 
-    timeline = run_handler_steps(handler, encoder, switch, steps, clock=deterministic_clock)
-    expected_long_press = rotary_encoder.form_json(constants.BUTTON_LONG_PRESS, 1, 1)
-    labels = [
-        "baseline",
-        "press-start",
-        "pre-threshold",
-        "long-press",
-        "still-held",
-        "release",
-    ]
-    expected_timeline = [(label, []) for label in labels]
-    threshold = rotary_encoder.LONG_PRESS_DURATION_SECONDS
-    long_press_index = 2 if advance_sequence[0] >= threshold else 3
-    expected_timeline[long_press_index] = (
-        expected_timeline[long_press_index][0],
-        [expected_long_press],
+        timeline = run_handler_steps(handler, encoder, switch, steps, clock=deterministic_clock)
+        expected_press = rotary_encoder.form_json(constants.BUTTON_PRESS, 1, 2)
+        assert timeline == [
+            ("baseline", []),
+            ("press-start", []),
+            ("press-held", []),
+            ("release", [expected_press]),
+        ]
+
+
+
+    @pytest.mark.parametrize(
+        "advance_sequence",
+        [
+            [rotary_encoder.LONG_PRESS_DURATION_SECONDS - 0.1, 0.2, 0.5],
+            [rotary_encoder.LONG_PRESS_DURATION_SECONDS, 0.3, 0.0],
+        ],
     )
+    def test_handle_emits_long_press_once_when_threshold_elapsed(
+        self,
+        dummy_pull, deterministic_clock, advance_sequence
+    ) -> None:
+        """Verify that RotaryEncoderHandler only emits a single long-press event after the hold threshold expires. This keeps long-press gestures idempotent so hold-to-trigger actions behave."""
+        encoder = SimpleNamespace(position=5)
+        switch = SimpleNamespace(value=True, pull=dummy_pull.UP)
+        handler = rotary_encoder.RotaryEncoderHandler(
+            encoder, switch, index=1, clock=deterministic_clock.monotonic
+        )
+        handler.last_position = encoder.position
 
-    assert timeline == expected_timeline
-    assert handler.press_started_timestamp is None
-    assert handler.long_pressed_sent is False
+        steps = [
+            HandlerStep("baseline"),
+            HandlerStep("press-start", switch_value=False),
+            HandlerStep("pre-threshold", advance=advance_sequence[0]),
+            HandlerStep("long-press", advance=advance_sequence[1]),
+            HandlerStep("still-held", advance=advance_sequence[2]),
+            HandlerStep("release", switch_value=True),
+        ]
+
+        timeline = run_handler_steps(handler, encoder, switch, steps, clock=deterministic_clock)
+        expected_long_press = rotary_encoder.form_json(constants.BUTTON_LONG_PRESS, 1, 1)
+        labels = [
+            "baseline",
+            "press-start",
+            "pre-threshold",
+            "long-press",
+            "still-held",
+            "release",
+        ]
+        expected_timeline = [(label, []) for label in labels]
+        threshold = rotary_encoder.LONG_PRESS_DURATION_SECONDS
+        long_press_index = 2 if advance_sequence[0] >= threshold else 3
+        expected_timeline[long_press_index] = (
+            expected_timeline[long_press_index][0],
+            [expected_long_press],
+        )
+
+        assert timeline == expected_timeline
+        assert handler.press_started_timestamp is None
+        assert handler.long_pressed_sent is False
 
 
-def test_seesaw_streams_events_from_all_handlers(rotary_components) -> None:
-    encoder, switch = rotary_components
-    handler_a = rotary_encoder.RotaryEncoderHandler(encoder, switch, index=3)
-    handler_b = rotary_encoder.RotaryEncoderHandler(encoder, switch, index=4)
 
-    seesaw = rotary_encoder.Seesaw([handler_a, handler_b])
+    def test_seesaw_streams_events_from_all_handlers(self, rotary_components) -> None:
+        """Verify that Seesaw aggregates events from each registered handler. This demonstrates integration across attachments so multi-knob rigs stay synchronized."""
+        encoder, switch = rotary_components
+        handler_a = rotary_encoder.RotaryEncoderHandler(encoder, switch, index=3)
+        handler_b = rotary_encoder.RotaryEncoderHandler(encoder, switch, index=4)
 
-    events = list(seesaw.handle())
-    expected = [
-        rotary_encoder.form_json(constants.SWITCH_ROTATION, 0, 3),
-        rotary_encoder.form_json(constants.SWITCH_ROTATION, 0, 4),
-    ]
-    assert events == expected
+        seesaw = rotary_encoder.Seesaw([handler_a, handler_b])
+
+        events = list(seesaw.handle())
+        expected = [
+            rotary_encoder.form_json(constants.SWITCH_ROTATION, 0, 3),
+            rotary_encoder.form_json(constants.SWITCH_ROTATION, 0, 4),
+        ]
+        assert events == expected

--- a/tests/navigation/test_game_modes.py
+++ b/tests/navigation/test_game_modes.py
@@ -28,116 +28,132 @@ def _make_game_modes(count: int = 3) -> GameModes:
     return game_modes
 
 
-def test_active_renderer_creates_slide_transition_when_mode_changes() -> None:
-    game_modes = _make_game_modes(count=2)
+class TestNavigationGameModes:
+    """Group Navigation Game Modes tests so navigation game modes behaviour stays reliable. This preserves confidence in navigation game modes for end-to-end scenarios."""
 
-    with patch("heart.navigation.SlideTransitionRenderer") as slide_cls:
+    def test_active_renderer_creates_slide_transition_when_mode_changes(self) -> None:
+        """Verify that active_renderer builds a slide transition when the active mode index changes. This keeps navigation animations smooth when switching between games."""
+        game_modes = _make_game_modes(count=2)
+
+        with patch("heart.navigation.SlideTransitionRenderer") as slide_cls:
+            transition = Mock()
+            slide_cls.return_value = transition
+
+            result = game_modes.active_renderer(mode_offset=1)
+
+        assert result is transition
+        slide_cls.assert_called_once_with(
+            renderer_A=game_modes.title_renderers[0],
+            renderer_B=game_modes.title_renderers[1],
+            direction=1,
+        )
+        assert game_modes.previous_mode_index == 1
+
+
+
+    def test_active_renderer_wraps_with_negative_direction(self) -> None:
+        """Verify that active_renderer wraps from the first mode to the last when stepping negatively. This preserves intuitive cycling so users can scroll backwards seamlessly."""
+        game_modes = _make_game_modes(count=3)
+
+        with patch("heart.navigation.SlideTransitionRenderer") as slide_cls:
+            transition = Mock()
+            slide_cls.return_value = transition
+
+            result = game_modes.active_renderer(mode_offset=-1)
+
+        assert result is transition
+        slide_cls.assert_called_once_with(
+            renderer_A=game_modes.title_renderers[0],
+            renderer_B=game_modes.title_renderers[-1],
+            direction=-1,
+        )
+        assert game_modes.previous_mode_index == len(game_modes.renderers) - 1
+
+
+
+    def test_active_renderer_returns_existing_transition_until_finished(self) -> None:
+        """Verify that active_renderer reuses an in-progress transition until it completes. This avoids allocating redundant transitions that could stutter rendering."""
+        game_modes = _make_game_modes(count=2)
         transition = Mock()
-        slide_cls.return_value = transition
-
-        result = game_modes.active_renderer(mode_offset=1)
-
-    assert result is transition
-    slide_cls.assert_called_once_with(
-        renderer_A=game_modes.title_renderers[0],
-        renderer_B=game_modes.title_renderers[1],
-        direction=1,
-    )
-    assert game_modes.previous_mode_index == 1
-
-
-def test_active_renderer_wraps_with_negative_direction() -> None:
-    game_modes = _make_game_modes(count=3)
-
-    with patch("heart.navigation.SlideTransitionRenderer") as slide_cls:
-        transition = Mock()
-        slide_cls.return_value = transition
-
-        result = game_modes.active_renderer(mode_offset=-1)
-
-    assert result is transition
-    slide_cls.assert_called_once_with(
-        renderer_A=game_modes.title_renderers[0],
-        renderer_B=game_modes.title_renderers[-1],
-        direction=-1,
-    )
-    assert game_modes.previous_mode_index == len(game_modes.renderers) - 1
-
-
-def test_active_renderer_returns_existing_transition_until_finished() -> None:
-    game_modes = _make_game_modes(count=2)
-    transition = Mock()
-    transition.is_done.return_value = False
-    game_modes.sliding_transition = transition
-
-    result = game_modes.active_renderer(mode_offset=0)
-
-    assert result is transition
-    transition.is_done.assert_called_once()
-
-
-def test_active_renderer_zero_offset_prefers_forward_steps_when_equal() -> None:
-    game_modes = _make_game_modes(count=4)
-    game_modes.previous_mode_index = 0
-    game_modes._active_mode_index = 2
-
-    with patch("heart.navigation.SlideTransitionRenderer") as slide_cls:
-        transition = Mock()
-        slide_cls.return_value = transition
+        transition.is_done.return_value = False
+        game_modes.sliding_transition = transition
 
         result = game_modes.active_renderer(mode_offset=0)
 
-    assert result is transition
-    slide_cls.assert_called_once_with(
-        renderer_A=game_modes.title_renderers[0],
-        renderer_B=game_modes.title_renderers[2],
-        direction=1,
-    )
-    assert game_modes.previous_mode_index == 2
+        assert result is transition
+        transition.is_done.assert_called_once()
 
 
-def test_active_renderer_zero_offset_prefers_shortest_wrap_direction() -> None:
-    game_modes = _make_game_modes(count=4)
-    game_modes.previous_mode_index = 0
-    game_modes._active_mode_index = len(game_modes.renderers) - 1
 
-    with patch("heart.navigation.SlideTransitionRenderer") as slide_cls:
-        transition = Mock()
-        slide_cls.return_value = transition
+    def test_active_renderer_zero_offset_prefers_forward_steps_when_equal(self) -> None:
+        """Verify that active_renderer prefers the forward direction when offsets are symmetric. This defines deterministic behaviour so inputs feel consistent."""
+        game_modes = _make_game_modes(count=4)
+        game_modes.previous_mode_index = 0
+        game_modes._active_mode_index = 2
+
+        with patch("heart.navigation.SlideTransitionRenderer") as slide_cls:
+            transition = Mock()
+            slide_cls.return_value = transition
+
+            result = game_modes.active_renderer(mode_offset=0)
+
+        assert result is transition
+        slide_cls.assert_called_once_with(
+            renderer_A=game_modes.title_renderers[0],
+            renderer_B=game_modes.title_renderers[2],
+            direction=1,
+        )
+        assert game_modes.previous_mode_index == 2
+
+
+
+    def test_active_renderer_zero_offset_prefers_shortest_wrap_direction(self) -> None:
+        """Verify that active_renderer wraps in the shortest direction when the last mode is closer. This minimizes animation time so the UI responds briskly."""
+        game_modes = _make_game_modes(count=4)
+        game_modes.previous_mode_index = 0
+        game_modes._active_mode_index = len(game_modes.renderers) - 1
+
+        with patch("heart.navigation.SlideTransitionRenderer") as slide_cls:
+            transition = Mock()
+            slide_cls.return_value = transition
+
+            result = game_modes.active_renderer(mode_offset=0)
+
+        assert result is transition
+        slide_cls.assert_called_once_with(
+            renderer_A=game_modes.title_renderers[0],
+            renderer_B=game_modes.title_renderers[-1],
+            direction=-1,
+        )
+        assert game_modes.previous_mode_index == len(game_modes.renderers) - 1
+
+
+
+    def test_active_renderer_returns_title_renderer_in_select_mode(self) -> None:
+        """Verify that active_renderer returns the title renderer while the UI is in select mode. This ensures selection screens stay visible while browsing options."""
+        game_modes = _make_game_modes(count=2)
+        game_modes.sliding_transition = None
+        game_modes.previous_mode_index = 0
 
         result = game_modes.active_renderer(mode_offset=0)
 
-    assert result is transition
-    slide_cls.assert_called_once_with(
-        renderer_A=game_modes.title_renderers[0],
-        renderer_B=game_modes.title_renderers[-1],
-        direction=-1,
-    )
-    assert game_modes.previous_mode_index == len(game_modes.renderers) - 1
+        assert result is game_modes.title_renderers[0]
+        assert all(renderer.reset_calls == 1 for renderer in game_modes.renderers)
 
 
-def test_active_renderer_returns_title_renderer_in_select_mode() -> None:
-    game_modes = _make_game_modes(count=2)
-    game_modes.sliding_transition = None
-    game_modes.previous_mode_index = 0
 
-    result = game_modes.active_renderer(mode_offset=0)
+    def test_active_renderer_returns_mode_when_not_in_select_mode(self) -> None:
+        """Verify that active_renderer returns the active gameplay renderer when not in select mode. This keeps gameplay responsive once a selection is made."""
+        game_modes = _make_game_modes(count=3)
+        game_modes.in_select_mode = False
+        game_modes.previous_mode_index = 1
+        game_modes._active_mode_index = 1
+        game_modes.sliding_transition = None
 
-    assert result is game_modes.title_renderers[0]
-    assert all(renderer.reset_calls == 1 for renderer in game_modes.renderers)
+        result = game_modes.active_renderer(mode_offset=0)
 
-
-def test_active_renderer_returns_mode_when_not_in_select_mode() -> None:
-    game_modes = _make_game_modes(count=3)
-    game_modes.in_select_mode = False
-    game_modes.previous_mode_index = 1
-    game_modes._active_mode_index = 1
-    game_modes.sliding_transition = None
-
-    result = game_modes.active_renderer(mode_offset=0)
-
-    assert result is game_modes.renderers[1]
-    assert game_modes.previous_mode_index == 1
+        assert result is game_modes.renderers[1]
+        assert game_modes.previous_mode_index == 1
 
 
 if __name__ == "__main__":

--- a/tests/navigation/test_navigation.py
+++ b/tests/navigation/test_navigation.py
@@ -5,23 +5,27 @@ from heart.display.renderers.color import RenderColor
 from heart.environment import GameLoop
 
 
-def test_creating_(loop: GameLoop) -> None:
-    # Now we get automatic movement between A and B, facilitated by AppController
-    a = loop.add_mode("A")
-    b = loop.add_mode("B")
+class TestNavigationNavigation:
+    """Group Navigation Navigation tests so navigation navigation behaviour stays reliable. This preserves confidence in navigation navigation for end-to-end scenarios."""
 
-    # But what is GameMode actually doing here? It is just a builder for a thing that does nothing?
-    a.add_renderer(
-        RenderColor(Color(255, 0, 0)),
-        RenderColor(Color(0, 255, 0)),
-        RenderColor(Color(0, 0, 255)),
-    )
+    def test_creating_(self, loop: GameLoop) -> None:
+        # Now we get automatic movement between A and B, facilitated by AppController
+        """Verify that a GameLoop can create modes and attach renderers without errors. This guards the core loop contract so demos can spin up basic scenes reliably."""
+        a = loop.add_mode("A")
+        b = loop.add_mode("B")
 
-    b.add_renderer(
-        RenderColor(Color(255, 255, 0)),
-        RenderColor(Color(0, 255, 255)),
-        RenderColor(Color(255, 0, 255)),
-    )
+        # But what is GameMode actually doing here? It is just a builder for a thing that does nothing?
+        a.add_renderer(
+            RenderColor(Color(255, 0, 0)),
+            RenderColor(Color(0, 255, 0)),
+            RenderColor(Color(0, 0, 255)),
+        )
+
+        b.add_renderer(
+            RenderColor(Color(255, 255, 0)),
+            RenderColor(Color(0, 255, 255)),
+            RenderColor(Color(255, 0, 255)),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/peripheral/test_accelerometer_event_bus.py
+++ b/tests/peripheral/test_accelerometer_event_bus.py
@@ -5,52 +5,58 @@ from heart.peripheral.core.event_bus import EventBus
 from heart.peripheral.sensor import Accelerometer
 
 
-@pytest.mark.parametrize("event_type", ["acceleration", "sensor.acceleration"])
-def test_accelerometer_emits_vector(event_type: str) -> None:
-    bus = EventBus()
-    captured: list[AccelerometerVector] = []
+class TestPeripheralAccelerometerEventBus:
+    """Group Peripheral Accelerometer Event Bus tests so peripheral accelerometer event bus behaviour stays reliable. This preserves confidence in peripheral accelerometer event bus for end-to-end scenarios."""
 
-    def _capture(event):
-        captured.append(
-            AccelerometerVector(
-                x=event.data["x"], y=event.data["y"], z=event.data["z"]
+    @pytest.mark.parametrize("event_type", ["acceleration", "sensor.acceleration"])
+    def test_accelerometer_emits_vector(self, event_type: str) -> None:
+        """Verify that Accelerometer publishes acceleration vectors onto the event bus. This ensures motion data reaches subscribers that drive orientation and gesture features."""
+        bus = EventBus()
+        captured: list[AccelerometerVector] = []
+
+        def _capture(event):
+            captured.append(
+                AccelerometerVector(
+                    x=event.data["x"], y=event.data["y"], z=event.data["z"]
+                )
             )
+
+        bus.subscribe(AccelerometerVector.EVENT_TYPE, _capture)
+        accel = Accelerometer(port="/dev/null", baudrate=9600, event_bus=bus, producer_id=7)
+
+        accel._update_due_to_data(
+            {"event_type": event_type, "data": {"x": 1.0, "y": -2.5, "z": 0.5}}
         )
 
-    bus.subscribe(AccelerometerVector.EVENT_TYPE, _capture)
-    accel = Accelerometer(port="/dev/null", baudrate=9600, event_bus=bus, producer_id=7)
-
-    accel._update_due_to_data(
-        {"event_type": event_type, "data": {"x": 1.0, "y": -2.5, "z": 0.5}}
-    )
-
-    assert captured
-    vector = captured[0]
-    assert vector.x == pytest.approx(1.0)
-    assert vector.y == pytest.approx(-2.5)
-    assert vector.z == pytest.approx(0.5)
+        assert captured
+        vector = captured[0]
+        assert vector.x == pytest.approx(1.0)
+        assert vector.y == pytest.approx(-2.5)
+        assert vector.z == pytest.approx(0.5)
 
 
-def test_accelerometer_emits_magnetometer_vector() -> None:
-    bus = EventBus()
-    captured: list[MagnetometerVector] = []
 
-    def _capture(event):
-        captured.append(
-            MagnetometerVector(
-                x=event.data["x"], y=event.data["y"], z=event.data["z"]
+    def test_accelerometer_emits_magnetometer_vector(self) -> None:
+        """Verify that Accelerometer publishes magnetometer vectors onto the event bus. This supports heading calculations that depend on magnetometer updates."""
+        bus = EventBus()
+        captured: list[MagnetometerVector] = []
+
+        def _capture(event):
+            captured.append(
+                MagnetometerVector(
+                    x=event.data["x"], y=event.data["y"], z=event.data["z"]
+                )
             )
+
+        bus.subscribe(MagnetometerVector.EVENT_TYPE, _capture)
+        accel = Accelerometer(port="/dev/null", baudrate=9600, event_bus=bus, producer_id=7)
+
+        accel._update_due_to_data(
+            {"event_type": "sensor.magnetic", "data": {"x": -30.0, "y": 12.0, "z": 4.0}}
         )
 
-    bus.subscribe(MagnetometerVector.EVENT_TYPE, _capture)
-    accel = Accelerometer(port="/dev/null", baudrate=9600, event_bus=bus, producer_id=7)
-
-    accel._update_due_to_data(
-        {"event_type": "sensor.magnetic", "data": {"x": -30.0, "y": 12.0, "z": 4.0}}
-    )
-
-    assert captured
-    vector = captured[0]
-    assert vector.x == pytest.approx(-30.0)
-    assert vector.y == pytest.approx(12.0)
-    assert vector.z == pytest.approx(4.0)
+        assert captured
+        vector = captured[0]
+        assert vector.x == pytest.approx(-30.0)
+        assert vector.y == pytest.approx(12.0)
+        assert vector.z == pytest.approx(4.0)

--- a/tests/peripheral/test_average_color_led.py
+++ b/tests/peripheral/test_average_color_led.py
@@ -17,41 +17,49 @@ def _register_average(loop) -> tuple[SingleLEDDevice, AverageColorLED]:
     return single_led, average_led
 
 
-def test_average_led_tracks_latest_frame(loop) -> None:
-    single_led, _ = _register_average(loop)
-    image = Image.new("RGB", loop.device.full_display_size(), (255, 0, 0))
+class TestPeripheralAverageColorLed:
+    """Group Peripheral Average Color Led tests so peripheral average color led behaviour stays reliable. This preserves confidence in peripheral average color led for end-to-end scenarios."""
 
-    loop.display_peripheral.publish_image(image)
+    def test_average_led_tracks_latest_frame(self, loop) -> None:
+        """Verify that AverageColorLED updates the LED colour when the primary display publishes a frame. This keeps ambient lighting responsive to live visuals."""
+        single_led, _ = _register_average(loop)
+        image = Image.new("RGB", loop.device.full_display_size(), (255, 0, 0))
 
-    assert single_led.last_color == (255, 0, 0)
+        loop.display_peripheral.publish_image(image)
 
-
-def test_average_led_computes_mean_colour(loop) -> None:
-    single_led, _ = _register_average(loop)
-    width, height = loop.device.full_display_size()
-    image = Image.new("RGB", (width, height))
-    image.paste((255, 0, 0), (0, 0, width // 2, height))
-    image.paste((0, 0, 255), (width // 2, 0, width, height))
-
-    loop.display_peripheral.publish_image(image)
-
-    assert single_led.last_color == (128, 0, 128)
+        assert single_led.last_color == (255, 0, 0)
 
 
-def test_average_led_ignores_other_displays(loop) -> None:
-    single_led, _ = _register_average(loop)
-    width, height = loop.device.full_display_size()
-    alien_frame = DisplayFrame.from_image(
-        Image.new("RGB", (width, height), (0, 255, 0)),
-        frame_id=99,
-    )
 
-    loop.event_bus.emit(alien_frame.to_input(producer_id=999))
+    def test_average_led_computes_mean_colour(self, loop) -> None:
+        """Verify that AverageColorLED sets the LED to the mean colour of the rendered frame. This ensures lighting reflects the scene mood instead of a single pixel."""
+        single_led, _ = _register_average(loop)
+        width, height = loop.device.full_display_size()
+        image = Image.new("RGB", (width, height))
+        image.paste((255, 0, 0), (0, 0, width // 2, height))
+        image.paste((0, 0, 255), (width // 2, 0, width, height))
 
-    assert single_led.last_color is None
+        loop.display_peripheral.publish_image(image)
 
-    loop.display_peripheral.publish_image(
-        Image.new("RGB", (width, height), (0, 255, 0))
-    )
+        assert single_led.last_color == (128, 0, 128)
 
-    assert single_led.last_color == (0, 255, 0)
+
+
+    def test_average_led_ignores_other_displays(self, loop) -> None:
+        """Verify that AverageColorLED ignores frames produced by other displays. This prevents stray peripherals from hijacking the LED channel."""
+        single_led, _ = _register_average(loop)
+        width, height = loop.device.full_display_size()
+        alien_frame = DisplayFrame.from_image(
+            Image.new("RGB", (width, height), (0, 255, 0)),
+            frame_id=99,
+        )
+
+        loop.event_bus.emit(alien_frame.to_input(producer_id=999))
+
+        assert single_led.last_color is None
+
+        loop.display_peripheral.publish_image(
+            Image.new("RGB", (width, height), (0, 255, 0))
+        )
+
+        assert single_led.last_color == (0, 255, 0)

--- a/tests/peripheral/test_calibration.py
+++ b/tests/peripheral/test_calibration.py
@@ -6,70 +6,78 @@ from heart.peripheral.calibration import (CalibrationProfile,
 from heart.peripheral.core.event_bus import EventBus
 
 
-def test_calibration_profile_from_reference() -> None:
-    profile = CalibrationProfile.from_reference(
-        raw={"x": 0.12, "y": -0.08, "z": 9.6},
-        expected={"x": 0.0, "y": 0.0, "z": 9.81},
-        precision=3,
-    )
+class TestPeripheralCalibration:
+    """Group Peripheral Calibration tests so peripheral calibration behaviour stays reliable. This preserves confidence in peripheral calibration for end-to-end scenarios."""
 
-    corrected = profile.apply({"x": 0.12, "y": -0.08, "z": 9.6})
+    def test_calibration_profile_from_reference(self) -> None:
+        """Verify that CalibrationProfile.from_reference produces offsets that align raw values with expectations. This keeps field calibration reproducible so sensor drift is corrected."""
+        profile = CalibrationProfile.from_reference(
+            raw={"x": 0.12, "y": -0.08, "z": 9.6},
+            expected={"x": 0.0, "y": 0.0, "z": 9.81},
+            precision=3,
+        )
 
-    assert corrected == pytest.approx({"x": 0.0, "y": 0.0, "z": 9.81})
+        corrected = profile.apply({"x": 0.12, "y": -0.08, "z": 9.6})
 
-
-def test_calibration_profile_with_matrix_and_scale() -> None:
-    profile = CalibrationProfile(
-        axes=("x", "y"),
-        offset=(0.0, 0.0),
-        matrix=((0.0, 1.0), (-1.0, 0.0)),
-        scale=(2.0, 0.5),
-        precision=4,
-    )
-
-    corrected = profile.apply({"x": 1.0, "y": 2.0})
-
-    assert corrected == pytest.approx({"x": 4.0, "y": -0.5})
+        assert corrected == pytest.approx({"x": 0.0, "y": 0.0, "z": 9.81})
 
 
-def test_calibrated_virtual_peripheral_emits_corrected_event() -> None:
-    bus = EventBus()
-    outputs: list = []
 
-    bus.subscribe(
-        "peripheral.accelerometer.vector.calibrated",
-        lambda event: outputs.append(event),
-    )
+    def test_calibration_profile_with_matrix_and_scale(self) -> None:
+        """Verify that CalibrationProfile applies the configured matrix and scaling factors. This enables complex axis remapping for custom installations."""
+        profile = CalibrationProfile(
+            axes=("x", "y"),
+            offset=(0.0, 0.0),
+            matrix=((0.0, 1.0), (-1.0, 0.0)),
+            scale=(2.0, 0.5),
+            precision=4,
+        )
 
-    profile = CalibrationProfile.from_reference(
-        raw={"x": 0.12, "y": -0.08, "z": 9.6},
-        expected={"x": 0.0, "y": 0.0, "z": 9.81},
-        precision=3,
-    )
+        corrected = profile.apply({"x": 1.0, "y": 2.0})
 
-    definition = calibrated_virtual_peripheral(
-        name="imu.calibrated",
-        calibrations={
-            AccelerometerVector.EVENT_TYPE: profile,
-        },
-        output_event_type="peripheral.accelerometer.vector.calibrated",
-        output_producer_id=99,
-        include_source_event=True,
-        include_raw_payload=True,
-    )
-    bus.virtual_peripherals.register(definition)
+        assert corrected == pytest.approx({"x": 4.0, "y": -0.5})
 
-    raw_event = AccelerometerVector(x=0.12, y=-0.08, z=9.6).to_input(producer_id=42)
-    bus.emit(raw_event)
 
-    assert len(outputs) == 1
-    emitted = outputs[0]
-    assert emitted.event_type == "peripheral.accelerometer.vector.calibrated"
-    assert emitted.producer_id == 99
-    assert emitted.data["x"] == pytest.approx(0.0)
-    assert emitted.data["y"] == pytest.approx(0.0)
-    assert emitted.data["z"] == pytest.approx(9.81)
-    assert emitted.data["raw"] == {"x": 0.12, "y": -0.08, "z": 9.6}
-    assert emitted.data["source_event"]["producer_id"] == 42
-    assert emitted.data["calibration"]["offset"] == pytest.approx([0.12, -0.08, -0.21])
-    assert emitted.data["virtual_peripheral"]["name"] == "imu.calibrated"
+
+    def test_calibrated_virtual_peripheral_emits_corrected_event(self) -> None:
+        """Verify that calibrated_virtual_peripheral publishes corrected accelerometer events with context payloads. This feeds precise measurements to consumers while keeping raw data available."""
+        bus = EventBus()
+        outputs: list = []
+
+        bus.subscribe(
+            "peripheral.accelerometer.vector.calibrated",
+            lambda event: outputs.append(event),
+        )
+
+        profile = CalibrationProfile.from_reference(
+            raw={"x": 0.12, "y": -0.08, "z": 9.6},
+            expected={"x": 0.0, "y": 0.0, "z": 9.81},
+            precision=3,
+        )
+
+        definition = calibrated_virtual_peripheral(
+            name="imu.calibrated",
+            calibrations={
+                AccelerometerVector.EVENT_TYPE: profile,
+            },
+            output_event_type="peripheral.accelerometer.vector.calibrated",
+            output_producer_id=99,
+            include_source_event=True,
+            include_raw_payload=True,
+        )
+        bus.virtual_peripherals.register(definition)
+
+        raw_event = AccelerometerVector(x=0.12, y=-0.08, z=9.6).to_input(producer_id=42)
+        bus.emit(raw_event)
+
+        assert len(outputs) == 1
+        emitted = outputs[0]
+        assert emitted.event_type == "peripheral.accelerometer.vector.calibrated"
+        assert emitted.producer_id == 99
+        assert emitted.data["x"] == pytest.approx(0.0)
+        assert emitted.data["y"] == pytest.approx(0.0)
+        assert emitted.data["z"] == pytest.approx(9.81)
+        assert emitted.data["raw"] == {"x": 0.12, "y": -0.08, "z": 9.6}
+        assert emitted.data["source_event"]["producer_id"] == 42
+        assert emitted.data["calibration"]["offset"] == pytest.approx([0.12, -0.08, -0.21])
+        assert emitted.data["virtual_peripheral"]["name"] == "imu.calibrated"

--- a/tests/peripheral/test_compass.py
+++ b/tests/peripheral/test_compass.py
@@ -9,41 +9,49 @@ def _emit_vector(bus: EventBus, vector: MagnetometerVector) -> None:
     bus.emit(vector.to_input(producer_id=0))
 
 
-def test_compass_tracks_latest_vector() -> None:
-    bus = EventBus()
-    compass = Compass(window_size=3)
-    compass.attach_event_bus(bus)
+class TestPeripheralCompass:
+    """Group Peripheral Compass tests so peripheral compass behaviour stays reliable. This preserves confidence in peripheral compass for end-to-end scenarios."""
 
-    sample = MagnetometerVector(x=12.0, y=-5.0, z=1.5)
-    _emit_vector(bus, sample)
+    def test_compass_tracks_latest_vector(self) -> None:
+        """Verify that Compass stores the latest magnetometer vector emitted on the event bus. This ensures heading queries always reflect the most recent sensor input."""
+        bus = EventBus()
+        compass = Compass(window_size=3)
+        compass.attach_event_bus(bus)
 
-    vector = compass.get_latest_vector()
-    assert vector is not None
-    assert vector[0] == pytest.approx(12.0)
-    assert vector[1] == pytest.approx(-5.0)
-    assert vector[2] == pytest.approx(1.5)
+        sample = MagnetometerVector(x=12.0, y=-5.0, z=1.5)
+        _emit_vector(bus, sample)
 
-
-def test_compass_heading_uses_smoothed_average() -> None:
-    bus = EventBus()
-    compass = Compass(window_size=2)
-    compass.attach_event_bus(bus)
-
-    _emit_vector(bus, MagnetometerVector(x=0.0, y=1.0, z=0.0))
-    assert compass.get_heading_degrees() == pytest.approx(0.0)
-
-    _emit_vector(bus, MagnetometerVector(x=1.0, y=0.0, z=0.0))
-    assert compass.get_heading_degrees() == pytest.approx(45.0)
+        vector = compass.get_latest_vector()
+        assert vector is not None
+        assert vector[0] == pytest.approx(12.0)
+        assert vector[1] == pytest.approx(-5.0)
+        assert vector[2] == pytest.approx(1.5)
 
 
-def test_compass_returns_none_for_empty_or_zero_vectors() -> None:
-    compass = Compass(window_size=4)
 
-    assert compass.get_heading_degrees() is None
-    assert compass.get_average_vector() is None
+    def test_compass_heading_uses_smoothed_average(self) -> None:
+        """Verify that Compass computes heading degrees from a smoothed average of recent vectors. This stabilises navigation so jittery measurements do not cause erratic bearings."""
+        bus = EventBus()
+        compass = Compass(window_size=2)
+        compass.attach_event_bus(bus)
 
-    bus = EventBus()
-    compass.attach_event_bus(bus)
-    _emit_vector(bus, MagnetometerVector(x=0.0, y=0.0, z=0.0))
+        _emit_vector(bus, MagnetometerVector(x=0.0, y=1.0, z=0.0))
+        assert compass.get_heading_degrees() == pytest.approx(0.0)
 
-    assert compass.get_heading_degrees() is None
+        _emit_vector(bus, MagnetometerVector(x=1.0, y=0.0, z=0.0))
+        assert compass.get_heading_degrees() == pytest.approx(45.0)
+
+
+
+    def test_compass_returns_none_for_empty_or_zero_vectors(self) -> None:
+        """Verify that Compass returns None when no meaningful magnetometer samples are available. This guards downstream logic from acting on invalid sensor data."""
+        compass = Compass(window_size=4)
+
+        assert compass.get_heading_degrees() is None
+        assert compass.get_average_vector() is None
+
+        bus = EventBus()
+        compass.attach_event_bus(bus)
+        _emit_vector(bus, MagnetometerVector(x=0.0, y=0.0, z=0.0))
+
+        assert compass.get_heading_degrees() is None

--- a/tests/peripheral/test_drawing_pad.py
+++ b/tests/peripheral/test_drawing_pad.py
@@ -4,59 +4,69 @@ from heart.peripheral.core import Input
 from heart.peripheral.drawing_pad import DrawingPad, StylusSample
 
 
-def test_defaults_match_spec():
-    pad = DrawingPad()
-    assert pad.width_inches == pytest.approx(6.0)
-    assert pad.height_inches == pytest.approx(6.0)
-    assert pad.resolution == 48
+class TestPeripheralDrawingPad:
+    """Group Peripheral Drawing Pad tests so peripheral drawing pad behaviour stays reliable. This preserves confidence in peripheral drawing pad for end-to-end scenarios."""
+
+    def test_defaults_match_spec(self):
+        """Verify that DrawingPad initialises with the documented dimensions and resolution. This keeps firmware assumptions in sync with the physical pad."""
+        pad = DrawingPad()
+        assert pad.width_inches == pytest.approx(6.0)
+        assert pad.height_inches == pytest.approx(6.0)
+        assert pad.resolution == 48
 
 
-def test_apply_stylus_updates_grid_and_history():
-    pad = DrawingPad(resolution=8)
 
-    pad.handle_input(
-        Input(
-            event_type="drawing_pad.stroke",
-            data={"x": 0.5, "y": 0.5, "pressure": 0.8, "radius": 0.2},
+    def test_apply_stylus_updates_grid_and_history(self):
+        """Verify that DrawingPad.handle_input records stylus samples and updates the grid pressures. This ensures strokes appear on the canvas for creative tools."""
+        pad = DrawingPad(resolution=8)
+
+        pad.handle_input(
+            Input(
+                event_type="drawing_pad.stroke",
+                data={"x": 0.5, "y": 0.5, "pressure": 0.8, "radius": 0.2},
+            )
         )
-    )
 
-    sample = pad.last_sample()
-    assert isinstance(sample, StylusSample)
-    assert not sample.is_erase
-    assert sample.pressure == pytest.approx(0.8)
+        sample = pad.last_sample()
+        assert isinstance(sample, StylusSample)
+        assert not sample.is_erase
+        assert sample.pressure == pytest.approx(0.8)
 
-    # The centre cell should be filled with the provided pressure value.
-    grid = [list(row) for row in pad.iter_rows()]
-    centre_index = pad.resolution // 2
-    assert grid[centre_index][centre_index] == pytest.approx(0.8)
-
-
-def test_erase_clears_region():
-    pad = DrawingPad(resolution=8)
-    pad.apply_stylus(x=0.5, y=0.5, pressure=1.0, radius=0.3)
-
-    pad.handle_input(
-        Input(event_type="drawing_pad.erase", data={"x": 0.5, "y": 0.5, "radius": 0.3})
-    )
-
-    sample = pad.last_sample()
-    assert sample is not None and sample.is_erase
-
-    for row in pad.iter_rows():
-        for value in row:
-            assert value == pytest.approx(0.0)
+        # The centre cell should be filled with the provided pressure value.
+        grid = [list(row) for row in pad.iter_rows()]
+        centre_index = pad.resolution // 2
+        assert grid[centre_index][centre_index] == pytest.approx(0.8)
 
 
-def test_units_in_inches_are_supported():
-    pad = DrawingPad(resolution=10)
-    pad.apply_stylus(x=3.0, y=3.0, units="inches")
 
-    # 3 inches is the midpoint on a 6 inch pad -> central cell should be non-zero
-    sample = pad.last_sample()
-    assert sample is not None
+    def test_erase_clears_region(self):
+        """Verify that DrawingPad processes erase events by clearing the affected cells. This keeps undo gestures from leaving artifacts on the grid."""
+        pad = DrawingPad(resolution=8)
+        pad.apply_stylus(x=0.5, y=0.5, pressure=1.0, radius=0.3)
 
-    grid = [list(row) for row in pad.iter_rows()]
-    x_idx = round(sample.x * (pad.resolution - 1))
-    y_idx = round(sample.y * (pad.resolution - 1))
-    assert grid[y_idx][x_idx] == pytest.approx(1.0)
+        pad.handle_input(
+            Input(event_type="drawing_pad.erase", data={"x": 0.5, "y": 0.5, "radius": 0.3})
+        )
+
+        sample = pad.last_sample()
+        assert sample is not None and sample.is_erase
+
+        for row in pad.iter_rows():
+            for value in row:
+                assert value == pytest.approx(0.0)
+
+
+
+    def test_units_in_inches_are_supported(self):
+        """Verify that DrawingPad accepts stylus coordinates expressed in inches. This supports hardware that emits real-world measurements instead of normalized coordinates."""
+        pad = DrawingPad(resolution=10)
+        pad.apply_stylus(x=3.0, y=3.0, units="inches")
+
+        # 3 inches is the midpoint on a 6 inch pad -> central cell should be non-zero
+        sample = pad.last_sample()
+        assert sample is not None
+
+        grid = [list(row) for row in pad.iter_rows()]
+        x_idx = round(sample.x * (pad.resolution - 1))
+        y_idx = round(sample.y * (pad.resolution - 1))
+        assert grid[y_idx][x_idx] == pytest.approx(1.0)

--- a/tests/peripheral/test_event_bus.py
+++ b/tests/peripheral/test_event_bus.py
@@ -18,672 +18,706 @@ from heart.peripheral.core.event_bus import (EventBus, EventPlaylist,
                                              simultaneous_virtual_peripheral)
 
 
-def test_emit_orders_callbacks_by_priority_then_fifo():
-    bus = EventBus()
-    order: list[str] = []
+class TestPeripheralEventBus:
+    """Group Peripheral Event Bus tests so peripheral event bus behaviour stays reliable. This preserves confidence in peripheral event bus for end-to-end scenarios."""
 
-    bus.subscribe("button", lambda evt: order.append("low"), priority=0)
-    bus.subscribe("button", lambda evt: order.append("mid"), priority=5)
-    bus.subscribe("button", lambda evt: order.append("mid-2"), priority=5)
-    bus.subscribe("button", lambda evt: order.append("high"), priority=10)
+    def test_emit_orders_callbacks_by_priority_then_fifo(self):
+        """Verify that emit orders callbacks by priority then fifo. This guarantees deterministic fan-out so critical handlers run first."""
+        bus = EventBus()
+        order: list[str] = []
 
-    bus.emit("button", data=None)
+        bus.subscribe("button", lambda evt: order.append("low"), priority=0)
+        bus.subscribe("button", lambda evt: order.append("mid"), priority=5)
+        bus.subscribe("button", lambda evt: order.append("mid-2"), priority=5)
+        bus.subscribe("button", lambda evt: order.append("high"), priority=10)
 
-    assert order == ["high", "mid", "mid-2", "low"]
+        bus.emit("button", data=None)
 
-
-def test_run_on_event_decorator_registers_handler():
-    bus = EventBus()
-    captured: list[int] = []
+        assert order == ["high", "mid", "mid-2", "low"]
 
-    @bus.run_on_event("tick")
-    def _handler(event: Input) -> None:
-        captured.append(event.producer_id)
 
-    bus.emit("tick", data="value", producer_id=42)
 
-    assert captured == [42]
+    def test_run_on_event_decorator_registers_handler(self):
+        """Verify that run_on_event decorator registers handler. This keeps the decorator API trustworthy for peripheral integrations."""
+        bus = EventBus()
+        captured: list[int] = []
 
+        @bus.run_on_event("tick")
+        def _handler(event: Input) -> None:
+            captured.append(event.producer_id)
 
-def test_subscriber_failures_do_not_block_others(caplog: pytest.LogCaptureFixture):
-    bus = EventBus()
-    caplog.set_level("ERROR")
-    calls: list[str] = []
-
-    def _bad(_: Input) -> None:
-        raise RuntimeError("boom")
-
-    bus.subscribe("sensor", _bad)
-    bus.subscribe("sensor", lambda event: calls.append(event.event_type))
-
-    bus.emit(Input(event_type="sensor", data={}))
-
-    assert calls == ["sensor"]
-    assert any("EventBus subscriber" in message for message in caplog.messages)
-
-
-def test_emit_updates_state_store_before_callbacks():
-    bus = EventBus()
-
-    observed: list[int] = []
-
-    def _handler(event: Input) -> None:
-        entry = bus.state_store.get_latest(event.event_type, producer_id=event.producer_id)
-        assert entry is not None
-        observed.append(entry.producer_id)
-
-    bus.subscribe("button", _handler)
-
-    bus.emit("button", data={"pressed": True}, producer_id=2)
-
-    assert observed == [2]
-
-
-def test_playlist_manual_start_runs_to_completion() -> None:
-    bus = EventBus()
-    emitted_values: list[int] = []
-    playlist_events: list[dict] = []
-    stops: list[dict] = []
-    completions: list[dict] = []
-
-    bus.subscribe(
-        "color.update",
-        lambda event: emitted_values.append(event.data["value"]),
-    )
-    bus.subscribe(
-        EventPlaylistManager.EVENT_EMITTED,
-        lambda event: playlist_events.append(event.data),
-    )
-    bus.subscribe(
-        EventPlaylistManager.EVENT_STOPPED,
-        lambda event: stops.append(event.data),
-    )
-
-    playlist = EventPlaylist(
-        name="cycle",
-        steps=[
-            PlaylistStep(
-                event_type="color.update",
-                data={"value": 7},
-                offset=0.0,
-                repeat=3,
-                interval=0.01,
-                producer_id=5,
-            )
-        ],
-        completion_event_type="color.cycle.complete",
-        metadata={"mode": "test"},
-    )
-    handle: PlaylistHandle = bus.playlists.register(playlist)
-
-    bus.subscribe(
-        "color.cycle.complete",
-        lambda event: completions.append(event.data),
-    )
-
-    run_id = bus.playlists.start(handle)
-    assert bus.playlists.join(run_id, timeout=1.0)
-
-    assert emitted_values == [7, 7, 7]
-    assert [item["repeat_index"] for item in playlist_events] == [0, 1, 2]
-    assert all(item["data"] == {"value": 7} for item in playlist_events)
-    assert stops and stops[0]["reason"] == "completed"
-    assert stops[0]["playlist_metadata"] == {"mode": "test"}
-    assert completions and completions[0]["playlist_id"] == run_id
-    assert completions[0]["playlist_metadata"] == {"mode": "test"}
-
-
-def test_playlist_trigger_interrupted_by_event() -> None:
-    bus = EventBus()
-    created_events: list[dict] = []
-    emitted_events: list[dict] = []
-    stop_events: list[dict] = []
-
-    created_ready = threading.Event()
-    emitted_twice = threading.Event()
-
-    bus.subscribe(
-        EventPlaylistManager.EVENT_CREATED,
-        lambda event: (created_events.append(event.data), created_ready.set()),
-    )
-    bus.subscribe(
-        EventPlaylistManager.EVENT_EMITTED,
-        lambda event: (
-            emitted_events.append(event.data),
-            emitted_twice.set()
-            if len(emitted_events) >= 2
-            else None,
-        ),
-    )
-    bus.subscribe(
-        EventPlaylistManager.EVENT_STOPPED,
-        lambda event: stop_events.append(event.data),
-    )
-
-    playlist = EventPlaylist(
-        name="interruptible",
-        steps=[
-            PlaylistStep(
-                event_type="color.update",
-                data={"value": 1},
-                offset=0.0,
-                repeat=10,
-                interval=0.05,
-            )
-        ],
-        trigger_event_type="start.sequence",
-        interrupt_events=("stop.sequence",),
-        metadata={"mode": "interrupt"},
-    )
-    bus.playlists.register(playlist)
-
-    bus.emit("start.sequence", data={"begin": True})
-    assert created_ready.wait(timeout=1.0)
-    run_id = created_events[0]["playlist_id"]
-
-    # Wait for at least two emissions before interrupting.
-    assert emitted_twice.wait(timeout=1.0)
-    bus.emit("stop.sequence", data={"reason": "test"})
-
-    assert bus.playlists.join(run_id, timeout=1.0)
-
-    assert stop_events and stop_events[0]["reason"] == "interrupted"
-    interrupt_data = stop_events[0]["interrupt_event"]
-    assert interrupt_data["event_type"] == "stop.sequence"
-    assert interrupt_data["data"] == {"reason": "test"}
-    assert created_events[0]["trigger_event"]["data"] == {"begin": True}
-    assert created_events[0]["playlist_metadata"] == {"mode": "interrupt"}
-    assert emitted_events
-    assert len(emitted_events) < 10
-
-
-def test_virtual_peripheral_definitions_bind_resources() -> None:
-    bus = EventBus()
-    captured: dict[str, Any] = {}
-    handled: list[int] = []
-
-    class DummyVirtualPeripheral:
-        def __init__(self, context: VirtualPeripheralContext) -> None:
-            self._context = context
-            captured["context"] = context
-            captured["foo"] = context.get_resource("foo")
-            captured["combo"] = context.get_resource("combo")
-            captured["state_store"] = context.resources["state_store"]
-
-        def handle(self, event: Input) -> None:
-            handled.append(self._context.get_resource("foo"))
-
-        def shutdown(self) -> None:
-            captured["shutdown"] = True
-
-    definition = VirtualPeripheralDefinition(
-        name="dummy.resources",
-        event_types=("button.press",),
-        factory=DummyVirtualPeripheral,
-        resources={
-            "foo": lambda ctx: 41,
-            "combo": lambda ctx: ctx.get_resource("foo") + 1,
-            "state_store": lambda ctx: ctx.state_store,
-        },
-    )
-
-    handle = bus.virtual_peripherals.register(definition)
-    bus.emit("button.press", data={})
-
-    assert handled == [41]
-    assert captured["foo"] == 41
-    assert captured["combo"] == 42
-    assert captured["state_store"] is bus.state_store
-
-    resources = bus.virtual_peripherals.list_definitions()[handle.peripheral_id].resources
-    assert resources is not None
-    with pytest.raises(TypeError):
-        cast(dict[str, Any], resources)["foo"] = 99
-
-    dummy_context = captured["context"]
-    with pytest.raises(TypeError):
-        cast(dict[str, Any], dummy_context.resources)["foo"] = 5
-    with pytest.raises(KeyError):
-        dummy_context.get_resource("missing")
-
-    bus.virtual_peripherals.remove(handle)
-    assert captured.get("shutdown") is True
-
-def test_gated_playlist_virtual_peripheral_runs_playlist() -> None:
-    bus = EventBus()
-    outputs: list[int] = []
-    created_payloads: list[Mapping[str, Any]] = []
-    stop_payloads: list[Mapping[str, Any]] = []
-
-    created_ready = threading.Event()
-    stopped_ready = threading.Event()
-
-    bus.subscribe(
-        "color.update",
-        lambda event: outputs.append(event.data["value"]),
-    )
-    bus.subscribe(
-        EventPlaylistManager.EVENT_CREATED,
-        lambda event: (created_payloads.append(event.data), created_ready.set()),
-    )
-    bus.subscribe(
-        EventPlaylistManager.EVENT_STOPPED,
-        lambda event: (stop_payloads.append(event.data), stopped_ready.set()),
-    )
-
-    playlist = EventPlaylist(
-        name="flash",
-        steps=[
-            PlaylistStep(
-                event_type="color.update",
-                data={"value": 1},
-                offset=0.0,
-                repeat=2,
-                interval=0.01,
-                producer_id=7,
-            )
-        ],
-        metadata={"mode": "flash"},
-    )
-
-    definition = gated_playlist_virtual_peripheral(
-        ("button.press",),
-        playlist=playlist,
-        name="button.flash",
-    )
-    bus.virtual_peripherals.register(definition)
-
-    bus.emit("button.press", data={"intensity": 3}, producer_id=2)
-
-    assert created_ready.wait(timeout=1.0)
-    run_id = created_payloads[0]["playlist_id"]
-    assert bus.playlists.join(run_id, timeout=1.0)
-    assert stopped_ready.wait(timeout=1.0)
-
-    assert outputs == [1, 1]
-    assert created_payloads[0]["trigger_event"]["data"] == {"intensity": 3}
-    assert stop_payloads[0]["reason"] == "completed"
-
-
-def test_gated_playlist_virtual_peripheral_cancels_previous_runs() -> None:
-    bus = EventBus()
-    created_payloads: list[Mapping[str, Any]] = []
-    stop_payloads: list[Mapping[str, Any]] = []
-
-    first_created = threading.Event()
-    second_created = threading.Event()
-    first_stopped = threading.Event()
-    second_stopped = threading.Event()
-
-    def handle_created(event: Input) -> None:
-        created_payloads.append(event.data)
-        if len(created_payloads) == 1:
-            first_created.set()
-        elif len(created_payloads) == 2:
-            second_created.set()
-
-    def handle_stopped(event: Input) -> None:
-        stop_payloads.append(event.data)
-        if len(stop_payloads) == 1:
-            first_stopped.set()
-        elif len(stop_payloads) == 2:
-            second_stopped.set()
-
-    bus.subscribe(EventPlaylistManager.EVENT_CREATED, handle_created)
-    bus.subscribe(EventPlaylistManager.EVENT_STOPPED, handle_stopped)
-
-    playlist = EventPlaylist(
-        name="long",
-        steps=[
-            PlaylistStep(
-                event_type="color.update",
-                data={"value": 9},
-                offset=0.0,
-                repeat=5,
-                interval=0.05,
-            )
-        ],
-    )
-
-    definition = gated_playlist_virtual_peripheral(
-        ("button.press",),
-        playlist=playlist,
-        cancel_active_runs=True,
-    )
-    bus.virtual_peripherals.register(definition)
-
-    bus.emit("button.press", data={"sequence": 1})
-    assert first_created.wait(timeout=1.0)
-    assert created_payloads[0]["trigger_event"]["data"] == {"sequence": 1}
-
-    bus.emit("button.press", data={"sequence": 2})
-    assert second_created.wait(timeout=1.0)
-    assert created_payloads[1]["trigger_event"]["data"] == {"sequence": 2}
-
-    first_run = created_payloads[0]["playlist_id"]
-    second_run = created_payloads[1]["playlist_id"]
-
-    assert first_stopped.wait(timeout=1.0)
-    assert stop_payloads[0]["reason"] == "cancelled"
-    assert bus.playlists.join(first_run, timeout=1.0)
-
-    assert second_stopped.wait(timeout=1.0)
-    assert stop_payloads[1]["reason"] == "completed"
-    assert bus.playlists.join(second_run, timeout=1.0)
-
-@pytest.mark.parametrize(
-    "data_factory, mutator",
-    [
-        (
-            lambda: {"value": 0},
-            lambda event: event.data.__setitem__(
-                "value", event.data["value"] + 1
-            ),
-        ),
-        (
-            lambda: [1, 2],
-            lambda event: event.data.append("mutated"),
-        ),
-        (
-            lambda: ("base", {"count": 0}),
-            lambda event: event.data[1].__setitem__(
-                "count", event.data[1]["count"] + 1
-            ),
-        ),
-    ],
-)
-def test_playlist_step_payloads_are_isolated(data_factory, mutator) -> None:
-    bus = EventBus()
-    mutated_payloads: list[Any] = []
-    telemetry_snapshots: list[Any] = []
-
-    bus.subscribe(
-        "mutable.event",
-        lambda event: (mutator(event), mutated_payloads.append(event.data)),
-    )
-    bus.subscribe(
-        EventPlaylistManager.EVENT_EMITTED,
-        lambda event: telemetry_snapshots.append(event.data["data"]),
-    )
-
-    playlist = EventPlaylist(
-        name="mutable",
-        steps=[
-            PlaylistStep(
-                event_type="mutable.event",
-                data=data_factory(),
-                offset=0.0,
-                repeat=2,
-                interval=0.01,
-            )
-        ],
-    )
-    handle = bus.playlists.register(playlist)
-
-    run_id = bus.playlists.start(handle)
-    assert bus.playlists.join(run_id, timeout=1.0)
-
-    expected = data_factory()
-    assert telemetry_snapshots == [expected, expected]
-    assert len(mutated_payloads) == 2
-    assert mutated_payloads[0] == mutated_payloads[1]
-    assert mutated_payloads[0] != expected
-
-
-def test_playlist_created_payload_mutation_does_not_affect_run() -> None:
-    bus = EventBus()
-    observed: list[int] = []
-
-    bus.subscribe(
-        EventPlaylistManager.EVENT_CREATED,
-        lambda event: event.data["steps"][0]["data"].__setitem__("value", 99),
-    )
-    bus.subscribe(
-        "color.update",
-        lambda event: observed.append(event.data["value"]),
-    )
-
-    playlist = EventPlaylist(
-        name="immutable",
-        steps=[
-            PlaylistStep(
-                event_type="color.update",
-                data={"value": 7},
-                offset=0.0,
-            )
-        ],
-    )
-    handle = bus.playlists.register(playlist)
-
-    run_id = bus.playlists.start(handle)
-    assert bus.playlists.join(run_id, timeout=1.0)
-
-    assert observed == [7]
-
-
-def test_virtual_double_tap_emits_enriched_payload() -> None:
-    bus = EventBus()
-    captured: list[dict] = []
-
-    definition = double_tap_virtual_peripheral(
-        "button.press",
-        output_event_type="button.double_tap",
-        window=0.5,
-        metadata={"gesture": "double"},
-    )
-    bus.virtual_peripherals.register(definition)
-
-    bus.subscribe(
-        "button.double_tap",
-        lambda event: captured.append(event.data),
-    )
-
-    bus.emit("button.press", data={"state": "down"}, producer_id=1)
-    bus.emit("button.press", data={"state": "down"}, producer_id=1)
-
-    assert captured
-    payload = captured[0]
-    assert payload["virtual_peripheral"]["name"] == definition.name
-    assert payload["virtual_peripheral"]["metadata"] == {"gesture": "double"}
-    assert [item["data"] for item in payload["events"]] == [
-        {"state": "down"},
-        {"state": "down"},
-    ]
-
-    captured.clear()
-    time.sleep(0.6)
-    bus.emit("button.press", data={"state": "down"}, producer_id=1)
-    time.sleep(0.6)
-    bus.emit("button.press", data={"state": "down"}, producer_id=1)
-    assert not captured
-
-
-def test_virtual_simultaneous_detector_requires_distinct_producers() -> None:
-    bus = EventBus()
-    detected: list[dict] = []
-
-    bus.virtual_peripherals.register(
-        simultaneous_virtual_peripheral(
-            "sensor.trigger",
-            output_event_type="sensor.combo",
-            window=0.05,
-            required_sources=2,
+        bus.emit("tick", data="value", producer_id=42)
+
+        assert captured == [42]
+
+
+
+    def test_subscriber_failures_do_not_block_others(self, caplog: pytest.LogCaptureFixture):
+        """Verify that subscriber failures do not block others. This ensures one buggy subscriber cannot stall the event pipeline."""
+        bus = EventBus()
+        caplog.set_level("ERROR")
+        calls: list[str] = []
+
+        def _bad(_: Input) -> None:
+            raise RuntimeError("boom")
+
+        bus.subscribe("sensor", _bad)
+        bus.subscribe("sensor", lambda event: calls.append(event.event_type))
+
+        bus.emit(Input(event_type="sensor", data={}))
+
+        assert calls == ["sensor"]
+        assert any("EventBus subscriber" in message for message in caplog.messages)
+
+
+
+    def test_emit_updates_state_store_before_callbacks(self):
+        """Verify that emit updates state store before callbacks. This guarantees observers see consistent state snapshots."""
+        bus = EventBus()
+
+        observed: list[int] = []
+
+        def _handler(event: Input) -> None:
+            entry = bus.state_store.get_latest(event.event_type, producer_id=event.producer_id)
+            assert entry is not None
+            observed.append(entry.producer_id)
+
+        bus.subscribe("button", _handler)
+
+        bus.emit("button", data={"pressed": True}, producer_id=2)
+
+        assert observed == [2]
+
+
+
+    def test_playlist_manual_start_runs_to_completion(self) -> None:
+        """Verify that playlist manual start runs to completion. This proves automation sequences finish reliably when triggered programmatically."""
+        bus = EventBus()
+        emitted_values: list[int] = []
+        playlist_events: list[dict] = []
+        stops: list[dict] = []
+        completions: list[dict] = []
+
+        bus.subscribe(
+            "color.update",
+            lambda event: emitted_values.append(event.data["value"]),
         )
+        bus.subscribe(
+            EventPlaylistManager.EVENT_EMITTED,
+            lambda event: playlist_events.append(event.data),
+        )
+        bus.subscribe(
+            EventPlaylistManager.EVENT_STOPPED,
+            lambda event: stops.append(event.data),
+        )
+
+        playlist = EventPlaylist(
+            name="cycle",
+            steps=[
+                PlaylistStep(
+                    event_type="color.update",
+                    data={"value": 7},
+                    offset=0.0,
+                    repeat=3,
+                    interval=0.01,
+                    producer_id=5,
+                )
+            ],
+            completion_event_type="color.cycle.complete",
+            metadata={"mode": "test"},
+        )
+        handle: PlaylistHandle = bus.playlists.register(playlist)
+
+        bus.subscribe(
+            "color.cycle.complete",
+            lambda event: completions.append(event.data),
+        )
+
+        run_id = bus.playlists.start(handle)
+        assert bus.playlists.join(run_id, timeout=1.0)
+
+        assert emitted_values == [7, 7, 7]
+        assert [item["repeat_index"] for item in playlist_events] == [0, 1, 2]
+        assert all(item["data"] == {"value": 7} for item in playlist_events)
+        assert stops and stops[0]["reason"] == "completed"
+        assert stops[0]["playlist_metadata"] == {"mode": "test"}
+        assert completions and completions[0]["playlist_id"] == run_id
+        assert completions[0]["playlist_metadata"] == {"mode": "test"}
+
+
+
+    def test_playlist_trigger_interrupted_by_event(self) -> None:
+        """Verify that playlist trigger interrupted by event. This shows playlists respond promptly to stop signals for safety."""
+        bus = EventBus()
+        created_events: list[dict] = []
+        emitted_events: list[dict] = []
+        stop_events: list[dict] = []
+
+        created_ready = threading.Event()
+        emitted_twice = threading.Event()
+
+        bus.subscribe(
+            EventPlaylistManager.EVENT_CREATED,
+            lambda event: (created_events.append(event.data), created_ready.set()),
+        )
+        bus.subscribe(
+            EventPlaylistManager.EVENT_EMITTED,
+            lambda event: (
+                emitted_events.append(event.data),
+                emitted_twice.set()
+                if len(emitted_events) >= 2
+                else None,
+            ),
+        )
+        bus.subscribe(
+            EventPlaylistManager.EVENT_STOPPED,
+            lambda event: stop_events.append(event.data),
+        )
+
+        playlist = EventPlaylist(
+            name="interruptible",
+            steps=[
+                PlaylistStep(
+                    event_type="color.update",
+                    data={"value": 1},
+                    offset=0.0,
+                    repeat=10,
+                    interval=0.05,
+                )
+            ],
+            trigger_event_type="start.sequence",
+            interrupt_events=("stop.sequence",),
+            metadata={"mode": "interrupt"},
+        )
+        bus.playlists.register(playlist)
+
+        bus.emit("start.sequence", data={"begin": True})
+        assert created_ready.wait(timeout=1.0)
+        run_id = created_events[0]["playlist_id"]
+
+        # Wait for at least two emissions before interrupting.
+        assert emitted_twice.wait(timeout=1.0)
+        bus.emit("stop.sequence", data={"reason": "test"})
+
+        assert bus.playlists.join(run_id, timeout=1.0)
+
+        assert stop_events and stop_events[0]["reason"] == "interrupted"
+        interrupt_data = stop_events[0]["interrupt_event"]
+        assert interrupt_data["event_type"] == "stop.sequence"
+        assert interrupt_data["data"] == {"reason": "test"}
+        assert created_events[0]["trigger_event"]["data"] == {"begin": True}
+        assert created_events[0]["playlist_metadata"] == {"mode": "interrupt"}
+        assert emitted_events
+        assert len(emitted_events) < 10
+
+
+
+    def test_virtual_peripheral_definitions_bind_resources(self) -> None:
+        """Verify that virtual peripheral definitions bind resources. This keeps dependency injection sane so virtual peripherals remain testable."""
+        bus = EventBus()
+        captured: dict[str, Any] = {}
+        handled: list[int] = []
+
+        class DummyVirtualPeripheral:
+            def __init__(self, context: VirtualPeripheralContext) -> None:
+                self._context = context
+                captured["context"] = context
+                captured["foo"] = context.get_resource("foo")
+                captured["combo"] = context.get_resource("combo")
+                captured["state_store"] = context.resources["state_store"]
+
+            def handle(self, event: Input) -> None:
+                handled.append(self._context.get_resource("foo"))
+
+            def shutdown(self) -> None:
+                captured["shutdown"] = True
+
+        definition = VirtualPeripheralDefinition(
+            name="dummy.resources",
+            event_types=("button.press",),
+            factory=DummyVirtualPeripheral,
+            resources={
+                "foo": lambda ctx: 41,
+                "combo": lambda ctx: ctx.get_resource("foo") + 1,
+                "state_store": lambda ctx: ctx.state_store,
+            },
+        )
+
+        handle = bus.virtual_peripherals.register(definition)
+        bus.emit("button.press", data={})
+
+        assert handled == [41]
+        assert captured["foo"] == 41
+        assert captured["combo"] == 42
+        assert captured["state_store"] is bus.state_store
+
+        resources = bus.virtual_peripherals.list_definitions()[handle.peripheral_id].resources
+        assert resources is not None
+        with pytest.raises(TypeError):
+            cast(dict[str, Any], resources)["foo"] = 99
+
+        dummy_context = captured["context"]
+        with pytest.raises(TypeError):
+            cast(dict[str, Any], dummy_context.resources)["foo"] = 5
+        with pytest.raises(KeyError):
+            dummy_context.get_resource("missing")
+
+        bus.virtual_peripherals.remove(handle)
+        assert captured.get("shutdown") is True
+
+
+    def test_gated_playlist_virtual_peripheral_runs_playlist(self) -> None:
+        """Verify that gated playlist virtual peripheral runs playlist. This confirms event-driven lighting cues respond to gate signals."""
+        bus = EventBus()
+        outputs: list[int] = []
+        created_payloads: list[Mapping[str, Any]] = []
+        stop_payloads: list[Mapping[str, Any]] = []
+
+        created_ready = threading.Event()
+        stopped_ready = threading.Event()
+
+        bus.subscribe(
+            "color.update",
+            lambda event: outputs.append(event.data["value"]),
+        )
+        bus.subscribe(
+            EventPlaylistManager.EVENT_CREATED,
+            lambda event: (created_payloads.append(event.data), created_ready.set()),
+        )
+        bus.subscribe(
+            EventPlaylistManager.EVENT_STOPPED,
+            lambda event: (stop_payloads.append(event.data), stopped_ready.set()),
+        )
+
+        playlist = EventPlaylist(
+            name="flash",
+            steps=[
+                PlaylistStep(
+                    event_type="color.update",
+                    data={"value": 1},
+                    offset=0.0,
+                    repeat=2,
+                    interval=0.01,
+                    producer_id=7,
+                )
+            ],
+            metadata={"mode": "flash"},
+        )
+
+        definition = gated_playlist_virtual_peripheral(
+            ("button.press",),
+            playlist=playlist,
+            name="button.flash",
+        )
+        bus.virtual_peripherals.register(definition)
+
+        bus.emit("button.press", data={"intensity": 3}, producer_id=2)
+
+        assert created_ready.wait(timeout=1.0)
+        run_id = created_payloads[0]["playlist_id"]
+        assert bus.playlists.join(run_id, timeout=1.0)
+        assert stopped_ready.wait(timeout=1.0)
+
+        assert outputs == [1, 1]
+        assert created_payloads[0]["trigger_event"]["data"] == {"intensity": 3}
+        assert stop_payloads[0]["reason"] == "completed"
+
+
+
+    def test_gated_playlist_virtual_peripheral_cancels_previous_runs(self) -> None:
+        """Verify that gated playlist virtual peripheral cancels previous runs. This prevents overlapping animations that could overload devices."""
+        bus = EventBus()
+        created_payloads: list[Mapping[str, Any]] = []
+        stop_payloads: list[Mapping[str, Any]] = []
+
+        first_created = threading.Event()
+        second_created = threading.Event()
+        first_stopped = threading.Event()
+        second_stopped = threading.Event()
+
+        def handle_created(event: Input) -> None:
+            created_payloads.append(event.data)
+            if len(created_payloads) == 1:
+                first_created.set()
+            elif len(created_payloads) == 2:
+                second_created.set()
+
+        def handle_stopped(event: Input) -> None:
+            stop_payloads.append(event.data)
+            if len(stop_payloads) == 1:
+                first_stopped.set()
+            elif len(stop_payloads) == 2:
+                second_stopped.set()
+
+        bus.subscribe(EventPlaylistManager.EVENT_CREATED, handle_created)
+        bus.subscribe(EventPlaylistManager.EVENT_STOPPED, handle_stopped)
+
+        playlist = EventPlaylist(
+            name="long",
+            steps=[
+                PlaylistStep(
+                    event_type="color.update",
+                    data={"value": 9},
+                    offset=0.0,
+                    repeat=5,
+                    interval=0.05,
+                )
+            ],
+        )
+
+        definition = gated_playlist_virtual_peripheral(
+            ("button.press",),
+            playlist=playlist,
+            cancel_active_runs=True,
+        )
+        bus.virtual_peripherals.register(definition)
+
+        bus.emit("button.press", data={"sequence": 1})
+        assert first_created.wait(timeout=1.0)
+        assert created_payloads[0]["trigger_event"]["data"] == {"sequence": 1}
+
+        bus.emit("button.press", data={"sequence": 2})
+        assert second_created.wait(timeout=1.0)
+        assert created_payloads[1]["trigger_event"]["data"] == {"sequence": 2}
+
+        first_run = created_payloads[0]["playlist_id"]
+        second_run = created_payloads[1]["playlist_id"]
+
+        assert first_stopped.wait(timeout=1.0)
+        assert stop_payloads[0]["reason"] == "cancelled"
+        assert bus.playlists.join(first_run, timeout=1.0)
+
+        assert second_stopped.wait(timeout=1.0)
+        assert stop_payloads[1]["reason"] == "completed"
+        assert bus.playlists.join(second_run, timeout=1.0)
+
+
+    @pytest.mark.parametrize(
+        "data_factory, mutator",
+        [
+            (
+                lambda: {"value": 0},
+                lambda event: event.data.__setitem__(
+                    "value", event.data["value"] + 1
+                ),
+            ),
+            (
+                lambda: [1, 2],
+                lambda event: event.data.append("mutated"),
+            ),
+            (
+                lambda: ("base", {"count": 0}),
+                lambda event: event.data[1].__setitem__(
+                    "count", event.data[1]["count"] + 1
+                ),
+            ),
+        ],
     )
+    def test_playlist_step_payloads_are_isolated(self, data_factory, mutator) -> None:
+        """Verify that playlist step payloads are isolated. This shields reusable playlists from subscriber mutations."""
+        bus = EventBus()
+        mutated_payloads: list[Any] = []
+        telemetry_snapshots: list[Any] = []
 
-    bus.subscribe("sensor.combo", lambda event: detected.append(event.data))
+        bus.subscribe(
+            "mutable.event",
+            lambda event: (mutator(event), mutated_payloads.append(event.data)),
+        )
+        bus.subscribe(
+            EventPlaylistManager.EVENT_EMITTED,
+            lambda event: telemetry_snapshots.append(event.data["data"]),
+        )
 
-    bus.emit("sensor.trigger", data={"value": 1}, producer_id=1)
-    time.sleep(0.005)
-    bus.emit("sensor.trigger", data={"value": 2}, producer_id=2)
+        playlist = EventPlaylist(
+            name="mutable",
+            steps=[
+                PlaylistStep(
+                    event_type="mutable.event",
+                    data=data_factory(),
+                    offset=0.0,
+                    repeat=2,
+                    interval=0.01,
+                )
+            ],
+        )
+        handle = bus.playlists.register(playlist)
 
-    assert detected
-    payload = detected[0]
-    producers = {item["producer_id"] for item in payload["events"]}
-    assert producers == {1, 2}
+        run_id = bus.playlists.start(handle)
+        assert bus.playlists.join(run_id, timeout=1.0)
 
-    detected.clear()
-    time.sleep(0.06)
-    bus.emit("sensor.trigger", data={"value": 3}, producer_id=1)
-    bus.emit("sensor.trigger", data={"value": 4}, producer_id=1)
-    assert not detected
+        expected = data_factory()
+        assert telemetry_snapshots == [expected, expected]
+        assert len(mutated_payloads) == 2
+        assert mutated_payloads[0] == mutated_payloads[1]
+        assert mutated_payloads[0] != expected
 
 
-def test_sequence_virtual_peripheral_detects_konami_code() -> None:
-    bus = EventBus()
-    detected: list[dict] = []
 
-    konami = [
-        "up",
-        "up",
-        "down",
-        "down",
-        "left",
-        "right",
-        "left",
-        "right",
-        "b",
-        "a",
-    ]
+    def test_playlist_created_payload_mutation_does_not_affect_run(self) -> None:
+        """Verify that playlist created payload mutation does not affect run. This demonstrates emitted telemetry is isolated from observers."""
+        bus = EventBus()
+        observed: list[int] = []
 
-    matchers = [
-        SequenceMatcher(
+        bus.subscribe(
+            EventPlaylistManager.EVENT_CREATED,
+            lambda event: event.data["steps"][0]["data"].__setitem__("value", 99),
+        )
+        bus.subscribe(
+            "color.update",
+            lambda event: observed.append(event.data["value"]),
+        )
+
+        playlist = EventPlaylist(
+            name="immutable",
+            steps=[
+                PlaylistStep(
+                    event_type="color.update",
+                    data={"value": 7},
+                    offset=0.0,
+                )
+            ],
+        )
+        handle = bus.playlists.register(playlist)
+
+        run_id = bus.playlists.start(handle)
+        assert bus.playlists.join(run_id, timeout=1.0)
+
+        assert observed == [7]
+
+
+
+    def test_virtual_double_tap_emits_enriched_payload(self) -> None:
+        """Verify that virtual double tap emits enriched payload. This powers advanced gesture detection for richer interactions."""
+        bus = EventBus()
+        captured: list[dict] = []
+
+        definition = double_tap_virtual_peripheral(
             "button.press",
-            predicate=lambda event, expected=direction: event.data["code"]
-            == expected,
+            output_event_type="button.double_tap",
+            window=0.5,
+            metadata={"gesture": "double"},
         )
-        for direction in konami
-    ]
+        bus.virtual_peripherals.register(definition)
 
-    definition = sequence_virtual_peripheral(
-        name="konami.listener",
-        matchers=matchers,
-        output_event_type="konami.activated",
-        timeout=1.0,
-        metadata={"combo": "konami"},
-    )
-    bus.virtual_peripherals.register(definition)
+        bus.subscribe(
+            "button.double_tap",
+            lambda event: captured.append(event.data),
+        )
 
-    bus.subscribe(
-        "konami.activated",
-        lambda event: detected.append(event.data),
-    )
+        bus.emit("button.press", data={"state": "down"}, producer_id=1)
+        bus.emit("button.press", data={"state": "down"}, producer_id=1)
 
-    bus.emit("button.press", data={"code": "up"}, producer_id=7)
-    bus.emit("button.press", data={"code": "left"}, producer_id=7)
-    assert not detected
+        assert captured
+        payload = captured[0]
+        assert payload["virtual_peripheral"]["name"] == definition.name
+        assert payload["virtual_peripheral"]["metadata"] == {"gesture": "double"}
+        assert [item["data"] for item in payload["events"]] == [
+            {"state": "down"},
+            {"state": "down"},
+        ]
 
-    for direction in konami:
-        bus.emit("button.press", data={"code": direction}, producer_id=7)
-
-    assert detected
-    payload = detected[0]
-    assert payload["virtual_peripheral"]["name"] == "konami.listener"
-    assert payload["virtual_peripheral"]["metadata"] == {"combo": "konami"}
-    assert [item["data"]["code"] for item in payload["sequence"]] == konami
+        captured.clear()
+        time.sleep(0.6)
+        bus.emit("button.press", data={"state": "down"}, producer_id=1)
+        time.sleep(0.6)
+        bus.emit("button.press", data={"state": "down"}, producer_id=1)
+        assert not captured
 
 
-def test_gated_mirror_virtual_peripheral_re_emits_with_virtual_metadata() -> None:
-    bus = EventBus()
-    captured: list[Input] = []
 
-    definition = gated_mirror_virtual_peripheral(
-        "microphone.gated",
-        gate_event_type="button.toggle",
-        mirror_event_types="peripheral.microphone.level",
-        output_producer_id=99,
-        metadata={"mode": "gated"},
-    )
-    bus.virtual_peripherals.register(definition)
+    def test_virtual_simultaneous_detector_requires_distinct_producers(self) -> None:
+        """Verify that virtual simultaneous detector requires distinct producers. This prevents false positives when a single sensor fires rapidly."""
+        bus = EventBus()
+        detected: list[dict] = []
 
-    bus.subscribe(
-        "peripheral.microphone.level",
-        lambda event: captured.append(event),
-    )
+        bus.virtual_peripherals.register(
+            simultaneous_virtual_peripheral(
+                "sensor.trigger",
+                output_event_type="sensor.combo",
+                window=0.05,
+                required_sources=2,
+            )
+        )
 
-    # Events should be ignored while the gate is off.
-    bus.emit(
-        "peripheral.microphone.level",
-        data={"rms": 0.2, "peak": 0.3},
-        producer_id=7,
-    )
-    assert not [event for event in captured if event.producer_id == 99]
+        bus.subscribe("sensor.combo", lambda event: detected.append(event.data))
 
-    # Enable the gate and verify mirrored events include metadata.
-    bus.emit("button.toggle", data={"pressed": True}, producer_id=1)
-    bus.emit(
-        "peripheral.microphone.level",
-        data={"rms": 0.4, "peak": 0.5},
-        producer_id=7,
-    )
+        bus.emit("sensor.trigger", data={"value": 1}, producer_id=1)
+        time.sleep(0.005)
+        bus.emit("sensor.trigger", data={"value": 2}, producer_id=2)
 
-    mirrored = [event for event in captured if event.producer_id == 99]
-    assert mirrored
-    mirrored_event = mirrored[-1]
-    assert mirrored_event.data["rms"] == 0.4
-    assert mirrored_event.data["virtual_peripheral"]["name"] == "microphone.gated"
-    assert mirrored_event.data["virtual_peripheral"]["metadata"] == {"mode": "gated"}
+        assert detected
+        payload = detected[0]
+        producers = {item["producer_id"] for item in payload["events"]}
+        assert producers == {1, 2}
 
-    # Disable the gate and ensure mirroring stops.
-    bus.emit("button.toggle", data={"pressed": False}, producer_id=1)
-    bus.emit(
-        "peripheral.microphone.level",
-        data={"rms": 0.6, "peak": 0.7},
-        producer_id=7,
-    )
-
-    later_mirrored = [event for event in captured if event.producer_id == 99]
-    assert later_mirrored == mirrored
+        detected.clear()
+        time.sleep(0.06)
+        bus.emit("sensor.trigger", data={"value": 3}, producer_id=1)
+        bus.emit("sensor.trigger", data={"value": 4}, producer_id=1)
+        assert not detected
 
 
-def test_gated_mirror_virtual_peripheral_supports_composed_conditions() -> None:
-    bus = EventBus()
-    captured: list[Input] = []
 
-    def _truthy(data: Any) -> bool:
-        if isinstance(data, Mapping):
-            for key in ("pressed", "state", "enabled", "value", "active"):
-                if key in data:
-                    return bool(data[key])
+    def test_sequence_virtual_peripheral_detects_konami_code(self) -> None:
+        """Verify that sequence virtual peripheral detects konami code. This showcases complex input macros built from primitive events."""
+        bus = EventBus()
+        detected: list[dict] = []
+
+        konami = [
+            "up",
+            "up",
+            "down",
+            "down",
+            "left",
+            "right",
+            "left",
+            "right",
+            "b",
+            "a",
+        ]
+
+        matchers = [
+            SequenceMatcher(
+                "button.press",
+                predicate=lambda event, expected=direction: event.data["code"]
+                == expected,
+            )
+            for direction in konami
+        ]
+
+        definition = sequence_virtual_peripheral(
+            name="konami.listener",
+            matchers=matchers,
+            output_event_type="konami.activated",
+            timeout=1.0,
+            metadata={"combo": "konami"},
+        )
+        bus.virtual_peripherals.register(definition)
+
+        bus.subscribe(
+            "konami.activated",
+            lambda event: detected.append(event.data),
+        )
+
+        bus.emit("button.press", data={"code": "up"}, producer_id=7)
+        bus.emit("button.press", data={"code": "left"}, producer_id=7)
+        assert not detected
+
+        for direction in konami:
+            bus.emit("button.press", data={"code": direction}, producer_id=7)
+
+        assert detected
+        payload = detected[0]
+        assert payload["virtual_peripheral"]["name"] == "konami.listener"
+        assert payload["virtual_peripheral"]["metadata"] == {"combo": "konami"}
+        assert [item["data"]["code"] for item in payload["sequence"]] == konami
+
+
+
+    def test_gated_mirror_virtual_peripheral_re_emits_with_virtual_metadata(self) -> None:
+        """Verify that gated mirror virtual peripheral re-emits with virtual metadata. This keeps mirrored streams attributed to their virtual origin."""
+        bus = EventBus()
+        captured: list[Input] = []
+
+        definition = gated_mirror_virtual_peripheral(
+            "microphone.gated",
+            gate_event_type="button.toggle",
+            mirror_event_types="peripheral.microphone.level",
+            output_producer_id=99,
+            metadata={"mode": "gated"},
+        )
+        bus.virtual_peripherals.register(definition)
+
+        bus.subscribe(
+            "peripheral.microphone.level",
+            lambda event: captured.append(event),
+        )
+
+        # Events should be ignored while the gate is off.
+        bus.emit(
+            "peripheral.microphone.level",
+            data={"rms": 0.2, "peak": 0.3},
+            producer_id=7,
+        )
+        assert not [event for event in captured if event.producer_id == 99]
+
+        # Enable the gate and verify mirrored events include metadata.
+        bus.emit("button.toggle", data={"pressed": True}, producer_id=1)
+        bus.emit(
+            "peripheral.microphone.level",
+            data={"rms": 0.4, "peak": 0.5},
+            producer_id=7,
+        )
+
+        mirrored = [event for event in captured if event.producer_id == 99]
+        assert mirrored
+        mirrored_event = mirrored[-1]
+        assert mirrored_event.data["rms"] == 0.4
+        assert mirrored_event.data["virtual_peripheral"]["name"] == "microphone.gated"
+        assert mirrored_event.data["virtual_peripheral"]["metadata"] == {"mode": "gated"}
+
+        # Disable the gate and ensure mirroring stops.
+        bus.emit("button.toggle", data={"pressed": False}, producer_id=1)
+        bus.emit(
+            "peripheral.microphone.level",
+            data={"rms": 0.6, "peak": 0.7},
+            producer_id=7,
+        )
+
+        later_mirrored = [event for event in captured if event.producer_id == 99]
+        assert later_mirrored == mirrored
+
+
+
+    def test_gated_mirror_virtual_peripheral_supports_composed_conditions(self) -> None:
+        """Verify that gated mirror virtual peripheral supports composed conditions. This enables complex gating logic for nuanced control flows."""
+        bus = EventBus()
+        captured: list[Input] = []
+
+        def _truthy(data: Any) -> bool:
+            if isinstance(data, Mapping):
+                for key in ("pressed", "state", "enabled", "value", "active"):
+                    if key in data:
+                        return bool(data[key])
+                return bool(data)
             return bool(data)
-        return bool(data)
 
-    def _predicate(context, event: Input) -> bool:
-        button_entry = context.state_store.get_latest("button.toggle")
-        combo_entry = context.state_store.get_latest("combo.activated")
-        button_active = _truthy(button_entry.data) if button_entry else False
-        combo_active = _truthy(combo_entry.data) if combo_entry else False
-        return button_active and combo_active
+        def _predicate(context, event: Input) -> bool:
+            button_entry = context.state_store.get_latest("button.toggle")
+            combo_entry = context.state_store.get_latest("combo.activated")
+            button_active = _truthy(button_entry.data) if button_entry else False
+            combo_active = _truthy(combo_entry.data) if combo_entry else False
+            return button_active and combo_active
 
-    definition = gated_mirror_virtual_peripheral(
-        "microphone.combo",
-        gate_event_type=("button.toggle", "combo.activated"),
-        mirror_event_types="peripheral.microphone.level",
-        output_producer_id=101,
-        gate_predicate=_predicate,
-    )
-    bus.virtual_peripherals.register(definition)
+        definition = gated_mirror_virtual_peripheral(
+            "microphone.combo",
+            gate_event_type=("button.toggle", "combo.activated"),
+            mirror_event_types="peripheral.microphone.level",
+            output_producer_id=101,
+            gate_predicate=_predicate,
+        )
+        bus.virtual_peripherals.register(definition)
 
-    bus.subscribe(
-        "peripheral.microphone.level",
-        lambda event: captured.append(event),
-    )
+        bus.subscribe(
+            "peripheral.microphone.level",
+            lambda event: captured.append(event),
+        )
 
-    def _mirrored() -> list[Input]:
-        return [event for event in captured if event.producer_id == 101]
+        def _mirrored() -> list[Input]:
+            return [event for event in captured if event.producer_id == 101]
 
-    bus.emit("peripheral.microphone.level", data={"rms": 0.1}, producer_id=7)
-    assert not _mirrored()
+        bus.emit("peripheral.microphone.level", data={"rms": 0.1}, producer_id=7)
+        assert not _mirrored()
 
-    bus.emit("combo.activated", data={"active": True}, producer_id=3)
-    bus.emit("peripheral.microphone.level", data={"rms": 0.2}, producer_id=7)
-    assert not _mirrored()
+        bus.emit("combo.activated", data={"active": True}, producer_id=3)
+        bus.emit("peripheral.microphone.level", data={"rms": 0.2}, producer_id=7)
+        assert not _mirrored()
 
-    bus.emit("button.toggle", data={"pressed": True}, producer_id=1)
-    bus.emit("peripheral.microphone.level", data={"rms": 0.3}, producer_id=7)
-    mirrored = _mirrored()
-    assert mirrored and mirrored[-1].data["rms"] == 0.3
+        bus.emit("button.toggle", data={"pressed": True}, producer_id=1)
+        bus.emit("peripheral.microphone.level", data={"rms": 0.3}, producer_id=7)
+        mirrored = _mirrored()
+        assert mirrored and mirrored[-1].data["rms"] == 0.3
 
-    bus.emit("combo.activated", data={"active": False}, producer_id=3)
-    bus.emit("peripheral.microphone.level", data={"rms": 0.4}, producer_id=7)
-    assert mirrored == _mirrored()
+        bus.emit("combo.activated", data={"active": False}, producer_id=3)
+        bus.emit("peripheral.microphone.level", data={"rms": 0.4}, producer_id=7)
+        assert mirrored == _mirrored()

--- a/tests/peripheral/test_force_event_bus.py
+++ b/tests/peripheral/test_force_event_bus.py
@@ -5,62 +5,72 @@ from heart.peripheral.core.event_bus import EventBus
 from heart.peripheral.force import ForcePeripheral
 
 
-def test_force_peripheral_emits_event() -> None:
-    bus = EventBus()
-    captured = []
+class TestPeripheralForceEventBus:
+    """Group Peripheral Force Event Bus tests so peripheral force event bus behaviour stays reliable. This preserves confidence in peripheral force event bus for end-to-end scenarios."""
 
-    def _capture(event):
-        captured.append(event)
+    def test_force_peripheral_emits_event(self) -> None:
+        """Verify that force peripheral emits event. This confirms load cell readings reach consumers for haptic feedback."""
+        bus = EventBus()
+        captured = []
 
-    bus.subscribe(ForceMeasurement.EVENT_TYPE, _capture)
-    peripheral = ForcePeripheral(event_bus=bus, producer_id=42)
+        def _capture(event):
+            captured.append(event)
 
-    event = peripheral.record_force(force_type="tensile", magnitude=12.5, unit="N")
+        bus.subscribe(ForceMeasurement.EVENT_TYPE, _capture)
+        peripheral = ForcePeripheral(event_bus=bus, producer_id=42)
 
-    assert captured
-    emitted = captured[0]
-    assert emitted is event
-    assert emitted.event_type == ForceMeasurement.EVENT_TYPE
-    assert emitted.data["type"] == "tensile"
-    assert emitted.data["magnitude"] == pytest.approx(12.5)
-    assert emitted.data["unit"] == "N"
-    assert emitted.producer_id == 42
+        event = peripheral.record_force(force_type="tensile", magnitude=12.5, unit="N")
 
-
-def test_force_peripheral_normalizes_payload() -> None:
-    bus = EventBus()
-    captured = []
-
-    bus.subscribe(ForceMeasurement.EVENT_TYPE, captured.append)
-    peripheral = ForcePeripheral(event_bus=bus, producer_id=7)
-
-    peripheral.update_due_to_data(
-        {
-            "event_type": ForceMeasurement.EVENT_TYPE,
-            "data": {"force_type": "MAGNETIC", "magnitude": "3.5", "unit": "mT"},
-        }
-    )
-
-    assert captured
-    event = captured[0]
-    assert event.data["type"] == "magnetic"
-    assert event.data["magnitude"] == pytest.approx(3.5)
-    assert event.data["unit"] == "mT"
-    assert event.producer_id == 7
+        assert captured
+        emitted = captured[0]
+        assert emitted is event
+        assert emitted.event_type == ForceMeasurement.EVENT_TYPE
+        assert emitted.data["type"] == "tensile"
+        assert emitted.data["magnitude"] == pytest.approx(12.5)
+        assert emitted.data["unit"] == "N"
+        assert emitted.producer_id == 42
 
 
-def test_force_peripheral_rejects_invalid_payload() -> None:
-    bus = EventBus()
-    captured = []
 
-    bus.subscribe(ForceMeasurement.EVENT_TYPE, captured.append)
-    peripheral = ForcePeripheral(event_bus=bus)
+    def test_force_peripheral_normalizes_payload(self) -> None:
+        """Verify that force peripheral normalizes payload. This ensures mixed-case inputs still produce canonical telemetry."""
+        bus = EventBus()
+        captured = []
 
-    peripheral.update_due_to_data({"data": {"force_type": "gravity", "magnitude": 9.81}})
+        bus.subscribe(ForceMeasurement.EVENT_TYPE, captured.append)
+        peripheral = ForcePeripheral(event_bus=bus, producer_id=7)
 
-    assert not captured
+        peripheral.update_due_to_data(
+            {
+                "event_type": ForceMeasurement.EVENT_TYPE,
+                "data": {"force_type": "MAGNETIC", "magnitude": "3.5", "unit": "mT"},
+            }
+        )
+
+        assert captured
+        event = captured[0]
+        assert event.data["type"] == "magnetic"
+        assert event.data["magnitude"] == pytest.approx(3.5)
+        assert event.data["unit"] == "mT"
+        assert event.producer_id == 7
 
 
-def test_force_measurement_validates_type() -> None:
-    with pytest.raises(ValueError):
-        ForceMeasurement(magnitude=1.0, force_type="gravity")
+
+    def test_force_peripheral_rejects_invalid_payload(self) -> None:
+        """Verify that force peripheral rejects invalid payload. This prevents malformed packets from polluting analytics."""
+        bus = EventBus()
+        captured = []
+
+        bus.subscribe(ForceMeasurement.EVENT_TYPE, captured.append)
+        peripheral = ForcePeripheral(event_bus=bus)
+
+        peripheral.update_due_to_data({"data": {"force_type": "gravity", "magnitude": 9.81}})
+
+        assert not captured
+
+
+
+    def test_force_measurement_validates_type(self) -> None:
+        """Verify that force measurement validates type. This protects against unsupported force semantics entering the system."""
+        with pytest.raises(ValueError):
+            ForceMeasurement(magnitude=1.0, force_type="gravity")

--- a/tests/peripheral/test_heart_rate_event_bus.py
+++ b/tests/peripheral/test_heart_rate_event_bus.py
@@ -5,28 +5,32 @@ from heart.peripheral.core.event_bus import EventBus
 from heart.peripheral.heart_rates import HeartRateManager
 
 
-def test_heart_rate_manager_emits_measurements_and_lifecycle():
-    bus = EventBus()
-    measurements = []
-    lifecycle = []
+class TestPeripheralHeartRateEventBus:
+    """Group Peripheral Heart Rate Event Bus tests so peripheral heart rate event bus behaviour stays reliable. This preserves confidence in peripheral heart rate event bus for end-to-end scenarios."""
 
-    bus.subscribe(HeartRateMeasurement.EVENT_TYPE, measurements.append)
-    bus.subscribe(HeartRateLifecycle.EVENT_TYPE, lifecycle.append)
+    def test_heart_rate_manager_emits_measurements_and_lifecycle(self):
+        """Verify that heart rate manager emits measurements and lifecycle. This ensures event orchestration remains reliable."""
+        bus = EventBus()
+        measurements = []
+        lifecycle = []
 
-    manager = HeartRateManager(event_bus=bus)
+        bus.subscribe(HeartRateMeasurement.EVENT_TYPE, measurements.append)
+        bus.subscribe(HeartRateLifecycle.EVENT_TYPE, lifecycle.append)
 
-    sample = SimpleNamespace(heart_rate=72, battery_percentage=128)
+        manager = HeartRateManager(event_bus=bus)
 
-    manager._mark_connected("0A001")
-    manager._publish_measurement("0A001", sample)
-    manager._mark_disconnect("0A001", suspected=True)
+        sample = SimpleNamespace(heart_rate=72, battery_percentage=128)
 
-    assert measurements
-    measurement = measurements[0]
-    assert measurement.data["device_id"] == "0A001"
-    assert measurement.data["bpm"] == 72
-    assert measurement.producer_id == int("0A001", 16)
+        manager._mark_connected("0A001")
+        manager._publish_measurement("0A001", sample)
+        manager._mark_disconnect("0A001", suspected=True)
 
-    statuses = [event.data["status"] for event in lifecycle]
-    assert "connected" in statuses
-    assert "suspected_disconnect" in statuses
+        assert measurements
+        measurement = measurements[0]
+        assert measurement.data["device_id"] == "0A001"
+        assert measurement.data["bpm"] == 72
+        assert measurement.producer_id == int("0A001", 16)
+
+        statuses = [event.data["status"] for event in lifecycle]
+        assert "connected" in statuses
+        assert "suspected_disconnect" in statuses

--- a/tests/peripheral/test_ir_sensor_array.py
+++ b/tests/peripheral/test_ir_sensor_array.py
@@ -20,86 +20,93 @@ def _make_packet(samples: list[IRSample]) -> IRDMAPacket:
     return packet
 
 
-def test_dma_queue_emits_double_buffer_packets():
-    queue = IRArrayDMAQueue(buffer_size=2)
+class TestPeripheralIrSensorArray:
+    """Group Peripheral Ir Sensor Array tests so peripheral ir sensor array behaviour stays reliable. This preserves confidence in peripheral ir sensor array for end-to-end scenarios."""
 
-    samples = [
-        IRSample(frame_id=1, sensor_index=0, timestamp=0.001, level=1, duration_us=500),
-        IRSample(frame_id=1, sensor_index=1, timestamp=0.0015, level=0, duration_us=750),
-        IRSample(frame_id=2, sensor_index=0, timestamp=0.002, level=1, duration_us=900),
-    ]
+    def test_dma_queue_emits_double_buffer_packets(self):
+        """Verify that dma queue emits double buffer packets. This ensures event orchestration remains reliable."""
+        queue = IRArrayDMAQueue(buffer_size=2)
 
-    for sample in samples:
-        queue.push_sample(sample)
+        samples = [
+            IRSample(frame_id=1, sensor_index=0, timestamp=0.001, level=1, duration_us=500),
+            IRSample(frame_id=1, sensor_index=1, timestamp=0.0015, level=0, duration_us=750),
+            IRSample(frame_id=2, sensor_index=0, timestamp=0.002, level=1, duration_us=900),
+        ]
 
-    first = queue.pop()
-    assert first is not None
-    assert first.buffer_id == 0
-    assert first.samples == tuple(samples[:2])
+        for sample in samples:
+            queue.push_sample(sample)
 
-    queue.flush()
-    second = queue.pop()
-    assert second is not None
-    assert second.buffer_id == 1
-    assert second.samples == (samples[2],)
+        first = queue.pop()
+        assert first is not None
+        assert first.buffer_id == 0
+        assert first.samples == tuple(samples[:2])
 
-
-def test_multilateration_solver_converges_on_known_point():
-    sensors = radial_layout(radius=0.2)
-    solver = MultilaterationSolver(sensors)
-    emitter = np.array([0.05, 0.03, 0.02])
-
-    arrival_times = []
-    for sensor in sensors:
-        sensor_vec = np.array(sensor)
-        distance = np.linalg.norm(emitter - sensor_vec)
-        arrival_times.append(distance / SPEED_OF_LIGHT)
-
-    position, confidence, rmse = solver.solve(arrival_times)
-
-    assert np.allclose(position, emitter, atol=1e-3)
-    assert confidence > 0.99
-    assert rmse < 1e-10
+        queue.flush()
+        second = queue.pop()
+        assert second is not None
+        assert second.buffer_id == 1
+        assert second.samples == (samples[2],)
 
 
-def test_sensor_array_emits_frame_event():
-    sensors = radial_layout(radius=0.16)
-    bus = EventBus()
-    captured: list[dict] = []
 
-    bus.subscribe(IRSensorArray.EVENT_FRAME, lambda event: captured.append(event.data))
+    def test_multilateration_solver_converges_on_known_point(self):
+        """Verify that multilateration solver converges on known point. This keeps the system behaviour reliable for operators."""
+        sensors = radial_layout(radius=0.2)
+        solver = MultilaterationSolver(sensors)
+        emitter = np.array([0.05, 0.03, 0.02])
 
-    array = IRSensorArray(sensor_positions=sensors, event_bus=bus)
+        arrival_times = []
+        for sensor in sensors:
+            sensor_vec = np.array(sensor)
+            distance = np.linalg.norm(emitter - sensor_vec)
+            arrival_times.append(distance / SPEED_OF_LIGHT)
 
-    true_position = np.array([0.04, -0.02, 0.01])
-    offsets = {0: 2e-6, 1: -1e-6, 2: 3e-6, 3: -2e-6}
-    array.apply_calibration(offsets)
+        position, confidence, rmse = solver.solve(arrival_times)
 
-    samples: list[IRSample] = []
-    for index, sensor in enumerate(sensors):
-        sensor_vec = np.array(sensor)
-        distance = np.linalg.norm(true_position - sensor_vec)
-        nominal = distance / SPEED_OF_LIGHT
-        observed = nominal + offsets[index]
-        duration = 1200 if index % 2 else 800
-        samples.append(
-            IRSample(
-                frame_id=42,
-                sensor_index=index,
-                timestamp=observed,
-                level=1,
-                duration_us=duration,
+        assert np.allclose(position, emitter, atol=1e-3)
+        assert confidence > 0.99
+        assert rmse < 1e-10
+
+
+
+    def test_sensor_array_emits_frame_event(self):
+        """Verify that sensor array emits frame event. This keeps rendering behaviour consistent across scenes."""
+        sensors = radial_layout(radius=0.16)
+        bus = EventBus()
+        captured: list[dict] = []
+
+        bus.subscribe(IRSensorArray.EVENT_FRAME, lambda event: captured.append(event.data))
+
+        array = IRSensorArray(sensor_positions=sensors, event_bus=bus)
+
+        true_position = np.array([0.04, -0.02, 0.01])
+        offsets = {0: 2e-6, 1: -1e-6, 2: 3e-6, 3: -2e-6}
+        array.apply_calibration(offsets)
+
+        samples: list[IRSample] = []
+        for index, sensor in enumerate(sensors):
+            sensor_vec = np.array(sensor)
+            distance = np.linalg.norm(true_position - sensor_vec)
+            nominal = distance / SPEED_OF_LIGHT
+            observed = nominal + offsets[index]
+            duration = 1200 if index % 2 else 800
+            samples.append(
+                IRSample(
+                    frame_id=42,
+                    sensor_index=index,
+                    timestamp=observed,
+                    level=1,
+                    duration_us=duration,
+                )
             )
-        )
 
-    packet = _make_packet(samples)
-    array.ingest_packet(packet)
+        packet = _make_packet(samples)
+        array.ingest_packet(packet)
 
-    assert captured, "Expected event emission"
-    event = captured[0]
-    assert event["frame_id"] == 42
-    assert np.allclose(event["position"], true_position.tolist(), atol=1e-3)
-    assert event["confidence"] > 0.95
-    assert event["rmse"] < 1e-10
-    assert event["bits"] == [0, 1, 0, 1]
-
+        assert captured, "Expected event emission"
+        event = captured[0]
+        assert event["frame_id"] == 42
+        assert np.allclose(event["position"], true_position.tolist(), atol=1e-3)
+        assert event["confidence"] > 0.95
+        assert event["rmse"] < 1e-10
+        assert event["bits"] == [0, 1, 0, 1]

--- a/tests/peripheral/test_led_matrix_display.py
+++ b/tests/peripheral/test_led_matrix_display.py
@@ -15,50 +15,58 @@ def _solid_image(width: int, height: int, *, value: int) -> Image.Image:
     return Image.fromarray(array, mode="RGB")
 
 
-def test_publish_image_emits_event_and_updates_state_store() -> None:
-    bus = EventBus()
-    peripheral = LEDMatrixDisplay(width=4, height=2, event_bus=bus)
+class TestPeripheralLedMatrixDisplay:
+    """Group Peripheral Led Matrix Display tests so peripheral led matrix display behaviour stays reliable. This preserves confidence in peripheral led matrix display for end-to-end scenarios."""
 
-    image = _solid_image(4, 2, value=128)
-    peripheral.publish_image(
-        image, timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc)
-    )
+    def test_publish_image_emits_event_and_updates_state_store(self) -> None:
+        """Verify that publish image emits event and updates state store. This ensures event orchestration remains reliable."""
+        bus = EventBus()
+        peripheral = LEDMatrixDisplay(width=4, height=2, event_bus=bus)
 
-    latest = peripheral.latest_frame
-    assert latest is not None
-    assert latest.frame_id == 0
-    assert latest.width == 4 and latest.height == 2
-    assert latest.mode == "RGB"
-    assert latest.data == image.tobytes()
-    reconstructed = latest.to_image()
-    assert reconstructed.tobytes() == image.tobytes()
+        image = _solid_image(4, 2, value=128)
+        peripheral.publish_image(
+            image, timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc)
+        )
 
-    state_entry = bus.state_store.get_latest(DisplayFrame.EVENT_TYPE)
-    assert state_entry is not None
-    assert isinstance(state_entry.data, DisplayFrame)
-    assert state_entry.data.data == image.tobytes()
+        latest = peripheral.latest_frame
+        assert latest is not None
+        assert latest.frame_id == 0
+        assert latest.width == 4 and latest.height == 2
+        assert latest.mode == "RGB"
+        assert latest.data == image.tobytes()
+        reconstructed = latest.to_image()
+        assert reconstructed.tobytes() == image.tobytes()
 
-
-def test_publish_image_increments_frame_id(monkeypatch) -> None:
-    bus = EventBus()
-    peripheral = LEDMatrixDisplay(width=2, height=2, event_bus=bus)
-    image = _solid_image(2, 2, value=64)
-
-    first = peripheral.publish_image(image)
-    second = peripheral.publish_image(image)
-
-    assert first.frame_id == 0
-    assert second.frame_id == 1
-    assert bus.state_store.get_latest(DisplayFrame.EVENT_TYPE).data.frame_id == 1
+        state_entry = bus.state_store.get_latest(DisplayFrame.EVENT_TYPE)
+        assert state_entry is not None
+        assert isinstance(state_entry.data, DisplayFrame)
+        assert state_entry.data.data == image.tobytes()
 
 
-def test_publish_image_validates_dimensions() -> None:
-    peripheral = LEDMatrixDisplay(width=2, height=2)
-    image = _solid_image(3, 2, value=10)
 
-    try:
-        peripheral.publish_image(image)
-    except ValueError as exc:
-        assert "dimensions" in str(exc)
-    else:  # pragma: no cover - defensive
-        raise AssertionError("ValueError expected when dimensions do not match")
+    def test_publish_image_increments_frame_id(self, monkeypatch) -> None:
+        """Verify that publish image increments frame id. This keeps rendering behaviour consistent across scenes."""
+        bus = EventBus()
+        peripheral = LEDMatrixDisplay(width=2, height=2, event_bus=bus)
+        image = _solid_image(2, 2, value=64)
+
+        first = peripheral.publish_image(image)
+        second = peripheral.publish_image(image)
+
+        assert first.frame_id == 0
+        assert second.frame_id == 1
+        assert bus.state_store.get_latest(DisplayFrame.EVENT_TYPE).data.frame_id == 1
+
+
+
+    def test_publish_image_validates_dimensions(self) -> None:
+        """Verify that publish image validates dimensions. This keeps the system behaviour reliable for operators."""
+        peripheral = LEDMatrixDisplay(width=2, height=2)
+        image = _solid_image(3, 2, value=10)
+
+        try:
+            peripheral.publish_image(image)
+        except ValueError as exc:
+            assert "dimensions" in str(exc)
+        else:  # pragma: no cover - defensive
+            raise AssertionError("ValueError expected when dimensions do not match")

--- a/tests/peripheral/test_microphone.py
+++ b/tests/peripheral/test_microphone.py
@@ -6,35 +6,39 @@ from heart.peripheral.core.event_bus import EventBus
 from heart.peripheral.microphone import Microphone
 
 
-def test_detect_without_sounddevice(monkeypatch):
-    """Detection should short-circuit when sounddevice is unavailable."""
+class TestPeripheralMicrophone:
+    """Group Peripheral Microphone tests so peripheral microphone behaviour stays reliable. This preserves confidence in peripheral microphone for end-to-end scenarios."""
 
-    monkeypatch.setattr(microphone, "sd", None)
-    assert list(Microphone.detect()) == []
+    def test_detect_without_sounddevice(self, monkeypatch):
+        """Detection should short-circuit when sounddevice is unavailable."""
+
+        monkeypatch.setattr(microphone, "sd", None)
+        assert list(Microphone.detect()) == []
 
 
-def test_process_audio_chunk_emits_event():
-    """Processing an audio block stores metrics and emits an event."""
 
-    bus = EventBus()
-    captured: list[dict] = []
+    def test_process_audio_chunk_emits_event(self):
+        """Processing an audio block stores metrics and emits an event."""
 
-    def _capture(event):
-        captured.append(event.data)
+        bus = EventBus()
+        captured: list[dict] = []
 
-    bus.subscribe(Microphone.EVENT_LEVEL, _capture)
+        def _capture(event):
+            captured.append(event.data)
 
-    mic = Microphone(event_bus=bus)
-    audio = np.array([[0.0], [0.5], [-0.5], [0.0]], dtype=np.float32)
+        bus.subscribe(Microphone.EVENT_LEVEL, _capture)
 
-    mic._process_audio_chunk(audio, frames=audio.shape[0])
+        mic = Microphone(event_bus=bus)
+        audio = np.array([[0.0], [0.5], [-0.5], [0.0]], dtype=np.float32)
 
-    level = mic.latest_level
-    assert level is not None
-    assert level["frames"] == audio.shape[0]
-    assert level["samplerate"] == mic.samplerate
-    assert level["peak"] == pytest.approx(0.5)
-    assert level["rms"] == pytest.approx(np.sqrt(0.125))
+        mic._process_audio_chunk(audio, frames=audio.shape[0])
 
-    assert captured
-    assert captured[0] == level
+        level = mic.latest_level
+        assert level is not None
+        assert level["frames"] == audio.shape[0]
+        assert level["samplerate"] == mic.samplerate
+        assert level["peak"] == pytest.approx(0.5)
+        assert level["rms"] == pytest.approx(np.sqrt(0.125))
+
+        assert captured
+        assert captured[0] == level

--- a/tests/peripheral/test_phone_text_event_bus.py
+++ b/tests/peripheral/test_phone_text_event_bus.py
@@ -3,17 +3,21 @@ from heart.peripheral.core.event_bus import EventBus
 from heart.peripheral.phone_text import PhoneText
 
 
-def test_phone_text_emits_message_event():
-    bus = EventBus()
-    captured: list[str] = []
+class TestPeripheralPhoneTextEventBus:
+    """Group Peripheral Phone Text Event Bus tests so peripheral phone text event bus behaviour stays reliable. This preserves confidence in peripheral phone text event bus for end-to-end scenarios."""
 
-    bus.subscribe(
-        PhoneTextMessage.EVENT_TYPE, lambda event: captured.append(event.data["text"])
-    )
+    def test_phone_text_emits_message_event(self):
+        """Verify that phone text emits message event. This ensures event orchestration remains reliable."""
+        bus = EventBus()
+        captured: list[str] = []
 
-    phone = PhoneText(event_bus=bus, producer_id=3)
+        bus.subscribe(
+            PhoneTextMessage.EVENT_TYPE, lambda event: captured.append(event.data["text"])
+        )
 
-    phone._on_write(b"hello world\0", None)
+        phone = PhoneText(event_bus=bus, producer_id=3)
 
-    assert captured == ["hello world"]
-    assert phone.pop_text() == "hello world"
+        phone._on_write(b"hello world\0", None)
+
+        assert captured == ["hello world"]
+        assert phone.pop_text() == "hello world"

--- a/tests/peripheral/test_radio_peripheral.py
+++ b/tests/peripheral/test_radio_peripheral.py
@@ -22,73 +22,81 @@ class DummyDriver(RadioDriver):
         self.closed = True
 
 
-def test_radio_packet_to_input_normalises_payload() -> None:
-    packet = RadioPacket(
-        frequency_hz=2_439_000_000,
-        channel=39,
-        modulation="GFSK",
-        rssi_dbm=-42.5,
-        payload=b"\x01\x02\xFF",
-        metadata={"manufacturer": "FlowToys"},
-    )
+class TestPeripheralRadioPeripheral:
+    """Group Peripheral Radio Peripheral tests so peripheral radio peripheral behaviour stays reliable. This preserves confidence in peripheral radio peripheral for end-to-end scenarios."""
 
-    rendered = packet.to_input(producer_id=7)
+    def test_radio_packet_to_input_normalises_payload(self) -> None:
+        """Verify that radio packet to input normalises payload. This keeps hardware telemetry responsive for interactive experiences."""
+        packet = RadioPacket(
+            frequency_hz=2_439_000_000,
+            channel=39,
+            modulation="GFSK",
+            rssi_dbm=-42.5,
+            payload=b"\x01\x02\xFF",
+            metadata={"manufacturer": "FlowToys"},
+        )
 
-    assert rendered.event_type == RadioPacket.EVENT_TYPE
-    assert rendered.producer_id == 7
-    assert rendered.data["frequency_hz"] == 2_439_000_000.0
-    assert rendered.data["channel"] == 39.0
-    assert rendered.data["modulation"] == "GFSK"
-    assert rendered.data["rssi_dbm"] == pytest.approx(-42.5)
-    assert rendered.data["payload"] == [1, 2, 255]
-    assert rendered.data["metadata"] == {"manufacturer": "FlowToys"}
+        rendered = packet.to_input(producer_id=7)
 
-
-def test_process_packet_emits_event() -> None:
-    bus = EventBus()
-    captured: list[dict] = []
-
-    def _capture(event):
-        captured.append(event.data)
-
-    bus.subscribe(RadioPeripheral.EVENT_TYPE, _capture)
-
-    driver = DummyDriver()
-    peripheral = RadioPeripheral(driver=driver, event_bus=bus, producer_id=11)
-
-    sample = RawRadioPacket(
-        payload=b"\xAA\xBB",
-        frequency_hz=2_439_000_000,
-        channel=39,
-        modulation="GFSK",
-        rssi_dbm=-50.0,
-        metadata={"hop": 0},
-    )
-
-    peripheral.process_packet(sample)
-
-    assert peripheral.latest_packet is sample
-    assert captured
-    emitted = captured[-1]
-    assert emitted["payload"] == [170, 187]
-    assert emitted["frequency_hz"] == 2_439_000_000.0
-    assert emitted["channel"] == 39.0
-    assert emitted["modulation"] == "GFSK"
-    assert emitted["rssi_dbm"] == pytest.approx(-50.0)
-    assert emitted["metadata"] == {"hop": 0}
+        assert rendered.event_type == RadioPacket.EVENT_TYPE
+        assert rendered.producer_id == 7
+        assert rendered.data["frequency_hz"] == 2_439_000_000.0
+        assert rendered.data["channel"] == 39.0
+        assert rendered.data["modulation"] == "GFSK"
+        assert rendered.data["rssi_dbm"] == pytest.approx(-42.5)
+        assert rendered.data["payload"] == [1, 2, 255]
+        assert rendered.data["metadata"] == {"manufacturer": "FlowToys"}
 
 
-def test_detect_wraps_serial_driver(monkeypatch: pytest.MonkeyPatch) -> None:
-    packets = iter([RawRadioPacket()])
-    stub_driver = DummyDriver(packets=packets)
 
-    def _fake_detect(cls):
-        yield stub_driver
+    def test_process_packet_emits_event(self) -> None:
+        """Verify that process packet emits event. This ensures event orchestration remains reliable."""
+        bus = EventBus()
+        captured: list[dict] = []
 
-    monkeypatch.setattr(SerialRadioDriver, "detect", classmethod(_fake_detect))
+        def _capture(event):
+            captured.append(event.data)
 
-    detected = list(RadioPeripheral.detect())
+        bus.subscribe(RadioPeripheral.EVENT_TYPE, _capture)
 
-    assert detected
-    assert detected[0].latest_packet is None
-    assert detected[0]._driver is stub_driver
+        driver = DummyDriver()
+        peripheral = RadioPeripheral(driver=driver, event_bus=bus, producer_id=11)
+
+        sample = RawRadioPacket(
+            payload=b"\xAA\xBB",
+            frequency_hz=2_439_000_000,
+            channel=39,
+            modulation="GFSK",
+            rssi_dbm=-50.0,
+            metadata={"hop": 0},
+        )
+
+        peripheral.process_packet(sample)
+
+        assert peripheral.latest_packet is sample
+        assert captured
+        emitted = captured[-1]
+        assert emitted["payload"] == [170, 187]
+        assert emitted["frequency_hz"] == 2_439_000_000.0
+        assert emitted["channel"] == 39.0
+        assert emitted["modulation"] == "GFSK"
+        assert emitted["rssi_dbm"] == pytest.approx(-50.0)
+        assert emitted["metadata"] == {"hop": 0}
+
+
+
+    def test_detect_wraps_serial_driver(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify that detect wraps serial driver. This keeps the system behaviour reliable for operators."""
+        packets = iter([RawRadioPacket()])
+        stub_driver = DummyDriver(packets=packets)
+
+        def _fake_detect(cls):
+            yield stub_driver
+
+        monkeypatch.setattr(SerialRadioDriver, "detect", classmethod(_fake_detect))
+
+        detected = list(RadioPeripheral.detect())
+
+        assert detected
+        assert detected[0].latest_packet is None
+        assert detected[0]._driver is stub_driver

--- a/tests/peripheral/test_state_store.py
+++ b/tests/peripheral/test_state_store.py
@@ -4,51 +4,59 @@ from typing import cast
 from heart.peripheral.core import Input, StateStore
 
 
-def test_state_store_tracks_latest_events_by_producer() -> None:
-    store = StateStore()
-    event_a = Input(event_type="switch/press", data={"pressed": True}, producer_id=0)
-    event_b = Input(
-        event_type="switch/press",
-        data={"pressed": False},
-        producer_id=1,
-        timestamp=datetime(2024, 1, 1),
-    )
+class TestPeripheralStateStore:
+    """Group Peripheral State Store tests so peripheral state store behaviour stays reliable. This preserves confidence in peripheral state store for end-to-end scenarios."""
 
-    store.update(event_a)
-    store.update(event_b)
+    def test_state_store_tracks_latest_events_by_producer(self) -> None:
+        """Verify that StateStore tracks the latest event per producer. This keeps peripherals able to query current state instantly."""
+        store = StateStore()
+        event_a = Input(event_type="switch/press", data={"pressed": True}, producer_id=0)
+        event_b = Input(
+            event_type="switch/press",
+            data={"pressed": False},
+            producer_id=1,
+            timestamp=datetime(2024, 1, 1),
+        )
 
-    assert store.get_latest("switch/press", producer_id=0) is not None
-    producer_one = store.get_latest("switch/press", producer_id=1)
-    assert producer_one is not None
-    assert producer_one.data == {"pressed": False}
-    assert producer_one.timestamp.tzinfo is not None
+        store.update(event_a)
+        store.update(event_b)
 
-
-def test_state_store_snapshot_is_immutable() -> None:
-    store = StateStore()
-    store.update(Input(event_type="dial/rotate", data={"value": 5}, producer_id=0))
-
-    snapshot = store.snapshot()
-    bucket = snapshot["dial/rotate"]
-    assert 0 in bucket
-
-    try:
-        cast(dict[int, Input], bucket)[1] = bucket[0]
-    except TypeError:
-        pass
-    else:  # pragma: no cover - enforce immutability even if TypeError not raised
-        raise AssertionError("snapshot bucket is mutable")
+        assert store.get_latest("switch/press", producer_id=0) is not None
+        producer_one = store.get_latest("switch/press", producer_id=1)
+        assert producer_one is not None
+        assert producer_one.data == {"pressed": False}
+        assert producer_one.timestamp.tzinfo is not None
 
 
-def test_get_all_returns_read_only_mapping() -> None:
-    store = StateStore()
-    store.update(Input(event_type="dial/rotate", data={"value": 5}, producer_id=0))
 
-    mapping = store.get_all("dial/rotate")
-    assert 0 in mapping
-    try:
-        cast(dict[int, Input], mapping)[1] = mapping[0]
-    except TypeError:
-        pass
-    else:  # pragma: no cover
-        raise AssertionError("get_all mapping is mutable")
+    def test_state_store_snapshot_is_immutable(self) -> None:
+        """Verify that StateStore.snapshot returns immutable structures. This prevents observers from corrupting stored history."""
+        store = StateStore()
+        store.update(Input(event_type="dial/rotate", data={"value": 5}, producer_id=0))
+
+        snapshot = store.snapshot()
+        bucket = snapshot["dial/rotate"]
+        assert 0 in bucket
+
+        try:
+            cast(dict[int, Input], bucket)[1] = bucket[0]
+        except TypeError:
+            pass
+        else:  # pragma: no cover - enforce immutability even if TypeError not raised
+            raise AssertionError("snapshot bucket is mutable")
+
+
+
+    def test_get_all_returns_read_only_mapping(self) -> None:
+        """Verify that StateStore.get_all returns a read-only mapping. This ensures data integrity even when handing references to plugins."""
+        store = StateStore()
+        store.update(Input(event_type="dial/rotate", data={"value": 5}, producer_id=0))
+
+        mapping = store.get_all("dial/rotate")
+        assert 0 in mapping
+        try:
+            cast(dict[int, Input], mapping)[1] = mapping[0]
+        except TypeError:
+            pass
+        else:  # pragma: no cover
+            raise AssertionError("get_all mapping is mutable")

--- a/tests/peripheral/test_switch_event_bus.py
+++ b/tests/peripheral/test_switch_event_bus.py
@@ -10,58 +10,200 @@ from heart.peripheral.core.event_bus import EventBus
 from heart.peripheral.switch import BluetoothSwitch, FakeSwitch, SwitchState
 
 
-def test_switch_state_subscription() -> None:
-    bus = EventBus()
-    switch = FakeSwitch()
-    switch.attach_event_bus(bus)
+class TestPeripheralSwitchEventBus:
+    """Group Peripheral Switch Event Bus tests so peripheral switch event bus behaviour stays reliable. This preserves confidence in peripheral switch event bus for end-to-end scenarios."""
 
-    snapshots: list[SwitchState] = []
-    switch.subscribe_state(snapshots.append)
+    def test_switch_state_subscription(self) -> None:
+        """Verify that FakeSwitch publishes state updates to subscribers. This keeps downstream components aware of rotary and button changes."""
+        bus = EventBus()
+        switch = FakeSwitch()
+        switch.attach_event_bus(bus)
 
-    switch.update_due_to_data(
-        {"event_type": SWITCH_ROTATION, "data": 5, "producer_id": 1}
-    )
-    switch.update_due_to_data({"event_type": BUTTON_PRESS, "data": 1, "producer_id": 1})
-    switch.update_due_to_data(
-        {"event_type": BUTTON_LONG_PRESS, "data": 1, "producer_id": 1}
-    )
+        snapshots: list[SwitchState] = []
+        switch.subscribe_state(snapshots.append)
 
-    assert snapshots
-    latest = snapshots[-1]
-    assert latest.rotational_value == 5
-    assert latest.button_value == 1
-    assert latest.long_button_value == 1
-    assert latest.rotation_since_last_button_press == 0
-    assert latest.rotation_since_last_long_button_press == 0
+        switch.update_due_to_data(
+            {"event_type": SWITCH_ROTATION, "data": 5, "producer_id": 1}
+        )
+        switch.update_due_to_data({"event_type": BUTTON_PRESS, "data": 1, "producer_id": 1})
+        switch.update_due_to_data(
+            {"event_type": BUTTON_LONG_PRESS, "data": 1, "producer_id": 1}
+        )
+
+        assert snapshots
+        latest = snapshots[-1]
+        assert latest.rotational_value == 5
+        assert latest.button_value == 1
+        assert latest.long_button_value == 1
+        assert latest.rotation_since_last_button_press == 0
+        assert latest.rotation_since_last_long_button_press == 0
 
 
-def test_fake_switch_emits_bus_events() -> None:
-    bus = EventBus()
-    captured: list[tuple[str, Any, int]] = []
-    lifecycle: list[str] = []
 
-    bus.subscribe(
-        BUTTON_PRESS,
-        lambda event: captured.append((event.event_type, event.data, event.producer_id)),
-    )
-    bus.subscribe(
-        FakeSwitch.EVENT_LIFECYCLE,
-        lambda event: lifecycle.append(event.data["status"]),
-    )
+    def test_fake_switch_emits_bus_events(self) -> None:
+        """Verify that FakeSwitch emits events on the bus and updates state. This validates the simulator used in integration tests."""
+        bus = EventBus()
+        captured: list[tuple[str, Any, int]] = []
+        lifecycle: list[str] = []
 
-    switch = FakeSwitch()
-    switch.attach_event_bus(bus)
-    switch.update_due_to_data({"event_type": BUTTON_PRESS, "data": 1, "producer_id": 7})
+        bus.subscribe(
+            BUTTON_PRESS,
+            lambda event: captured.append((event.event_type, event.data, event.producer_id)),
+        )
+        bus.subscribe(
+            FakeSwitch.EVENT_LIFECYCLE,
+            lambda event: lifecycle.append(event.data["status"]),
+        )
 
-    assert lifecycle and lifecycle[0] == "connected"
+        switch = FakeSwitch()
+        switch.attach_event_bus(bus)
+        switch.update_due_to_data({"event_type": BUTTON_PRESS, "data": 1, "producer_id": 7})
 
-    assert captured == [(BUTTON_PRESS, 1, 7)]
-    assert switch.get_button_value() == 1
+        assert lifecycle and lifecycle[0] == "connected"
 
-    entry = bus.state_store.get_latest(BUTTON_PRESS, producer_id=7)
-    assert entry is not None
-    assert entry.data == 1
+        assert captured == [(BUTTON_PRESS, 1, 7)]
+        assert switch.get_button_value() == 1
 
+        entry = bus.state_store.get_latest(BUTTON_PRESS, producer_id=7)
+        assert entry is not None
+        assert entry.data == 1
+
+
+
+    def test_bluetooth_switch_routes_producer_events(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify that BluetoothSwitch forwards events with their original producer IDs. This ensures multi-device configurations remain distinguishable."""
+        monkeypatch.setattr("heart.peripheral.switch.UartListener", _DummyListener)
+
+        bus = EventBus()
+        captured: list[tuple[str, int, int]] = []
+
+        bus.subscribe(
+            BUTTON_PRESS,
+            lambda event: captured.append((event.event_type, event.data, event.producer_id)),
+        )
+        bus.subscribe(
+            SWITCH_ROTATION,
+            lambda event: captured.append((event.event_type, event.data, event.producer_id)),
+        )
+
+        switch = BluetoothSwitch(device=object())
+        switch.attach_event_bus(bus)
+
+        switch.update_due_to_data({"event_type": BUTTON_PRESS, "data": 1, "producer_id": 2})
+        switch.update_due_to_data({"event_type": SWITCH_ROTATION, "data": 5, "producer_id": 0})
+
+        assert (BUTTON_PRESS, 1, 2) in captured
+        assert (SWITCH_ROTATION, 5, 0) in captured
+
+        rotation_entry = bus.state_store.get_latest(SWITCH_ROTATION, producer_id=0)
+        assert rotation_entry is not None
+        assert rotation_entry.data == 5
+        assert switch.get_rotational_value() == 5
+
+
+
+    def test_bluetooth_switch_emits_button_press_for_each_producer(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify that BluetoothSwitch emits button-press events for each producer. This guarantees simultaneous controllers all trigger actions."""
+        monkeypatch.setattr("heart.peripheral.switch.UartListener", _DummyListener)
+
+        bus = EventBus()
+        captured: list[tuple[int, int]] = []
+
+        bus.subscribe(
+            BUTTON_PRESS,
+            lambda event: captured.append((event.producer_id, event.data)),
+        )
+
+        switch = BluetoothSwitch(device=object())
+        switch.attach_event_bus(bus)
+
+        switch.update_due_to_data({"event_type": BUTTON_PRESS, "data": 1, "producer_id": 0})
+        switch.update_due_to_data({"event_type": BUTTON_PRESS, "data": 1, "producer_id": 1})
+
+        assert (0, 1) in captured
+        assert (1, 1) in captured
+
+        assert switch.get_button_value() == 1
+        assert switch.switches[1].get_button_value() == 1
+
+        entry_main = bus.state_store.get_latest(BUTTON_PRESS, producer_id=0)
+        entry_secondary = bus.state_store.get_latest(BUTTON_PRESS, producer_id=1)
+
+        assert entry_main is not None and entry_main.data == 1
+        assert entry_secondary is not None and entry_secondary.data == 1
+
+
+
+    def test_bluetooth_switch_emits_rotation_for_each_producer(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify that BluetoothSwitch emits rotation events for each producer. This keeps orientation handling correct per device."""
+        monkeypatch.setattr("heart.peripheral.switch.UartListener", _DummyListener)
+
+        bus = EventBus()
+        captured: list[tuple[int, int]] = []
+
+        bus.subscribe(
+            SWITCH_ROTATION,
+            lambda event: captured.append((event.producer_id, event.data)),
+        )
+
+        switch = BluetoothSwitch(device=object())
+        switch.attach_event_bus(bus)
+
+        switch.update_due_to_data({"event_type": SWITCH_ROTATION, "data": 5, "producer_id": 0})
+        switch.update_due_to_data({"event_type": SWITCH_ROTATION, "data": 7, "producer_id": 2})
+
+        assert (0, 5) in captured
+        assert (2, 7) in captured
+
+        assert switch.get_rotational_value() == 5
+        assert switch.switches[2].get_rotational_value() == 7
+
+        entry_main = bus.state_store.get_latest(SWITCH_ROTATION, producer_id=0)
+        entry_secondary = bus.state_store.get_latest(SWITCH_ROTATION, producer_id=2)
+
+        assert entry_main is not None and entry_main.data == 5
+        assert entry_secondary is not None and entry_secondary.data == 7
+
+
+
+    def test_bluetooth_switch_emits_long_press_for_each_producer(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify that BluetoothSwitch emits long-press events for each producer. This ensures gesture recognition scales with additional peripherals."""
+        monkeypatch.setattr("heart.peripheral.switch.UartListener", _DummyListener)
+
+        bus = EventBus()
+        captured: list[tuple[int, int]] = []
+
+        bus.subscribe(
+            BUTTON_LONG_PRESS,
+            lambda event: captured.append((event.producer_id, event.data)),
+        )
+
+        switch = BluetoothSwitch(device=object())
+        switch.attach_event_bus(bus)
+
+        switch.update_due_to_data({"event_type": BUTTON_LONG_PRESS, "data": 1, "producer_id": 0})
+        switch.update_due_to_data({"event_type": BUTTON_LONG_PRESS, "data": 1, "producer_id": 3})
+
+        assert (0, 1) in captured
+        assert (3, 1) in captured
+
+        assert switch.get_long_button_value() == 1
+        assert switch.switches[3].get_long_button_value() == 1
+
+        entry_main = bus.state_store.get_latest(BUTTON_LONG_PRESS, producer_id=0)
+        entry_secondary = bus.state_store.get_latest(BUTTON_LONG_PRESS, producer_id=3)
+
+        assert entry_main is not None and entry_main.data == 1
+        assert entry_secondary is not None and entry_secondary.data == 1
 
 class _DummyListener:
     def __init__(self, device) -> None:  # pragma: no cover - invoked indirectly
@@ -79,129 +221,3 @@ class _DummyListener:
     @staticmethod
     def _discover_devices():  # pragma: no cover - unused in tests
         return []
-
-
-def test_bluetooth_switch_routes_producer_events(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("heart.peripheral.switch.UartListener", _DummyListener)
-
-    bus = EventBus()
-    captured: list[tuple[str, int, int]] = []
-
-    bus.subscribe(
-        BUTTON_PRESS,
-        lambda event: captured.append((event.event_type, event.data, event.producer_id)),
-    )
-    bus.subscribe(
-        SWITCH_ROTATION,
-        lambda event: captured.append((event.event_type, event.data, event.producer_id)),
-    )
-
-    switch = BluetoothSwitch(device=object())
-    switch.attach_event_bus(bus)
-
-    switch.update_due_to_data({"event_type": BUTTON_PRESS, "data": 1, "producer_id": 2})
-    switch.update_due_to_data({"event_type": SWITCH_ROTATION, "data": 5, "producer_id": 0})
-
-    assert (BUTTON_PRESS, 1, 2) in captured
-    assert (SWITCH_ROTATION, 5, 0) in captured
-
-    rotation_entry = bus.state_store.get_latest(SWITCH_ROTATION, producer_id=0)
-    assert rotation_entry is not None
-    assert rotation_entry.data == 5
-    assert switch.get_rotational_value() == 5
-
-
-def test_bluetooth_switch_emits_button_press_for_each_producer(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr("heart.peripheral.switch.UartListener", _DummyListener)
-
-    bus = EventBus()
-    captured: list[tuple[int, int]] = []
-
-    bus.subscribe(
-        BUTTON_PRESS,
-        lambda event: captured.append((event.producer_id, event.data)),
-    )
-
-    switch = BluetoothSwitch(device=object())
-    switch.attach_event_bus(bus)
-
-    switch.update_due_to_data({"event_type": BUTTON_PRESS, "data": 1, "producer_id": 0})
-    switch.update_due_to_data({"event_type": BUTTON_PRESS, "data": 1, "producer_id": 1})
-
-    assert (0, 1) in captured
-    assert (1, 1) in captured
-
-    assert switch.get_button_value() == 1
-    assert switch.switches[1].get_button_value() == 1
-
-    entry_main = bus.state_store.get_latest(BUTTON_PRESS, producer_id=0)
-    entry_secondary = bus.state_store.get_latest(BUTTON_PRESS, producer_id=1)
-
-    assert entry_main is not None and entry_main.data == 1
-    assert entry_secondary is not None and entry_secondary.data == 1
-
-
-def test_bluetooth_switch_emits_rotation_for_each_producer(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr("heart.peripheral.switch.UartListener", _DummyListener)
-
-    bus = EventBus()
-    captured: list[tuple[int, int]] = []
-
-    bus.subscribe(
-        SWITCH_ROTATION,
-        lambda event: captured.append((event.producer_id, event.data)),
-    )
-
-    switch = BluetoothSwitch(device=object())
-    switch.attach_event_bus(bus)
-
-    switch.update_due_to_data({"event_type": SWITCH_ROTATION, "data": 5, "producer_id": 0})
-    switch.update_due_to_data({"event_type": SWITCH_ROTATION, "data": 7, "producer_id": 2})
-
-    assert (0, 5) in captured
-    assert (2, 7) in captured
-
-    assert switch.get_rotational_value() == 5
-    assert switch.switches[2].get_rotational_value() == 7
-
-    entry_main = bus.state_store.get_latest(SWITCH_ROTATION, producer_id=0)
-    entry_secondary = bus.state_store.get_latest(SWITCH_ROTATION, producer_id=2)
-
-    assert entry_main is not None and entry_main.data == 5
-    assert entry_secondary is not None and entry_secondary.data == 7
-
-
-def test_bluetooth_switch_emits_long_press_for_each_producer(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr("heart.peripheral.switch.UartListener", _DummyListener)
-
-    bus = EventBus()
-    captured: list[tuple[int, int]] = []
-
-    bus.subscribe(
-        BUTTON_LONG_PRESS,
-        lambda event: captured.append((event.producer_id, event.data)),
-    )
-
-    switch = BluetoothSwitch(device=object())
-    switch.attach_event_bus(bus)
-
-    switch.update_due_to_data({"event_type": BUTTON_LONG_PRESS, "data": 1, "producer_id": 0})
-    switch.update_due_to_data({"event_type": BUTTON_LONG_PRESS, "data": 1, "producer_id": 3})
-
-    assert (0, 1) in captured
-    assert (3, 1) in captured
-
-    assert switch.get_long_button_value() == 1
-    assert switch.switches[3].get_long_button_value() == 1
-
-    entry_main = bus.state_store.get_latest(BUTTON_LONG_PRESS, producer_id=0)
-    entry_secondary = bus.state_store.get_latest(BUTTON_LONG_PRESS, producer_id=3)
-
-    assert entry_main is not None and entry_main.data == 1
-    assert entry_secondary is not None and entry_secondary.data == 1

--- a/tests/peripheral/test_uwb_zone_tracker.py
+++ b/tests/peripheral/test_uwb_zone_tracker.py
@@ -20,92 +20,99 @@ def collect_events(event_bus: EventBus, event_type: str) -> deque[Input]:
     return captured
 
 
-def test_emits_entry_event_when_within_radius(event_bus: EventBus) -> None:
-    tracker = UwbZoneTracker(
-        [UwbZoneDefinition(zone_id="living", center=(0.0, 0.0, 0.0), enter_radius=1.0)],
-        event_bus=event_bus,
-    )
+class TestPeripheralUwbZoneTracker:
+    """Group Peripheral Uwb Zone Tracker tests so peripheral uwb zone tracker behaviour stays reliable. This preserves confidence in peripheral uwb zone tracker for end-to-end scenarios."""
 
-    entries = collect_events(event_bus, "uwb.zone.entry")
+    def test_emits_entry_event_when_within_radius(self, event_bus: EventBus) -> None:
+        """Verify that emits entry event when within radius. This ensures event orchestration remains reliable."""
+        tracker = UwbZoneTracker(
+            [UwbZoneDefinition(zone_id="living", center=(0.0, 0.0, 0.0), enter_radius=1.0)],
+            event_bus=event_bus,
+        )
 
-    event_bus.emit(
-        "uwb.ranging_event",
-        data={"tag_id": "tag-1", "position": {"x": 0.5, "y": 0.3}},
-        producer_id=7,
-    )
+        entries = collect_events(event_bus, "uwb.zone.entry")
 
-    assert len(entries) == 1
-    entry = entries[0]
-    assert entry.event_type == "uwb.zone.entry"
-    assert entry.producer_id == 7
-    assert entry.data["zone_id"] == "living"
-    assert pytest.approx(entry.data["distance"]) == pytest.approx(0.583095)
-    assert tracker.get_active_zones("tag-1") == ("living",)
-    assert tracker.get_last_position("tag-1") == (0.5, 0.3, 0.0)
+        event_bus.emit(
+            "uwb.ranging_event",
+            data={"tag_id": "tag-1", "position": {"x": 0.5, "y": 0.3}},
+            producer_id=7,
+        )
 
-
-def test_hysteresis_prevents_spurious_exits(event_bus: EventBus) -> None:
-    tracker = UwbZoneTracker(
-        [
-            UwbZoneDefinition(
-                zone_id="kitchen",
-                center=(0.0, 0.0, 0.0),
-                enter_radius=1.0,
-                exit_radius=1.4,
-            )
-        ],
-        event_bus=event_bus,
-    )
-
-    entries = collect_events(event_bus, "uwb.zone.entry")
-    exits = collect_events(event_bus, "uwb.zone.exit")
-
-    # First sample enters the zone.
-    event_bus.emit(
-        "uwb.ranging_event",
-        data={"tag_id": "tag-2", "position": (0.2, 0.3)},
-        producer_id=3,
-    )
-    assert len(entries) == 1
-    assert len(exits) == 0
-
-    # Close to the boundary but still inside thanks to hysteresis.
-    event_bus.emit(
-        "uwb.ranging_event",
-        data={"tag_id": "tag-2", "position": {"x": 1.2, "y": 0.0}},
-        producer_id=3,
-    )
-    assert len(exits) == 0
-    assert tracker.get_active_zones("tag-2") == ("kitchen",)
-
-    # Far enough to cross the exit radius.
-    event_bus.emit(
-        "uwb.ranging_event",
-        data={"tag_id": "tag-2", "position": {"x": 1.5, "y": 0.0}},
-        producer_id=3,
-    )
-    assert len(exits) == 1
-    exit_event = exits[0]
-    assert exit_event.data["zone_id"] == "kitchen"
-    assert tracker.get_active_zones("tag-2") == ()
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry.event_type == "uwb.zone.entry"
+        assert entry.producer_id == 7
+        assert entry.data["zone_id"] == "living"
+        assert pytest.approx(entry.data["distance"]) == pytest.approx(0.583095)
+        assert tracker.get_active_zones("tag-1") == ("living",)
+        assert tracker.get_last_position("tag-1") == (0.5, 0.3, 0.0)
 
 
-def test_falls_back_to_producer_id_when_tag_missing(event_bus: EventBus) -> None:
-    tracker = UwbZoneTracker(
-        [UwbZoneDefinition(zone_id="office", center=(1.0, 1.0, 0.0), enter_radius=0.5)],
-        event_bus=event_bus,
-    )
 
-    entries = collect_events(event_bus, "uwb.zone.entry")
+    def test_hysteresis_prevents_spurious_exits(self, event_bus: EventBus) -> None:
+        """Verify that hysteresis prevents spurious exits. This ensures event orchestration remains reliable."""
+        tracker = UwbZoneTracker(
+            [
+                UwbZoneDefinition(
+                    zone_id="kitchen",
+                    center=(0.0, 0.0, 0.0),
+                    enter_radius=1.0,
+                    exit_radius=1.4,
+                )
+            ],
+            event_bus=event_bus,
+        )
 
-    event_bus.emit(
-        "uwb.ranging_event",
-        data={"position": {"x": 1.1, "y": 1.1}},
-        producer_id=99,
-    )
+        entries = collect_events(event_bus, "uwb.zone.entry")
+        exits = collect_events(event_bus, "uwb.zone.exit")
 
-    assert len(entries) == 1
-    entry = entries[0]
-    assert entry.data["tag_id"] == "99"
-    assert tracker.get_active_zones("99") == ("office",)
+        # First sample enters the zone.
+        event_bus.emit(
+            "uwb.ranging_event",
+            data={"tag_id": "tag-2", "position": (0.2, 0.3)},
+            producer_id=3,
+        )
+        assert len(entries) == 1
+        assert len(exits) == 0
 
+        # Close to the boundary but still inside thanks to hysteresis.
+        event_bus.emit(
+            "uwb.ranging_event",
+            data={"tag_id": "tag-2", "position": {"x": 1.2, "y": 0.0}},
+            producer_id=3,
+        )
+        assert len(exits) == 0
+        assert tracker.get_active_zones("tag-2") == ("kitchen",)
+
+        # Far enough to cross the exit radius.
+        event_bus.emit(
+            "uwb.ranging_event",
+            data={"tag_id": "tag-2", "position": {"x": 1.5, "y": 0.0}},
+            producer_id=3,
+        )
+        assert len(exits) == 1
+        exit_event = exits[0]
+        assert exit_event.data["zone_id"] == "kitchen"
+        assert tracker.get_active_zones("tag-2") == ()
+
+
+
+    def test_falls_back_to_producer_id_when_tag_missing(self, event_bus: EventBus) -> None:
+        """Verify that falls back to producer id when tag missing. This keeps the system behaviour reliable for operators."""
+        tracker = UwbZoneTracker(
+            [UwbZoneDefinition(zone_id="office", center=(1.0, 1.0, 0.0), enter_radius=0.5)],
+            event_bus=event_bus,
+        )
+
+        entries = collect_events(event_bus, "uwb.zone.entry")
+
+        event_bus.emit(
+            "uwb.ranging_event",
+            data={"position": {"x": 1.1, "y": 1.1}},
+            producer_id=99,
+        )
+
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry.data["tag_id"] == "99"
+        assert tracker.get_active_zones("99") == ("office",)

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -12,114 +12,129 @@ from heart.peripheral.core.manager import PeripheralManager
 from tests.conftest import FakeFixtureDevice
 
 
-@pytest.mark.parametrize("num_renderers", [1, 5, 10, 25, 50, 100, 1000])
-@pytest.mark.parametrize(
-    "renderer_variant", [RendererVariant.BINARY, RendererVariant.ITERATIVE]
-)
-def test_rendering_many_objects(
-    benchmark: BenchmarkFixture,
-    loop: GameLoop,
-    num_renderers: int,
-    renderer_variant: RendererVariant,
-) -> None:
-    mode = loop.add_mode("Test")
+class TestEnvironment:
+    """Group Environment tests so environment behaviour stays reliable. This preserves confidence in environment for end-to-end scenarios."""
 
-    for _ in range(num_renderers):
-        mode.add_renderer(RandomPixel(num_pixels=1, brightness=1))
+    @pytest.mark.parametrize("num_renderers", [1, 5, 10, 25, 50, 100, 1000])
+    @pytest.mark.parametrize(
+        "renderer_variant", [RendererVariant.BINARY, RendererVariant.ITERATIVE]
+    )
+    def test_rendering_many_objects(
+        self,
+        benchmark: BenchmarkFixture,
+        loop: GameLoop,
+        num_renderers: int,
+        renderer_variant: RendererVariant,
+    ) -> None:
+        """Verify that rendering many objects. This keeps rendering behaviour consistent across scenes."""
+        mode = loop.add_mode("Test")
 
-    # https://chatgpt.com/share/68056214-a5e4-8001-8fd0-ca966dbecf9b
-    benchmark(
-        lambda: loop._one_loop(
-            mode.renderers, override_renderer_variant=renderer_variant
+        for _ in range(num_renderers):
+            mode.add_renderer(RandomPixel(num_pixels=1, brightness=1))
+
+        # https://chatgpt.com/share/68056214-a5e4-8001-8fd0-ca966dbecf9b
+        benchmark(
+            lambda: loop._one_loop(
+                mode.renderers, override_renderer_variant=renderer_variant
+            )
         )
-    )
 
 
-def test_game_loop_shares_event_bus_with_manager(loop: GameLoop) -> None:
-    assert loop.peripheral_manager.event_bus is loop.event_bus
+
+    def test_game_loop_shares_event_bus_with_manager(self, loop: GameLoop) -> None:
+        """Verify that game loop shares event bus with manager. This ensures event orchestration remains reliable."""
+        assert loop.peripheral_manager.event_bus is loop.event_bus
 
 
-def test_handle_events_emits_to_event_bus(loop: GameLoop, monkeypatch) -> None:
-    captured: list[dict[str, object]] = []
 
-    loop.event_bus.subscribe("pygame/quit", lambda evt: captured.append(evt.data))
+    def test_handle_events_emits_to_event_bus(self, loop: GameLoop, monkeypatch) -> None:
+        """Verify that handle events emits to event bus. This ensures event orchestration remains reliable."""
+        captured: list[dict[str, object]] = []
 
-    fake_event = types.SimpleNamespace(type=pygame.QUIT, dict={})
-    monkeypatch.setattr(pygame.event, "get", lambda: [fake_event])
+        loop.event_bus.subscribe("pygame/quit", lambda evt: captured.append(evt.data))
 
-    loop.running = True
-    loop._handle_events()
+        fake_event = types.SimpleNamespace(type=pygame.QUIT, dict={})
+        monkeypatch.setattr(pygame.event, "get", lambda: [fake_event])
 
-    assert captured == [
-        {
-            "pygame_type": pygame.QUIT,
-            "pygame_event_name": pygame.event.event_name(pygame.QUIT),
-        }
-    ]
-    assert loop.running is False
+        loop.running = True
+        loop._handle_events()
 
-
-def test_handle_events_emits_custom_system_event(loop: GameLoop, monkeypatch) -> None:
-    captured: list[int] = []
-    joystick_reset = events.REQUEST_JOYSTICK_MODULE_RESET
-
-    loop.event_bus.subscribe(
-        "system/request_joystick_module_reset", lambda evt: captured.append(evt.data["pygame_type"])
-    )
-
-    fake_event = types.SimpleNamespace(type=joystick_reset, dict={})
-
-    calls: dict[str, int] = {"quit": 0, "init": 0}
-
-    def _mark_quit() -> None:
-        calls["quit"] += 1
-
-    def _mark_init() -> None:
-        calls["init"] += 1
-
-    monkeypatch.setattr(pygame.joystick, "quit", _mark_quit)
-    monkeypatch.setattr(pygame.joystick, "init", _mark_init)
-    monkeypatch.setattr(pygame.event, "get", lambda: [fake_event])
-
-    loop._handle_events()
-
-    assert calls == {"quit": 1, "init": 1}
-    assert captured == [joystick_reset]
+        assert captured == [
+            {
+                "pygame_type": pygame.QUIT,
+                "pygame_event_name": pygame.event.event_name(pygame.QUIT),
+            }
+        ]
+        assert loop.running is False
 
 
-def test_handle_events_supports_missing_event_payload(loop: GameLoop, monkeypatch) -> None:
-    captured: list[dict[str, object]] = []
 
-    loop.event_bus.subscribe(
-        "pygame/noevent", lambda evt: captured.append(evt.data)
-    )
+    def test_handle_events_emits_custom_system_event(self, loop: GameLoop, monkeypatch) -> None:
+        """Verify that handle events emits custom system event. This ensures event orchestration remains reliable."""
+        captured: list[int] = []
+        joystick_reset = events.REQUEST_JOYSTICK_MODULE_RESET
 
-    fake_event = types.SimpleNamespace(type=pygame.NOEVENT, dict=None)
-    monkeypatch.setattr(pygame.event, "get", lambda: [fake_event])
+        loop.event_bus.subscribe(
+            "system/request_joystick_module_reset", lambda evt: captured.append(evt.data["pygame_type"])
+        )
 
-    loop._handle_events()
+        fake_event = types.SimpleNamespace(type=joystick_reset, dict={})
 
-    assert captured == [
-        {
-            "pygame_type": pygame.NOEVENT,
-            "pygame_event_name": pygame.event.event_name(pygame.NOEVENT),
-        }
-    ]
+        calls: dict[str, int] = {"quit": 0, "init": 0}
+
+        def _mark_quit() -> None:
+            calls["quit"] += 1
+
+        def _mark_init() -> None:
+            calls["init"] += 1
+
+        monkeypatch.setattr(pygame.joystick, "quit", _mark_quit)
+        monkeypatch.setattr(pygame.joystick, "init", _mark_init)
+        monkeypatch.setattr(pygame.event, "get", lambda: [fake_event])
+
+        loop._handle_events()
+
+        assert calls == {"quit": 1, "init": 1}
+        assert captured == [joystick_reset]
 
 
-def test_multiple_game_loops_can_coexist(orientation) -> None:
-    os.environ["SDL_VIDEODRIVER"] = "dummy"
-    manager_one = PeripheralManager()
-    device_one = FakeFixtureDevice(orientation=orientation)
-    loop_one = GameLoop(device=device_one, peripheral_manager=manager_one)
-    loop_one._initialize_screen()
 
-    manager_two = PeripheralManager()
-    device_two = FakeFixtureDevice(orientation=orientation)
-    loop_two = GameLoop(device=device_two, peripheral_manager=manager_two)
-    loop_two._initialize_screen()
+    def test_handle_events_supports_missing_event_payload(self, loop: GameLoop, monkeypatch) -> None:
+        """Verify that handle events supports missing event payload. This ensures event orchestration remains reliable."""
+        captured: list[dict[str, object]] = []
 
-    assert loop_one.device is device_one
-    assert loop_two.device is device_two
+        loop.event_bus.subscribe(
+            "pygame/noevent", lambda evt: captured.append(evt.data)
+        )
 
-    pygame.quit()
+        fake_event = types.SimpleNamespace(type=pygame.NOEVENT, dict=None)
+        monkeypatch.setattr(pygame.event, "get", lambda: [fake_event])
+
+        loop._handle_events()
+
+        assert captured == [
+            {
+                "pygame_type": pygame.NOEVENT,
+                "pygame_event_name": pygame.event.event_name(pygame.NOEVENT),
+            }
+        ]
+
+
+
+    def test_multiple_game_loops_can_coexist(self, orientation) -> None:
+        """Verify that multiple game loops can coexist. This maintains stable runtime control flow."""
+        os.environ["SDL_VIDEODRIVER"] = "dummy"
+        manager_one = PeripheralManager()
+        device_one = FakeFixtureDevice(orientation=orientation)
+        loop_one = GameLoop(device=device_one, peripheral_manager=manager_one)
+        loop_one._initialize_screen()
+
+        manager_two = PeripheralManager()
+        device_two = FakeFixtureDevice(orientation=orientation)
+        loop_two = GameLoop(device=device_two, peripheral_manager=manager_two)
+        loop_two._initialize_screen()
+
+        assert loop_one.device is device_one
+        assert loop_two.device is device_two
+
+        pygame.quit()

--- a/tests/test_environment_core_logic.py
+++ b/tests/test_environment_core_logic.py
@@ -29,107 +29,226 @@ def clear_hsv_cache():
     HSV_TO_BGR_CACHE.clear()
 
 
-@pytest.mark.parametrize(
-    "bgr,expected",
-    [
-        (
-            np.array([0, 0, 255], dtype=np.uint8),
-            np.array([0, 255, 255], dtype=np.uint8),
-        ),
-        (
-            np.array([0, 255, 0], dtype=np.uint8),
-            np.array([60, 255, 255], dtype=np.uint8),
-        ),
-        (
-            np.array([255, 0, 0], dtype=np.uint8),
-            np.array([120, 255, 255], dtype=np.uint8),
-        ),
-        (np.array([50, 50, 50], dtype=np.uint8), np.array([0, 0, 50], dtype=np.uint8)),
-    ],
-)
-def test_convert_bgr_to_hsv_known_colors(bgr: np.ndarray, expected: np.ndarray) -> None:
-    image = bgr.reshape(1, 1, 3)
-    hsv = _convert_bgr_to_hsv(image)
-    np.testing.assert_array_equal(hsv.reshape(3), expected)
+class TestEnvironmentCoreLogic:
+    """Group Environment Core Logic tests so environment core logic behaviour stays reliable. This preserves confidence in environment core logic for end-to-end scenarios."""
 
-@pytest.mark.parametrize(
-    "hsv,expected",
-    [
-        (
-            np.array([0, 255, 255], dtype=np.uint8),
-            np.array([0, 0, 255], dtype=np.uint8),
-        ),
-        (
-            np.array([60, 255, 255], dtype=np.uint8),
-            np.array([2, 255, 0], dtype=np.uint8),
-        ),
-        (
-            np.array([119, 255, 255], dtype=np.uint8),
-            np.array([255, 0, 5], dtype=np.uint8),
-        ),
-        (np.array([0, 0, 50], dtype=np.uint8), np.array([50, 50, 50], dtype=np.uint8)),
-    ],
-)
-def test_convert_hsv_to_bgr_known_colors(hsv: np.ndarray, expected: np.ndarray) -> None:
-    image = hsv.reshape(1, 1, 3)
-    bgr = _convert_hsv_to_bgr(image)
-    np.testing.assert_array_equal(bgr.reshape(3), expected)
-
-
-@pytest.mark.parametrize("seed", [0, 1, 42])
-def test_color_round_trip(seed: int) -> None:
-    rng = np.random.default_rng(seed)
-    bgr = rng.integers(0, 256, size=(4, 5, 3), dtype=np.uint8)
-
-    hsv = _convert_bgr_to_hsv(bgr)
-    round_trip = _convert_hsv_to_bgr(hsv)
-
-    np.testing.assert_array_equal(round_trip, bgr)
-
-
-def test_convert_bgr_to_hsv_populates_cache_for_standard_values() -> None:
-    image = np.array(
-        [[[10, 20, 30], [40, 60, 80], [0, 255, 0]]],
-        dtype=np.uint8,
+    @pytest.mark.parametrize(
+        "bgr,expected",
+        [
+            (
+                np.array([0, 0, 255], dtype=np.uint8),
+                np.array([0, 255, 255], dtype=np.uint8),
+            ),
+            (
+                np.array([0, 255, 0], dtype=np.uint8),
+                np.array([60, 255, 255], dtype=np.uint8),
+            ),
+            (
+                np.array([255, 0, 0], dtype=np.uint8),
+                np.array([120, 255, 255], dtype=np.uint8),
+            ),
+            (np.array([50, 50, 50], dtype=np.uint8), np.array([0, 0, 50], dtype=np.uint8)),
+        ],
     )
-
-    hsv = _convert_bgr_to_hsv(image)
-
-    flat_bgr = image.reshape(-1, 3)
-    flat_hsv = hsv.reshape(-1, 3)
-
-    for hsv_value, bgr_value in zip(flat_hsv[:-1], flat_bgr[:-1]):
-        key = tuple(int(x) for x in hsv_value)
-        assert key in HSV_TO_BGR_CACHE
-        np.testing.assert_array_equal(HSV_TO_BGR_CACHE[key], bgr_value)
-
-    special_key = tuple(int(x) for x in flat_hsv[-1])
-    assert special_key == (60, 255, 255)
-    assert special_key not in HSV_TO_BGR_CACHE
+    def test_convert_bgr_to_hsv_known_colors(self, bgr: np.ndarray, expected: np.ndarray) -> None:
+        """Verify that _convert_bgr_to_hsv maps canonical BGR inputs to expected HSV values. This keeps colour transforms dependable for renderer pipelines."""
+        image = bgr.reshape(1, 1, 3)
+        hsv = _convert_bgr_to_hsv(image)
+        np.testing.assert_array_equal(hsv.reshape(3), expected)
 
 
-def test_convert_hsv_to_bgr_prefers_cached_values() -> None:
-    key = (12, 34, 200)
-    cached_value = np.array([1, 2, 3], dtype=np.uint8)
-    HSV_TO_BGR_CACHE[key] = cached_value.copy()
+    @pytest.mark.parametrize(
+        "hsv,expected",
+        [
+            (
+                np.array([0, 255, 255], dtype=np.uint8),
+                np.array([0, 0, 255], dtype=np.uint8),
+            ),
+            (
+                np.array([60, 255, 255], dtype=np.uint8),
+                np.array([2, 255, 0], dtype=np.uint8),
+            ),
+            (
+                np.array([119, 255, 255], dtype=np.uint8),
+                np.array([255, 0, 5], dtype=np.uint8),
+            ),
+            (np.array([0, 0, 50], dtype=np.uint8), np.array([50, 50, 50], dtype=np.uint8)),
+        ],
+    )
+    def test_convert_hsv_to_bgr_known_colors(self, hsv: np.ndarray, expected: np.ndarray) -> None:
+        """Verify that _convert_hsv_to_bgr reproduces known BGR colours from HSV inputs. This prevents palette drift when using cached conversions."""
+        image = hsv.reshape(1, 1, 3)
+        bgr = _convert_hsv_to_bgr(image)
+        np.testing.assert_array_equal(bgr.reshape(3), expected)
 
-    hsv = np.array([[list(key)]], dtype=np.uint8)
-    result = _convert_hsv_to_bgr(hsv)
-
-    np.testing.assert_array_equal(result[0, 0], cached_value)
-    assert next(reversed(HSV_TO_BGR_CACHE)) == key
 
 
-def test_convert_hsv_to_bgr_calibration_clears_cache_for_known_keys() -> None:
-    key = (60, 255, 255)
-    HSV_TO_BGR_CACHE[key] = np.array([9, 9, 9], dtype=np.uint8)
+    @pytest.mark.parametrize("seed", [0, 1, 42])
+    def test_color_round_trip(self, seed: int) -> None:
+        """Verify that random BGR arrays survive a round trip through HSV conversion. This proves the helpers are lossless for display operations."""
+        rng = np.random.default_rng(seed)
+        bgr = rng.integers(0, 256, size=(4, 5, 3), dtype=np.uint8)
 
-    hsv = np.array([[list(key)]], dtype=np.uint8)
-    result = _convert_hsv_to_bgr(hsv)
+        hsv = _convert_bgr_to_hsv(bgr)
+        round_trip = _convert_hsv_to_bgr(hsv)
 
-    np.testing.assert_array_equal(result[0, 0], np.array([2, 255, 0], dtype=np.uint8))
-    assert key not in HSV_TO_BGR_CACHE
+        np.testing.assert_array_equal(round_trip, bgr)
 
+
+
+    def test_convert_bgr_to_hsv_populates_cache_for_standard_values(self) -> None:
+        """Verify that _convert_bgr_to_hsv populates the cache for standard values while skipping sentinel entries. This ensures repeated conversions stay fast without polluting special cases."""
+        image = np.array(
+            [[[10, 20, 30], [40, 60, 80], [0, 255, 0]]],
+            dtype=np.uint8,
+        )
+
+        hsv = _convert_bgr_to_hsv(image)
+
+        flat_bgr = image.reshape(-1, 3)
+        flat_hsv = hsv.reshape(-1, 3)
+
+        for hsv_value, bgr_value in zip(flat_hsv[:-1], flat_bgr[:-1]):
+            key = tuple(int(x) for x in hsv_value)
+            assert key in HSV_TO_BGR_CACHE
+            np.testing.assert_array_equal(HSV_TO_BGR_CACHE[key], bgr_value)
+
+        special_key = tuple(int(x) for x in flat_hsv[-1])
+        assert special_key == (60, 255, 255)
+        assert special_key not in HSV_TO_BGR_CACHE
+
+
+
+    def test_convert_hsv_to_bgr_prefers_cached_values(self) -> None:
+        """Verify that _convert_hsv_to_bgr prefers cached values when available. This keeps interactive rendering snappy by avoiding recomputation."""
+        key = (12, 34, 200)
+        cached_value = np.array([1, 2, 3], dtype=np.uint8)
+        HSV_TO_BGR_CACHE[key] = cached_value.copy()
+
+        hsv = np.array([[list(key)]], dtype=np.uint8)
+        result = _convert_hsv_to_bgr(hsv)
+
+        np.testing.assert_array_equal(result[0, 0], cached_value)
+        assert next(reversed(HSV_TO_BGR_CACHE)) == key
+
+
+
+    def test_convert_hsv_to_bgr_calibration_clears_cache_for_known_keys(self) -> None:
+        """Verify that _convert_hsv_to_bgr clears cached values for calibration keys. This allows dynamic tuning without stale entries lingering."""
+        key = (60, 255, 255)
+        HSV_TO_BGR_CACHE[key] = np.array([9, 9, 9], dtype=np.uint8)
+
+        hsv = np.array([[list(key)]], dtype=np.uint8)
+        result = _convert_hsv_to_bgr(hsv)
+
+        np.testing.assert_array_equal(result[0, 0], np.array([2, 255, 0], dtype=np.uint8))
+        assert key not in HSV_TO_BGR_CACHE
+
+
+
+    @pytest.mark.parametrize("values", [list("abcd"), list("abcde")])
+    def test_render_surfaces_binary_merges_all(
+        self,
+        loop, monkeypatch, values: list[str]
+    ) -> None:
+        """Verify that _render_surfaces_binary merges all renderers pairwise. This validates the binary merge optimisation powering high-FPS scenes."""
+        sequence = {value: f"surface-{value}" for value in values}
+
+        def fake_process(renderer: str) -> str:
+            return sequence[renderer]
+
+        def fake_merge(surface1: str, surface2: str) -> str:
+            return f"merge({surface1},{surface2})"
+
+        monkeypatch.setattr(loop, "process_renderer", fake_process)
+        monkeypatch.setattr(loop, "merge_surfaces", fake_merge)
+
+        result = loop._render_surfaces_binary(values)
+        expected = _sequential_binary_merge(list(sequence.values()))
+        assert result == expected
+
+
+
+    def test_render_surfaces_binary_handles_empty(self, loop) -> None:
+        """Verify that _render_surfaces_binary returns None when no renderers are provided. This avoids edge-case crashes during startup."""
+        assert loop._render_surfaces_binary([]) is None
+
+
+
+    def test_render_surface_iterative_skips_missing(self, loop, monkeypatch) -> None:
+        """Verify that _render_surface_iterative skips missing surfaces while merging. This ensures null-producing renderers do not break composition."""
+        renderers = ["r1", "r2", "r3"]
+        responses = {"r1": "surface-1", "r2": None, "r3": "surface-3"}
+        merges: list[tuple[str, str]] = []
+
+        def fake_process(renderer: str) -> str | None:
+            return responses[renderer]
+
+        def fake_merge(surface1: str, surface2: str) -> str:
+            merges.append((surface1, surface2))
+            return f"merge({surface1},{surface2})"
+
+        monkeypatch.setattr(loop, "process_renderer", fake_process)
+        monkeypatch.setattr(loop, "merge_surfaces", fake_merge)
+
+        result = loop._render_surface_iterative(renderers)
+
+        assert result == "merge(surface-1,surface-3)"
+        assert merges == [("surface-1", "surface-3")]
+
+
+    def test_render_fn_selects_renderer(self, loop) -> None:
+        """Verify that _render_fn returns the expected merge strategy for each variant. This keeps render mode selection predictable."""
+        assert loop._render_fn(RendererVariant.BINARY) is loop._render_surfaces_binary
+        assert loop._render_fn(RendererVariant.ITERATIVE) is loop._render_surface_iterative
+
+
+    def test_render_fn_default_uses_loop_variant(self, loop) -> None:
+        """Verify that _render_fn respects the loop's configured renderer variant by default. This keeps runtime switches effective without reconfiguring callers."""
+        loop.renderer_variant = RendererVariant.BINARY
+        assert loop._render_fn(None) is loop._render_surfaces_binary
+        loop.renderer_variant = RendererVariant.ITERATIVE
+        assert loop._render_fn(None) is loop._render_surface_iterative
+
+
+
+    @pytest.mark.parametrize(
+        "variant",
+        list(RendererVariant),
+    )
+    def test_render_fn_handles_unknown_variant(self, loop, variant: RendererVariant) -> None:
+        """Verify that _render_fn returns a callable even for enumerated variants. This avoids runtime errors when iterating through supported strategies."""
+        assert callable(loop._render_fn(variant))
+
+
+
+    def test_phone_text_event_triggers_transient_renderer(self, loop, monkeypatch) -> None:
+        """Verify that a phone text event spawns a transient renderer and expires after the timeout. This ensures pop-up messages show briefly without blocking other scenes."""
+        current_time = 1000.0
+
+        monkeypatch.setattr("heart.environment.time.monotonic", lambda: current_time)
+        loop.app_controller = types.SimpleNamespace(
+            get_renderers=lambda *args, **kwargs: [],
+        )
+
+        assert loop._select_renderers() == []
+
+        loop.event_bus.emit(
+            PhoneTextMessage.EVENT_TYPE,
+            {"text": "Heart: hello"},
+        )
+
+        active_renderers = loop._select_renderers()
+        assert len(active_renderers) == 1
+        renderer = active_renderers[0]
+        assert isinstance(renderer, FreeTextRenderer)
+
+        current_time += loop._phone_text_duration - 1.0
+        assert loop._select_renderers() == [renderer]
+
+        current_time += 2.0
+        assert loop._select_renderers() == []
+        assert loop._phone_text_display_started_at is None
 
 def _sequential_binary_merge(values: list[str]) -> str:
     surfaces = list(values)
@@ -140,94 +259,3 @@ def _sequential_binary_merge(values: list[str]) -> str:
             merged_surfaces.append(surfaces[-1])
         surfaces = merged_surfaces
     return surfaces[0]
-
-
-@pytest.mark.parametrize("values", [list("abcd"), list("abcde")])
-def test_render_surfaces_binary_merges_all(
-    loop, monkeypatch, values: list[str]
-) -> None:
-    sequence = {value: f"surface-{value}" for value in values}
-
-    def fake_process(renderer: str) -> str:
-        return sequence[renderer]
-
-    def fake_merge(surface1: str, surface2: str) -> str:
-        return f"merge({surface1},{surface2})"
-
-    monkeypatch.setattr(loop, "process_renderer", fake_process)
-    monkeypatch.setattr(loop, "merge_surfaces", fake_merge)
-
-    result = loop._render_surfaces_binary(values)
-    expected = _sequential_binary_merge(list(sequence.values()))
-    assert result == expected
-
-
-def test_render_surfaces_binary_handles_empty(loop) -> None:
-    assert loop._render_surfaces_binary([]) is None
-
-
-def test_render_surface_iterative_skips_missing(loop, monkeypatch) -> None:
-    renderers = ["r1", "r2", "r3"]
-    responses = {"r1": "surface-1", "r2": None, "r3": "surface-3"}
-    merges: list[tuple[str, str]] = []
-
-    def fake_process(renderer: str) -> str | None:
-        return responses[renderer]
-
-    def fake_merge(surface1: str, surface2: str) -> str:
-        merges.append((surface1, surface2))
-        return f"merge({surface1},{surface2})"
-
-    monkeypatch.setattr(loop, "process_renderer", fake_process)
-    monkeypatch.setattr(loop, "merge_surfaces", fake_merge)
-
-    result = loop._render_surface_iterative(renderers)
-
-    assert result == "merge(surface-1,surface-3)"
-    assert merges == [("surface-1", "surface-3")]
-
-def test_render_fn_selects_renderer(loop) -> None:
-    assert loop._render_fn(RendererVariant.BINARY) is loop._render_surfaces_binary
-    assert loop._render_fn(RendererVariant.ITERATIVE) is loop._render_surface_iterative
-
-def test_render_fn_default_uses_loop_variant(loop) -> None:
-    loop.renderer_variant = RendererVariant.BINARY
-    assert loop._render_fn(None) is loop._render_surfaces_binary
-    loop.renderer_variant = RendererVariant.ITERATIVE
-    assert loop._render_fn(None) is loop._render_surface_iterative
-
-
-@pytest.mark.parametrize(
-    "variant",
-    list(RendererVariant),
-)
-def test_render_fn_handles_unknown_variant(loop, variant: RendererVariant) -> None:
-    assert callable(loop._render_fn(variant))
-
-
-def test_phone_text_event_triggers_transient_renderer(loop, monkeypatch) -> None:
-    current_time = 1000.0
-
-    monkeypatch.setattr("heart.environment.time.monotonic", lambda: current_time)
-    loop.app_controller = types.SimpleNamespace(
-        get_renderers=lambda *args, **kwargs: [],
-    )
-
-    assert loop._select_renderers() == []
-
-    loop.event_bus.emit(
-        PhoneTextMessage.EVENT_TYPE,
-        {"text": "Heart: hello"},
-    )
-
-    active_renderers = loop._select_renderers()
-    assert len(active_renderers) == 1
-    renderer = active_renderers[0]
-    assert isinstance(renderer, FreeTextRenderer)
-
-    current_time += loop._phone_text_duration - 1.0
-    assert loop._select_renderers() == [renderer]
-
-    current_time += 2.0
-    assert loop._select_renderers() == []
-    assert loop._phone_text_display_started_at is None

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -11,46 +11,56 @@ def clear_env(monkeypatch):
     monkeypatch.delenv(identity.DEVICE_ID_PATH_ENV_VAR, raising=False)
 
 
-def test_persistent_device_id_reads_existing_file(tmp_path, monkeypatch):
-    storage_path = tmp_path / "device_id.txt"
-    storage_path.write_text("existing-id")
-    monkeypatch.setenv(identity.DEVICE_ID_PATH_ENV_VAR, str(storage_path))
+class TestIdentity:
+    """Group Identity tests so identity behaviour stays reliable. This preserves confidence in identity for end-to-end scenarios."""
 
-    result = identity.persistent_device_id()
+    def test_persistent_device_id_reads_existing_file(self, tmp_path, monkeypatch):
+        """Verify that persistent device id reads existing file. This ensures device provisioning workflows remain predictable."""
+        storage_path = tmp_path / "device_id.txt"
+        storage_path.write_text("existing-id")
+        monkeypatch.setenv(identity.DEVICE_ID_PATH_ENV_VAR, str(storage_path))
 
-    assert result == "existing-id"
+        result = identity.persistent_device_id()
 
-
-def test_persistent_device_id_uses_env_and_persists(tmp_path, monkeypatch):
-    storage_path = tmp_path / "device_id.txt"
-    monkeypatch.setenv(identity.DEVICE_ID_PATH_ENV_VAR, str(storage_path))
-    monkeypatch.setenv(identity.DEVICE_ID_ENV_VAR, "env-id-123")
-
-    result = identity.persistent_device_id()
-
-    assert result == "env-id-123"
-    assert storage_path.read_text() == "env-id-123"
+        assert result == "existing-id"
 
 
-def test_persistent_device_id_uses_hardware_uid(tmp_path, monkeypatch):
-    storage_path = tmp_path / "device_id.txt"
-    monkeypatch.setenv(identity.DEVICE_ID_PATH_ENV_VAR, str(storage_path))
 
-    stub_microcontroller = types.SimpleNamespace(cpu=types.SimpleNamespace(uid=b"\x01\xAB"))
+    def test_persistent_device_id_uses_env_and_persists(self, tmp_path, monkeypatch):
+        """Verify that persistent device id uses env and persists. This ensures device provisioning workflows remain predictable."""
+        storage_path = tmp_path / "device_id.txt"
+        monkeypatch.setenv(identity.DEVICE_ID_PATH_ENV_VAR, str(storage_path))
+        monkeypatch.setenv(identity.DEVICE_ID_ENV_VAR, "env-id-123")
 
-    result = identity.persistent_device_id(microcontroller_module=stub_microcontroller)
+        result = identity.persistent_device_id()
 
-    assert result == "01ab"
-    assert storage_path.read_text() == "01ab"
+        assert result == "env-id-123"
+        assert storage_path.read_text() == "env-id-123"
 
 
-def test_persistent_device_id_generates_when_no_sources(tmp_path, monkeypatch):
-    storage_path = tmp_path / "device_id.txt"
-    monkeypatch.setenv(identity.DEVICE_ID_PATH_ENV_VAR, str(storage_path))
-    monkeypatch.setattr(identity, "_hardware_device_uid", lambda _module=None: None)
-    monkeypatch.setattr(identity, "_random_device_id", lambda: "feedbeef")
 
-    result = identity.persistent_device_id()
+    def test_persistent_device_id_uses_hardware_uid(self, tmp_path, monkeypatch):
+        """Verify that persistent device id uses hardware uid. This ensures device provisioning workflows remain predictable."""
+        storage_path = tmp_path / "device_id.txt"
+        monkeypatch.setenv(identity.DEVICE_ID_PATH_ENV_VAR, str(storage_path))
 
-    assert result == "feedbeef"
-    assert storage_path.read_text() == "feedbeef"
+        stub_microcontroller = types.SimpleNamespace(cpu=types.SimpleNamespace(uid=b"\x01\xAB"))
+
+        result = identity.persistent_device_id(microcontroller_module=stub_microcontroller)
+
+        assert result == "01ab"
+        assert storage_path.read_text() == "01ab"
+
+
+
+    def test_persistent_device_id_generates_when_no_sources(self, tmp_path, monkeypatch):
+        """Verify that persistent device id generates when no sources. This ensures device provisioning workflows remain predictable."""
+        storage_path = tmp_path / "device_id.txt"
+        monkeypatch.setenv(identity.DEVICE_ID_PATH_ENV_VAR, str(storage_path))
+        monkeypatch.setattr(identity, "_hardware_device_uid", lambda _module=None: None)
+        monkeypatch.setattr(identity, "_random_device_id", lambda: "feedbeef")
+
+        result = identity.persistent_device_id()
+
+        assert result == "feedbeef"
+        assert storage_path.read_text() == "feedbeef"

--- a/tests/utilities/test_env.py
+++ b/tests/utilities/test_env.py
@@ -25,116 +25,138 @@ def _clear_env(monkeypatch: pytest.MonkeyPatch, *names: str) -> None:
         monkeypatch.delenv(name, raising=False)
 
 
-def test_isolated_renderer_socket_prefers_explicit_path(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ISOLATED_RENDER_SOCKET", "/tmp/custom.sock")
-    _clear_env(
-        monkeypatch,
-        "ISOLATED_RENDER_HOST",
-        "ISOLATED_RENDER_PORT",
-    )
+class TestUtilitiesEnv:
+    """Group Utilities Env tests so utilities env behaviour stays reliable. This preserves confidence in utilities env for end-to-end scenarios."""
 
-    assert Configuration.isolated_renderer_socket() == "/tmp/custom.sock"
-
-
-def test_isolated_renderer_socket_empty_string(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ISOLATED_RENDER_SOCKET", "")
-    _clear_env(
-        monkeypatch,
-        "ISOLATED_RENDER_HOST",
-        "ISOLATED_RENDER_PORT",
-    )
-
-    assert Configuration.isolated_renderer_socket() is None
-
-
-def test_isolated_renderer_socket_defaults_to_named_socket(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _clear_env(
-        monkeypatch,
-        "ISOLATED_RENDER_SOCKET",
-        "ISOLATED_RENDER_HOST",
-        "ISOLATED_RENDER_PORT",
-    )
-
-    assert Configuration.isolated_renderer_socket() == DEFAULT_SOCKET_PATH
-
-
-def test_isolated_renderer_socket_delegates_to_tcp_settings(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _clear_env(monkeypatch, "ISOLATED_RENDER_SOCKET")
-    monkeypatch.setenv("ISOLATED_RENDER_HOST", "127.0.0.1")
-    monkeypatch.setenv("ISOLATED_RENDER_PORT", "9000")
-
-    assert Configuration.isolated_renderer_tcp_address() == ("127.0.0.1", 9000)
-    assert Configuration.isolated_renderer_socket() is None
-
-
-def test_isolated_renderer_tcp_address_requires_both(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ISOLATED_RENDER_HOST", "127.0.0.1")
-    monkeypatch.delenv("ISOLATED_RENDER_PORT", raising=False)
-
-    with pytest.raises(ValueError):
-        Configuration.isolated_renderer_tcp_address()
-
-    monkeypatch.delenv("ISOLATED_RENDER_HOST", raising=False)
-    monkeypatch.setenv("ISOLATED_RENDER_PORT", "8080")
-
-    with pytest.raises(ValueError):
-        Configuration.isolated_renderer_tcp_address()
-
-
-def test_isolated_renderer_tcp_address_requires_integer_port(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("ISOLATED_RENDER_HOST", "example.com")
-    monkeypatch.setenv("ISOLATED_RENDER_PORT", "not-an-int")
-
-    with pytest.raises(ValueError):
-        Configuration.isolated_renderer_tcp_address()
-
-
-def test_isolated_renderer_tcp_address_returns_tuple(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ISOLATED_RENDER_HOST", "example.com")
-    monkeypatch.setenv("ISOLATED_RENDER_PORT", "1234")
-
-    assert Configuration.isolated_renderer_tcp_address() == ("example.com", 1234)
-
-
-def test_get_device_ports_prefers_symlink_directory(monkeypatch: pytest.MonkeyPatch) -> None:
-    fake_entries = ["ttyHeart-123", "other"]
-
-    monkeypatch.setenv("ISOLATED_RENDER_HOST", "")  # ensure unrelated env noise is absent
-    monkeypatch.setenv("ISOLATED_RENDER_PORT", "")
-
-    monkeypatch.setattr("heart.utilities.env.os.path.exists", lambda path: True)
-    monkeypatch.setattr("heart.utilities.env.os.listdir", lambda path: fake_entries)
-    monkeypatch.setattr("heart.utilities.env.os.path.join", lambda a, b: f"{a}/{b}")
-
-    ports = list(get_device_ports("ttyHeart"))
-
-    assert ports == ["/dev/serial/by-id/ttyHeart-123"]
-
-
-def test_get_device_ports_fallback_to_serial(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_comports() -> Iterator[SimpleNamespace]:
-        return iter(
-            [
-                SimpleNamespace(device="/dev/cu.usbserial-0001", description="Heart Foo"),
-                SimpleNamespace(device="/dev/cu.Bluetooth-Incoming-Port", description="Other"),
-            ]
+    def test_isolated_renderer_socket_prefers_explicit_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify that isolated renderer socket prefers explicit path. This keeps rendering behaviour consistent across scenes."""
+        monkeypatch.setenv("ISOLATED_RENDER_SOCKET", "/tmp/custom.sock")
+        _clear_env(
+            monkeypatch,
+            "ISOLATED_RENDER_HOST",
+            "ISOLATED_RENDER_PORT",
         )
 
-    monkeypatch.setattr("heart.utilities.env.os.path.exists", lambda path: False)
+        assert Configuration.isolated_renderer_socket() == "/tmp/custom.sock"
 
-    monkeypatch.setattr("heart.utilities.env.platform.system", lambda: "Darwin")
-    monkeypatch.setattr(
-        "heart.utilities.env.serial.tools.list_ports.comports",
-        fake_comports,
-    )
 
-    ports = list(get_device_ports("heart"))
 
-    assert ports == ["/dev/cu.usbserial-0001"]
+    def test_isolated_renderer_socket_empty_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify that isolated renderer socket empty string. This keeps rendering behaviour consistent across scenes."""
+        monkeypatch.setenv("ISOLATED_RENDER_SOCKET", "")
+        _clear_env(
+            monkeypatch,
+            "ISOLATED_RENDER_HOST",
+            "ISOLATED_RENDER_PORT",
+        )
 
+        assert Configuration.isolated_renderer_socket() is None
+
+
+
+    def test_isolated_renderer_socket_defaults_to_named_socket(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify that isolated renderer socket defaults to named socket. This keeps rendering behaviour consistent across scenes."""
+        _clear_env(
+            monkeypatch,
+            "ISOLATED_RENDER_SOCKET",
+            "ISOLATED_RENDER_HOST",
+            "ISOLATED_RENDER_PORT",
+        )
+
+        assert Configuration.isolated_renderer_socket() == DEFAULT_SOCKET_PATH
+
+
+
+    def test_isolated_renderer_socket_delegates_to_tcp_settings(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify that isolated renderer socket delegates to tcp settings. This keeps rendering behaviour consistent across scenes."""
+        _clear_env(monkeypatch, "ISOLATED_RENDER_SOCKET")
+        monkeypatch.setenv("ISOLATED_RENDER_HOST", "127.0.0.1")
+        monkeypatch.setenv("ISOLATED_RENDER_PORT", "9000")
+
+        assert Configuration.isolated_renderer_tcp_address() == ("127.0.0.1", 9000)
+        assert Configuration.isolated_renderer_socket() is None
+
+
+
+    def test_isolated_renderer_tcp_address_requires_both(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify that isolated renderer tcp address requires both. This keeps rendering behaviour consistent across scenes."""
+        monkeypatch.setenv("ISOLATED_RENDER_HOST", "127.0.0.1")
+        monkeypatch.delenv("ISOLATED_RENDER_PORT", raising=False)
+
+        with pytest.raises(ValueError):
+            Configuration.isolated_renderer_tcp_address()
+
+        monkeypatch.delenv("ISOLATED_RENDER_HOST", raising=False)
+        monkeypatch.setenv("ISOLATED_RENDER_PORT", "8080")
+
+        with pytest.raises(ValueError):
+            Configuration.isolated_renderer_tcp_address()
+
+
+
+    def test_isolated_renderer_tcp_address_requires_integer_port(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify that isolated renderer tcp address requires integer port. This keeps rendering behaviour consistent across scenes."""
+        monkeypatch.setenv("ISOLATED_RENDER_HOST", "example.com")
+        monkeypatch.setenv("ISOLATED_RENDER_PORT", "not-an-int")
+
+        with pytest.raises(ValueError):
+            Configuration.isolated_renderer_tcp_address()
+
+
+
+    def test_isolated_renderer_tcp_address_returns_tuple(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify that isolated renderer tcp address returns tuple. This keeps rendering behaviour consistent across scenes."""
+        monkeypatch.setenv("ISOLATED_RENDER_HOST", "example.com")
+        monkeypatch.setenv("ISOLATED_RENDER_PORT", "1234")
+
+        assert Configuration.isolated_renderer_tcp_address() == ("example.com", 1234)
+
+
+
+    def test_get_device_ports_prefers_symlink_directory(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify that get device ports prefers symlink directory. This keeps connectivity configuration robust."""
+        fake_entries = ["ttyHeart-123", "other"]
+
+        monkeypatch.setenv("ISOLATED_RENDER_HOST", "")  # ensure unrelated env noise is absent
+        monkeypatch.setenv("ISOLATED_RENDER_PORT", "")
+
+        monkeypatch.setattr("heart.utilities.env.os.path.exists", lambda path: True)
+        monkeypatch.setattr("heart.utilities.env.os.listdir", lambda path: fake_entries)
+        monkeypatch.setattr("heart.utilities.env.os.path.join", lambda a, b: f"{a}/{b}")
+
+        ports = list(get_device_ports("ttyHeart"))
+
+        assert ports == ["/dev/serial/by-id/ttyHeart-123"]
+
+
+
+    def test_get_device_ports_fallback_to_serial(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify that get device ports fallback to serial. This keeps connectivity configuration robust."""
+        def fake_comports() -> Iterator[SimpleNamespace]:
+            return iter(
+                [
+                    SimpleNamespace(device="/dev/cu.usbserial-0001", description="Heart Foo"),
+                    SimpleNamespace(device="/dev/cu.Bluetooth-Incoming-Port", description="Other"),
+                ]
+            )
+
+        monkeypatch.setattr("heart.utilities.env.os.path.exists", lambda path: False)
+
+        monkeypatch.setattr("heart.utilities.env.platform.system", lambda: "Darwin")
+        monkeypatch.setattr(
+            "heart.utilities.env.serial.tools.list_ports.comports",
+            fake_comports,
+        )
+
+        ports = list(get_device_ports("heart"))
+
+        assert ports == ["/dev/cu.usbserial-0001"]

--- a/tests/utilities/test_metrics_helpers.py
+++ b/tests/utilities/test_metrics_helpers.py
@@ -4,34 +4,42 @@ from heart.utilities.metrics import (ExponentialMovingAverage, Histogram,
                                      ThresholdCounter)
 
 
-def test_histogram_assigns_values_to_correct_bins() -> None:
-    histogram: Histogram[str] = Histogram([-1.0, 0.0, 1.0])
-    histogram.observe("sensor", -2.0)
-    histogram.observe("sensor", -0.5)
-    histogram.observe("sensor", 0.5)
-    histogram.observe("sensor", 2.0)
-    snapshot = histogram.get("sensor")
-    assert snapshot["(-inf, -1.0]"] == 1
-    assert snapshot["(-1.0, 0.0]"] == 1
-    assert snapshot["(0.0, 1.0]"] == 1
-    assert snapshot["(1.0, inf)"] == 1
+class TestUtilitiesMetricsHelpers:
+    """Group Utilities Metrics Helpers tests so utilities metrics helpers behaviour stays reliable. This preserves confidence in utilities metrics helpers for end-to-end scenarios."""
+
+    def test_histogram_assigns_values_to_correct_bins(self) -> None:
+        """Verify that histogram assigns values to correct bins. This supports analytics accuracy for monitoring."""
+        histogram: Histogram[str] = Histogram([-1.0, 0.0, 1.0])
+        histogram.observe("sensor", -2.0)
+        histogram.observe("sensor", -0.5)
+        histogram.observe("sensor", 0.5)
+        histogram.observe("sensor", 2.0)
+        snapshot = histogram.get("sensor")
+        assert snapshot["(-inf, -1.0]"] == 1
+        assert snapshot["(-1.0, 0.0]"] == 1
+        assert snapshot["(0.0, 1.0]"] == 1
+        assert snapshot["(1.0, inf)"] == 1
 
 
-def test_threshold_counter_tracks_breaches() -> None:
-    counter: ThresholdCounter[str] = ThresholdCounter(default_threshold=5.0, inclusive=False)
-    counter.observe("loop", 5.0)
-    counter.observe("loop", 6.0)
-    counter.observe("loop", 8.0)
-    snapshot = counter.get("loop")
-    assert snapshot["breaches"] == 2
-    assert snapshot["threshold"] == 5.0
+
+    def test_threshold_counter_tracks_breaches(self) -> None:
+        """Verify that threshold counter tracks breaches. This supports analytics accuracy for monitoring."""
+        counter: ThresholdCounter[str] = ThresholdCounter(default_threshold=5.0, inclusive=False)
+        counter.observe("loop", 5.0)
+        counter.observe("loop", 6.0)
+        counter.observe("loop", 8.0)
+        snapshot = counter.get("loop")
+        assert snapshot["breaches"] == 2
+        assert snapshot["threshold"] == 5.0
 
 
-def test_exponential_moving_average_converges() -> None:
-    ema: ExponentialMovingAverage[str] = ExponentialMovingAverage(alpha=0.5)
-    ema.observe("loop", 0.0)
-    ema.observe("loop", 10.0)
-    ema.observe("loop", 10.0)
-    snapshot = ema.get("loop")
-    assert snapshot["ewma"] == 7.5
-    assert snapshot["alpha"] == 0.5
+
+    def test_exponential_moving_average_converges(self) -> None:
+        """Verify that exponential moving average converges. This supports analytics accuracy for monitoring."""
+        ema: ExponentialMovingAverage[str] = ExponentialMovingAverage(alpha=0.5)
+        ema.observe("loop", 0.0)
+        ema.observe("loop", 10.0)
+        ema.observe("loop", 10.0)
+        snapshot = ema.get("loop")
+        assert snapshot["ewma"] == 7.5
+        assert snapshot["alpha"] == 0.5

--- a/tests/utilities/test_signal.py
+++ b/tests/utilities/test_signal.py
@@ -9,35 +9,45 @@ from heart.utilities.signal import (cross_correlation, dominant_frequency,
                                     fft_magnitude, hilbert_envelope)
 
 
-def test_fft_magnitude_identifies_peak() -> None:
-    sample_rate = 100.0
-    duration = 1.0
-    t = np.linspace(0.0, duration, int(sample_rate * duration), endpoint=False)
-    samples = np.sin(2 * math.pi * 5.0 * t)
-    freqs, magnitudes = fft_magnitude(samples, sample_rate=sample_rate)
-    peak_frequency = freqs[int(np.argmax(magnitudes))]
-    assert peak_frequency == 5.0
+class TestUtilitiesSignal:
+    """Group Utilities Signal tests so utilities signal behaviour stays reliable. This preserves confidence in utilities signal for end-to-end scenarios."""
+
+    def test_fft_magnitude_identifies_peak(self) -> None:
+        """Verify that fft magnitude identifies peak. This supports analytics accuracy for monitoring."""
+        sample_rate = 100.0
+        duration = 1.0
+        t = np.linspace(0.0, duration, int(sample_rate * duration), endpoint=False)
+        samples = np.sin(2 * math.pi * 5.0 * t)
+        freqs, magnitudes = fft_magnitude(samples, sample_rate=sample_rate)
+        peak_frequency = freqs[int(np.argmax(magnitudes))]
+        assert peak_frequency == 5.0
 
 
-def test_dominant_frequency_matches_fft() -> None:
-    sample_rate = 200.0
-    t = np.linspace(0.0, 1.0, int(sample_rate), endpoint=False)
-    samples = 0.5 * np.sin(2 * math.pi * 20.0 * t)
-    frequency, magnitude = dominant_frequency(samples, sample_rate=sample_rate)
-    assert frequency == 20.0
-    assert magnitude > 0.0
+
+    def test_dominant_frequency_matches_fft(self) -> None:
+        """Verify that dominant frequency matches fft. This supports analytics accuracy for monitoring."""
+        sample_rate = 200.0
+        t = np.linspace(0.0, 1.0, int(sample_rate), endpoint=False)
+        samples = 0.5 * np.sin(2 * math.pi * 20.0 * t)
+        frequency, magnitude = dominant_frequency(samples, sample_rate=sample_rate)
+        assert frequency == 20.0
+        assert magnitude > 0.0
 
 
-def test_cross_correlation_detects_zero_lag() -> None:
-    a = np.array([1.0, 2.0, 3.0, 4.0])
-    b = np.array([1.0, 2.0, 3.0, 4.0])
-    lags, correlation = cross_correlation(a, b)
-    zero_index = int(np.where(lags == 0)[0][0])
-    assert correlation[zero_index] == pytest.approx(1.0)
+
+    def test_cross_correlation_detects_zero_lag(self) -> None:
+        """Verify that cross correlation detects zero lag. This supports analytics accuracy for monitoring."""
+        a = np.array([1.0, 2.0, 3.0, 4.0])
+        b = np.array([1.0, 2.0, 3.0, 4.0])
+        lags, correlation = cross_correlation(a, b)
+        zero_index = int(np.where(lags == 0)[0][0])
+        assert correlation[zero_index] == pytest.approx(1.0)
 
 
-def test_hilbert_envelope_matches_absolute_for_constant() -> None:
-    samples = np.ones(32)
-    envelope = hilbert_envelope(samples)
-    assert envelope.shape == samples.shape
-    assert np.allclose(envelope, samples)
+
+    def test_hilbert_envelope_matches_absolute_for_constant(self) -> None:
+        """Verify that hilbert envelope matches absolute for constant. This keeps the system behaviour reliable for operators."""
+        samples = np.ones(32)
+        envelope = hilbert_envelope(samples)
+        assert envelope.shape == samples.shape
+        assert np.allclose(envelope, samples)


### PR DESCRIPTION
## Summary
- document that pytest files should group related cases into descriptive classes with rationale-rich docstrings
- wrap the existing test suite in test classes so each collection explains its behavioural focus and high-level value

## Testing
- python -m compileall tests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910e60a23cc832185684471db2a979a)