### PR TITLE
Move test environment setup into fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,10 @@
-import os
 import sys
 import types
 from collections import deque
 from typing import Callable
 
-import pytest
 import pygame
+import pytest
 
 from heart.device import Cube, Device
 from heart.environment import GameLoop
@@ -36,10 +35,22 @@ class _StubClock:
 
 
 @pytest.fixture(autouse=True)
+def dummy_sdl_video_driver(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SDL_VIDEODRIVER", "dummy")
+    yield
+
+
+@pytest.fixture(autouse=True)
 def init_pygame() -> None:
     pygame.init()
     yield
     pygame.quit()
+
+
+@pytest.fixture
+def enable_input_event_bus(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENABLE_INPUT_EVENT_BUS", "1")
+    yield
 
 
 @pytest.fixture
@@ -110,7 +121,6 @@ def manager() -> PeripheralManager:
 
 @pytest.fixture()
 def loop(manager, device) -> GameLoop:
-    os.environ["SDL_VIDEODRIVER"] = "dummy"
     loop = GameLoop(device=device, peripheral_manager=manager)
     # We just initialize the PyGame screen because peripherals and the fact that we expect, in practice,
     # for this to be a singleton _shouldn't_ be that important for testing

--- a/tests/display/test_screen_recorder.py
+++ b/tests/display/test_screen_recorder.py
@@ -1,7 +1,4 @@
-import os
 from pathlib import Path
-
-os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
 
 import pytest
 from PIL import Image, ImageSequence

--- a/tests/display/test_spritesheet_loop_renderer.py
+++ b/tests/display/test_spritesheet_loop_renderer.py
@@ -1,7 +1,3 @@
-import os
-
-os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
-
 import pygame
 import pytest
 

--- a/tests/display/test_three_d_glasses_renderer.py
+++ b/tests/display/test_three_d_glasses_renderer.py
@@ -1,7 +1,3 @@
-import os
-
-os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
-
 import numpy as np
 import pygame
 import pytest
@@ -10,6 +6,7 @@ from heart.assets import loader as assets_loader
 from heart.device import Rectangle
 from heart.display.renderers.three_d_glasses import ThreeDGlassesRenderer
 from heart.peripheral.core.manager import PeripheralManager
+
 
 class TestDisplayThreeDGlassesRenderer:
     """Group Display Three D Glasses Renderer tests so display three d glasses renderer behaviour stays reliable. This preserves confidence in display three d glasses renderer for end-to-end scenarios."""

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,4 +1,3 @@
-import os
 import types
 
 import pygame
@@ -123,7 +122,6 @@ class TestEnvironment:
 
     def test_multiple_game_loops_can_coexist(self, orientation) -> None:
         """Verify that multiple game loops can coexist. This maintains stable runtime control flow."""
-        os.environ["SDL_VIDEODRIVER"] = "dummy"
         manager_one = PeripheralManager()
         device_one = FakeFixtureDevice(orientation=orientation)
         loop_one = GameLoop(device=device_one, peripheral_manager=manager_one)

--- a/tests/test_virtual_feedback_flow.py
+++ b/tests/test_virtual_feedback_flow.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from collections.abc import Mapping
 
 import pygame
@@ -85,11 +84,7 @@ def _fused_metrics_definition(
     )
 
 
-def test_virtual_feedback_flow(orientation) -> None:
-    os.environ["SDL_VIDEODRIVER"] = "dummy"
-    previous_bus_flag = os.environ.get("ENABLE_INPUT_EVENT_BUS")
-    os.environ["ENABLE_INPUT_EVENT_BUS"] = "1"
-
+def test_virtual_feedback_flow(orientation, enable_input_event_bus) -> None:
     try:
         sensor_events = ("tests.sensor.alpha", "tests.sensor.beta")
         fused_event = "tests.virtual.metrics"
@@ -147,8 +142,4 @@ def test_virtual_feedback_flow(orientation) -> None:
         assert feedback_loop.event_bus is primary_loop.event_bus
         assert single_led.last_color == colour
     finally:
-        if previous_bus_flag is None:
-            os.environ.pop("ENABLE_INPUT_EVENT_BUS", None)
-        else:
-            os.environ["ENABLE_INPUT_EVENT_BUS"] = previous_bus_flag
         pygame.quit()


### PR DESCRIPTION
## Summary
- add autouse fixtures that configure SDL and optional input event bus flags for tests
- remove inline environment variable manipulation from individual test modules

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911f7e66d688321a47677f1fbc228d8)