### PR TITLE
Refactor water title screen renderer

### DIFF
--- a/docs/migrations/renderer_atomic.md
+++ b/docs/migrations/renderer_atomic.md
@@ -25,9 +25,9 @@ status so incremental updates stay coordinated.
   - `FreeTextRenderer` (`src/heart/display/renderers/free_text.py`) – stores
     wrapped text layout and font sizing in atomic state while preserving
     phone-text integration.
-  - `WaterTitleScreen` (`src/heart/display/renderers/water_title_screen.py`) –
-    tracks wave animation timing atomically so consumer loops receive
-    consistent offsets across frames.
+  - `WaterTitleScreen` (`src/heart/display/renderers/water_title_screen/renderer.py`) –
+    tracks wave animation timing via a provider-driven state stream so consumer
+    loops receive consistent offsets across frames.
   - `SpritesheetLoopRandom` (`src/heart/display/renderers/spritesheet_random.py`)
     – keeps the switch consumer while moving frame counters and screen
     selection into immutable state for per-frame randomisation safety.

--- a/docs/program_configuration.md
+++ b/docs/program_configuration.md
@@ -50,6 +50,7 @@ Use `heart.navigation` helpers to manage scheduling:
 Example fragment from `lib_2025.py`:
 
 ```python
+from heart.display.renderers.text import TextRendering
 from heart.display.renderers.water_cube import WaterCube
 from heart.display.renderers.water_title_screen import WaterTitleScreen
 from heart.navigation import ComposedRenderer
@@ -57,9 +58,14 @@ from heart.navigation import ComposedRenderer
 
 def configure(loop: GameLoop) -> None:
     water_mode = loop.add_mode(
-        ComposedRenderer([WaterTitleScreen(), TextRendering.default("water")])
+        ComposedRenderer(
+            [
+                loop.context_container.resolve(WaterTitleScreen),
+                TextRendering.default("water"),
+            ]
+        )
     )
-    water_mode.add_renderer(WaterCube())
+    water_mode.resolve_renderer(loop.context_container, WaterCube)
 ```
 
 ## Integrating Peripheral Data

--- a/docs/research/water_title_screen_refactor.md
+++ b/docs/research/water_title_screen_refactor.md
@@ -1,0 +1,29 @@
+# Water title screen renderer refactor
+
+## Context
+
+The water title screen previously bundled its state, timing, and drawing logic
+into a single module. Aligning it with the Water and Life renderer structure
+reduces coupling and allows the state updates to be driven by the shared
+peripheral clocks instead of ad-hoc `time.time()` calls.
+
+## Changes made
+
+- Introduced `WaterTitleScreenState` in
+  `src/heart/display/renderers/water_title_screen/state.py` to capture the wave
+  offset.
+- Added `WaterTitleScreenStateProvider` in
+  `src/heart/display/renderers/water_title_screen/provider.py`, which advances
+  the wave offset on every `game_tick` using the latest `pygame.Clock` delta.
+- Moved rendering logic to
+  `src/heart/display/renderers/water_title_screen/renderer.py`, keeping it
+  focused on drawing with the provided state.
+- Registered the provider with the dependency container so scenes can resolve
+  the renderer without manual wiring.
+
+## Materials
+
+- `src/heart/display/renderers/water_title_screen/state.py`
+- `src/heart/display/renderers/water_title_screen/provider.py`
+- `src/heart/display/renderers/water_title_screen/renderer.py`
+- `src/heart/display/renderers/water_title_screen/__init__.py`

--- a/src/heart/display/renderers/water_title_screen/__init__.py
+++ b/src/heart/display/renderers/water_title_screen/__init__.py
@@ -1,0 +1,7 @@
+from heart.display.renderers.water_title_screen.provider import \
+    WaterTitleScreenStateProvider
+from heart.display.renderers.water_title_screen.renderer import \
+    WaterTitleScreen  # noqa: F401
+from heart.peripheral.core.providers import container
+
+container[WaterTitleScreenStateProvider] = WaterTitleScreenStateProvider

--- a/src/heart/display/renderers/water_title_screen/provider.py
+++ b/src/heart/display/renderers/water_title_screen/provider.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import reactivex
+from pygame.time import Clock
+from reactivex import operators as ops
+
+from heart.display.renderers.water_title_screen.state import \
+    WaterTitleScreenState
+from heart.peripheral.core.manager import PeripheralManager
+from heart.peripheral.core.providers import ObservableProvider
+
+
+class WaterTitleScreenStateProvider(ObservableProvider[WaterTitleScreenState]):
+    def __init__(self, peripheral_manager: PeripheralManager, wave_speed: float = 0.5):
+        self._peripheral_manager = peripheral_manager
+        self._wave_speed = wave_speed
+
+    def observable(self) -> reactivex.Observable[WaterTitleScreenState]:
+        clocks = self._peripheral_manager.clock.pipe(
+            ops.filter(lambda clock: clock is not None),
+            ops.share(),
+        )
+
+        initial_state = WaterTitleScreenState.initial()
+
+        def advance_state(state: WaterTitleScreenState, clock: Clock) -> WaterTitleScreenState:
+            dt_seconds = max(clock.get_time() / 1000.0, 1.0 / 120.0)
+            return state.advance(self._wave_speed, dt_seconds)
+
+        return (
+            self._peripheral_manager.game_tick.pipe(
+                ops.with_latest_from(clocks),
+                ops.map(lambda latest: latest[1]),
+                ops.scan(advance_state, seed=initial_state),
+                ops.start_with(initial_state),
+                ops.share(),
+            )
+        )

