### PR TITLE
Initialize composed renderers without warmup gate

### DIFF
--- a/src/heart/navigation.py
+++ b/src/heart/navigation.py
@@ -246,8 +246,7 @@ class ComposedRenderer(BaseRenderer):
         orientation: Orientation,
     ) -> None:
         for renderer in self.renderers:
-            if renderer.warmup:
-                renderer.initialize(window, clock, peripheral_manager, orientation)
+            renderer.initialize(window, clock, peripheral_manager, orientation)
 
     def add_renderer(self, *renderer: BaseRenderer):
         self.renderers.extend(renderer)

--- a/tests/navigation/test_composed_renderer_initialization.py
+++ b/tests/navigation/test_composed_renderer_initialization.py
@@ -1,0 +1,42 @@
+"""Ensure composed navigation initializes child renderers before processing."""
+
+import pygame
+
+from heart.device import Rectangle
+from heart.display.renderers import AtomicBaseRenderer
+from heart.navigation import ComposedRenderer
+from heart.peripheral.core.manager import PeripheralManager
+
+
+class _ColdAtomicRenderer(AtomicBaseRenderer[int]):
+    """Atomic renderer without warmup that still requires initialization."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.warmup = False
+
+    def _create_initial_state(self, *_args, **_kwargs) -> int:
+        return 0
+
+    def real_process(self, *_args, **_kwargs) -> None:
+        return None
+
+
+class TestComposedRendererInitialization:
+    """Validate composed renderer warms up child state even when warmup is disabled."""
+
+    def test_initializes_child_renderer_with_warmup_disabled(self) -> None:
+        """The composed renderer should initialize children regardless of warmup flags to avoid atomic errors."""
+
+        renderer = _ColdAtomicRenderer()
+        composed = ComposedRenderer([renderer])
+
+        window = pygame.Surface((2, 2))
+        composed.initialize(
+            window=window,
+            clock=pygame.time.Clock(),
+            peripheral_manager=PeripheralManager(),
+            orientation=Rectangle.with_layout(1, 1),
+        )
+
+        assert renderer.is_initialized() is True


### PR DESCRIPTION
## Summary
- initialize composed renderers regardless of warmup flags so atomic/stateful renderers get set up before processing
- add regression coverage to ensure ComposedRenderer initializes children even when warmup is disabled

## Testing
- make test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693efa89264c83218df66b791c66441d)