### PR TITLE
Refactor hilbert and spritesheet renderers

### DIFF
--- a/docs/migrations/renderer_atomic.md
+++ b/docs/migrations/renderer_atomic.md
@@ -112,9 +112,15 @@ status so incremental updates stay coordinated.
     (`src/heart/display/renderers/internal/event_stream.py`) – promote sequence
     counters and latest frames into atomic state so event bus producers and
     consumers resume cleanly across scene transitions.
+  - `HilbertScene` (`src/heart/display/renderers/hilbert_curve/renderer.py`) –
+    keeps curve interpolation progress and zoom state in immutable snapshots
+    driven by a dedicated provider so morph/zoom cycles stay deterministic.
   - `PacmanGhostRenderer` (`src/heart/display/renderers/pacman.py`) – keeps the
     chase direction, animation toggle, and sprite position immutable so the
     Pac-Man vignette restarts consistently between playlist entries.
+  - `SpritesheetLoop` (`src/heart/display/renderers/spritesheet/renderer.py`) –
+    splits frame sequencing into a provider-managed state stream so input-driven
+    pacing and loop progression are stored atomically before rendering.
 - Remaining renderers will be migrated iteratively. Track additional updates by
   appending to this list with accompanying test references.
 

--- a/src/heart/display/renderers/hilbert_curve/__init__.py
+++ b/src/heart/display/renderers/hilbert_curve/__init__.py
@@ -1,0 +1,3 @@
+from heart.display.renderers.hilbert_curve.renderer import HilbertScene
+
+__all__ = ["HilbertScene"]

