### PR TITLE
Preserve SlidingImage cache when resetting

### DIFF
--- a/docs/migrations/renderer_atomic.md
+++ b/docs/migrations/renderer_atomic.md
@@ -40,6 +40,8 @@ status so incremental updates stay coordinated.
   - `SlidingImage` (`src/heart/display/renderers/sliding_image.py`) – caches
     the scaled surface during initialization and tracks the wrap-around offset
     in atomic state so cube-sized slides remain deterministic for consumers.
+    Resetting the renderer now preserves the cached surface so returning to
+    scene select screens does not blank the banner animation.
   - `SlidingRenderer` (`src/heart/display/renderers/sliding_image.py`) – wraps
     a composed renderer while keeping the sliding offset immutable for
     downstream loops that expect predictable frame hand-offs.

--- a/src/heart/display/renderers/sliding_image.py
+++ b/src/heart/display/renderers/sliding_image.py
@@ -83,6 +83,14 @@ class SlidingImage(AtomicBaseRenderer[SlidingImageState]):
         if offset:
             window.blit(image, (state.width - offset, 0))
 
+    def reset(self) -> None:
+        state = self.state
+        if state.image is None or state.width == 0:
+            super().reset()
+            return
+
+        self.update_state(offset=0, speed=self._configured_speed)
+
 
 @dataclass
 class SlidingRendererState:

--- a/tests/display/test_sliding_image_renderer.py
+++ b/tests/display/test_sliding_image_renderer.py
@@ -1,0 +1,51 @@
+"""Validate behaviour of the SlidingImage renderer."""
+
+import pygame
+
+from heart.assets.loader import Loader
+from heart.display.renderers.sliding_image import SlidingImage
+
+
+def test_reset_preserves_cached_surface(monkeypatch, orientation, manager, stub_clock_factory) -> None:
+    """Ensure SlidingImage keeps its cached surface across resets so scene transitions do not blank marquee banners."""
+
+    base_surface = pygame.Surface((32, 8), pygame.SRCALPHA)
+    base_surface.fill((10, 20, 30, 255))
+    monkeypatch.setattr(Loader, "load", lambda _: base_surface)
+
+    window = pygame.Surface((256, 64), pygame.SRCALPHA)
+    clock = stub_clock_factory(0)
+
+    renderer = SlidingImage("banner.png", speed=4)
+    renderer.initialize(window, clock, manager, orientation)
+
+    initial_state = renderer.state
+    assert initial_state.image is not None
+    assert initial_state.width == window.get_width()
+    image_ref = initial_state.image
+
+    window.fill((0, 0, 0, 0))
+    offset_before = renderer.state.offset
+    renderer.process(window, clock, manager, orientation)
+    processed_state = renderer.state
+    assert processed_state.offset == (
+        offset_before + processed_state.speed
+    ) % processed_state.width
+    assert window.get_at((0, 0))[:3] == (10, 20, 30)
+
+    renderer.reset()
+    after_reset_state = renderer.state
+    assert after_reset_state.image is image_ref
+    assert after_reset_state.width == processed_state.width
+    assert after_reset_state.offset == 0
+    assert after_reset_state.speed == 4
+
+    window.fill((0, 0, 0, 0))
+    offset_before_second = renderer.state.offset
+    renderer.process(window, clock, manager, orientation)
+    after_second_process_state = renderer.state
+    assert after_second_process_state.offset == (
+        offset_before_second + after_second_process_state.speed
+    ) % after_second_process_state.width
+    assert window.get_at((0, 0))[:3] == (10, 20, 30)
+    assert after_second_process_state.image is image_ref


### PR DESCRIPTION
## Summary
- keep the cached SlidingImage surface when reset is invoked so the banner draws after returning to select mode
- document the SlidingImage reset behaviour in the renderer migration notes
- add a regression test covering cached-surface preservation across resets

## Testing
- make format
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912b74aa4108321b67337edac6f69b4)