### PR TITLE
Migrate RenderImage to AtomicBaseRenderer

### DIFF
--- a/docs/migrations/renderer_atomic.md
+++ b/docs/migrations/renderer_atomic.md
@@ -16,10 +16,13 @@ status so incremental updates stay coordinated.
   - `TextRendering` (`src/heart/display/renderers/text.py`) – migrates text
     layout to an immutable state snapshot while preserving switch-driven
     rotation across copy decks.
+  - `RenderImage` (`src/heart/display/renderers/image.py`) – loads assets during
+    initialization, caches the scaled surface in renderer state, and remains
+    compatible with loops that expect simple blit-only behaviour.
 - Remaining renderers will be migrated iteratively. Track additional updates by
   appending to this list with accompanying test references.
 
-Progress indicator: `[###>------------------]`
+Progress indicator: `[####>-----------------]`
 
 ## Validation
 


### PR DESCRIPTION
## Summary
- migrate RenderImage to AtomicBaseRenderer with an immutable state cache for the loaded surface
- document the RenderImage migration in the renderer atomic progress log and update the progress indicator

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911fe16953483218a3d338fcb3adf9c)