### PR TITLE
Refactor artist and kirby renderers into packages

### DIFF
--- a/docs/research/renderer_refactor_artist_kirby.md
+++ b/docs/research/renderer_refactor_artist_kirby.md
@@ -1,0 +1,15 @@
+# Renderer packaging refactor: artist and kirby scenes
+
+## Context
+
+The `ArtistScene` and `KirbyScene` renderers previously lived in single monolithic modules under `src/heart/display/renderers`. That layout made it difficult to share initialization logic or track scene construction inputs.
+
+## Changes
+
+- Introduced dedicated packages (`artist/` and `kirby/`) with `state`, `provider`, and `renderer` modules for each scene collection.
+- Providers now assemble the scene lists, keeping asset wiring and configuration isolated from rendering behaviour.
+- Renderers are thin `MultiScene` subclasses that consume provider outputs, improving parity with other renderers such as `water_cube` and `life`.
+
+## Impact
+
+The new layout separates responsibilities and makes it easier to swap or extend scene lists without modifying rendering code. Future changes (e.g., new assets or parameterized providers) can be added by adjusting provider construction while keeping rendering behaviour stable.

--- a/src/heart/display/renderers/artist/__init__.py
+++ b/src/heart/display/renderers/artist/__init__.py
@@ -1,0 +1,4 @@
+from heart.display.renderers.artist.provider import \
+    ArtistStateProvider as ArtistStateProvider
+from heart.display.renderers.artist.renderer import ArtistScene as ArtistScene
+from heart.display.renderers.artist.state import ArtistState as ArtistState

--- a/src/heart/display/renderers/artist/provider.py
+++ b/src/heart/display/renderers/artist/provider.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from heart.display.color import Color
+from heart.display.renderers import BaseRenderer
+from heart.display.renderers.artist.state import ArtistState
+from heart.display.renderers.image import RenderImage
+from heart.display.renderers.sliding_image import SlidingImage
+from heart.display.renderers.spritesheet import SpritesheetLoop
+from heart.display.renderers.text import TextRendering
+from heart.display.renderers.yolisten import YoListenRenderer
+
+
+class ArtistStateProvider:
+    def build(self) -> ArtistState:
+        scenes: list[BaseRenderer] = []
+
+        for artist in [
+            "imaginal_disk_animated",
+            "rainbow_tesseract",
+            "dancing_robot",
+            "jamie_xx_life",
+            "john_summit_neon",
+            "troyboi_glitch_cartwheel",
+        ]:
+            scenes.append(
+                SpritesheetLoop(
+                    sheet_file_path=f"artist/{artist}.png",
+                    metadata_file_path=f"artist/{artist}.json",
+                    boomerang=(artist != "troyboi_glitch_cartwheel"),
+                )
+            )
+
+        for artist in [
+            "jamie_xx_in_color",
+        ]:
+            scenes.append(
+                SpritesheetLoop.from_frame_data(
+                    sheet_file_path=f"artist/{artist}.png",
+                    duration=75,
+                    boomerang=False,
+                    skip_last_frame=True,
+                )
+            )
+
+        scenes.append(
+            SlidingImage(
+                image_file="artist/virji_spritesheet.png",
+                speed=1,
+            )
+        )
+
+        scenes.append(YoListenRenderer())
+        return ArtistState(scenes=scenes)
+
+    @staticmethod
+    def title_renderers() -> list[BaseRenderer]:
+        return [
+            RenderImage(image_file="artist/imaginal_disk.png"),
+            TextRendering(
+                text=["artist"],
+                font="Roboto",
+                font_size=14,
+                color=Color(255, 105, 180),
+                y_location=32,
+            ),
+        ]

