### PR TITLE
Fix sliding image renderer state retention

### DIFF
--- a/src/heart/display/renderers/sliding_image/provider.py
+++ b/src/heart/display/renderers/sliding_image/provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pygame
 import reactivex
 from reactivex import operators as ops
 
@@ -20,12 +21,18 @@ class SlidingImageStateProvider(ObservableProvider[SlidingImageState]):
         self._peripheral_manager = peripheral_manager
         self._speed = max(1, speed)
         self._width = width
+        self._image: pygame.Surface | None = None
 
     def set_width(self, width: int) -> None:
         self._width = max(0, width)
 
+    def set_image(self, image: pygame.Surface) -> None:
+        self._image = image
+
     def _initial_state(self) -> SlidingImageState:
-        return SlidingImageState(speed=self._speed, width=self._width)
+        return SlidingImageState(
+            speed=self._speed, width=self._width, image=self._image
+        )
 
     def observable(self) -> reactivex.Observable[SlidingImageState]:
         initial_state = self._initial_state()
@@ -33,10 +40,17 @@ class SlidingImageStateProvider(ObservableProvider[SlidingImageState]):
         def advance(state: SlidingImageState) -> SlidingImageState:
             width = state.width or self._width
             if width <= 0:
-                return SlidingImageState(speed=state.speed, width=width)
+                return SlidingImageState(
+                    speed=state.speed, width=width, image=state.image
+                )
 
             offset = (state.offset + state.speed) % width
-            return SlidingImageState(offset=offset, speed=state.speed, width=width)
+            return SlidingImageState(
+                offset=offset,
+                speed=state.speed,
+                width=width,
+                image=state.image,
+            )
 
         return (
             self._peripheral_manager.game_tick.pipe(

--- a/src/heart/display/renderers/sliding_image/renderer.py
+++ b/src/heart/display/renderers/sliding_image/renderer.py
@@ -59,12 +59,14 @@ class SlidingImage(AtomicBaseRenderer[SlidingImageState]):
         width, _ = image.get_size()
 
         self._image = image
+        self._provider.set_image(image)
         self._provider.set_width(width)
         self.set_state(
             SlidingImageState(
                 offset=0,
                 speed=self._configured_speed,
                 width=width,
+                image=image,
             )
         )
 
@@ -80,6 +82,8 @@ class SlidingImage(AtomicBaseRenderer[SlidingImageState]):
     ) -> None:
         if self._image is None or self.state.width <= 0:
             return
+
+        self.mutate_state(lambda state: state.advance())
 
         offset = self.state.offset
         width = self.state.width

--- a/src/heart/display/renderers/sliding_image/state.py
+++ b/src/heart/display/renderers/sliding_image/state.py
@@ -2,19 +2,24 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import pygame
+
 
 @dataclass(frozen=True)
 class SlidingImageState:
     offset: int = 0
     speed: int = 1
     width: int = 0
+    image: pygame.Surface | None = None
 
     def advance(self) -> "SlidingImageState":
         if self.width <= 0:
             return self
 
         offset = (self.offset + self.speed) % self.width
-        return SlidingImageState(offset=offset, speed=self.speed, width=self.width)
+        return SlidingImageState(
+            offset=offset, speed=self.speed, width=self.width, image=self.image
+        )
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- embed the cached surface in the sliding image state and propagate it through the provider
- advance the sliding image offset during processing so cached frames move as expected

## Testing
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693efd1f2b3c8321aea3475bba5a5dbb)