### PR TITLE
Convert FreeTextRenderer to AtomicBaseRenderer

### DIFF
--- a/docs/migrations/renderer_atomic.md
+++ b/docs/migrations/renderer_atomic.md
@@ -22,10 +22,13 @@ status so incremental updates stay coordinated.
   - `SlideTransitionRenderer` (`src/heart/display/renderers/slide.py`) – tracks
     slide offsets atomically while orchestrating transition timing across two
     child renderers.
+  - `FreeTextRenderer` (`src/heart/display/renderers/free_text.py`) – stores
+    wrapped text layout and font sizing in atomic state while preserving
+    phone-text integration.
 - Remaining renderers will be migrated iteratively. Track additional updates by
   appending to this list with accompanying test references.
 
-Progress indicator: `[#####>----------------]`
+Progress indicator: `[######>---------------]`
 
 ## Validation
 


### PR DESCRIPTION
## Summary
- migrate FreeTextRenderer to AtomicBaseRenderer with an immutable state snapshot for cached text layout details
- adjust rendering logic to derive fonts from cached sizes and reuse the font cache safely
- document the migration progress in docs/migrations/renderer_atomic.md

## Testing
- make format
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691200be4b808321a590c2c44584339f)