### PR TITLE
Refactor cloth sail and multicolor renderers into stateful components

### DIFF
--- a/docs/renderers_stateful_refactor.md
+++ b/docs/renderers_stateful_refactor.md
@@ -1,0 +1,17 @@
+# Renderer state refactors for cloth sail and multicolor
+
+## Overview
+
+The cloth sail and multicolor renderers now follow the provider/state/renderer split used by other stateful effects. Each renderer consumes a dedicated provider that emits immutable state snapshots driven by the shared game tick and clock stream.
+
+## Implementation notes
+
+- `heart.display.renderers.cloth_sail` now stores shader timing inside `ClothSailState`, advanced by `ClothSailStateProvider` using the main clock cadence. The renderer reads `elapsed_seconds` instead of tracking `perf_counter` internally.
+- `heart.display.renderers.multicolor` keeps the procedural color math in the renderer while the `MulticolorStateProvider` handles elapsed-time accumulation. The renderer uses the provided `elapsed_seconds` to generate frames.
+- Program configurations instantiate renderers with their matching providers so the state streams come from the shared `PeripheralManager` observables.
+
+## Files touched
+
+- `src/heart/display/renderers/cloth_sail/` now contains `provider.py`, `renderer.py`, and `state.py` to isolate timing state from OpenGL drawing code.
+- `src/heart/display/renderers/multicolor/` mirrors the same structure for the multicolor effect.
+- `src/heart/programs/configurations/cloth_sail.py` and `src/heart/programs/configurations/lib_2025.py` construct the new providers before wiring renderers into modes.

--- a/src/heart/display/renderers/cloth_sail/__init__.py
+++ b/src/heart/display/renderers/cloth_sail/__init__.py
@@ -1,0 +1,29 @@
+from heart.display.renderers.cloth_sail.provider import \
+    ClothSailStateProvider  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    ClothSailRenderer  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glBindBuffer  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import glClear  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glClearColor  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glDisableVertexAttribArray  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glDrawArrays  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glEnableVertexAttribArray  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glReadPixels  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glUniform1f  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glUniform2f  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glUseProgram  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glVertexAttribPointer  # noqa: F401
+from heart.display.renderers.cloth_sail.renderer import \
+    glViewport  # noqa: F401
+from heart.display.renderers.cloth_sail.state import \
+    ClothSailState  # noqa: F401

--- a/src/heart/display/renderers/cloth_sail/provider.py
+++ b/src/heart/display/renderers/cloth_sail/provider.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import reactivex
+from pygame.time import Clock
+from reactivex import operators as ops
+
+from heart.display.renderers.cloth_sail.state import ClothSailState
+from heart.peripheral.core.manager import PeripheralManager
+from heart.peripheral.core.providers import ObservableProvider
+
+
+class ClothSailStateProvider(ObservableProvider[ClothSailState]):
+    def __init__(self, peripheral_manager: PeripheralManager) -> None:
+        self._peripheral_manager = peripheral_manager
+
+    def observable(self) -> reactivex.Observable[ClothSailState]:
+        clocks = self._peripheral_manager.clock.pipe(
+            ops.filter(lambda clock: clock is not None),
+            ops.share(),
+        )
+
+        initial_state = ClothSailState()
+
+        def advance_state(
+            state: ClothSailState, clock: Clock
+        ) -> ClothSailState:
+            dt_seconds = max(clock.get_time() / 1000.0, 1.0 / 120.0)
+            return state.advance(dt_seconds)
+
+        return (
+            self._peripheral_manager.game_tick.pipe(
+                ops.with_latest_from(clocks),
+                ops.map(lambda latest: latest[1]),
+                ops.scan(advance_state, seed=initial_state),
+                ops.start_with(initial_state),
+                ops.share(),
+            )
+        )

--- a/src/heart/display/renderers/cloth_sail/state.py
+++ b/src/heart/display/renderers/cloth_sail/state.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ClothSailState:
+    elapsed_seconds: float = 0.0
+
+    def advance(self, dt_seconds: float) -> "ClothSailState":
+        return ClothSailState(elapsed_seconds=self.elapsed_seconds + dt_seconds)

--- a/src/heart/display/renderers/multicolor/__init__.py
+++ b/src/heart/display/renderers/multicolor/__init__.py
@@ -1,0 +1,6 @@
+from heart.display.renderers.multicolor.provider import \
+    MulticolorStateProvider  # noqa: F401
+from heart.display.renderers.multicolor.renderer import \
+    MulticolorRenderer  # noqa: F401
+from heart.display.renderers.multicolor.state import \
+    MulticolorState  # noqa: F401

