### PR TITLE
Convert Tixyland renderer to AtomicBaseRenderer

### DIFF
--- a/docs/migrations/renderer_atomic.md
+++ b/docs/migrations/renderer_atomic.md
@@ -31,10 +31,13 @@ status so incremental updates stay coordinated.
   - `SpritesheetLoopRandom` (`src/heart/display/renderers/spritesheet_random.py`)
     – keeps the switch consumer while moving frame counters and screen
     selection into immutable state for per-frame randomisation safety.
+  - `Tixyland` (`src/heart/display/renderers/tixyland.py`) – carries the
+    time-tracking accumulator atomically so shader functions invoked by loops
+    receive a deterministic elapsed time value.
 - Remaining renderers will be migrated iteratively. Track additional updates by
   appending to this list with accompanying test references.
 
-Progress indicator: `[########>-------------]`
+Progress indicator: `[#########>------------]`
 
 ## Validation
 


### PR DESCRIPTION
## Summary
- migrate the Tixyland renderer to `AtomicBaseRenderer`, keeping the shader callback while tracking elapsed time via immutable state
- document the Tixyland migration in `docs/migrations/renderer_atomic.md` and update the progress indicator

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691210a2e8ac832193504ad9ca5eda4a)