### PR TITLE
Refactor renderers into provider-state pipelines

### DIFF
--- a/docs/code_flow.md
+++ b/docs/code_flow.md
@@ -35,6 +35,8 @@ flowchart LR
         direction TB
         Loop["GameLoop Service\n(start + main loop)"]
         AppRouter["AppController / Mode Router"]
+        Providers["State Providers\n(timer + peripheral streams)"]
+        RendererState["Renderer State Streams"]
         ModeServices["Mode Services & Renderers"]
         FrameComposer["Frame Composer\n(surface merge + timing)"]
     end
@@ -64,7 +66,7 @@ flowchart LR
     Configurer --> AppRouter
     Loop --> AppRouter
     Loop --> FrameComposer
-    AppRouter --> ModeServices --> FrameComposer --> DisplaySvc
+    AppRouter --> Providers --> RendererState --> ModeServices --> FrameComposer --> DisplaySvc
     DisplaySvc --> LocalScreen
     DisplaySvc --> Capture --> DeviceBridge --> LedMatrix
     Capture --> AverageMirror --> SingleLED
@@ -75,12 +77,17 @@ flowchart LR
     PeripheralMgr --> Sensors --> AppRouter
     PeripheralMgr --> HeartRate --> AppRouter
     PeripheralMgr --> PhoneText --> AppRouter
