### PR TITLE
Render streamed frames on cube in Beats renderer

### DIFF
--- a/docs/beats-cube-renderer.md
+++ b/docs/beats-cube-renderer.md
@@ -1,0 +1,19 @@
+# Beats cube renderer integration
+
+## Overview
+
+The Beats Electron renderer now draws streamed PNG frames onto a rotating WebGL cube instead of an `<img>` element. The cube is implemented in `experimental/beats/src/components/stream-cube.tsx` and consumes frame updates from `ImageProvider` via the existing `useStreamedImage()` hook. The previous image-based path remains available as a fallback when WebGL cannot initialise.
+
+## Key behaviours
+
+- The cube uses a Three.js `WebGLRenderer` with a `BoxGeometry` and six `MeshStandardMaterial` instances so incoming textures wrap every face.
+- When `imgURL` is `null`, the renderer shows a generated checkerboard texture to keep the GPU pipeline stable during stream gaps.
+- Failed WebGL context creation triggers a transparent fallback to the legacy `<img>` rendering path in `experimental/beats/src/components/stream.tsx`.
+- The render loop animates the cube on both the X and Y axes and resizes in response to a `ResizeObserver` attached to the container element.
+- Texture lifecycles are managed by disposing previous maps on update and tearing down the renderer, materials, and fallback texture on unmount.
+
+## Touchpoints
+
+- Rendering: `experimental/beats/src/components/stream-cube.tsx`
+- Stream view composition and fallback handling: `experimental/beats/src/components/stream.tsx`
+- Frame source: `experimental/beats/src/actions/ws/providers/ImageProvider.tsx`

