### PR TITLE
Refactor stateful renderers to consume event bus state

### DIFF
--- a/docs/research/stateful_renderers_event_bus.md
+++ b/docs/research/stateful_renderers_event_bus.md
@@ -1,0 +1,32 @@
+# Event-driven state updates for renderer inputs
+
+## Overview
+
+Stateful renderers previously polled `PeripheralManager` on each frame to
+hydrate their internal snapshots. `FreeTextRenderer` queried
+`PeripheralManager.get_phone_text()` for the most recent BLE message while
+`MarioRenderer` called `PeripheralManager.get_accelerometer()` to check the
+current acceleration vector. Both patterns contradicted the push-based
+model used by `SwitchStateConsumer` and forced renderers to hold live
+references to peripherals during rendering.
+
+## Changes
+
+- Added `AccelerometerConsumer` under
+  `src/heart/display/renderers/internal/accelerometer.py` to cache the last
+  `AccelerometerVector` published on the event bus and expose a
+  `latest_acceleration()` helper for renderers.
+- Updated `MarioRenderer` (`src/heart/display/renderers/mario.py`) to
+  inherit the new mixin, subscribe to accelerometer updates during
+  `initialize()`, and drive loop transitions from cached vectors instead of
+  polling the manager each frame.
+- Taught `FreeTextRenderer` (`src/heart/display/renderers/free_text.py`) to
+  subscribe directly to `PhoneTextMessage` events, cache the latest text, and
+  drop its stored `PhoneText` peripheral reference.
+
+## Impact
+
+Renderers rely solely on cached event-driven state during `process()`,
+eliminating per-frame calls to `PeripheralManager`. Subscriptions are
+established during `initialize()` and cleaned up in `reset()`, mirroring the
+pattern already in place for switch state consumers.

--- a/src/heart/display/renderers/free_text.py
+++ b/src/heart/display/renderers/free_text.py
@@ -9,8 +9,13 @@ from heart import DeviceDisplayMode
 from heart.assets.loader import Loader
 from heart.device import Orientation
 from heart.display.renderers import AtomicBaseRenderer
+from heart.events.types import PhoneTextMessage
+from heart.peripheral.core import Input
+from heart.peripheral.core.event_bus import EventBus, SubscriptionHandle
 from heart.peripheral.core.manager import PeripheralManager
-from heart.peripheral.phone_text import PhoneText
+from heart.utilities.logging import get_logger
+
+_LOGGER = get_logger(__name__)
 
 
 @dataclass(frozen=True)
@@ -29,7 +34,9 @@ class FreeTextRenderer(AtomicBaseRenderer[FreeTextRendererState]):
         """Create a *FreeTextRenderer*."""
 
         self._font_cache: dict[int, pygame.font.Font] = {}
-        self._phone_text: PhoneText | None = None
+        self._latest_text: str | None = None
+        self._event_bus: EventBus | None = None
+        self._subscription: SubscriptionHandle | None = None
 
         # Font size bounds (inclusive)
         self._font_size_max: int = 12
@@ -51,10 +58,7 @@ class FreeTextRenderer(AtomicBaseRenderer[FreeTextRendererState]):
     ) -> None:
         """Initialise the renderer and warm the default font cache."""
 
-        # Locate the PhoneText peripheral once – it's expected to be present if
-        # this renderer is used, but we handle the case where it isn't to avoid
-        # crashes.
-        self._phone_text = peripheral_manager.get_phone_text()
+        self._ensure_subscription(peripheral_manager)
 
         initial_font = self._get_font(self._initial_font_size)
         self.update_state(
@@ -63,6 +67,49 @@ class FreeTextRenderer(AtomicBaseRenderer[FreeTextRendererState]):
         )
 
         super().initialize(window, clock, peripheral_manager, orientation)
+
+    def reset(self) -> None:
+        self._unsubscribe()
+        self._latest_text = None
+        super().reset()
+
+    def _ensure_subscription(self, peripheral_manager: PeripheralManager) -> None:
+        if self._subscription is not None:
+            return
+        bus = getattr(peripheral_manager, "event_bus", None)
+        if bus is None:
+            _LOGGER.debug("FreeTextRenderer missing event bus; text will remain static")
+            return
+        self._event_bus = bus
+        self._subscription = bus.subscribe(
+            PhoneTextMessage.EVENT_TYPE,
+            self._handle_phone_text_event,
+        )
+
+    def _unsubscribe(self) -> None:
+        if self._event_bus is None or self._subscription is None:
+            self._event_bus = None
+            self._subscription = None
+            return
+        try:
+            self._event_bus.unsubscribe(self._subscription)
+        except Exception:  # pragma: no cover - defensive cleanup
+            _LOGGER.exception("Failed to unsubscribe FreeTextRenderer")
+        finally:
+            self._event_bus = None
+            self._subscription = None
+
+    def _handle_phone_text_event(self, event: Input) -> None:
+        payload = event.data
+        if isinstance(payload, PhoneTextMessage):
+            text = payload.text
+        else:
+            try:
+                text = str(payload["text"])
+            except (KeyError, TypeError, ValueError):
+                _LOGGER.debug("Ignoring malformed phone text payload: %s", payload)
+                return
+        self._latest_text = text
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -130,11 +177,7 @@ class FreeTextRenderer(AtomicBaseRenderer[FreeTextRendererState]):
         orientation: Orientation,
     ) -> None:
         # Fetch the most recent text (or a placeholder).
