### PR TITLE
Refactor L-system renderer into provider/state/renderer

### DIFF
--- a/docs/renderers_l_system_refactor.md
+++ b/docs/renderers_l_system_refactor.md
@@ -1,0 +1,14 @@
+# L-system renderer refactor
+
+This update restructures the L-system renderer into the provider/state/renderer pattern already used by other animated scenes. The refactor keeps the grammar drawing logic intact while moving the state advancement into an observable provider so the renderer only needs to translate state into pixels.
+
+## Components
+
+- `src/heart/display/renderers/l_system/state.py` keeps the turtle-grammar string and tracks elapsed time between updates.
+- `src/heart/display/renderers/l_system/provider.py` advances the grammar whenever a second of simulated time elapses, driven by the shared peripheral clock stream.
+- `src/heart/display/renderers/l_system/renderer.py` consumes the current grammar and draws it on the full device surface using the existing turtle rules.
+- `src/heart/programs/configurations/l_system.py` now resolves the provider from the shared container and injects it into the renderer.
+
+## Usage notes
+
+The renderer remains in `DeviceDisplayMode.FULL`, so it still renders across the full cube surface. The provider seeds the renderer with an initial grammar immediately, so callers do not need an explicit initialization pass beyond constructing the renderer with the resolved provider.

--- a/src/heart/display/renderers/l_system/__init__.py
+++ b/src/heart/display/renderers/l_system/__init__.py
@@ -1,0 +1,7 @@
+from heart.display.renderers.l_system.provider import \
+    LSystemStateProvider  # noqa: F401
+from heart.display.renderers.l_system.renderer import LSystem  # noqa: F401
+from heart.display.renderers.l_system.state import LSystemState  # noqa: F401
+from heart.peripheral.core.providers import container
+
+container[LSystemStateProvider] = LSystemStateProvider

--- a/src/heart/display/renderers/l_system/provider.py
+++ b/src/heart/display/renderers/l_system/provider.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import reactivex
+from pygame.time import Clock
+from reactivex import operators as ops
+
+from heart.display.renderers.l_system.state import LSystemState
+from heart.peripheral.core.manager import PeripheralManager
+from heart.peripheral.core.providers import ObservableProvider
+
+
+class LSystemStateProvider(ObservableProvider[LSystemState]):
+    def __init__(
+        self,
+        peripheral_manager: PeripheralManager,
+        update_interval_ms: float = 1000.0,
+    ) -> None:
+        self._peripheral_manager = peripheral_manager
+        self._update_interval_ms = update_interval_ms
+
+    def observable(self) -> reactivex.Observable[LSystemState]:
+        clocks = self._peripheral_manager.clock.pipe(
+            ops.filter(lambda clock: clock is not None),
+            ops.share(),
+        )
+
+        initial_state = LSystemState.initial()
+
+        def advance(state: LSystemState, clock: Clock) -> LSystemState:
+            return state.advance(
+                dt_ms=float(clock.get_time()),
+                update_interval_ms=self._update_interval_ms,
+            )
+
+        return (
+            self._peripheral_manager.game_tick.pipe(
+                ops.with_latest_from(clocks),
+                ops.map(lambda latest: latest[1]),
+                ops.scan(advance, seed=initial_state),
+                ops.start_with(initial_state),
+                ops.share(),
+            )
+        )

