### PR TITLE
Use helper utilities for asset path resolution

### DIFF
--- a/docs/pixel_model_renderer.md
+++ b/docs/pixel_model_renderer.md
@@ -24,9 +24,10 @@ It lives at `src/heart/display/renderers/pixel_model.py` and exposes the same
 
 ```
 from heart.display.renderers.pixel_model import PixelModelRenderer
+from heart.utilities.paths import docs_asset_path
 
 renderer = PixelModelRenderer(
-    model_path="docs/assets/models/pixel_runner.obj",
+    model_path=docs_asset_path("models", "pixel_runner.obj"),
     target_rows=96,
     palette_levels=6,
 )
@@ -43,6 +44,6 @@ screen is a high-resolution laptop display.
 
 ## Sample asset
 
-`docs/assets/models/pixel_runner.obj` provides a low-poly runner silhouette that
-is already centred and scaled. Use it to validate the renderer wiring before
-bringing in external assets.
+`docs_asset_path("models", "pixel_runner.obj")` resolves a low-poly runner
+silhouette that is already centred and scaled. Use it to validate the renderer
+wiring before bringing in external assets.

--- a/src/heart/assets/loader.py
+++ b/src/heart/assets/loader.py
@@ -1,15 +1,24 @@
 import json
 import os
 from functools import cache
+from pathlib import Path
 from typing import Any
 
 import pygame
 
+from heart.utilities.paths import heart_asset_path
+
 
 class Loader:
     @classmethod
+    def resolve_path(cls, path: str | os.PathLike[str]) -> Path:
+        """Return the absolute path to a file in ``src/heart/assets``."""
+
+        return heart_asset_path(path)
+
+    @classmethod
     def _resolve_path(cls, path):
-        return os.path.join(os.path.dirname(__file__), path)
+        return os.fspath(cls.resolve_path(path))
 
     @classmethod
     @cache

--- a/src/heart/programs/configurations/pixel_model_demo.py
+++ b/src/heart/programs/configurations/pixel_model_demo.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 from heart.display.renderers.pixel_model import PixelModelRenderer
 from heart.programs.configurations import base
+from heart.utilities.paths import docs_asset_path
 
 
 def build_configuration() -> base.ProgramConfiguration:
@@ -13,10 +12,10 @@ def build_configuration() -> base.ProgramConfiguration:
 
     configuration = base.ProgramConfiguration()
     mode = configuration.create_mode("pixel_model")
-    model_path = Path("docs/assets/models/pixel_runner.obj")
+    model_path = docs_asset_path("models", "pixel_runner.obj")
     mode.add_renderer(
         PixelModelRenderer(
-            model_path=str(model_path),
+            model_path=model_path,
             target_rows=96,
             palette_levels=6,
         )

--- a/src/heart/utilities/paths.py
+++ b/src/heart/utilities/paths.py
@@ -1,0 +1,36 @@
+"""Path helpers for resolving locations inside the repository."""
+
+from __future__ import annotations
+
+from functools import cache
+from os import PathLike
+from pathlib import Path
+from typing import Iterable
+
+PathInput = str | PathLike[str]
+
+
+def _build_relative_path(parts: Iterable[PathInput]) -> Path:
+    path = Path()
+    for part in parts:
+        path /= Path(part)
+    return path
+
+
+@cache
+def repo_root() -> Path:
+    """Return the root directory of the repository."""
+
+    return Path(__file__).resolve().parents[2]
+
+
+def heart_asset_path(*relative_parts: PathInput) -> Path:
+    """Resolve a path inside ``src/heart/assets``."""
+
+    return repo_root() / "src" / "heart" / "assets" / _build_relative_path(relative_parts)
+
+
+def docs_asset_path(*relative_parts: PathInput) -> Path:
+    """Resolve a path inside ``docs/assets``."""
+
+    return repo_root() / "docs" / "assets" / _build_relative_path(relative_parts)


### PR DESCRIPTION
## Summary
- add path helpers to centralize repository, heart asset, and docs asset locations
- update the asset loader and pixel model demo configuration to rely on the helpers
- refresh the pixel model renderer documentation to reference the new helpers

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912bd20db3883219b4a696fe054fb1c)