### PR TITLE
Fix MetadataScreen initialization warmup attribute

### DIFF
--- a/src/heart/display/renderers/metadata_screen.py
+++ b/src/heart/display/renderers/metadata_screen.py
@@ -16,6 +16,7 @@ logger = get_logger("HeartRateManager")
 
 class MetadataScreen(BaseRenderer):
     def __init__(self) -> None:
+        super().__init__()
         self.device_display_mode = DeviceDisplayMode.FULL
         self.current_frame = 0
 


### PR DESCRIPTION
## Summary
- call the base renderer initializer from `MetadataScreen` so the warmup flag is set before the renderer is used

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912bd7416a8832183ca2f707117e3ef)