### PR TITLE
Fix spritesheet random renderer display mode

### DIFF
--- a/src/heart/display/renderers/spritesheet_random.py
+++ b/src/heart/display/renderers/spritesheet_random.py
@@ -44,7 +44,6 @@ class SpritesheetLoopRandom(
         screen_count: int,
     ) -> None:
         SwitchStateConsumer.__init__(self)
-        self.device_display_mode = DeviceDisplayMode.FULL
         self.screen_width, self.screen_height = screen_width, screen_height
         self.screen_count = screen_count
         self.file = sheet_file_path
@@ -73,6 +72,7 @@ class SpritesheetLoopRandom(
         self.y = 30
 
         AtomicBaseRenderer.__init__(self)
+        self.device_display_mode = DeviceDisplayMode.FULL
 
     def initialize(
         self,


### PR DESCRIPTION
## Summary
- ensure `SpritesheetLoopRandom` assigns `device_display_mode` after `AtomicBaseRenderer` initialization so the full-screen surface is preserved

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912b78619a08321a7635a35cb42b7b7)