--- a/docs/planning/beats-cube-streaming.md
+++ b/docs/planning/beats-cube-streaming.md
@@ -1,0 +1,92 @@
+# Refactor plan: render streamed images on a cube in the Beats Electron renderer
+
+## Problem Statement
+
+The Beats Electron renderer currently draws streamed PNG frames directly into an `<img>` tag via `src/components/stream.tsx`, so there is no ability to map the texture onto 3D geometry. We need a plan to refactor the renderer so the streamed image is applied to a WebGL cube while preserving the existing websocket-driven frame pipeline and status overlays.
+
+## Materials
+
+- Node.js and npm as defined in `experimental/beats/package.json` (Electron 39, Vite 7, React 19, TypeScript 5.9).
+- Existing websocket frame source provided by `src/actions/ws/providers/ImageProvider.tsx` and `frameStream`.
+- Rendering components under `experimental/beats/src`, especially `components/stream.tsx` and layout wrappers that host the viewer area.
+- Three.js (or a lightweight alternative such as `@react-three/fiber` and `three`) for WebGL rendering on the renderer side.
+- Access to the Electron renderer build (Vite) to validate GPU context creation and hot reload behaviour.
+- Design assets (placeholder checkerboard texture) for bootstrapping when no stream frames are available.
+
+## Opening Abstract
+
+This refactor introduces a WebGL-backed rendering path for streamed camera frames. Instead of piping the base64 frame data straight into an `<img>` element, the frames will be decoded into textures and applied to a cube mesh within a dedicated canvas component. The refactor keeps websocket connectivity, FPS smoothing, and status indicators intact while isolating the WebGL lifecycle in a single React component. By hard-coding the mesh to a cube, we simplify MVP scope and leave hooks for future shape selection.
+
+## Success Criteria
+
+| Behaviour | Validation signal | Owner |
+| --- | --- | --- |
+| Streamed frames appear on all six faces of a cube rendered in the viewer area | Visual confirmation in the renderer window with real or mocked frames | Renderer developer |
+| FPS display and websocket status remain accurate | `fps` value from `useStreamedImage()` matches incoming frame cadence; status badge still toggles | Frontend engineer |
+| Rendering path handles stream interruptions gracefully | When `imgURL` is null, the cube uses a fallback texture and avoids crashes | Renderer developer |
+| Cube rendering does not regress existing layout | Surrounding UI (footer, separators) retains sizing and alignment in `stream.tsx` | UI maintainer |
+
+## Task Breakdown Checklists
+
+### Discovery
+
+- [ ] Audit `src/components/stream.tsx` and identify the container element where the canvas can replace the `<img>` tag.
+- [ ] Verify how `ImageProvider` cleans up object URLs to ensure texture disposal will not leak GPU memory.
+- [ ] Confirm Vite/Electron build supports WebGL context creation and whether `three` is already a dependency.
+- [ ] Map keyboard/mouse interaction requirements (e.g., auto-rotation only) to avoid over-scoping controls.
+
+### Implementation
+
+- [ ] Add rendering dependencies (`three` and optionally `@react-three/fiber`) to `experimental/beats/package.json` if absent.
+- [ ] Create `src/components/stream-cube.tsx` that owns a `<canvas>` and renders a cube textured with the latest frame.
+- [ ] Convert `imgURL` blob URLs into `THREE.Texture` objects, disposing previous textures when frames update.
+- [ ] Drive cube rotation with a requestAnimationFrame loop to keep motion even when frames are static.
+- [ ] Replace `<StreamedImage>` usage in `stream.tsx` with the cube component while keeping footer/status elements unchanged.
+- [ ] Provide a fallback texture (checkerboard or solid colour) when `imgURL` is null to avoid flashing blank faces.
+- [ ] Wire cleanup to dispose of renderer, scene, and textures when the component unmounts or when websocket disconnects.
+
+### Validation
+
+- [ ] Use a mock frame generator to send static and rapidly changing frames, verifying texture updates across all cube faces.
+- [ ] Check that FPS readouts match expected frame counts during test streams.
+- [ ] Resize the window to confirm the cube resizes correctly within the existing flex layout.
+- [ ] Run `npm run lint` and `npm run test` (or `make test` at repo root) to ensure no regressions elsewhere.
+
+## Narrative Walkthrough
+
+The current stream viewer is a thin wrapper that decodes base64 PNG strings into blob URLs and feeds them into an `<img>` tag. The refactor replaces this passive image element with a small WebGL scene. A new `StreamCube` component will mount a `<canvas>` inside the existing viewer region and initialise a Three.js scene containing a single cube mesh. On every incoming frame, the component converts the blob URL provided by `useStreamedImage()` into a texture, applies it to a `THREE.MeshStandardMaterial`, and swaps it onto the cube. As frames arrive, previous textures are disposed to keep GPU memory bounded. The cube will rotate slowly along two axes via a requestAnimationFrame loop so the mapped image is visible from multiple angles without user input.
+
+`stream.tsx` keeps its layout responsibilities: it reserves vertical space for the viewer, renders the cube canvas in place of the `<StreamedImage>` wrapper, and retains the separator and footer. The websocket address display and `StreamStatus` indicator continue to consume `useWS()` and `useStreamedImage()` outputs, so no backend contract changes are required. To make error handling predictable, the cube uses a fallback texture whenever `imgURL` is `null`; this keeps the GPU pipeline stable during stream outages while allowing the status badge to show inactivity.
+
+Lifecycle management is critical because Electron windows may be opened and closed repeatedly during development. The plan emphasises disposing of render targets, textures, and event listeners when the cube component unmounts. Because `ImageProvider` already revokes object URLs, the cube only needs to release Three.js resources it owns. The rendering loop should pause when the component is not visible or when the websocket disconnects to conserve CPU/GPU cycles.
+
+## Visual Reference
+
+```mermaid
+graph TD
+  A[frameStream payload (base64 PNG)] --> B[ImageProvider converts to blob URL]
+  B --> C[StreamCube loads URL into THREE.Texture]
+  C --> D[Cube mesh with 6 material slots]
+  D --> E[Rotating render loop on <canvas>]
+  E --> F[Stream footer (FPS, status, URL)]
+```
+
+## Risk Analysis
+
+| Risk | Probability | Impact | Mitigation | Early warning |
+| --- | --- | --- | --- | --- |
+| GPU resource leaks from repeated texture creation | Medium | High | Dispose textures on each frame update; reuse materials; profile with Chrome DevTools | Renderer memory grows over time or GPU crashes |
+| WebGL context fails in some environments | Low | Medium | Detect context creation failure and fall back to existing `<img>` path | Console errors about context loss |
+| Frame-rate drops due to render loop overhead | Medium | Medium | Cap rotation update rate and throttle texture uploads to frame arrivals | FPS readout diverges from expected input |
+| Layout regressions in stream view | Low | Medium | Keep container sizing identical and test responsive breakpoints | Misaligned footer or overflow clipping |
+
+### Mitigation Checklist
+
+- [ ] Add a guard that falls back to `<img>` rendering when `THREE.WebGLRenderer` cannot initialise.
+- [ ] Instrument texture creation/disposal with debug logs during development builds.
+- [ ] Profile render loop and texture upload timings using Chromium performance tools in Electron.
+- [ ] Keep viewer container styles unchanged to minimize CSS churn.
+
+## Outcome Snapshot
+
+After the refactor, the Beats Electron renderer will show the streamed feed wrapped around a rotating cube inside the existing viewer panel. Status badges still indicate websocket health and FPS, and the viewer remains responsive to window resizes. The rendering code is isolated in `StreamCube`, making it easy to swap in different shapes later or extend the material pipeline without disturbing websocket or layout logic.