+    PeripheralMgr --> Providers
 
     class CLI,Registry,Configurer,ModeServices,FrameComposer service;
     class Loop,AppRouter orchestrator;
     class PeripheralMgr,Switch,Gamepad,Sensors,HeartRate,PhoneText input;
     class DisplaySvc,LocalScreen,Capture,DeviceBridge,LedMatrix,AverageMirror,SingleLED output;
 ```
+
+State providers now sit between the peripheral feeds and mode renderers, translating device inputs and timers into immutable
+state snapshots before any pixels are drawn. Renderers operate purely on those state objects, which keeps peripheral handling
+and shader logic decoupled while still allowing the game loop to orchestrate timing.
 
 ## Rendering Procedure
 

--- a/docs/renderer_refactor_update.md
+++ b/docs/renderer_refactor_update.md
@@ -4,6 +4,7 @@
 
 - Split the combined BPM playlist into `combined_bpm_screen/{provider.py,state.py,renderer.py}` so timer handling now lives in `CombinedBpmScreenStateProvider` while the renderer only delegates to metadata and max-BPM screens.
 - Migrated metadata HUD logic into `metadata_screen/{provider.py,state.py,renderer.py}` with `MetadataScreenStateProvider` streaming animation state for each monitor.
+- Broke out `cloth_sail`, `multicolor`, and `three_d_glasses` into provider/state/renderer triplets so timing, shader inputs, and frame sequencing are produced upstream and renderers only translate state into pixels.
 
 ## Notes for implementers
 

--- a/src/heart/display/renderers/cloth_sail/__init__.py
+++ b/src/heart/display/renderers/cloth_sail/__init__.py
@@ -1,0 +1,29 @@
+from heart.display.renderers.cloth_sail.provider import \
+    ClothSailStateProvider  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    ClothSailRenderer  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glBindBuffer  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import glClear  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glClearColor  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glDisableVertexAttribArray  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glDrawArrays  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glEnableVertexAttribArray  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glReadPixels  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glUniform1f  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glUniform2f  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glUseProgram  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glVertexAttribPointer  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glViewport  # noqa: F401
+from heart.display.renderers.cloth_sail.state import \
+    ClothSailState  # noqa: F401

--- a/src/heart/display/renderers/cloth_sail/provider.py
+++ b/src/heart/display/renderers/cloth_sail/provider.py
@@ -1,0 +1,29 @@
+import time
+
+import reactivex
+from reactivex import operators as ops
+
+from heart.display.renderers.cloth_sail.state import ClothSailState
+from heart.peripheral.core.providers import ObservableProvider
+
+
+class ClothSailStateProvider(ObservableProvider[ClothSailState]):
+    def __init__(self, tick_seconds: float = 1 / 60) -> None:
+        self._start_time = time.perf_counter()
+        self._tick_seconds = tick_seconds
+        self._initial_state = ClothSailState(start_time=self._start_time, elapsed=0.0)
+
+    def observable(self) -> reactivex.Observable[ClothSailState]:
+        def tick_to_state(_: int, __: ClothSailState | None = None) -> ClothSailState:
+            elapsed = time.perf_counter() - self._start_time
+            return ClothSailState(start_time=self._start_time, elapsed=elapsed)
+
+        return reactivex.interval(self._tick_seconds).pipe(
+            ops.map(tick_to_state),
+            ops.start_with(self._initial_state),
+            ops.share(),
+        )
+
+    @property
+    def initial_state(self) -> ClothSailState:
+        return self._initial_state

--- a/src/heart/display/renderers/cloth_sail/state.py
+++ b/src/heart/display/renderers/cloth_sail/state.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ClothSailState:
+    start_time: float
+    elapsed: float

--- a/src/heart/display/renderers/multicolor/__init__.py
+++ b/src/heart/display/renderers/multicolor/__init__.py
@@ -1,0 +1,6 @@
+from heart.display.renderers.multicolor.provider import \
+    MulticolorStateProvider  # noqa: F401
+from heart.display.renderers.multicolor.renderer import \
+    MulticolorRenderer  # noqa: F401
+from heart.display.renderers.multicolor.state import \
+    MulticolorState  # noqa: F401

--- a/src/heart/display/renderers/multicolor/provider.py
+++ b/src/heart/display/renderers/multicolor/provider.py
@@ -1,0 +1,21 @@
+import time
+
+import reactivex
+from reactivex import operators as ops
+
+from heart.display.renderers.multicolor.state import MulticolorState
+from heart.peripheral.core.providers import ObservableProvider
+
+
+class MulticolorStateProvider(ObservableProvider[MulticolorState]):
+    def __init__(self, tick_seconds: float = 1 / 30) -> None:
+        self._tick_seconds = tick_seconds
+
+    def observable(self) -> reactivex.Observable[MulticolorState]:
+        initial = MulticolorState(timestamp=time.time())
+
+        return reactivex.interval(self._tick_seconds).pipe(
+            ops.map(lambda _: MulticolorState(timestamp=time.time())),
+            ops.start_with(initial),
+            ops.share(),
+        )

--- a/src/heart/display/renderers/multicolor/renderer.py
+++ b/src/heart/display/renderers/multicolor/renderer.py
@@ -1,5 +1,4 @@
 import math
-import time
 
 import numba as nb
 import numpy as np
@@ -7,8 +6,9 @@ import pygame
 
 from heart import DeviceDisplayMode
 from heart.device import Orientation
-from heart.display.renderers import BaseRenderer
-from heart.peripheral.core.manager import PeripheralManager
+from heart.display.renderers import StatefulBaseRenderer
+from heart.display.renderers.multicolor.provider import MulticolorStateProvider
+from heart.display.renderers.multicolor.state import MulticolorState
 
 
 @nb.njit(fastmath=True)
@@ -24,9 +24,7 @@ def patterns(x: float, y: float, t: float) -> float:
 
 
 @nb.njit(fastmath=True)
-def map_value(
-    value: float, min1: float, max1: float, min2: float, max2: float
-) -> float:
+def map_value(value: float, min1: float, max1: float, min2: float, max2: float) -> float:
     """Map a value from one range to another."""
     return min2 + (value - min1) * (max2 - min2) / (max1 - min1)
 
@@ -64,26 +62,17 @@ def cubehelix_rainbow(t: float) -> tuple:
 @nb.njit(fastmath=True, parallel=True)
 def generate_pattern(width: int, height: int, current_time: float) -> np.ndarray:
     """Generate the pattern as a numpy array."""
-    # Create output array (RGB)
     output = np.empty((height, width, 3), dtype=np.uint8)
 
-    # Generate pattern for each pixel
     for y in nb.prange(height):
         for x in range(width):
-            # Normalize coordinates to -1 to 1 range
             uv_x = (x - width / 2) / height
             uv_y = (y - height / 2) / height
 
-            # Calculate pattern value
             col = patterns(uv_x, uv_y, current_time * 1.5)
-
-            # Map pattern value to color range
             c1 = map_value(col, -1.0, 1.0, 0.0, 0.9)
-
-            # Get color from cubehelix rainbow
             r, g, b = cubehelix_rainbow(c1)
 
-            # Convert to 0-255 range and set color
             output[y, x, 0] = int(clamp(r * 255, 0, 255))
             output[y, x, 1] = int(clamp(g * 255, 0, 255))
             output[y, x, 2] = int(clamp(b * 255, 0, 255))
@@ -91,36 +80,18 @@ def generate_pattern(width: int, height: int, current_time: float) -> np.ndarray
     return output
 
 
-class MulticolorRenderer(BaseRenderer):
-    def __init__(self) -> None:
-        super().__init__()
+class MulticolorRenderer(StatefulBaseRenderer[MulticolorState]):
+    def __init__(self, provider: MulticolorStateProvider | None = None) -> None:
+        super().__init__(builder=provider or MulticolorStateProvider())
         self.device_display_mode = DeviceDisplayMode.MIRRORED
-        self.start_time = None
 
-    def process(
+    def real_process(
         self,
         window: pygame.Surface,
         clock: pygame.time.Clock,
-        peripheral_manager: PeripheralManager,
         orientation: Orientation,
     ) -> None:
-        """Process and render the multicolor scene.
-
-        Args:
-            window: The pygame surface to render to
-            clock: The pygame clock for timing
-            peripheral_manager: Manager for accessing peripheral devices
-            orientation: The current device orientation
-
-        """
-        # Get window dimensions
         width, height = window.get_size()
-
-        # Generate pattern using JIT-compiled function
-        pattern_array = generate_pattern(width, height, time.time())
-
-        # Convert numpy array to pygame surface
+        pattern_array = generate_pattern(width, height, self.state.timestamp)
         pattern_surface = pygame.surfarray.make_surface(pattern_array)
-
-        # Draw the pattern surface to the window
         window.blit(pattern_surface, (0, 0))

--- a/src/heart/display/renderers/multicolor/state.py
+++ b/src/heart/display/renderers/multicolor/state.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MulticolorState:
+    timestamp: float

--- a/src/heart/display/renderers/three_d_glasses/__init__.py
+++ b/src/heart/display/renderers/three_d_glasses/__init__.py
@@ -1,0 +1,6 @@
+from heart.display.renderers.three_d_glasses.provider import \
+    ThreeDGlassesStateProvider  # noqa: F401
+from heart.display.renderers.three_d_glasses.renderer import \
+    ThreeDGlassesRenderer  # noqa: F401
+from heart.display.renderers.three_d_glasses.state import \
+    ThreeDGlassesState  # noqa: F401

--- a/src/heart/display/renderers/three_d_glasses/provider.py
+++ b/src/heart/display/renderers/three_d_glasses/provider.py
@@ -1,0 +1,32 @@
+import reactivex
+from reactivex.subject import BehaviorSubject
+
+from heart.display.renderers.three_d_glasses.state import ThreeDGlassesState
+from heart.peripheral.core.providers import ObservableProvider
+
+
+class ThreeDGlassesStateProvider(ObservableProvider[ThreeDGlassesState]):
+    def __init__(self, frame_count: int, frame_duration_ms: int = 650) -> None:
+        if frame_count <= 0:
+            raise ValueError("ThreeDGlassesStateProvider requires at least one frame")
+
+        self._frame_count = frame_count
+        self._frame_duration_ms = frame_duration_ms
+        self._state = BehaviorSubject(ThreeDGlassesState(current_index=0, elapsed_ms=0.0))
+
+    def observable(self) -> reactivex.Observable[ThreeDGlassesState]:
+        return self._state
+
+    def advance(self, elapsed_ms: float) -> None:
+        previous = self._state.value
+        accumulated = previous.elapsed_ms + elapsed_ms
+        frame_steps = int(accumulated // self._frame_duration_ms)
+        next_index = (previous.current_index + frame_steps) % self._frame_count
+        next_elapsed = accumulated % self._frame_duration_ms
+        self._state.on_next(
+            ThreeDGlassesState(current_index=next_index, elapsed_ms=next_elapsed)
+        )
+
+    @property
+    def initial_state(self) -> ThreeDGlassesState:
+        return self._state.value

--- a/src/heart/display/renderers/three_d_glasses/state.py
+++ b/src/heart/display/renderers/three_d_glasses/state.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ThreeDGlassesState:
+    current_index: int = 0
+    elapsed_ms: float = 0.0


### PR DESCRIPTION
## Summary
- split the cloth_sail, multicolor, and three_d_glasses renderers into provider/state/renderer modules with explicit state streams
- seeded renderer state lifecycles so tests and runtime consumers can safely access provider data
- documented the new renderer flow and refreshed the runtime code flow diagram

## Testing
- make test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dba057f608321a987ce46c0dd03c9)