### PR TITLE
Convert WaterTitleScreen to AtomicBaseRenderer

### DIFF
--- a/docs/migrations/renderer_atomic.md
+++ b/docs/migrations/renderer_atomic.md
@@ -25,10 +25,13 @@ status so incremental updates stay coordinated.
   - `FreeTextRenderer` (`src/heart/display/renderers/free_text.py`) – stores
     wrapped text layout and font sizing in atomic state while preserving
     phone-text integration.
+  - `WaterTitleScreen` (`src/heart/display/renderers/water_title_screen.py`) –
+    tracks wave animation timing atomically so consumer loops receive
+    consistent offsets across frames.
 - Remaining renderers will be migrated iteratively. Track additional updates by
   appending to this list with accompanying test references.
 
-Progress indicator: `[######>---------------]`
+Progress indicator: `[#######>--------------]`
 
 ## Validation
 

--- a/src/heart/display/renderers/water_title_screen.py
+++ b/src/heart/display/renderers/water_title_screen.py
@@ -1,5 +1,6 @@
 import math
 import time
+from dataclasses import dataclass
 
 import pygame
 from pygame import Surface
@@ -7,7 +8,7 @@ from pygame.time import Clock
 
 from heart import DeviceDisplayMode
 from heart.device import Orientation
-from heart.display.renderers import BaseRenderer
+from heart.display.renderers import AtomicBaseRenderer
 from heart.peripheral.core.manager import PeripheralManager
 from heart.utilities.logging import get_logger
 
@@ -16,17 +17,20 @@ DEFAULT_TIME_BETWEEN_FRAMES_MS = 400
 logger = get_logger("WaterTitleScreen")
 
 
-class WaterTitleScreen(BaseRenderer):
+@dataclass(frozen=True)
+class WaterTitleScreenState:
+    wave_offset: float
+    last_frame_time: float
+
+
+class WaterTitleScreen(AtomicBaseRenderer[WaterTitleScreenState]):
     """A simple water animation title screen with water moving from left to right."""
 
     def __init__(self) -> None:
-        super().__init__()
-        self.device_display_mode = DeviceDisplayMode.FULL
         self.face_px = 64  # physical LED face resolution
         self.cube_px_w = self.face_px * 4  # 256
         self.cube_px_h = self.face_px  # 64
         self.water_level = self.face_px // 2  # Half full
-        self.wave_offset = 0  # Current wave position
         self.wave_speed = 0.5  # Speed of wave movement
         self.wave_height = 5  # Height of wave in pixels
         self.wave_length = self.face_px * 1.5  # Length of wave
@@ -34,12 +38,15 @@ class WaterTitleScreen(BaseRenderer):
         # Water color (blue)
         self.water_color = (0, 90, 255)
 
-        # Time tracking
-        self.last_frame_time = time.time()
+        AtomicBaseRenderer.__init__(self)
+        self.device_display_mode = DeviceDisplayMode.FULL
 
-    def _generate_wave_height(self, x: int) -> float:
+    def _create_initial_state(self) -> WaterTitleScreenState:
+        return WaterTitleScreenState(wave_offset=0.0, last_frame_time=time.time())
+
+    def _generate_wave_height(self, x: int, wave_offset: float) -> float:
         """Generate height of wave at position x."""
-        wave_pos = (x + self.wave_offset) % (self.cube_px_w * 2)
+        wave_pos = (x + wave_offset) % (self.cube_px_w * 2)
         # Sine wave for water surface
         wave = math.sin(wave_pos * 2 * math.pi / self.wave_length) * self.wave_height
         return self.water_level + wave
@@ -52,19 +59,19 @@ class WaterTitleScreen(BaseRenderer):
         orientation: Orientation,
     ) -> None:
         # Update animation
+        state = self.state
         current_time = time.time()
-        elapsed = current_time - self.last_frame_time
-        self.last_frame_time = current_time
+        elapsed = current_time - state.last_frame_time
+        updated_wave_offset = state.wave_offset + self.wave_speed * elapsed * 60
 
-        # Move the wave
-        self.wave_offset += self.wave_speed * elapsed * 60  # Scale by expected 60fps
+        self.update_state(wave_offset=updated_wave_offset, last_frame_time=current_time)
 
         # Clear the window
         window.fill((0, 0, 0))
 
         # Render directly to the window
         for x in range(self.cube_px_w):
-            height = int(self._generate_wave_height(x))
+            height = int(self._generate_wave_height(x, updated_wave_offset))
             # Draw water column
             if height > 0:
                 pygame.draw.line(


### PR DESCRIPTION
## Summary
- migrate WaterTitleScreen to use AtomicBaseRenderer and encapsulate wave animation timing in immutable state
- document the WaterTitleScreen migration progress update

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69120a7e1f7c8321a4c7c7916ca7125d)