--- a/src/heart/display/renderers/multicolor/provider.py
+++ b/src/heart/display/renderers/multicolor/provider.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import reactivex
+from pygame.time import Clock
+from reactivex import operators as ops
+
+from heart.display.renderers.multicolor.state import MulticolorState
+from heart.peripheral.core.manager import PeripheralManager
+from heart.peripheral.core.providers import ObservableProvider
+
+
+class MulticolorStateProvider(ObservableProvider[MulticolorState]):
+    def __init__(self, peripheral_manager: PeripheralManager) -> None:
+        self._peripheral_manager = peripheral_manager
+
+    def observable(self) -> reactivex.Observable[MulticolorState]:
+        clocks = self._peripheral_manager.clock.pipe(
+            ops.filter(lambda clock: clock is not None),
+            ops.share(),
+        )
+
+        initial_state = MulticolorState()
+
+        def advance_state(
+            state: MulticolorState, clock: Clock
+        ) -> MulticolorState:
+            dt_seconds = max(clock.get_time() / 1000.0, 1.0 / 120.0)
+            return state.advance(dt_seconds)
+
+        return (
+            self._peripheral_manager.game_tick.pipe(
+                ops.with_latest_from(clocks),
+                ops.map(lambda latest: latest[1]),
+                ops.scan(advance_state, seed=initial_state),
+                ops.start_with(initial_state),
+                ops.share(),
+            )
+        )

--- a/src/heart/display/renderers/multicolor/state.py
+++ b/src/heart/display/renderers/multicolor/state.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MulticolorState:
+    elapsed_seconds: float = 0.0
+
+    def advance(self, dt_seconds: float) -> "MulticolorState":
+        return MulticolorState(elapsed_seconds=self.elapsed_seconds + dt_seconds)

--- a/src/heart/programs/configurations/cloth_sail.py
+++ b/src/heart/programs/configurations/cloth_sail.py
@@ -1,9 +1,14 @@
 """Configuration for the farmhouse-nautical cloth renderer."""
 
-from heart.display.renderers.cloth_sail import ClothSailRenderer
+from heart.display.renderers.cloth_sail import (ClothSailRenderer,
+                                                ClothSailStateProvider)
 from heart.environment import GameLoop
 
 
 def configure(loop: GameLoop) -> None:
     mode = loop.add_mode("cloth_sail")
-    mode.add_renderer(ClothSailRenderer())
+    mode.add_renderer(
+        ClothSailRenderer(
+            builder=ClothSailStateProvider(loop.peripheral_manager)
+        )
+    )

--- a/src/heart/programs/configurations/lib_2025.py
+++ b/src/heart/programs/configurations/lib_2025.py
@@ -12,7 +12,8 @@ from heart.display.renderers.image import RenderImage
 from heart.display.renderers.kirby import KirbyScene
 from heart.display.renderers.mandelbrot.scene import MandelbrotMode
 from heart.display.renderers.mandelbrot.title import MandelbrotTitle
-from heart.display.renderers.multicolor import MulticolorRenderer
+from heart.display.renderers.multicolor import (MulticolorRenderer,
+                                                MulticolorStateProvider)
 from heart.display.renderers.random_pixel import RandomPixel
 from heart.display.renderers.spritesheet import SpritesheetLoop
 from heart.display.renderers.spritesheet_random import SpritesheetLoopRandom
@@ -84,10 +85,15 @@ def configure(loop: GameLoop) -> None:
         renderer=MarioRenderer
     )
 
+    def multicolor_renderer() -> MulticolorRenderer:
+        return MulticolorRenderer(
+            builder=MulticolorStateProvider(loop.peripheral_manager)
+        )
+
     shroomed_mode = loop.add_mode(
         ComposedRenderer(
             [
-                MulticolorRenderer(),
+                multicolor_renderer(),
                 TextRendering(
                     text=["shroomed"],
                     font="Roboto",
@@ -101,7 +107,7 @@ def configure(loop: GameLoop) -> None:
     shroomed_mode.add_renderer(
         ComposedRenderer(
             [
-                MulticolorRenderer(),
+                multicolor_renderer(),
                 SpritesheetLoop("ness.png", "ness.json"),
             ]
         )


### PR DESCRIPTION
## Summary
- split the cloth sail and multicolor renderers into provider/state/renderer modules
- keep renderer construction backwards compatible while wiring program configs to the new providers
- document the stateful refactor and expose GL hooks needed for tests

## Testing
- make test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693db85390308321a3a0abbb6e21a36a)