### PR TITLE
Add READMEs for src folder overviews

### DIFF
--- a/src/heart/assets/README.md
+++ b/src/heart/assets/README.md
@@ -1,0 +1,1 @@
+This directory stores sprites, fonts, and animation data used by the Heart display pipeline. The assets are loaded through helpers like `loader.py` and kept in source form (PNG, JSON, Aseprite) so visual programs can reuse them across devices.

--- a/src/heart/device/README.md
+++ b/src/heart/device/README.md
@@ -1,0 +1,1 @@
+Device abstractions for rendering targets. Classes here describe the physical layout of displays (rectangular panels or cubes) and provide device-specific interfaces for sending frames to LEDs or simulated outputs.

--- a/src/heart/display/README.md
+++ b/src/heart/display/README.md
@@ -1,0 +1,1 @@
+Rendering logic for the Heart visuals. This package defines color utilities, frame models, renderers, shaders, and recording helpers that turn program output into images for physical or simulated displays.

--- a/src/heart/events/README.md
+++ b/src/heart/events/README.md
@@ -1,0 +1,1 @@
+Lightweight event definitions used across the Heart runtime. Shared type definitions keep device input, sensor readings, and control signals consistent between modules.

--- a/src/heart/firmware_io/README.md
+++ b/src/heart/firmware_io/README.md
@@ -1,1 +1,1 @@
-This is ported into the devices. Please update carefully as the devices only have a limited subset of Python available (e.g. no `import json`)
+I/O helpers that run on constrained firmware builds. These modules bridge sensors and actuators (accelerometer, rotary encoder, Bluetooth) while avoiding heavy dependencies because target devices have a limited Python subset (for example, no `import json`).

--- a/src/heart/manage/README.md
+++ b/src/heart/manage/README.md
@@ -1,1 +1,1 @@
-Project-level management scripts
+Utility scripts for managing Heart deployments. Use these helpers to install external display drivers, update dependencies, and run maintenance tasks on target hardware.

--- a/src/heart/modules/README.md
+++ b/src/heart/modules/README.md
@@ -1,0 +1,1 @@
+Self-contained visual modules and demos. Each subpackage bundles assets and logic for a specific experience (for example, Mario scenes or cellular automata) that can be scheduled by the runtime.

--- a/src/heart/peripheral/README.md
+++ b/src/heart/peripheral/README.md
@@ -1,0 +1,1 @@
+Drivers and abstractions for external peripherals. This package contains sensor integrations (IMUs, microphones, infrared arrays), input devices (keyboards, gamepads), radios, and shared configuration helpers that feed data into the Heart runtime.

--- a/src/heart/programs/README.md
+++ b/src/heart/programs/README.md
@@ -1,0 +1,1 @@
+Program registry and configuration entry points. Use these modules to declare available experiences and map configuration names to the functions that build and launch them.

--- a/src/heart/utilities/README.md
+++ b/src/heart/utilities/README.md
@@ -1,0 +1,1 @@
+Shared helpers used across the project. Modules here handle environment configuration, logging control, filesystem paths, signal handling, and simple statistics utilities.


### PR DESCRIPTION
## Summary
- add short README descriptions to each top-level package under src/heart
- clarify firmware_io and manage documentation about their roles

## Testing
- make format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ef90188d88321aafc614746b122ac)