--- a/experimental/beats/src/components/stream-cube.tsx
+++ b/experimental/beats/src/components/stream-cube.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+
+import { Skeleton } from "./ui/skeleton";
+
+const CAMERA_DISTANCE = 4;
+const ROTATION_DELTA = { x: 0.01, y: 0.015 } as const;
+
+export type StreamCubeProps = {
+  imgURL: string | null;
+  onContextError?: () => void;
+};
+
+export function StreamCube({ imgURL, onContextError }: StreamCubeProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
+  const sceneRef = useRef<THREE.Scene | null>(null);
+  const cameraRef = useRef<THREE.PerspectiveCamera | null>(null);
+  const cubeRef = useRef<THREE.Mesh<THREE.BoxGeometry, THREE.MeshStandardMaterial[]> | null>(
+    null,
+  );
+  const fallbackTextureRef = useRef<THREE.Texture | null>(null);
+  const lastTextureRef = useRef<THREE.Texture | null>(null);
+  const animationRef = useRef<number | null>(null);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const canvas = canvasRef.current;
+
+    if (!container || !canvas) return undefined;
+
+    try {
+      const renderer = new THREE.WebGLRenderer({
+        antialias: true,
+        alpha: true,
+        canvas,
+      });
+      renderer.setPixelRatio(window.devicePixelRatio);
+      renderer.outputColorSpace = THREE.SRGBColorSpace;
+
+      const scene = new THREE.Scene();
+      scene.background = null;
+
+      const { clientWidth: width, clientHeight: height } = container;
+      const camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 100);
+      camera.position.set(0, 0, CAMERA_DISTANCE);
+
+      const ambient = new THREE.AmbientLight(0xffffff, 0.6);
+      const directional = new THREE.DirectionalLight(0xffffff, 0.8);
+      directional.position.set(2, 3, 4);
+      scene.add(ambient, directional);
+
+      const geometry = new THREE.BoxGeometry(2, 2, 2);
+      const fallbackTexture = createFallbackTexture();
+      const materials = Array.from({ length: 6 }, () =>
+        new THREE.MeshStandardMaterial({ map: fallbackTexture }),
+      );
+      const cube = new THREE.Mesh(geometry, materials);
+      scene.add(cube);
+
+      renderer.setSize(width, height, false);
+
+      rendererRef.current = renderer;
+      sceneRef.current = scene;
+      cameraRef.current = camera;
+      cubeRef.current = cube;
+      fallbackTextureRef.current = fallbackTexture;
+
+      const renderFrame = () => {
+        cube.rotation.x += ROTATION_DELTA.x;
+        cube.rotation.y += ROTATION_DELTA.y;
+        renderer.render(scene, camera);
+        animationRef.current = window.requestAnimationFrame(renderFrame);
+      };
+      renderFrame();
+
+      const handleResize = () => {
+        const { clientWidth, clientHeight } = container;
+        renderer.setSize(clientWidth, clientHeight, false);
+        camera.aspect = clientWidth / clientHeight;
+        camera.updateProjectionMatrix();
+      };
+
+      const resizeObserver = new ResizeObserver(handleResize);
+      resizeObserver.observe(container);
+      resizeObserverRef.current = resizeObserver;
+    } catch (error) {
+      onContextError?.();
+      console.error("Failed to initialize WebGL renderer", error);
+    }
+
+    return () => {
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+      }
+
+      resizeObserverRef.current?.disconnect();
+
+      cubeRef.current?.geometry.dispose();
+      cubeRef.current?.material.forEach((material) => {
+        if (material.map && material.map !== fallbackTextureRef.current) {
+          material.map.dispose();
+        }
+        material.dispose();
+      });
+
+      if (fallbackTextureRef.current) {
+        fallbackTextureRef.current.dispose();
+      }
+
+      if (lastTextureRef.current) {
+        lastTextureRef.current.dispose();
+      }
+
+      rendererRef.current?.dispose();
+      rendererRef.current = null;
+      sceneRef.current = null;
+      cameraRef.current = null;
+      cubeRef.current = null;
+      fallbackTextureRef.current = null;
+      lastTextureRef.current = null;
+      resizeObserverRef.current = null;
+    };
+  }, [onContextError]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const applyTexture = async () => {
+      if (!cubeRef.current || !fallbackTextureRef.current) return;
+
+      let nextTexture: THREE.Texture | null = null;
+      try {
+        nextTexture = imgURL ? await loadTexture(imgURL) : fallbackTextureRef.current;
+      } catch (error) {
+        console.warn("Failed to load streamed texture; using fallback", error);
+        nextTexture = fallbackTextureRef.current;
+      }
+
+      if (cancelled || !cubeRef.current || !nextTexture) {
+        if (nextTexture && nextTexture !== fallbackTextureRef.current) {
+          nextTexture.dispose();
+        }
+        return;
+      }
+
+      const materials = cubeRef.current.material;
+      materials.forEach((material) => {
+        const previousMap = material.map;
+        material.map = nextTexture;
+        material.needsUpdate = true;
+        if (previousMap && previousMap !== nextTexture && previousMap !== fallbackTextureRef.current) {
+          previousMap.dispose();
+        }
+      });
+
+      if (lastTextureRef.current && lastTextureRef.current !== nextTexture) {
+        lastTextureRef.current.dispose();
+      }
+
+      lastTextureRef.current = nextTexture === fallbackTextureRef.current ? null : nextTexture;
+    };
+
+    applyTexture();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [imgURL]);
+
+  return (
+    <div ref={containerRef} className="relative flex-1 min-h-[240px] w-full rounded-md bg-muted/40">
+      <canvas ref={canvasRef} className="size-full" />
+      {!rendererRef.current && <Skeleton className="absolute inset-0" />}
+    </div>
+  );
+}
+
+function createFallbackTexture() {
+  const size = 128;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const context = canvas.getContext("2d");
+
+  if (!context) {
+    throw new Error("Failed to create 2D context for fallback texture");
+  }
+
+  const colors = ["#111827", "#1f2937"];
+  const squareSize = size / 8;
+
+  for (let y = 0; y < 8; y += 1) {
+    for (let x = 0; x < 8; x += 1) {
+      context.fillStyle = colors[(x + y) % 2];
+      context.fillRect(x * squareSize, y * squareSize, squareSize, squareSize);
+    }
+  }
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.RepeatWrapping;
+  texture.repeat.set(2, 2);
+
+  return texture;
+}
+
+function loadTexture(url: string) {
+  return new Promise<THREE.Texture>((resolve, reject) => {
+    const loader = new THREE.TextureLoader();
+    loader.load(
+      url,
+      (texture) => {
+        texture.colorSpace = THREE.SRGBColorSpace;
+        resolve(texture);
+      },
+      undefined,
+      (error) => reject(error),
+    );
+  });
+}