--- a/src/heart/display/renderers/artist/renderer.py
+++ b/src/heart/display/renderers/artist/renderer.py
@@ -1,0 +1,14 @@
+from heart.display.renderers import BaseRenderer
+from heart.display.renderers.artist.provider import ArtistStateProvider
+from heart.navigation import MultiScene
+
+
+class ArtistScene(MultiScene):
+    def __init__(self, provider: ArtistStateProvider | None = None) -> None:
+        self._provider = provider or ArtistStateProvider()
+        artist_state = self._provider.build()
+        super().__init__(artist_state.scenes)
+
+    @staticmethod
+    def title_scene() -> list[BaseRenderer]:
+        return ArtistStateProvider.title_renderers()

--- a/src/heart/display/renderers/artist/state.py
+++ b/src/heart/display/renderers/artist/state.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+from heart.display.renderers import BaseRenderer
+
+
+@dataclass
+class ArtistState:
+    scenes: list[BaseRenderer]

--- a/src/heart/display/renderers/kirby/__init__.py
+++ b/src/heart/display/renderers/kirby/__init__.py
@@ -1,0 +1,4 @@
+from heart.display.renderers.kirby.provider import \
+    KirbyStateProvider as KirbyStateProvider
+from heart.display.renderers.kirby.renderer import KirbyScene as KirbyScene
+from heart.display.renderers.kirby.state import KirbyState as KirbyState

--- a/src/heart/display/renderers/kirby/provider.py
+++ b/src/heart/display/renderers/kirby/provider.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from heart.display.color import Color
+from heart.display.renderers import BaseRenderer
+from heart.display.renderers.kirby.state import KirbyState
+from heart.display.renderers.spritesheet import SpritesheetLoop
+from heart.display.renderers.text import TextRendering
+
+
+class KirbyStateProvider:
+    def build(self) -> KirbyState:
+        scenes: list[BaseRenderer] = [
+            SpritesheetLoop(
+                sheet_file_path=f"{kirby}.png",
+                metadata_file_path=f"{kirby}.json",
+            )
+            for kirby in [
+                "kirby_flying_32",
+                "kirby_cell_64",
+                "kirby_sleep_64",
+                "tornado_kirby",
+                "swimming_kirby",
+                "running_kirby",
+                "rolling_kirby",
+                "fighting_kirby",
+            ]
+        ]
+        return KirbyState(scenes=scenes)
+
+    @staticmethod
+    def title_renderers() -> list[BaseRenderer]:
+        return [
+            TextRendering(
+                text=["kirby mode"],
+                font="Roboto",
+                font_size=14,
+                color=Color.kirby(),
+                y_location=35,
+            ),
+            SpritesheetLoop(
+                sheet_file_path="kirby_flying_32.png",
+                metadata_file_path="kirby_flying_32.json",
+                image_scale=1 / 3,
+                offset_y=-5,
+                disable_input=True,
+            ),
+        ]

--- a/src/heart/display/renderers/kirby/renderer.py
+++ b/src/heart/display/renderers/kirby/renderer.py
@@ -1,0 +1,14 @@
+from heart.display.renderers import BaseRenderer
+from heart.display.renderers.kirby.provider import KirbyStateProvider
+from heart.navigation import MultiScene
+
+
+class KirbyScene(MultiScene):
+    def __init__(self, provider: KirbyStateProvider | None = None) -> None:
+        self._provider = provider or KirbyStateProvider()
+        kirby_state = self._provider.build()
+        super().__init__(kirby_state.scenes)
+
+    @staticmethod
+    def title_scene() -> list[BaseRenderer]:
+        return KirbyStateProvider.title_renderers()

--- a/src/heart/display/renderers/kirby/state.py
+++ b/src/heart/display/renderers/kirby/state.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+from heart.display.renderers import BaseRenderer
+
+
+@dataclass
+class KirbyState:
+    scenes: list[BaseRenderer]


### PR DESCRIPTION
## Summary
- split the artist and kirby scenes into provider/state/renderer modules
- keep scene construction in dedicated providers while renderers stay thin MultiScene wrappers
- adjust configuration imports and document the renderer packaging changes

## Testing
- make format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693db77c0d40832186aa35910ac489c6)