### PR TITLE
Migrate Life renderer to AtomicBaseRenderer

### DIFF
--- a/docs/migrations/renderer_atomic.md
+++ b/docs/migrations/renderer_atomic.md
@@ -34,10 +34,13 @@ status so incremental updates stay coordinated.
   - `Tixyland` (`src/heart/display/renderers/tixyland.py`) – carries the
     time-tracking accumulator atomically so shader functions invoked by loops
     receive a deterministic elapsed time value.
+  - `Life` (`src/heart/display/renderers/life.py`) – records the seeded grid
+    and latest switch-derived seed in immutable state so cellular automata
+    updates remain deterministic across warm-up and loop execution.
 - Remaining renderers will be migrated iteratively. Track additional updates by
   appending to this list with accompanying test references.
 
-Progress indicator: `[#########>------------]`
+Progress indicator: `[##########>-----------]`
 
 ## Validation
 


### PR DESCRIPTION
## Summary
- convert the Life renderer to inherit from AtomicBaseRenderer with a dedicated LifeState snapshot
- update the renderer logic to manage the cellular automata grid and seed through immutable state helpers
- record the migration progress in docs/migrations/renderer_atomic.md

## Testing
- make format
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691212ff5f948321a9ee6e70040e93d3)