--- a/src/heart/display/renderers/l_system/renderer.py
+++ b/src/heart/display/renderers/l_system/renderer.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import math
+from collections import deque
+
+import numpy as np
+import pygame
+from pygame import Surface
+from pygame.time import Clock
+
+from heart import DeviceDisplayMode
+from heart.device import Orientation
+from heart.display.renderers import StatefulBaseRenderer
+from heart.display.renderers.l_system.provider import LSystemStateProvider
+from heart.display.renderers.l_system.state import LSystemState
+
+
+class LSystem(StatefulBaseRenderer[LSystemState]):
+    def __init__(self, builder: LSystemStateProvider) -> None:
+        super().__init__(builder=builder)
+        self.device_display_mode = DeviceDisplayMode.FULL
+
+    def _draw_grammar(self, window: Surface, grammar: str) -> None:
+        # variables : F G
+        # constants : + −
+        # start  : F
+        # rules  : (F → F+G), (G → F-G)
+        # angle  : 90°
+        # Here, F and G both mean "draw forward", + means "turn left by angle", and − means "turn right by angle". --> F+G−F−G+F
+
+        # variables : X F
+        # constants : + − [ ]
+        # start  : X
+        # rules  : (X → F+[[X]-X]-F[-FX]+X), (F → FF)
+        # angle  : 25°
+
+        angle = 25
+
+        def calc_movement(L, angle):
+            # Normalize angle between 0 and 360
+            angle = angle % 360
+            theta = math.radians(angle)
+            x_movement = L * math.cos(theta)
+            y_movement = L * math.sin(theta)
+            return x_movement, y_movement
+
+        min_length = 0
+        for L in range(1, 100):
+            x_move, y_move = calc_movement(L, angle)
+            if x_move >= 1 and y_move >= 1:
+                min_length = L
+                break
+
+        current_angle = 0
+        position = np.array(window.get_size()) // 2
+        stack = deque()
+        for char in grammar:
+            if char == "F" or char == "G":
+                direction = calc_movement(min_length, current_angle)
+                new_position = position + direction
+                pygame.draw.line(window, (255, 255, 255), position, new_position)
+                position = new_position
+            elif char == "X":
+                pass
+            elif char == "+":
+                current_angle += angle
+            elif char == "-":
+                current_angle -= angle
+            elif char == "[":
+                stack.append((position, current_angle))
+            elif char == "]":
+                position, current_angle = stack.pop()
+
+    def real_process(
+        self,
+        window: Surface,
+        clock: Clock,
+        orientation: Orientation,
+    ) -> None:
+        self._draw_grammar(window, self.state.grammar)

--- a/src/heart/display/renderers/l_system/state.py
+++ b/src/heart/display/renderers/l_system/state.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+def _update_grammar(grammar: str) -> str:
+    expanded = ""
+    for char in grammar:
+        if char == "X":
+            expanded += "F+[[X]-X]-F[-FX]+X"
+        elif char == "F":
+            expanded += "FF"
+    return expanded
+
+
+@dataclass(frozen=True)
+class LSystemState:
+    grammar: str = "X"
+    time_since_last_update_ms: float = 0.0
+
+    def advance(self, dt_ms: float, update_interval_ms: float) -> "LSystemState":
+        accumulated = self.time_since_last_update_ms + dt_ms
+        grammar = self.grammar
+
+        while accumulated >= update_interval_ms:
+            grammar = _update_grammar(grammar)
+            accumulated -= update_interval_ms
+
+        return LSystemState(grammar=grammar, time_since_last_update_ms=accumulated)
+
+    @classmethod
+    def initial(cls) -> "LSystemState":
+        return cls()

--- a/src/heart/programs/configurations/l_system.py
+++ b/src/heart/programs/configurations/l_system.py
@@ -1,7 +1,9 @@
-from heart.display.renderers.l_system import LSystem
+from heart.display.renderers.l_system import LSystem, LSystemStateProvider
 from heart.environment import GameLoop
 
 
 def configure(loop: GameLoop) -> None:
     mode = loop.add_mode()
-    mode.add_renderer(LSystem())
+    mode.add_renderer(
+        LSystem(builder=loop.context_container.resolve(LSystemStateProvider))
+    )


### PR DESCRIPTION
## Summary
- restructure the L-system renderer into provider, state, and renderer modules registered with the shared container
- move grammar evolution into a peripheral-driven observable stream feeding the renderer
- update the L-system configuration and add documentation describing the new layout

## Testing
- make format


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693daf6ba1d4832190f02293287f93cb)