### PR TITLE
Restore SpritesheetLoop compatibility with legacy constructors

### DIFF
--- a/src/heart/display/renderers/pixels/__init__.py
+++ b/src/heart/display/renderers/pixels/__init__.py
@@ -4,7 +4,8 @@ from heart.display.renderers.pixels.provider import \
     RainStateProvider  # noqa: F401
 from heart.display.renderers.pixels.provider import \
     SlinkyStateProvider  # noqa: F401
-from heart.display.renderers.pixels.renderer import (Border,  # noqa: F401
-                                                     Rain, Slinky)
-from heart.display.renderers.pixels.state import (BorderState,  # noqa: F401
-                                                  RainState, SlinkyState)
+from heart.display.renderers.pixels.renderer import Border  # noqa: F401
+from heart.display.renderers.pixels.renderer import Rain, Slinky  # noqa: F401
+from heart.display.renderers.pixels.state import BorderState  # noqa: F401
+from heart.display.renderers.pixels.state import RainState  # noqa: F401
+from heart.display.renderers.pixels.state import SlinkyState  # noqa: F401

--- a/src/heart/display/renderers/spritesheet/__init__.py
+++ b/src/heart/display/renderers/spritesheet/__init__.py
@@ -1,5 +1,18 @@
 from heart.display.renderers.spritesheet.provider import SpritesheetProvider
 from heart.display.renderers.spritesheet.renderer import (
     SpritesheetLoop, create_spritesheet_loop)
+from heart.display.renderers.spritesheet.state import (BoundingBox,
+                                                       FrameDescription,
+                                                       LoopPhase, Size,
+                                                       SpritesheetLoopState)
 
-__all__ = ["SpritesheetLoop", "create_spritesheet_loop", "SpritesheetProvider"]
+__all__ = [
+    "BoundingBox",
+    "FrameDescription",
+    "LoopPhase",
+    "Size",
+    "SpritesheetLoopState",
+    "SpritesheetLoop",
+    "create_spritesheet_loop",
+    "SpritesheetProvider",
+]

--- a/src/heart/display/renderers/spritesheet/provider.py
+++ b/src/heart/display/renderers/spritesheet/provider.py
@@ -151,9 +151,10 @@ class SpritesheetProvider:
         loop_count = state.loop_count
         phase = state.phase
         reverse_direction = state.reverse_direction
-        time_since_last_update = (state.time_since_last_update or 0) + elapsed_ms
+        previous_elapsed = state.time_since_last_update
+        time_since_last_update = (previous_elapsed or 0) + elapsed_ms
 
-        if time_since_last_update > kf_duration:
+        if previous_elapsed is None or time_since_last_update > kf_duration:
             if self.boomerang and phase == LoopPhase.LOOP:
                 current_frame = current_frame - 1 if reverse_direction else current_frame + 1
             else:

--- a/src/heart/display/renderers/spritesheet/renderer.py
+++ b/src/heart/display/renderers/spritesheet/renderer.py
@@ -6,16 +6,82 @@ from heart import DeviceDisplayMode
 from heart.device import Orientation
 from heart.display.renderers import AtomicBaseRenderer
 from heart.display.renderers.spritesheet.provider import SpritesheetProvider
-from heart.display.renderers.spritesheet.state import SpritesheetLoopState
+from heart.display.renderers.spritesheet.state import (FrameDescription,
+                                                       SpritesheetLoopState)
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.switch import SwitchState
 
 
 class SpritesheetLoop(AtomicBaseRenderer[SpritesheetLoopState]):
-    def __init__(self, provider: SpritesheetProvider) -> None:
-        self.provider = provider
+    def __init__(
+        self,
+        provider: SpritesheetProvider | str | None = None,
+        sheet_file_path: str | None = None,
+        metadata_file_path: str | None = None,
+        *,
+        image_scale: float = 1.0,
+        offset_x: int = 0,
+        offset_y: int = 0,
+        disable_input: bool = False,
+        boomerang: bool = False,
+        frame_data: list[FrameDescription] | None = None,
+        skip_last_frame: bool = False,
+    ) -> None:
+        sheet_argument = sheet_file_path
+        if isinstance(provider, SpritesheetProvider):
+            resolved_provider = provider
+        else:
+            if isinstance(provider, str):
+                if sheet_argument is not None:
+                    raise TypeError(
+                        "Provide a SpritesheetProvider or a sheet file path, not both."
+                    )
+                sheet_argument = provider
+
+            if sheet_argument is None:
+                raise TypeError(
+                    "A SpritesheetProvider or sheet_file_path must be provided."
+                )
+
+            resolved_provider = SpritesheetProvider(
+                sheet_file_path=sheet_argument,
+                metadata_file_path=metadata_file_path,
+                image_scale=image_scale,
+                offset_x=offset_x,
+                offset_y=offset_y,
+                disable_input=disable_input,
+                boomerang=boomerang,
+                frame_data=frame_data,
+                skip_last_frame=skip_last_frame,
+            )
+
+        self.provider = resolved_provider
         self.device_display_mode = DeviceDisplayMode.MIRRORED
         super().__init__()
+
+    @classmethod
+    def from_frame_data(
+        cls,
+        sheet_file_path: str,
+        duration: int,
+        image_scale: float = 1.0,
+        offset_x: int = 0,
+        offset_y: int = 0,
+        disable_input: bool = False,
+        boomerang: bool = False,
+        skip_last_frame: bool = False,
+    ) -> SpritesheetLoop:
+        provider = SpritesheetProvider.from_frame_data(
+            sheet_file_path,
+            duration,
+            image_scale=image_scale,
+            offset_x=offset_x,
+            offset_y=offset_y,
+            disable_input=disable_input,
+            boomerang=boomerang,
+            skip_last_frame=skip_last_frame,
+        )
+        return cls(provider)
 
     def _create_initial_state(
         self,


### PR DESCRIPTION
## Summary
- reintroduce legacy SpritesheetLoop constructor and from_frame_data helper while delegating to SpritesheetProvider
- export previous spritesheet symbols from the package __init__ to support existing imports
- align spritesheet frame advancement timing with prior behaviour and clean up lint warnings in pixels imports

## Testing
- make test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f057094848321bc24a1c78ab66329)