### PR TITLE
Add virtual feedback flow integration test

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,11 +25,13 @@ This guide outlines the preferred conventions for writing Markdown documents in 
 ## Call Out Key Syntax Elements
 
 - Use fenced code blocks with a language identifier for command-line or code snippets, for example:
-  
+
   ```bash
   make format
   ```
+
 - Use inline code (`` `like this` ``) to highlight filenames, commands, or configuration keys.
+
 - Bold important warnings or decision points. Reserve italics for emphasis or terminology being defined.
 
 ## Organize Tabular and Supplementary Information
@@ -47,7 +49,7 @@ This guide outlines the preferred conventions for writing Markdown documents in 
 
 ## Maintain Cross-References and Context
 
-- When referencing code, cite the module path or script name explicitly, e.g., `See \`src/drivers/imu.py\``.
+- When referencing code, cite the module path or script name explicitly, e.g., `See \`src/drivers/imu.py\`\`.
 - Link to related documents within the repository using relative paths so navigation works from any branch, for example: `[Driver bring-up checklist](./planning/driver_bringup.md)`.
 - Provide a short "Further reading" section at the end of long-form guides to aggregate related resources.
 

--- a/docs/device_display_resolution.md
+++ b/docs/device_display_resolution.md
@@ -3,15 +3,15 @@
 The local device driver relies on platform-specific helpers to determine the host
 screen dimensions before scaling rendered frames.
 
-* `src/heart/device/local.py` defines three providers that implement
+- `src/heart/device/local.py` defines three providers that implement
   `DisplayResolutionProvider`:
-  * `MacDisplayResolutionProvider` parses `system_profiler SPDisplaysDataType`
+  - `MacDisplayResolutionProvider` parses `system_profiler SPDisplaysDataType`
     output and extracts the primary display resolution.
-  * `XrandrDisplayResolutionProvider` inspects `xrandr --query` output to
+  - `XrandrDisplayResolutionProvider` inspects `xrandr --query` output to
     support Linux and X11 forwarding scenarios.
-  * `FallbackDisplayResolutionProvider` emits the default 1920×1080 resolution
+  - `FallbackDisplayResolutionProvider` emits the default 1920×1080 resolution
     for platforms that do not expose a detection path.
-* `_get_display_resolution()` remains the module-level entry point, caching the
+- `_get_display_resolution()` remains the module-level entry point, caching the
   detected result via `functools.lru_cache` so other call sites can continue to
   use the helper without change.
 

--- a/docs/virtual_feedback_demo.md
+++ b/docs/virtual_feedback_demo.md
@@ -1,0 +1,29 @@
+# Virtual feedback flow example
+
+`tests/test_virtual_feedback_flow.py` exercises a compact example of two sensor
+peripherals feeding a virtual peripheral that aggregates their values before the
+result is rendered. The test mirrors `test_multiple_game_loops_can_coexist` by
+building the scenario from existing fixtures and helpers rather than introducing
+new runtime code.
+
+## Flow summary
+
+| Stage | Implementation | Notes |
+| --- | --- | --- |
+| Sensor input | `_StaticScalarPeripheral` derives from the base `Peripheral` and provides a `push` helper so tests can emit values without threads. 【F:tests/test_virtual_feedback_flow.py†L19-L38】 |
+| Virtual fusion | `_MetricFusionVirtualPeripheral` listens for both scalar streams and publishes mean and spread metrics once both have reported. 【F:tests/test_virtual_feedback_flow.py†L41-L74】 |
+| LED matrix hand-off | The test synthesises a colour from the fused metrics and publishes it through the `LEDMatrixDisplay` provided by `GameLoop`. 【F:tests/test_virtual_feedback_flow.py†L108-L121】 |
+| Feedback loop | `AverageColorLED` mirrors the LED matrix colour into a `SingleLEDDevice`, demonstrating a second loop sharing the same event bus. 【F:tests/test_virtual_feedback_flow.py†L90-L121】 |
+
+## Running the example
+
+Execute the test with pytest to observe the flow:
+
+```bash
+pytest tests/test_virtual_feedback_flow.py -k virtual_feedback_flow -vv
+```
+
+The assertions confirm that:
+
+- Both `GameLoop` instances share the same event bus. 【F:tests/test_virtual_feedback_flow.py†L123-L124】
+- The mirrored single LED receives the colour derived from the fused metrics. 【F:tests/test_virtual_feedback_flow.py†L118-L124】

--- a/tests/test_virtual_feedback_flow.py
+++ b/tests/test_virtual_feedback_flow.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+import pygame
+from PIL import Image
+
+from heart.device.single_led import SingleLEDDevice
+from heart.environment import GameLoop
+from heart.peripheral.average_color_led import AverageColorLED
+from heart.peripheral.core import Input, Peripheral
+from heart.peripheral.core.event_bus import (VirtualPeripheralContext,
+                                             VirtualPeripheralDefinition,
+                                             _VirtualPeripheral)
+from heart.peripheral.core.manager import PeripheralManager
+from tests.conftest import FakeFixtureDevice
+
+
+class _StaticScalarPeripheral(Peripheral):
+    """Utility peripheral that pushes scalar samples on demand."""
+
+    def __init__(self, event_type: str) -> None:
+        super().__init__()
+        self._event_type = event_type
+
+    def push(self, value: float) -> None:
+        self.emit_event(self._event_type, {"value": value})
+
+    def run(self) -> None:  # pragma: no cover - passive test helper
+        return None
+
+
+class _MetricFusionVirtualPeripheral(_VirtualPeripheral):
+    """Combine the latest readings from two sensor streams."""
+
+    def __init__(
+        self,
+        context: VirtualPeripheralContext,
+        *,
+        event_types: tuple[str, str],
+        output_event: str,
+    ) -> None:
+        super().__init__(context)
+        self._event_types = event_types
+        self._output_event = output_event
+        self._latest: dict[str, float] = {}
+
+    def handle(self, event: Input) -> None:
+        if event.event_type not in self._event_types:
+            return
+        payload = event.data
+        if not isinstance(payload, Mapping) or "value" not in payload:
+            return
+        try:
+            value = float(payload["value"])
+        except (TypeError, ValueError):
+            return
+        self._latest[event.event_type] = value
+        if len(self._latest) < len(self._event_types):
+            return
+        values = [self._latest.get(name) for name in self._event_types]
+        if any(sample is None for sample in values):
+            return
+        spread = max(values) - min(values)
+        mean = sum(values) / len(values)
+        self._context.emit(
+            self._output_event,
+            {"metrics": {"mean": mean, "spread": spread}},
+        )
+
+
+def _fused_metrics_definition(
+    event_types: tuple[str, str],
+    output_event: str,
+) -> VirtualPeripheralDefinition:
+    return VirtualPeripheralDefinition(
+        name="tests.metric_fusion",
+        event_types=event_types,
+        factory=lambda context: _MetricFusionVirtualPeripheral(
+            context,
+            event_types=event_types,
+            output_event=output_event,
+        ),
+    )
+
+
+def test_virtual_feedback_flow(orientation) -> None:
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
+    previous_bus_flag = os.environ.get("ENABLE_INPUT_EVENT_BUS")
+    os.environ["ENABLE_INPUT_EVENT_BUS"] = "1"
+
+    try:
+        sensor_events = ("tests.sensor.alpha", "tests.sensor.beta")
+        fused_event = "tests.virtual.metrics"
+
+        primary_manager = PeripheralManager()
+        primary_loop = GameLoop(
+            device=FakeFixtureDevice(orientation=orientation),
+            peripheral_manager=primary_manager,
+        )
+        primary_loop._initialize_screen()
+
+        feedback_manager = PeripheralManager()
+        feedback_loop = GameLoop(
+            device=FakeFixtureDevice(orientation=orientation),
+            peripheral_manager=feedback_manager,
+            event_bus=primary_loop.event_bus,
+        )
+        feedback_loop._initialize_screen()
+
+        sensors = [_StaticScalarPeripheral(event) for event in sensor_events]
+        for sensor in sensors:
+            primary_manager.register(sensor)
+
+        definition = _fused_metrics_definition(sensor_events, fused_event)
+        primary_loop.event_bus.virtual_peripherals.register(definition)
+
+        single_led = SingleLEDDevice()
+        mirror = AverageColorLED(
+            device=single_led,
+            source_display=primary_loop.display_peripheral,
+        )
+        feedback_manager.register(mirror)
+
+        for index, sensor in enumerate(sensors):
+            sensor.push(0.25 + 0.5 * index)
+
+        latest_metrics = primary_loop.event_bus.state_store.get_latest(fused_event)
+        assert latest_metrics is not None
+        payload = latest_metrics.data
+        assert isinstance(payload, Mapping)
+        metrics = payload.get("metrics")
+        assert isinstance(metrics, Mapping)
+        mean = float(metrics["mean"])
+        spread = float(metrics["spread"])
+
+        colour = (
+            int(round(mean * 255)),
+            int(round(spread * 255)),
+            int(round((1.0 - mean) * 255)),
+        )
+        image = Image.new("RGB", primary_loop.device.full_display_size(), colour)
+        primary_loop.display_peripheral.publish_image(image)
+
+        assert feedback_manager.event_bus is primary_loop.event_bus
+        assert feedback_loop.event_bus is primary_loop.event_bus
+        assert single_led.last_color == colour
+    finally:
+        if previous_bus_flag is None:
+            os.environ.pop("ENABLE_INPUT_EVENT_BUS", None)
+        else:
+            os.environ["ENABLE_INPUT_EVENT_BUS"] = previous_bus_flag
+        pygame.quit()


### PR DESCRIPTION
## Summary
- add `tests/test_virtual_feedback_flow.py` to exercise fused sensor metrics and LED mirroring using existing fixtures
- update `docs/virtual_feedback_demo.md` to describe the test-driven flow and normalize Markdown formatting
- drop the prior `virtual_feedback_demo` runtime configuration that required bespoke peripherals

## Testing
- make format
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911ea0ccb74832181b8b27d23013457)