### PR TITLE
Convert SpritesheetLoopRandom to AtomicBaseRenderer

### DIFF
--- a/docs/migrations/renderer_atomic.md
+++ b/docs/migrations/renderer_atomic.md
@@ -28,10 +28,13 @@ status so incremental updates stay coordinated.
   - `WaterTitleScreen` (`src/heart/display/renderers/water_title_screen.py`) –
     tracks wave animation timing atomically so consumer loops receive
     consistent offsets across frames.
+  - `SpritesheetLoopRandom` (`src/heart/display/renderers/spritesheet_random.py`)
+    – keeps the switch consumer while moving frame counters and screen
+    selection into immutable state for per-frame randomisation safety.
 - Remaining renderers will be migrated iteratively. Track additional updates by
   appending to this list with accompanying test references.
 
-Progress indicator: `[#######>--------------]`
+Progress indicator: `[########>-------------]`
 
 ## Validation
 


### PR DESCRIPTION
## Summary
- migrate `SpritesheetLoopRandom` to use `AtomicBaseRenderer` with an immutable state container
- keep the switch consumer binding while updating per-frame timing and screen selection to rely on atomic state
- document the migration progress for `SpritesheetLoopRandom`

## Testing
- make test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69120e713e808321ab5cc617c31485d3)