--- a/experimental/beats/src/components/stream.tsx
+++ b/experimental/beats/src/components/stream.tsx
@@ -1,6 +1,9 @@
 import { useStreamedImage } from "@/actions/ws/providers/ImageProvider";
 import { useWS } from "@/actions/ws/websocket";
 import { Antenna } from "lucide-react";
+import { useState } from "react";
+
+import { StreamCube } from "./stream-cube";
 import { Separator } from "./ui/separator";
 import { Skeleton } from "./ui/skeleton";
 
@@ -16,7 +19,7 @@ export function StreamStatus(
     ...divProps
   }: React.ComponentProps<"div"> & {
     streamIsActive: boolean;
-  }
+  },
 ) {
   return (
     <div
@@ -28,7 +31,6 @@ export function StreamStatus(
     </div>
   );
 }
-
 
 export function StreamedImage({ imgURL }: { imgURL: string | null }) {
   if (!imgURL) return <Skeleton className="size-full" />;
@@ -45,22 +47,29 @@ export function StreamedImage({ imgURL }: { imgURL: string | null }) {
 export function Stream() {
   const ws = useWS();
   const { imgURL, isActive, fps } = useStreamedImage();
+  const [useImageFallback, setUseImageFallback] = useState(false);
 
   return (
     <div className="flex h-full flex-col select-none">
-      <div className="flex-1 w-full" />
-
-      {/* Display the streamed image */}
-      <StreamedImage imgURL={imgURL} />
+      <div className="flex-1 w-full min-h-0">
+        {useImageFallback ? (
+          <StreamedImage imgURL={imgURL} />
+        ) : (
+          <StreamCube
+            imgURL={imgURL}
+            onContextError={() => setUseImageFallback(true)}
+          />
+        )}
+      </div>
 
       <Separator className="my-4 flex-none" />
 
       {/* Footer */}
       <div className="flex-none mb-2 flex items-center justify-between gap-4 px-2">
         <span className="text-xs text-muted-foreground font-tomorrow uppercase">
-        fps: <b>{isActive ? fps : 0}</b>
+          fps: <b>{isActive ? fps : 0}</b>
         </span>
-        <div className="text-xs text-muted-foreground font-tomorrow" >
+        <div className="text-xs text-muted-foreground font-tomorrow">
           {ws?.socket?.url}
         </div>
         <StreamStatus streamIsActive={isActive} />


### PR DESCRIPTION
## Summary
- render streamed frames onto a rotating Three.js cube in the Beats stream view with resize handling and fallback textures
- fall back to the legacy <img> renderer when WebGL initialization fails
- document the cube renderer lifecycle and touchpoints under docs

## Testing
- make format
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c3103c7448321a6947f8397a01b24)