--- a/src/heart/display/renderers/water_title_screen/renderer.py
+++ b/src/heart/display/renderers/water_title_screen/renderer.py
@@ -1,6 +1,4 @@
 import math
-import time
-from dataclasses import dataclass
 
 import pygame
 from pygame import Surface
@@ -8,52 +6,33 @@ from pygame.time import Clock
 
 from heart import DeviceDisplayMode
 from heart.device import Orientation
-from heart.display.renderers import AtomicBaseRenderer
-from heart.peripheral.core.manager import PeripheralManager
-from heart.utilities.logging import get_logger
-
-DEFAULT_TIME_BETWEEN_FRAMES_MS = 400
-
-logger = get_logger("WaterTitleScreen")
+from heart.display.renderers import StatefulBaseRenderer
+from heart.display.renderers.water_title_screen.provider import \
+    WaterTitleScreenStateProvider
+from heart.display.renderers.water_title_screen.state import \
+    WaterTitleScreenState
 
 
-@dataclass(frozen=True)
-class WaterTitleScreenState:
-    wave_offset: float
-    last_frame_time: float
-
-
-class WaterTitleScreen(AtomicBaseRenderer[WaterTitleScreenState]):
+class WaterTitleScreen(StatefulBaseRenderer[WaterTitleScreenState]):
     """A simple water animation title screen with water moving from left to right."""
 
-    def __init__(self) -> None:
+    def __init__(self, builder: WaterTitleScreenStateProvider) -> None:
+        super().__init__(builder=builder)
         self.face_px = 64  # physical LED face resolution
         self.cube_px_w = self.face_px * 4  # 256
         self.cube_px_h = self.face_px  # 64
         self.water_level = self.face_px // 2  # Half full
-        self.wave_speed = 0.5  # Speed of wave movement
         self.wave_height = 5  # Height of wave in pixels
         self.wave_length = self.face_px * 1.5  # Length of wave
 
         # Water color (blue)
         self.water_color = (0, 90, 255)
 
-        AtomicBaseRenderer.__init__(self)
         self.device_display_mode = DeviceDisplayMode.FULL
-
-    def _create_initial_state(
-        self,
-        window: pygame.Surface,
-        clock: pygame.time.Clock,
-        peripheral_manager: PeripheralManager,
-        orientation: Orientation
-    ):
-        return WaterTitleScreenState(wave_offset=0.0, last_frame_time=time.time())
 
     def _generate_wave_height(self, x: int, wave_offset: float) -> float:
         """Generate height of wave at position x."""
         wave_pos = (x + wave_offset) % (self.cube_px_w * 2)
-        # Sine wave for water surface
         wave = math.sin(wave_pos * 2 * math.pi / self.wave_length) * self.wave_height
         return self.water_level + wave
 
@@ -63,21 +42,12 @@ class WaterTitleScreen(AtomicBaseRenderer[WaterTitleScreenState]):
         clock: Clock,
         orientation: Orientation,
     ) -> None:
-        # Update animation
-        state = self.state
-        current_time = time.time()
-        elapsed = current_time - state.last_frame_time
-        updated_wave_offset = state.wave_offset + self.wave_speed * elapsed * 60
+        wave_offset = self.state.wave_offset
 
-        self.update_state(wave_offset=updated_wave_offset, last_frame_time=current_time)
-
-        # Clear the window
         window.fill((0, 0, 0))
 
-        # Render directly to the window
         for x in range(self.cube_px_w):
-            height = int(self._generate_wave_height(x, updated_wave_offset))
-            # Draw water column
+            height = int(self._generate_wave_height(x, wave_offset))
             if height > 0:
                 pygame.draw.line(
                     window,

--- a/src/heart/display/renderers/water_title_screen/state.py
+++ b/src/heart/display/renderers/water_title_screen/state.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class WaterTitleScreenState:
+    wave_offset: float
+
+    @classmethod
+    def initial(cls) -> "WaterTitleScreenState":
+        return cls(wave_offset=0.0)
+
+    def advance(self, wave_speed: float, dt_seconds: float) -> "WaterTitleScreenState":
+        return WaterTitleScreenState(
+            wave_offset=self.wave_offset + wave_speed * dt_seconds * 60.0
+        )

--- a/src/heart/programs/configurations/lib_2025.py
+++ b/src/heart/programs/configurations/lib_2025.py
@@ -124,7 +124,7 @@ def configure(loop: GameLoop) -> None:
     water_mode = loop.add_mode(
         ComposedRenderer(
             [
-                WaterTitleScreen(),
+                loop.context_container.resolve(WaterTitleScreen),
                 TextRendering(
                     text=["water"],
                     font="Roboto",


### PR DESCRIPTION
## Summary
- split the water title screen renderer into provider, state, and renderer modules registered with the dependency container
- drive the wave animation state from the shared game tick/clock stream and update lib_2025 to resolve the renderer through the container
- refresh docs with the new structure and record the refactor details

## Testing
- make format
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c38b5e6208321a461f8d9051aa85b)