### PR TITLE
Add renderer event bus publisher/subscriber pipeline

### DIFF
--- a/docs/research/renderer_event_bus.md
+++ b/docs/research/renderer_event_bus.md
@@ -1,0 +1,22 @@
+# Renderer Event Bus Bridge
+
+## Summary
+
+Renderer pipelines can now emit and consume intermediate frames through the shared event bus. `RendererEventPublisher` wraps any `BaseRenderer` and converts its output surface into a `RendererFrame` payload (`src/heart/display/renderers/internal/event_stream.py`). Downstream consumers register with `RendererEventSubscriber` or the updated `RenderImage` to subscribe to those frames, avoiding direct surface hand-offs.
+
+## Motivation
+
+Composed renderers previously passed `pygame.Surface` objects through method parameters or mutable state. That coupling made it difficult to fan out intermediate results to multiple consumers and prevented reuse across game modes. Publishing frames on the event bus promotes loose coupling: any renderer can observe shared channels, respect producer IDs, and rebuild the surface locally.
+
+## Event Flow
+
+1. A publisher renders into its provided surface and immediately encodes the pixels into a `RendererFrame` event. The payload carries the logical channel, renderer name, frame sequence, and raw bytes. (`RendererEventPublisher.from_surface()`)
+1. The event bus records the payload in the `StateStore` and synchronously invokes subscribers. (`src/heart/peripheral/core/event_bus.py`)
+1. Subscribers filter by channel (and optional producer ID), rebuild a `pygame.Surface`, scale it to the active window, and blit the result. (`RendererEventSubscriber._handle_frame()`)
+1. `RenderImage` now delegates to the subscriber path when `subscribe_channel` is provided, caching the rendered surface in its atomic state for reuse by transitions or testing. (`src/heart/display/renderers/image.py`)
+
+## Observations and Follow-up
+
+- `RendererFrame` lives alongside other event payloads and serializes bytes without assuming the final display size. Consumers scale as needed, so upstream publishers can target their native resolution. (`src/heart/events/types.py`)
+- Tests cover the integration path from publisher to subscriber to guarantee surfaces round-trip through the bus. (`tests/display/test_renderer_event_stream.py`)
+- Future work: expose richer metadata contracts (e.g., color space, depth) and add throttling controls so high-frequency publishers do not starve the event bus.

--- a/src/heart/display/renderers/image.py
+++ b/src/heart/display/renderers/image.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 import pygame
@@ -5,6 +7,8 @@ import pygame
 from heart.assets.loader import Loader
 from heart.device import Orientation
 from heart.display.renderers import AtomicBaseRenderer
+from heart.display.renderers.internal.event_stream import \
+    RendererEventSubscriber
 from heart.peripheral.core.manager import PeripheralManager
 
 
@@ -14,8 +18,26 @@ class RenderImageState:
 
 
 class RenderImage(AtomicBaseRenderer[RenderImageState]):
-    def __init__(self, image_file: str) -> None:
+    """Render an image sourced from an asset file or a renderer event stream."""
+
+    def __init__(
+        self,
+        image_file: str | None = None,
+        *,
+        subscribe_channel: str | None = None,
+        producer_id: int | None = None,
+        subscriber_priority: int = 0,
+    ) -> None:
+        if image_file is None and subscribe_channel is None:
+            raise ValueError(
+                "RenderImage requires an image_file or subscribe_channel",
+            )
+
         self._image_file = image_file
+        self._subscribe_channel = subscribe_channel
+        self._producer_id = producer_id
+        self._subscriber_priority = subscriber_priority
+        self._subscriber: RendererEventSubscriber | None = None
         AtomicBaseRenderer.__init__(self)
 
     def _create_initial_state(self) -> RenderImageState:
@@ -28,9 +50,20 @@ class RenderImage(AtomicBaseRenderer[RenderImageState]):
         peripheral_manager: PeripheralManager,
         orientation: Orientation,
     ) -> None:
-        image = Loader.load(self._image_file).convert_alpha()
-        image = pygame.transform.scale(image, window.get_size())
-        self.update_state(image=image)
+        if self._subscribe_channel is not None:
+            if self._subscriber is None:
+                self._subscriber = RendererEventSubscriber(
+                    channel=self._subscribe_channel,
+                    producer_id=self._producer_id,
+                    priority=self._subscriber_priority,
+                )
+            self._subscriber.initialize(window, clock, peripheral_manager, orientation)
+
+        if self._image_file is not None:
+            image = Loader.load(self._image_file).convert_alpha()
+            image = pygame.transform.scale(image, window.get_size())
+            self.update_state(image=image)
+
         super().initialize(window, clock, peripheral_manager, orientation)
 
     def process(
@@ -40,6 +73,18 @@ class RenderImage(AtomicBaseRenderer[RenderImageState]):
         peripheral_manager: PeripheralManager,
         orientation: Orientation,
     ) -> None:
-        if self.state.image is None:
-            return
-        window.blit(self.state.image, (0, 0))
+        rendered = False
+        if self._subscriber is not None:
+            has_frame = self._subscriber.has_frame()
+            self._subscriber.process(window, clock, peripheral_manager, orientation)
+            if has_frame:
+                self.update_state(image=window.copy())
+                rendered = True
+
+        if not rendered and self.state.image is not None:
+            window.blit(self.state.image, (0, 0))
+
+    def reset(self) -> None:
+        if self._subscriber is not None:
+            self._subscriber.reset()
+        super().reset()

--- a/src/heart/display/renderers/internal/event_stream.py
+++ b/src/heart/display/renderers/internal/event_stream.py
@@ -1,0 +1,190 @@
+"""Utilities for bridging renderer output through the event bus."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable, Mapping
+from typing import Any
+
+import pygame
+
+from heart.display.renderers import BaseRenderer
+from heart.events.types import RendererFrame
+from heart.peripheral.core import Input
+from heart.peripheral.core.event_bus import EventBus, SubscriptionHandle
+from heart.peripheral.core.manager import PeripheralManager
+from heart.utilities.logging import get_logger
+
+_LOGGER = get_logger(__name__)
+
+
+class RendererEventPublisher(BaseRenderer):
+    """Wrap a renderer and publish its frames onto the event bus."""
+
+    def __init__(
+        self,
+        renderer: BaseRenderer,
+        *,
+        channel: str,
+        producer_id: int | None = None,
+        pixel_format: str = "RGBA",
+        metadata_factory: Callable[[pygame.Surface], Mapping[str, Any]] | None = None,
+    ) -> None:
+        super().__init__()
+        if not channel:
+            raise ValueError("RendererEventPublisher channel must be provided")
+        self._renderer = renderer
+        self._channel = channel
+        self._producer_id = producer_id if producer_id is not None else id(renderer)
+        self._pixel_format = pixel_format
+        self._metadata_factory = metadata_factory
+        self._sequence = 0
+
+        # Mirror display configuration so upstream sizing remains accurate.
+        self.device_display_mode = renderer.device_display_mode
+        self.supports_frame_accumulator = renderer.supports_frame_accumulator
+
+    def reset(self) -> None:
+        self._renderer.reset()
+        self._sequence = 0
+        super().reset()
+
+    def process(
+        self,
+        window: pygame.Surface,
+        clock: pygame.time.Clock,
+        peripheral_manager: PeripheralManager,
+        orientation,
+    ) -> None:
+        self._renderer._internal_process(window, clock, peripheral_manager, orientation)
+        bus = getattr(peripheral_manager, "event_bus", None)
+        if bus is None:
+            _LOGGER.debug(
+                "RendererEventPublisher dropped frame; manager missing event bus",
+            )
+            return
+        metadata: Mapping[str, Any] | None = None
+        if self._metadata_factory is not None:
+            try:
+                metadata = dict(self._metadata_factory(window))
+            except Exception:  # pragma: no cover - defensive logging only
+                _LOGGER.exception("RendererEventPublisher metadata_factory failed")
+        frame = RendererFrame.from_surface(
+            self._channel,
+            window,
+            renderer=self._renderer.name,
+            frame_id=self._sequence,
+            pixel_format=self._pixel_format,
+            metadata=metadata,
+        )
+        self._sequence += 1
+        bus.emit(frame.to_input(producer_id=self._producer_id))
+
+
+class RendererEventSubscriber(BaseRenderer):
+    """Render the latest :class:`RendererFrame` observed on the event bus."""
+
+    def __init__(
+        self,
+        *,
+        channel: str,
+        producer_id: int | None = None,
+        priority: int = 0,
+    ) -> None:
+        super().__init__()
+        if not channel:
+            raise ValueError("RendererEventSubscriber channel must be provided")
+        self._channel = channel
+        self._producer_id = producer_id
+        self._priority = priority
+        self._subscription: SubscriptionHandle | None = None
+        self._event_bus: EventBus | None = None
+        self._latest_surface: pygame.Surface | None = None
+        self._frame_lock = threading.Lock()
+        self._target_size: tuple[int, int] | None = None
+
+    def reset(self) -> None:
+        if self._event_bus is not None and self._subscription is not None:
+            try:
+                self._event_bus.unsubscribe(self._subscription)
+            except Exception:  # pragma: no cover - defensive logging only
+                _LOGGER.exception("Failed to unsubscribe renderer event subscriber")
+        self._subscription = None
+        self._event_bus = None
+        with self._frame_lock:
+            self._latest_surface = None
+        super().reset()
+
+    def initialize(
+        self,
+        window: pygame.Surface,
+        clock: pygame.time.Clock,
+        peripheral_manager: PeripheralManager,
+        orientation,
+    ) -> None:
+        self._target_size = window.get_size()
+        self._ensure_subscription(peripheral_manager)
+        super().initialize(window, clock, peripheral_manager, orientation)
+
+    def process(
+        self,
+        window: pygame.Surface,
+        clock: pygame.time.Clock,
+        peripheral_manager: PeripheralManager,
+        orientation,
+    ) -> None:
+        if self._subscription is None:
+            self._ensure_subscription(peripheral_manager)
+        with self._frame_lock:
+            surface = self._latest_surface.copy() if self._latest_surface else None
+        if surface is None:
+            return
+        window.blit(surface, (0, 0))
+
+    def has_frame(self) -> bool:
+        """Return ``True`` when at least one frame has been observed."""
+
+        with self._frame_lock:
+            return self._latest_surface is not None
+
+    def peek_latest_surface(self) -> pygame.Surface | None:
+        """Return a copy of the most recent frame without mutating state."""
+
+        with self._frame_lock:
+            if self._latest_surface is None:
+                return None
+            return self._latest_surface.copy()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_subscription(self, peripheral_manager: PeripheralManager) -> None:
+        if self._subscription is not None:
+            return
+        bus = getattr(peripheral_manager, "event_bus", None)
+        if bus is None:
+            _LOGGER.debug(
+                "RendererEventSubscriber missing event bus; rendering will stall",
+            )
+            return
+        self._event_bus = bus
+        self._subscription = bus.subscribe(
+            RendererFrame.EVENT_TYPE,
+            self._handle_frame,
+            priority=self._priority,
+        )
+
+    def _handle_frame(self, event: Input) -> None:
+        payload = event.data
+        if not isinstance(payload, RendererFrame):
+            return
+        if payload.channel != self._channel:
+            return
+        if self._producer_id is not None and event.producer_id != self._producer_id:
+            return
+        surface = payload.to_surface()
+        if self._target_size and surface.get_size() != self._target_size:
+            surface = pygame.transform.smoothscale(surface, self._target_size)
+        with self._frame_lock:
+            self._latest_surface = surface
+

--- a/src/heart/events/__init__.py
+++ b/src/heart/events/__init__.py
@@ -21,5 +21,6 @@ from .types import HeartRateMeasurement as HeartRateMeasurement
 from .types import InputEventPayload as InputEventPayload
 from .types import MicrophoneLevel as MicrophoneLevel
 from .types import PhoneTextMessage as PhoneTextMessage
+from .types import RendererFrame as RendererFrame
 from .types import SwitchButton as SwitchButton
 from .types import SwitchRotation as SwitchRotation

--- a/tests/display/test_renderer_event_stream.py
+++ b/tests/display/test_renderer_event_stream.py
@@ -1,0 +1,49 @@
+import pygame
+
+from heart import DeviceDisplayMode
+from heart.device import Cube
+from heart.display.color import Color
+from heart.display.renderers.color import RenderColor
+from heart.display.renderers.image import RenderImage
+from heart.display.renderers.internal.event_stream import \
+    RendererEventPublisher
+from heart.peripheral.core.event_bus import EventBus
+from heart.peripheral.core.manager import PeripheralManager
+
+
+class TestRendererEventStream:
+    """Verify renderer event publishers interoperate with subscribers to harden compositor experiments."""
+
+    def test_publisher_emits_frames_consumed_by_render_image(self) -> None:
+        """Ensure renderer frames traverse the event bus so stateful consumers no longer require direct surface injection."""
+
+        pygame.init()
+        try:
+            bus = EventBus()
+            manager = PeripheralManager(event_bus=bus)
+            clock = pygame.time.Clock()
+            orientation = Cube.sides()
+
+            color_source = RenderColor(Color(24, 48, 96))
+            color_source.device_display_mode = DeviceDisplayMode.FULL
+            publisher = RendererEventPublisher(
+                color_source, channel="renderer://test"
+            )
+            publisher.device_display_mode = DeviceDisplayMode.FULL
+            subscriber = RenderImage(subscribe_channel="renderer://test")
+            subscriber.device_display_mode = DeviceDisplayMode.FULL
+
+            # Prime subscriber so the event bus subscription is active before frames publish.
+            warmup_surface = pygame.Surface((8, 8), pygame.SRCALPHA)
+            subscriber._internal_process(warmup_surface, clock, manager, orientation)
+
+            publisher_surface = pygame.Surface((8, 8), pygame.SRCALPHA)
+            publisher._internal_process(publisher_surface, clock, manager, orientation)
+
+            output_surface = pygame.Surface((8, 8), pygame.SRCALPHA)
+            subscriber._internal_process(output_surface, clock, manager, orientation)
+
+            assert subscriber.state.image is not None
+            assert output_surface.get_at((0, 0))[:3] == (24, 48, 96)
+        finally:
+            pygame.quit()


### PR DESCRIPTION
## Summary
- add a RendererFrame payload and event stream helpers so renderers can publish frames onto the event bus
- update RenderImage to subscribe to renderer frame channels and cover the flow with a new integration test
- document the renderer event bus bridge design under docs/research

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912007745608321b8be4ae87f39c532)