### PR TITLE
Refactor text renderer into modular package

### DIFF
--- a/docs/text_renderer_structure.md
+++ b/docs/text_renderer_structure.md
@@ -1,0 +1,9 @@
+# Text renderer structure
+
+The text renderer now mirrors the layout used by other modular renderers such as Water and Life. Its code lives under `heart/display/renderers/text/` and is divided into:
+
+- `provider.py`: builds the `TextRenderingState`, wiring the main switch subscription to mutate the state when rotations occur.
+- `state.py`: defines the dataclass that stores the current text, font configuration, color, and positional offsets and lazily constructs the pygame font.
+- `renderer.py`: contains the rendering logic and uses the provider to initialize state before blitting the centered or positioned text onto the display surface.
+
+Existing imports (`from heart.display.renderers.text import TextRendering`) remain valid because the new package re-exports the renderer and supporting classes.

--- a/src/heart/display/renderers/text/__init__.py
+++ b/src/heart/display/renderers/text/__init__.py
@@ -1,0 +1,6 @@
+from heart.display.renderers.text.provider import \
+    TextRenderingProvider as TextRenderingProvider
+from heart.display.renderers.text.renderer import \
+    TextRendering as TextRendering
+from heart.display.renderers.text.state import \
+    TextRenderingState as TextRenderingState

--- a/src/heart/display/renderers/text/provider.py
+++ b/src/heart/display/renderers/text/provider.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pygame
+
+from heart.device import Orientation
+from heart.display.color import Color
+from heart.display.renderers.text.state import TextRenderingState
+from heart.peripheral.core.manager import PeripheralManager
+
+
+class TextRenderingProvider:
+    def __init__(
+        self,
+        *,
+        text: list[str],
+        font_name: str,
+        font_size: int,
+        color: Color,
+        x_location: int | None,
+        y_location: int | None,
+    ) -> None:
+        self._text = tuple(text)
+        self._font_name = font_name
+        self._font_size = font_size
+        self._color = color
+        self._x_location = x_location
+        self._y_location = y_location
+
+    def build(
+        self,
+        peripheral_manager: PeripheralManager,
+        orientation: Orientation,
+        window: pygame.Surface,
+        clock: pygame.time.Clock,
+    ) -> TextRenderingState:
+        state = TextRenderingState(
+            switch_state=None,
+            text=self._text,
+            font_name=self._font_name,
+            font_size=self._font_size,
+            color=self._color,
+            x_location=self._x_location,
+            y_location=self._y_location,
+        )
+
+        def new_switch_state(value):
+            state.switch_state = value
+
+        source = peripheral_manager.get_main_switch_subscription()
+        source.subscribe(
+            on_next=new_switch_state,
+            on_error=lambda e: print("Error Occurred: {0}".format(e)),
+        )
+
+        return state
+
+    @classmethod
+    def default(cls, text: str) -> "TextRenderingProvider":
+        return cls(
+            text=[text],
+            font_name="Roboto",
+            font_size=14,
+            color=Color(255, 105, 180),
+            x_location=None,
+            y_location=None,
+        )

--- a/src/heart/display/renderers/text/state.py
+++ b/src/heart/display/renderers/text/state.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import cached_property
+
+import pygame
+
+from heart.display.color import Color
+from heart.peripheral.switch import SwitchState
+
+
+@dataclass
+class TextRenderingState:
+    switch_state: SwitchState | None
+    text: tuple[str, ...]
+    font_name: str
+    font_size: int
+    color: Color
+    x_location: int | None
+    y_location: int | None
+
+    @cached_property
+    def font(self) -> pygame.font.Font:
+        return pygame.font.SysFont(
+            self.font_name,
+            self.font_size,
+        )


### PR DESCRIPTION
## Summary
- restructure the text renderer into a dedicated package with provider, state, and renderer modules
- update initialization to delegate state setup to the provider while keeping existing import paths intact
- document the new layout and responsibilities of the text renderer components

## Testing
- make format
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c33bf714c8321a791be49e23d2cfe)