### PR TITLE
Migrate pacman pixel renderers to atomic state

### DIFF
--- a/docs/migrations/renderer_atomic.md
+++ b/docs/migrations/renderer_atomic.md
@@ -49,10 +49,27 @@ status so incremental updates stay coordinated.
   - `Slinky` (`src/heart/display/renderers/pixels.py`) – tracks the falling
     anchor and bounce position in immutable state so loop consumers can safely
     reuse instances without carrying prior frame state.
+  - `RandomPixel` (`src/heart/display/renderers/pixels.py`) – keeps the optional
+    override colour in atomic state so brightness adjustments sample a stable
+    palette even when instances are re-used.
+  - `Border` (`src/heart/display/renderers/pixels.py`) – stores the configured
+    colour atomically so composed scenes can flip border hues without mutating
+    shared renderer attributes.
+  - `RandomPixel` (`src/heart/display/renderers/pacman.py`) – aligns the arcade
+    palette sampler with atomic state so switch-driven playlists can swap in a
+    fixed colour when required.
+  - `Border` (`src/heart/display/renderers/pacman.py`) – migrates the decorative
+    outline to atomic colour state while preserving configurable display modes.
+  - `Rain` (`src/heart/display/renderers/pacman.py`) – mirrors the drop state
+    tracking used elsewhere so the pacman playlist receives deterministic spawn
+    points across loop resets.
+  - `Slinky` (`src/heart/display/renderers/pacman.py`) – keeps the falling
+    anchor in atomic state so the animation restarts cleanly when composed in
+    arcade sequences.
 - Remaining renderers will be migrated iteratively. Track additional updates by
   appending to this list with accompanying test references.
 
-Progress indicator: `[##############>-------]`
+Progress indicator: `[####################>---]`
 
 ## Validation
 

--- a/src/heart/display/renderers/pacman.py
+++ b/src/heart/display/renderers/pacman.py
@@ -1,4 +1,5 @@
 import random
+from dataclasses import dataclass
 
 import pygame
 
@@ -6,15 +7,38 @@ from heart import DeviceDisplayMode
 from heart.assets.loader import Loader
 from heart.device import Orientation
 from heart.display.color import Color
-from heart.display.renderers import BaseRenderer
+from heart.display.renderers import AtomicBaseRenderer, BaseRenderer
 from heart.peripheral.core.manager import PeripheralManager
 
 
-class RandomPixel(BaseRenderer):
-    def __init__(self, num_pixels=1) -> None:
-        super().__init__()
-        self.device_display_mode = DeviceDisplayMode.FULL
+@dataclass
+class RandomPixelState:
+    color: Color | None
+
+
+@dataclass
+class BorderState:
+    color: Color
+
+
+@dataclass
+class RainState:
+    starting_point: int = 0
+    current_y: int = 0
+
+
+@dataclass
+class SlinkyState:
+    starting_point: int = 0
+    current_y: int = 0
+
+
+class RandomPixel(AtomicBaseRenderer[RandomPixelState]):
+    def __init__(self, num_pixels: int = 1, color: Color | None = None) -> None:
         self.num_pixels = num_pixels