-        last_text: str | None = (
-            self._phone_text.get_last_text()
-            if self._phone_text
-            else "Waiting for text..."
-        )
+        last_text = self._latest_text or "Waiting for text..."
 
         # Skip rendering if we have nothing to show.
         if not last_text:

--- a/src/heart/display/renderers/internal/__init__.py
+++ b/src/heart/display/renderers/internal/__init__.py
@@ -1,4 +1,5 @@
 """Internal helpers for renderer performance features."""
 
+from .accelerometer import AccelerometerConsumer as AccelerometerConsumer
 from .frame_accumulator import FrameAccumulator as FrameAccumulator
 from .switch_state import SwitchStateConsumer as SwitchStateConsumer

--- a/src/heart/display/renderers/internal/accelerometer.py
+++ b/src/heart/display/renderers/internal/accelerometer.py
@@ -1,0 +1,88 @@
+"""Accelerometer subscription utilities for renderers."""
+
+from __future__ import annotations
+
+from heart.events.types import AccelerometerVector
+from heart.peripheral.core import Input
+from heart.peripheral.core.event_bus import EventBus, SubscriptionHandle
+from heart.peripheral.core.manager import PeripheralManager
+from heart.utilities.logging import get_logger
+
+_LOGGER = get_logger(__name__)
+
+
+class AccelerometerConsumer:
+    """Mixin that caches accelerometer vectors for renderers."""
+
+    def __init__(self) -> None:
+        super().__init__()  # type: ignore[misc] - cooperative multiple inheritance
+        self._accelerometer_event_bus: EventBus | None = None
+        self._accelerometer_subscription: SubscriptionHandle | None = None
+        self._latest_accelerometer: tuple[float, float, float] | None = None
+
+    def bind_accelerometer(self, peripheral_manager: PeripheralManager) -> None:
+        """Subscribe to accelerometer updates from ``peripheral_manager``."""
+
+        if self._accelerometer_subscription is not None:
+            return
+        bus = getattr(peripheral_manager, "event_bus", None)
+        if bus is None:
+            _LOGGER.debug(
+                "AccelerometerConsumer missing event bus; accelerometer data will stay static",
+            )
+            return
+        self._accelerometer_event_bus = bus
+        self._accelerometer_subscription = bus.subscribe(
+            AccelerometerVector.EVENT_TYPE,
+            self._handle_accelerometer_event,
+        )
+
+    def unbind_accelerometer(self) -> None:
+        """Stop receiving accelerometer updates."""
+
+        if self._accelerometer_event_bus is None or self._accelerometer_subscription is None:
+            self._accelerometer_event_bus = None
+            self._accelerometer_subscription = None
+            return
+        try:
+            self._accelerometer_event_bus.unsubscribe(self._accelerometer_subscription)
+        except Exception:  # pragma: no cover - defensive cleanup
+            _LOGGER.exception("Failed to unsubscribe accelerometer consumer")
+        finally:
+            self._accelerometer_event_bus = None
+            self._accelerometer_subscription = None
+
+    def latest_acceleration(self) -> tuple[float, float, float] | None:
+        """Return the most recent accelerometer vector, if any."""
+
+        return self._latest_accelerometer
+
+    def reset(self) -> None:
+        self.unbind_accelerometer()
+        super().reset()  # type: ignore[misc]
+
+    # ------------------------------------------------------------------
+    # Hooks
+    # ------------------------------------------------------------------
+    def on_accelerometer_vector(self, vector: tuple[float, float, float]) -> None:
+        """Hook invoked after ``vector`` is cached."""
+
+    def _handle_accelerometer_event(self, event: Input) -> None:
+        payload = event.data
+        if isinstance(payload, AccelerometerVector):
+            vector = (payload.x, payload.y, payload.z)
+        else:
+            try:
+                vector = (
+                    float(payload["x"]),
+                    float(payload["y"]),
+                    float(payload["z"]),
+                )
+            except (KeyError, TypeError, ValueError):
+                _LOGGER.debug("Ignoring malformed accelerometer payload: %s", payload)
+                return
+        self._latest_accelerometer = vector
+        try:
+            self.on_accelerometer_vector(vector)
+        except Exception:  # pragma: no cover - renderer hook failures shouldn't break bus
+            _LOGGER.exception("AccelerometerConsumer hook failed")


### PR DESCRIPTION
## Summary
- add an AccelerometerConsumer mixin that caches accelerometer vectors from the event bus for renderers
- update MarioRenderer to subscribe to accelerometer updates during initialization instead of polling the manager
- teach FreeTextRenderer to consume PhoneTextMessage events and document the event-driven renderer workflow

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912bc57d8f0832187b56a7b5e8b940f)