### PR TITLE
Restore Life renderer full display mode

### DIFF
--- a/src/heart/display/renderers/life.py
+++ b/src/heart/display/renderers/life.py
@@ -22,11 +22,14 @@ class LifeState:
 class Life(SwitchStateConsumer, AtomicBaseRenderer[LifeState]):
     def __init__(self) -> None:
         SwitchStateConsumer.__init__(self)
-        self.device_display_mode = DeviceDisplayMode.FULL
 
         self.kernel = np.array([[1, 1, 1], [1, 0, 1], [1, 1, 1]])
 
         AtomicBaseRenderer.__init__(self)
+        # AtomicBaseRenderer reinitializes device_display_mode; restore FULL to
+        # preserve the original renderer behaviour of operating on the entire
+        # device surface rather than the per-tile mirrored view.
+        self.device_display_mode = DeviceDisplayMode.FULL
 
     def _update_grid(self, grid):
         # convolve the grid with the kernel to count neighbors


### PR DESCRIPTION
## Summary
- ensure the Life renderer re-enables DeviceDisplayMode.FULL after the atomic base initialization to maintain full-surface rendering

## Testing
- make format
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912b771f47c832185e78ab757d461a7)