+        self._initial_color = color
+        AtomicBaseRenderer.__init__(self)
+        self.device_display_mode = DeviceDisplayMode.FULL
 
     def process(
         self,
@@ -28,11 +52,17 @@ class RandomPixel(BaseRenderer):
             x = random.randint(0, width - 1)
             y = random.randint(0, height - 1)
 
-            random_color = Color.random()
+            random_color = self.state.color or Color.random()
             window.set_at((x, y), random_color._as_tuple())
 
+    def _create_initial_state(self) -> RandomPixelState:
+        return RandomPixelState(color=self._initial_color)
 
-class Border(BaseRenderer):
+    def set_color(self, color: Color | None) -> None:
+        self.update_state(color=color)
+
+
+class Border(AtomicBaseRenderer[BorderState]):
     def __init__(
         self,
         width: int,
@@ -40,10 +70,10 @@ class Border(BaseRenderer):
         display_mode: DeviceDisplayMode = DeviceDisplayMode.FULL,
     ) -> None:
         # TODO: This whole freaking this is broken
-        super().__init__()
+        self._initial_color = color or Color.random()
+        AtomicBaseRenderer.__init__(self)
         self.device_display_mode = display_mode
         self.width = width
-        self.color = color or Color.random()
 
     def process(
         self,
@@ -55,23 +85,34 @@ class Border(BaseRenderer):
         width, height = window.get_size()
         pygame.draw.rect(
             window,
-            self.color._as_tuple(),
+            self.state.color._as_tuple(),
             (0, 0, width, height),
             self.width,
         )
 
+    def _create_initial_state(self) -> BorderState:
+        return BorderState(color=self._initial_color)
 
-class Rain(BaseRenderer):
+    def set_color(self, color: Color) -> None:
+        self.update_state(color=color)
+
+
+class Rain(AtomicBaseRenderer[RainState]):
     def __init__(self) -> None:
         # TODO: This whole freaking this is broken
-        super().__init__()
+        AtomicBaseRenderer.__init__(self)
         self.device_display_mode = DeviceDisplayMode.FULL
         self.l = 8
         self.starting_color = Color(r=173, g=216, b=230)
 
-    def _change_starting_point(self, width):
-        self.starting_point = random.randint(0, width)
-        self.current_y = 0
+    def _create_initial_state(self) -> RainState:
+        return RainState()
+
+    def _change_starting_point(self, width, *, current_y: int = 0) -> None:
+        self.update_state(
+            starting_point=random.randint(0, width),
+            current_y=current_y,
+        )
 
     def initialize(
         self,
@@ -80,8 +121,8 @@ class Rain(BaseRenderer):
         peripheral_manager: PeripheralManager,
         orientation: Orientation,
     ):
-        self._change_starting_point(width=window.get_width())
-        self.current_y = random.randint(0, 20)
+        initial_y = random.randint(0, 20)
+        self._change_starting_point(width=window.get_width(), current_y=initial_y)
         super().initialize(window, clock, peripheral_manager, orientation)
 
     def process(
@@ -94,30 +135,38 @@ class Rain(BaseRenderer):
         width, height = window.get_size()
 
         # Move one unit
-        self.current_y += 1
+        state = self.state
+        new_y = state.current_y + 1
 
         # Now draw a rain drop
         # It should decrease the saturation, but also dim
 
         for i in range(self.l):
             color = self.starting_color.dim(fraction=i / self.l)
-            window.set_at((self.starting_point, self.current_y - i), color)
+            window.set_at((state.starting_point, new_y - i), color)
 
-        if self.current_y > height:
+        if new_y > height:
             self._change_starting_point(width=width)
+        else:
+            self.update_state(current_y=new_y)
 
 
-class Slinky(BaseRenderer):
+class Slinky(AtomicBaseRenderer[SlinkyState]):
     def __init__(self) -> None:
         # TODO: This whole freaking this is broken
-        super().__init__()
+        AtomicBaseRenderer.__init__(self)
         self.device_display_mode = DeviceDisplayMode.FULL
         self.l = 10
         self.starting_color = Color(r=255, g=165, b=0)
 
-    def _change_starting_point(self, width):
-        self.starting_point = random.randint(0, width)
-        self.current_y = 0
+    def _create_initial_state(self) -> SlinkyState:
+        return SlinkyState()
+
+    def _change_starting_point(self, width, *, current_y: int = 0) -> None:
+        self.update_state(
+            starting_point=random.randint(0, width),
+            current_y=current_y,
+        )
 
     def initialize(
         self,
@@ -126,8 +175,8 @@ class Slinky(BaseRenderer):
         peripheral_manager: PeripheralManager,
         orientation: Orientation,
     ):
-        self._change_starting_point(width=window.get_width())
-        self.current_y = random.randint(0, 20)
+        initial_y = random.randint(0, 20)
+        self._change_starting_point(width=window.get_width(), current_y=initial_y)
         super().initialize(window, clock, peripheral_manager, orientation)
 
     def process(
@@ -139,15 +188,16 @@ class Slinky(BaseRenderer):
     ) -> None:
         width, height = window.get_size()
         # Move one unit
-        self.current_y += 1
+        state = self.state
+        new_y = state.current_y + 1
 
         # Now draw a rain drop
         # It should decrease the saturation, but also dim
 
-        window.set_at((self.starting_point, self.current_y), self.starting_color)
+        window.set_at((state.starting_point, new_y), self.starting_color)
         f = self.starting_color.dim(fraction=1 / self.l)
-        window.set_at((self.starting_point + 1, self.current_y), f)
-        window.set_at((self.starting_point - 1, self.current_y), f)
+        window.set_at((state.starting_point + 1, new_y), f)
+        window.set_at((state.starting_point - 1, new_y), f)
         for i in range(self.l):
             # Make a triangle:
             # Brightness
@@ -157,15 +207,17 @@ class Slinky(BaseRenderer):
             # I want this to transition from Orange to Yellow as it moves, going through black as a center point
             final_color = list(self.starting_color)
             final_color = self.starting_color.dim(fraction=i / self.l)
-            window.set_at((self.starting_point, self.current_y + i), final_color)
-            window.set_at((self.starting_point, self.current_y - i), final_color)
+            window.set_at((state.starting_point, new_y + i), final_color)
+            window.set_at((state.starting_point, new_y - i), final_color)
             if i < 3:
                 f = self.dim(self.starting_color, fraction=(i + 1) / self.l)
-                window.set_at((self.starting_point + 1, self.current_y + i), f)
-                window.set_at((self.starting_point - 1, self.current_y - i), f)
+                window.set_at((state.starting_point + 1, new_y + i), f)
+                window.set_at((state.starting_point - 1, new_y - i), f)
 
-        if self.current_y > height:
+        if new_y > height:
             self._change_starting_point(width=width)
+        else:
+            self.update_state(current_y=new_y)
 
 
 ## More Ideas


### PR DESCRIPTION
## Summary
- migrate the random pixel and border renderers to `AtomicBaseRenderer` across pixel-focused modules
- port the Pac-Man rain and slinky animations onto immutable state snapshots to align with other atomic renderers
- document the additional migrations in `docs/migrations/renderer_atomic.md`

## Testing
- make test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912b705ce10832195ad67c4b3101ece)