--- a/src/heart/display/renderers/hilbert_curve/provider.py
+++ b/src/heart/display/renderers/hilbert_curve/provider.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import replace
+
+import numpy as np
+from numba import njit
+
+from heart.display.renderers.hilbert_curve.state import (BoundingBox,
+                                                         HilbertCurveState)
+
+
+def compute_bounding_box(points: np.ndarray) -> BoundingBox:
+    xs = [p[0] for p in points]
+    ys = [p[1] for p in points]
+    return min(xs), min(ys), max(xs), max(ys)
+
+
+@njit
+def d2xy(n: int, d: int) -> tuple[int, int]:
+    x = 0
+    y = 0
+    t = d
+    s = 1
+    while s < n:
+        rx = (t // 2) & 1
+        ry = (t ^ rx) & 1
+        if ry == 0:
+            if rx == 1:
+                x = s - 1 - x
+                y = s - 1 - y
+            temp = x
+            x = y
+            y = temp
+        x += s * rx
+        y += s * ry
+        t //= 4
+        s *= 2
+    return x, y
+
+
+@njit
+def hilbert_curve_points_numba(
+    order: int, width: int, height: int, xmargin: int, ymargin: int
+) -> np.ndarray:
+    n = 2**order
+    total_points = n * n
+
+    ymargin = ymargin or xmargin
+
+    draw_size = width - 2 * xmargin if width < height else height - 2 * ymargin
+    step = draw_size / (n - 1) if n > 1 else draw_size
+
+    points = np.empty((total_points, 2), dtype=np.float64)
+    for d in range(total_points):
+        x_grid, y_grid = d2xy(n, d)
+        points[d, 0] = xmargin + x_grid * step
+        points[d, 1] = ymargin + y_grid * step
+    return points
+
+
+@njit
+def resample_curve_numba(points: np.ndarray, num_samples: int) -> np.ndarray:
+    n = points.shape[0]
+    if n < 2:
+        return points
+
+    cumdist = np.empty(n, dtype=np.float64)
+    cumdist[0] = 0.0
+    for i in range(1, n):
+        dx = points[i, 0] - points[i - 1, 0]
+        dy = points[i, 1] - points[i - 1, 1]
+        cumdist[i] = cumdist[i - 1] + math.hypot(dx, dy)
+    total_length = cumdist[n - 1]
+
+    new_points = np.empty((num_samples, 2), dtype=np.float64)
+    j = 0
+    for i in range(num_samples):
+        td = i * total_length / (num_samples - 1)
+        while j < n - 1 and cumdist[j + 1] < td:
+            j += 1
+        if j >= n - 1:
+            new_points[i, 0] = points[n - 1, 0]
+            new_points[i, 1] = points[n - 1, 1]
+        else:
+            seg_length = cumdist[j + 1] - cumdist[j]
+            t_interp = 0.0
+            if seg_length != 0.0:
+                t_interp = (td - cumdist[j]) / seg_length
+            new_points[i, 0] = points[j, 0] + t_interp * (points[j + 1, 0] - points[j, 0])
+            new_points[i, 1] = points[j, 1] + t_interp * (points[j + 1, 1] - points[j, 1])
+    return new_points
+
+
+@njit
+def interpolate_curves_numba(curve1: np.ndarray, curve2: np.ndarray, alpha: float) -> np.ndarray:
+    n = curve1.shape[0]
+    interpolated = np.empty((n, 2), dtype=np.float64)
+    for i in range(n):
+        interpolated[i, 0] = (1 - alpha) * curve1[i, 0] + alpha * curve2[i, 0]
+        interpolated[i, 1] = (1 - alpha) * curve1[i, 1] + alpha * curve2[i, 1]
+    return interpolated
+
+
+@njit
+def transform_points(
+    points: np.ndarray,
+    alpha: float,
+    bbox: BoundingBox,
+    target_scale: float,
+    margin: int,
+) -> list[tuple[float, float]]:
+    min_x, min_y, _, _ = bbox
+    new_points: list[tuple[float, float]] = []
+    for p in points:
+        p_zoom = (
+            (p[0] - min_x) * target_scale + margin,
+            (p[1] - min_y) * target_scale + margin,
+        )
+        new_points.append(
+            (
+                (1 - alpha) * p[0] + alpha * p_zoom[0],
+                (1 - alpha) * p[1] + alpha * p_zoom[1],
+            )
+        )
+    return new_points
+
+
+class HilbertCurveProvider:
+    def __init__(
+        self,
+        *,
+        max_order: int = 7,
+        xmargin: int = 0,
+        ymargin: int | None = None,
+        resample_count: int = 10000,
+        morph_duration: float = 0.5,
+        hold_duration: float = 0.5,
+        zoom_duration: float = 3.0,
+        zoom_hold_duration: float = 1.0,
+        subset_exponent: int | None = None,
+    ) -> None:
+        self.max_order = max_order
+        self.xmargin = xmargin
+        self.ymargin = ymargin if ymargin is not None else xmargin
+        self.resample_count = resample_count
+        self.morph_duration = morph_duration
+        self.hold_duration = hold_duration
+        self.zoom_duration = zoom_duration
+        self.zoom_hold_duration = zoom_hold_duration
+        self.subset_exponent = subset_exponent or (max_order + 4)
+
+    def initial_state(self, *, width: int, height: int) -> HilbertCurveState:
+        current_order = 1
+        next_order = current_order + 1
+        base_points = hilbert_curve_points_numba(
+            current_order, width, height, self.xmargin, self.ymargin
+        )
+        current_curve = resample_curve_numba(base_points, self.resample_count)
+        next_points = hilbert_curve_points_numba(
+            next_order, width, height, self.xmargin, self.ymargin
+        )
+        target_curve = resample_curve_numba(next_points, self.resample_count)
+        now = time.time()
+        return HilbertCurveState(
+            width=width,
+            height=height,
+            xmargin=self.xmargin,
+            ymargin=self.ymargin,
+            resample_count=self.resample_count,
+            max_order=self.max_order,
+            current_order=current_order,
+            next_order=next_order,
+            current_curve=current_curve,
+            target_curve=target_curve,
+            next_points=next_points,
+            transition_state="morph",
+            morph_start_time=now,
+            zoom_start_time=None,
+            zoom_bbox=None,
+            target_scale=None,
+            frame_curve=current_curve,
+        )
+
+    def _advance_morph(self, state: HilbertCurveState, now: float) -> HilbertCurveState:
+        elapsed = now - state.morph_start_time
+        alpha = min(1.0, elapsed / self.morph_duration)
+        frame_curve = interpolate_curves_numba(state.current_curve, state.target_curve, alpha)
+
+        hold_duration = self.hold_duration if state.current_order < self.max_order - 2 else 0
+        if alpha < 1.0 or elapsed < self.morph_duration + hold_duration:
+            return replace(state, frame_curve=frame_curve)
+
+        if state.next_order == self.max_order:
+            zoom_bbox = compute_bounding_box(
+                frame_curve[: len(frame_curve) // (2**self.subset_exponent)]
+            )
+            draw_size = min(state.width, state.height) - (2 * state.xmargin)
+            bbox_width = zoom_bbox[2] - zoom_bbox[0]
+            bbox_height = zoom_bbox[3] - zoom_bbox[1]
+            target_scale = (draw_size * 2) / max(bbox_width, bbox_height)
+            return replace(
+                state,
+                transition_state="zoom",
+                zoom_start_time=now,
+                zoom_bbox=zoom_bbox,
+                target_scale=target_scale,
+                frame_curve=frame_curve,
+            )
+
+        current_order = state.next_order
+        next_order = current_order + 1
+        next_points = hilbert_curve_points_numba(
+            next_order, state.width, state.height, state.xmargin, state.ymargin
+        )
+        target_curve = resample_curve_numba(next_points, state.resample_count)
+        return replace(
+            state,
+            current_order=current_order,
+            next_order=next_order,
+            current_curve=frame_curve,
+            next_points=next_points,
+            target_curve=target_curve,
+            morph_start_time=now,
+            frame_curve=frame_curve,
+        )
+
+    def _advance_zoom(self, state: HilbertCurveState, now: float) -> HilbertCurveState:
+        assert state.zoom_start_time is not None
+        assert state.zoom_bbox is not None
+        assert state.target_scale is not None
+
+        zoom_elapsed = now - state.zoom_start_time
+        raw_alpha = min(zoom_elapsed / self.zoom_duration, 1.0)
+        zoom_alpha = -0.5 * (math.cos(math.pi * raw_alpha) - 1)
+
+        zoomed_curve = transform_points(
+            hilbert_curve_points_numba(
+                state.max_order, state.width, state.height, state.xmargin, state.ymargin
+            ),
+            zoom_alpha,
+            state.zoom_bbox,
+            state.target_scale,
+            state.xmargin,
+        )
+
+        if zoom_elapsed < self.zoom_duration + self.zoom_hold_duration:
+            return replace(state, frame_curve=np.array(zoomed_curve))
+
+        return self.initial_state(width=state.width, height=state.height)
+
+    def advance(self, state: HilbertCurveState, *, now: float) -> HilbertCurveState:
+        if state.transition_state == "zoom":
+            return self._advance_zoom(state, now)
+        return self._advance_morph(state, now)

--- a/src/heart/display/renderers/hilbert_curve/renderer.py
+++ b/src/heart/display/renderers/hilbert_curve/renderer.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import time
+
+import pygame
+
+from heart import DeviceDisplayMode
+from heart.device import Orientation
+from heart.display.renderers import AtomicBaseRenderer
+from heart.display.renderers.hilbert_curve.provider import HilbertCurveProvider
+from heart.display.renderers.hilbert_curve.state import HilbertCurveState
+from heart.peripheral.core.manager import PeripheralManager
+
+
+class HilbertScene(AtomicBaseRenderer[HilbertCurveState]):
+    def __init__(self, provider: HilbertCurveProvider | None = None) -> None:
+        self.provider = provider or HilbertCurveProvider()
+        self.device_display_mode = DeviceDisplayMode.MIRRORED
+        self.line_color = (215, 72, 148)
+        super().__init__()
+
+    def _create_initial_state(
+        self,
+        window: pygame.Surface,
+        clock: pygame.time.Clock,
+        peripheral_manager: PeripheralManager,
+        orientation: Orientation,
+    ) -> HilbertCurveState:
+        width, height = window.get_size()
+        return self.provider.initial_state(width=width, height=height)
+
+    def real_process(
+        self,
+        window: pygame.Surface,
+        clock: pygame.time.Clock,
+        orientation: Orientation,
+    ) -> None:
+        state = self.provider.advance(self.state, now=time.time())
+        self.set_state(state)
+
+        window.fill((0, 0, 0))
+        if len(state.frame_curve) > 1:
+            pygame.draw.lines(window, self.line_color, False, state.frame_curve, 1)
+

--- a/src/heart/display/renderers/hilbert_curve/state.py
+++ b/src/heart/display/renderers/hilbert_curve/state.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+BoundingBox = tuple[float, float, float, float]
+Phase = Literal["morph", "zoom"]
+
+
+@dataclass(frozen=True)
+class HilbertCurveState:
+    width: int
+    height: int
+    xmargin: int
+    ymargin: int
+    resample_count: int
+    max_order: int
+    current_order: int
+    next_order: int
+    current_curve: np.ndarray
+    target_curve: np.ndarray
+    next_points: np.ndarray
+    transition_state: Phase
+    morph_start_time: float
+    zoom_start_time: float | None
+    zoom_bbox: BoundingBox | None
+    target_scale: float | None
+    frame_curve: np.ndarray

--- a/src/heart/display/renderers/spritesheet/__init__.py
+++ b/src/heart/display/renderers/spritesheet/__init__.py
@@ -1,0 +1,5 @@
+from heart.display.renderers.spritesheet.provider import SpritesheetProvider
+from heart.display.renderers.spritesheet.renderer import (
+    SpritesheetLoop, create_spritesheet_loop)
+
+__all__ = ["SpritesheetLoop", "create_spritesheet_loop", "SpritesheetProvider"]

--- a/src/heart/display/renderers/spritesheet/provider.py
+++ b/src/heart/display/renderers/spritesheet/provider.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from heart.assets.loader import Loader
+from heart.display.models import KeyFrame
+from heart.display.renderers.spritesheet.state import (BoundingBox,
+                                                       FrameDescription,
+                                                       LoopPhase, Size,
+                                                       SpritesheetLoopState)
+from heart.peripheral.core.manager import PeripheralManager
+from heart.peripheral.gamepad.peripheral_mappings import (BitDoLite2,
+                                                          BitDoLite2Bluetooth)
+from heart.peripheral.switch import SwitchState
+from heart.utilities.env import Configuration
+
+
+class SpritesheetProvider:
+    def __init__(
+        self,
+        sheet_file_path: str,
+        metadata_file_path: str | None = None,
+        *,
+        image_scale: float = 1.0,
+        offset_x: int = 0,
+        offset_y: int = 0,
+        disable_input: bool = False,
+        boomerang: bool = False,
+        frame_data: list[FrameDescription] | None = None,
+        skip_last_frame: bool = False,
+    ) -> None:
+        self.disable_input = disable_input
+        self.file = sheet_file_path
+        self.boomerang = boomerang
+        self.image_scale = image_scale
+        self.offset_x = offset_x
+        self.offset_y = offset_y
+        self.skip_last_frame = skip_last_frame
+
+        assert frame_data is not None or metadata_file_path is not None, (
+            "Must provide either frame_data or metadata_file_path"
+        )
+
+        self.frames: dict[LoopPhase, list[KeyFrame]] = {
+            LoopPhase.START: [],
+            LoopPhase.LOOP: [],
+            LoopPhase.END: [],
+        }
+
+        if frame_data is None:
+            frame_data = Loader.load_json(metadata_file_path)
+            for key in frame_data["frames"]:
+                frame_obj = FrameDescription.from_dict(frame_data["frames"][key])
+                frame = frame_obj.frame
+                parsed_tag, _ = key.split(" ", 1)
+                tag = LoopPhase(parsed_tag) if parsed_tag in LoopPhase._value2member_map_ else LoopPhase.LOOP
+                self.frames[tag].append(
+                    KeyFrame(
+                        (
+                            frame.x,
+                            frame.y,
+                            frame.w,
+                            frame.h,
+                        ),
+                        frame_obj.duration,
+                    )
+                )
+        else:
+            for frame_description in frame_data:
+                self.frames[LoopPhase.LOOP].append(
+                    KeyFrame(
+                        (
+                            frame_description.frame.x,
+                            frame_description.frame.y,
+                            frame_description.frame.w,
+                            frame_description.frame.h,
+                        ),
+                        frame_description.duration,
+                    )
+                )
+
+        has_start = len(self.frames[LoopPhase.START]) > 0
+        self.initial_phase = LoopPhase.START if has_start else LoopPhase.LOOP
+
+    def _configure_gamepad(self, peripheral_manager: PeripheralManager) -> Any:
+        if self.disable_input:
+            return None
+        try:
+            return peripheral_manager.get_gamepad()
+        except ValueError:
+            return None
+
+    def initial_state(
+        self,
+        *,
+        window: Any,
+        clock: Any,
+        peripheral_manager: PeripheralManager,
+    ) -> SpritesheetLoopState:
+        return SpritesheetLoopState(
+            phase=self.initial_phase,
+            spritesheet=Loader.load_spirtesheet(self.file),
+            gamepad=self._configure_gamepad(peripheral_manager),
+        )
+
+    def handle_switch(self, state: SpritesheetLoopState, switch_state: SwitchState) -> SpritesheetLoopState:
+        if self.disable_input:
+            return state
+
+        duration_scale = state.duration_scale
+        last_rotation = state.last_switch_rotation or 0
+        current_rotation = switch_state.rotation_since_last_button_press
+        if current_rotation > last_rotation:
+            duration_scale += 0.05
+        elif current_rotation < last_rotation:
+            duration_scale -= 0.05
+
+        return replace(
+            state,
+            duration_scale=duration_scale,
+            last_switch_rotation=current_rotation,
+            switch_state=switch_state,
+        )
+
+    def _apply_gamepad_input(self, state: SpritesheetLoopState) -> SpritesheetLoopState:
+        if self.disable_input:
+            return state
+
+        gamepad = state.gamepad
+        if gamepad is None or not gamepad.is_connected():
+            return state
+
+        mapping = BitDoLite2Bluetooth() if Configuration.is_pi() else BitDoLite2()
+        duration_scale = state.duration_scale
+        if gamepad.axis_passed_threshold(mapping.AXIS_R):
+            duration_scale += 0.005
+        elif gamepad.axis_passed_threshold(mapping.AXIS_L):
+            duration_scale -= 0.005
+
+        return replace(state, duration_scale=duration_scale)
+
+    def _next_frame(
+        self,
+        state: SpritesheetLoopState,
+        *,
+        kf_duration: float,
+        elapsed_ms: float,
+    ) -> SpritesheetLoopState:
+        current_frame = state.current_frame
+        loop_count = state.loop_count
+        phase = state.phase
+        reverse_direction = state.reverse_direction
+        time_since_last_update = (state.time_since_last_update or 0) + elapsed_ms
+
+        if time_since_last_update > kf_duration:
+            if self.boomerang and phase == LoopPhase.LOOP:
+                current_frame = current_frame - 1 if reverse_direction else current_frame + 1
+            else:
+                current_frame += 1
+
+            time_since_last_update = 0
+
+            if self.boomerang and phase == LoopPhase.LOOP:
+                if current_frame >= len(self.frames[phase]) - 1:
+                    reverse_direction = True
+                    current_frame = len(self.frames[phase]) - 1
+                elif current_frame <= 0:
+                    reverse_direction = False
+                    current_frame = 0
+                    loop_count += 1
+                    if loop_count >= 4:
+                        loop_count = 0
+                        if len(self.frames[LoopPhase.END]) > 0:
+                            phase = LoopPhase.END
+                            current_frame = 0
+                            reverse_direction = False
+                        elif len(self.frames[LoopPhase.START]) > 0:
+                            phase = LoopPhase.START
+                            current_frame = 0
+                            reverse_direction = False
+            elif current_frame >= len(self.frames[phase]):
+                current_frame = 0
+                if phase == LoopPhase.START:
+                    phase = LoopPhase.LOOP
+                elif phase == LoopPhase.LOOP:
+                    if loop_count < 4:
+                        loop_count += 1
+                    else:
+                        loop_count = 0
+                        if len(self.frames[LoopPhase.END]) > 0:
+                            phase = LoopPhase.END
+                        elif len(self.frames[LoopPhase.START]) > 0:
+                            phase = LoopPhase.START
+                elif phase == LoopPhase.END:
+                    phase = LoopPhase.START
+
+        return replace(
+            state,
+            current_frame=current_frame,
+            loop_count=loop_count,
+            phase=phase,
+            reverse_direction=reverse_direction,
+            time_since_last_update=time_since_last_update,
+        )
+
+    def advance(self, state: SpritesheetLoopState, *, clock: Any) -> SpritesheetLoopState:
+        state = self._apply_gamepad_input(state)
+
+        current_kf = self.frames[state.phase][state.current_frame]
+        if self.disable_input:
+            kf_duration = current_kf.duration
+        else:
+            kf_duration = current_kf.duration - (current_kf.duration * state.duration_scale)
+
+        return self._next_frame(state, kf_duration=kf_duration, elapsed_ms=clock.get_time())
+
+    def reset_state(self, state: SpritesheetLoopState) -> SpritesheetLoopState:
+        return replace(
+            state,
+            phase=self.initial_phase,
+            current_frame=0,
+            loop_count=0,
+            duration_scale=0.0,
+            time_since_last_update=None,
+            reverse_direction=False,
+        )
+
+    @classmethod
+    def from_frame_data(
+        cls,
+        sheet_file_path: str,
+        duration: int,
+        image_scale: float = 1.0,
+        offset_x: int = 0,
+        offset_y: int = 0,
+        disable_input: bool = False,
+        boomerang: bool = False,
+        skip_last_frame: bool = False,
+    ) -> SpritesheetProvider:
+        sheet = Loader.load_spirtesheet(sheet_file_path)
+        size = sheet.get_size()
+        number_of_frames = size[0] // 64
+        if skip_last_frame:
+            number_of_frames -= 1
+        frame_descriptions = []
+        for frame_number in range(number_of_frames):
+            x = frame_number * 64
+            y = 0
+            w = 64
+            h = size[1]
+            frame_descriptions.append(
+                FrameDescription(
+                    frame=BoundingBox(x=x, y=y, w=w, h=h),
+                    spriteSourceSize=BoundingBox(x=0, y=0, w=w, h=h),
+                    sourceSize=Size(w=w, h=h),
+                    duration=duration,
+                    rotated=False,
+                    trimmed=False,
+                )
+            )
+
+        return cls(
+            sheet_file_path=sheet_file_path,
+            metadata_file_path=None,
+            image_scale=image_scale,
+            offset_x=offset_x,
+            offset_y=offset_y,
+            disable_input=disable_input,
+            boomerang=boomerang,
+            frame_data=frame_descriptions,
+            skip_last_frame=skip_last_frame,
+        )

--- a/src/heart/display/renderers/spritesheet/renderer.py
+++ b/src/heart/display/renderers/spritesheet/renderer.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import pygame
+
+from heart import DeviceDisplayMode
+from heart.device import Orientation
+from heart.display.renderers import AtomicBaseRenderer
+from heart.display.renderers.spritesheet.provider import SpritesheetProvider
+from heart.display.renderers.spritesheet.state import SpritesheetLoopState
+from heart.peripheral.core.manager import PeripheralManager
+from heart.peripheral.switch import SwitchState
+
+
+class SpritesheetLoop(AtomicBaseRenderer[SpritesheetLoopState]):
+    def __init__(self, provider: SpritesheetProvider) -> None:
+        self.provider = provider
+        self.device_display_mode = DeviceDisplayMode.MIRRORED
+        super().__init__()
+
+    def _create_initial_state(
+        self,
+        window: pygame.Surface,
+        clock: pygame.time.Clock,
+        peripheral_manager: PeripheralManager,
+        orientation: Orientation,
+    ) -> SpritesheetLoopState:
+        return self.provider.initial_state(
+            window=window, clock=clock, peripheral_manager=peripheral_manager
+        )
+
+    def on_switch_state(self, state: SwitchState) -> None:
+        self.set_state(self.provider.handle_switch(self.state, state))
+
+    def reset(self) -> None:
+        super().reset()
+        self.set_state(self.provider.reset_state(self.state))
+
+    def real_process(
+        self,
+        window: pygame.Surface,
+        clock: pygame.time.Clock,
+        orientation: Orientation,
+    ) -> None:
+        state = self.provider.advance(self.state, clock=clock)
+        self.set_state(state)
+
+        spritesheet = state.spritesheet
+        if spritesheet is None:
+            return
+
+        screen_width, screen_height = window.get_size()
+        current_kf = self.provider.frames[state.phase][state.current_frame]
+        image = spritesheet.image_at(current_kf.frame)
+        scaled = pygame.transform.scale(
+            image,
+            (
+                int(screen_width * self.provider.image_scale),
+                int(screen_height * self.provider.image_scale),
+            ),
+        )
+        center_x = (screen_width - scaled.get_width()) // 2
+        center_y = (screen_height - scaled.get_height()) // 2
+
+        final_x = center_x + self.provider.offset_x
+        final_y = center_y + self.provider.offset_y
+
+        window.blit(scaled, (final_x, final_y))
+
+
+def create_spritesheet_loop(
+    peripheral_manager: PeripheralManager, *args: object, **kwargs: object
+) -> SpritesheetLoop:
+    provider = SpritesheetProvider(*args, **kwargs)
+    renderer = SpritesheetLoop(provider)
+    renderer.configure_peripherals(peripheral_manager)
+    return renderer

--- a/src/heart/display/renderers/spritesheet/state.py
+++ b/src/heart/display/renderers/spritesheet/state.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from heart.peripheral.gamepad.gamepad import Gamepad
+from heart.peripheral.switch import SwitchState
+
+
+@dataclass(frozen=True)
+class Size:
+    w: int
+    h: int
+
+
+@dataclass(frozen=True)
+class BoundingBox(Size):
+    x: int
+    y: int
+
+
+@dataclass(frozen=True)
+class FrameDescription:
+    frame: BoundingBox
+    spriteSourceSize: BoundingBox
+    sourceSize: Size
+    duration: int
+    rotated: bool
+    trimmed: bool
+
+    @classmethod
+    def from_dict(cls, json_data: dict[str, Any]):
+        return cls(
+            frame=BoundingBox(
+                x=json_data["frame"]["x"],
+                y=json_data["frame"]["y"],
+                w=json_data["frame"]["w"],
+                h=json_data["frame"]["h"],
+            ),
+            spriteSourceSize=BoundingBox(
+                x=json_data["spriteSourceSize"]["x"],
+                y=json_data["spriteSourceSize"]["y"],
+                w=json_data["spriteSourceSize"]["w"],
+                h=json_data["spriteSourceSize"]["h"],
+            ),
+            sourceSize=Size(
+                w=json_data["sourceSize"]["w"],
+                h=json_data["sourceSize"]["h"],
+            ),
+            duration=json_data["duration"],
+            rotated=json_data["rotated"],
+            trimmed=json_data["trimmed"],
+        )
+
+
+class LoopPhase(Enum):
+    START = "start"
+    LOOP = "loop"
+    END = "end"
+
+
+@dataclass(frozen=True)
+class SpritesheetLoopState:
+    spritesheet: Any | None = None
+    current_frame: int = 0
+    loop_count: int = 0
+    phase: LoopPhase = LoopPhase.LOOP
+    time_since_last_update: float | None = None
+    duration_scale: float = 0.0
+    last_switch_rotation: float | None = None
+    reverse_direction: bool = False
+    gamepad: Gamepad | None = None
+    switch_state: SwitchState | None = None


### PR DESCRIPTION
## Summary
- split the Hilbert renderer into provider, state, and rendering modules with provider-driven morph/zoom progress
- move the spritesheet loop renderer into a provider/state/renderer package and keep input-driven frame pacing in provider logic
- document the renderer migrations in the atomic renderer progress note

## Testing
- make format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f010f3e8c83219963186e9afb6b12)