### PR TITLE
Convert TextRendering to AtomicBaseRenderer

### DIFF
--- a/docs/migrations/renderer_atomic.md
+++ b/docs/migrations/renderer_atomic.md
@@ -13,10 +13,13 @@ status so incremental updates stay coordinated.
   - `RenderColor` (`src/heart/display/renderers/color.py`) – now maintains
     immutable colour state and exposes `set_color` for callers that need to
     refresh the fill value.
+  - `TextRendering` (`src/heart/display/renderers/text.py`) – migrates text
+    layout to an immutable state snapshot while preserving switch-driven
+    rotation across copy decks.
 - Remaining renderers will be migrated iteratively. Track additional updates by
   appending to this list with accompanying test references.
 
-Progress indicator: `[#>--------------------]`
+Progress indicator: `[###>------------------]`
 
 ## Validation
 


### PR DESCRIPTION
## Summary
- migrate TextRendering to AtomicBaseRenderer with immutable state management
- initialize pygame font through state updates and preserve switch-based rotation semantics
- document the renderer migration progress for TextRendering in the atomic migration log

## Testing
- make format
- make test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911fb90f77483219787cd05b39d8c60)