### PR TITLE
Convert SlideTransitionRenderer to use AtomicBaseRenderer state

### DIFF
--- a/docs/migrations/renderer_atomic.md
+++ b/docs/migrations/renderer_atomic.md
@@ -19,10 +19,13 @@ status so incremental updates stay coordinated.
   - `RenderImage` (`src/heart/display/renderers/image.py`) – loads assets during
     initialization, caches the scaled surface in renderer state, and remains
     compatible with loops that expect simple blit-only behaviour.
+  - `SlideTransitionRenderer` (`src/heart/display/renderers/slide.py`) – tracks
+    slide offsets atomically while orchestrating transition timing across two
+    child renderers.
 - Remaining renderers will be migrated iteratively. Track additional updates by
   appending to this list with accompanying test references.
 
-Progress indicator: `[####>-----------------]`
+Progress indicator: `[#####>----------------]`
 
 ## Validation
 

--- a/src/heart/display/renderers/slide.py
+++ b/src/heart/display/renderers/slide.py
@@ -1,12 +1,22 @@
+from dataclasses import dataclass
+
 import pygame
 
 from heart import DeviceDisplayMode
 from heart.device import Orientation, Rectangle
-from heart.display.renderers import BaseRenderer
+from heart.display.renderers import AtomicBaseRenderer, BaseRenderer
 from heart.peripheral.core.manager import PeripheralManager
 
 
-class SlideTransitionRenderer(BaseRenderer):
+@dataclass
+class SlideTransitionState:
+    x_offset: int = 0
+    target_offset: int | None = None
+    sliding: bool = True
+    screen_w: int = 0
+
+
+class SlideTransitionRenderer(AtomicBaseRenderer[SlideTransitionState]):
     """Slides renderer_B into view while renderer_A moves out.
 
     direction  =  1  → B comes from the right  (A → left) direction  = -1  → B comes
@@ -22,20 +32,19 @@ class SlideTransitionRenderer(BaseRenderer):
         direction: int = 1,
         slide_speed: int = 10,
     ) -> None:
-        super().__init__()
         self.renderer_A = renderer_A
         self.renderer_B = renderer_B
         self.direction = 1 if direction >= 0 else -1
         self.slide_speed = slide_speed  # Use the parameter value instead of hardcoding
 
         self.device_display_mode = DeviceDisplayMode.MIRRORED
+        AtomicBaseRenderer.__init__(self)
 
-        self._x_offset = 0
-        self._target_offset = None
-        self._sliding = True
+    def _create_initial_state(self) -> SlideTransitionState:
+        return SlideTransitionState()
 
     def is_done(self) -> bool:
-        return not self._sliding
+        return not self.state.sliding
 
     def process(
         self,
@@ -46,38 +55,46 @@ class SlideTransitionRenderer(BaseRenderer):
     ) -> None:
         """
         1. Lazily work out screen width / target.
-        2. Advance the slide (updates self._x_offset).
+        2. Advance the slide (updates the atomic state offset).
         3. Ask each child renderer to draw onto its own temp surface.
         4. Blit those temps to `window` at their current offsets.
         """
         # ----------------------------------------------------------------- #
         # lazy-init measurements
         # ----------------------------------------------------------------- #
-        if self._target_offset is None:
-            self._screen_w = window.get_width()
-            # A ends off-screen opposite B’s spawn edge
-            self._target_offset = -self.direction * self._screen_w
+        state = self.state
+
+        screen_w = window.get_width()
+        if state.target_offset is None or state.screen_w != screen_w:
+            target_offset = -self.direction * screen_w
+            self.update_state(
+                target_offset=target_offset,
+                screen_w=screen_w,
+            )
+            state = self.state
 
         # ----------------------------------------------------------------- #
         # 1. advance the slide
         # ----------------------------------------------------------------- #
-        if self._sliding:
-            dist = self._target_offset - self._x_offset
+        if state.sliding and state.target_offset is not None:
+            dist = state.target_offset - state.x_offset
             step_size = (
                 dist
                 if abs(dist) <= self.slide_speed  # snap on final frame
                 else self.slide_speed * (1 if dist > 0 else -1)
             )
-            self._x_offset += step_size
+            new_offset = state.x_offset + step_size
+            still_sliding = True
 
             # Check if we've reached or passed the target in either direction
-            if (self.direction > 0 and self._x_offset <= self._target_offset) or (
-                self.direction < 0 and self._x_offset >= self._target_offset
+            if (self.direction > 0 and new_offset <= state.target_offset) or (
+                self.direction < 0 and new_offset >= state.target_offset
             ):
-                self._x_offset = (
-                    self._target_offset
-                )  # Ensure it stops exactly at target
-                self._sliding = False
+                new_offset = state.target_offset
+                still_sliding = False
+
+            self.update_state(x_offset=new_offset, sliding=still_sliding)
+            state = self.state
 
         # ----------------------------------------------------------------- #
         # 2. render both children to off-screen surfaces
@@ -98,8 +115,8 @@ class SlideTransitionRenderer(BaseRenderer):
         #    A : starts 0 → slides to ±screen_w
         #    B : starts ±screen_w → slides to 0
         # ----------------------------------------------------------------- #
-        offset_A = (self._x_offset, 0)
-        offset_B = (self._x_offset + self.direction * self._screen_w, 0)
+        offset_A = (state.x_offset, 0)
+        offset_B = (state.x_offset + self.direction * state.screen_w, 0)
 
         # Draw the renderers at their current positions
         window.blit(surf_A, offset_A)


### PR DESCRIPTION
## Summary
- migrate SlideTransitionRenderer to AtomicBaseRenderer with an immutable transition state container
- compute slide offsets via atomic state updates and expose completion status through the new state snapshot
- document the migration progress update in docs/migrations/renderer_atomic.md

## Testing
- make format
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911ff600ac08321a3816de9e041a80d)