### PR TITLE
Switch configurations to resolve renderers

### DIFF
--- a/docs/program_configuration.md
+++ b/docs/program_configuration.md
@@ -23,12 +23,14 @@ Describe how to construct repeatable playlists of modes and renderers so the Hea
 ## Minimal Module Example
 
 ```python
+from heart.renderers.max_bpm_screen import MaxBpmScreen
 from heart.renderers.text import TextRendering
 from heart.environment import GameLoop
 
 
 def configure(loop: GameLoop) -> None:
     hello_mode = loop.add_mode("hello")
+    hello_mode.resolve_renderer(loop.context_container, MaxBpmScreen)
     hello_mode.add_renderer(
         TextRendering.default(text="Hello, world!", y_location=16)
     )
@@ -37,7 +39,8 @@ def configure(loop: GameLoop) -> None:
 Important behaviours:
 
 - `loop.add_mode(<label or renderer>)` registers a selectable mode. Pass a string for a simple label or a renderer that supplies its own title screen.
-- `mode.add_renderer(...)` appends renderers that execute sequentially each frame, enabling overlays or layered effects.
+- `mode.resolve_renderer(container, RendererClass)` instantiates renderers via the dependency-injection container so shared providers and runtime wiring stay centralized.
+- `mode.add_renderer(...)` remains available for renderers that must be constructed with explicit parameters at configuration time.
 - `loop.app_controller.add_sleep_mode()` inserts a low-power fallback. The CLI toggles this path with `--add-low-power-mode/--no-add-low-power-mode`.
 
 ## Building Playlists

--- a/docs/runtime_overview.md
+++ b/docs/runtime_overview.md
@@ -31,7 +31,7 @@ Refer to [code_flow.md](code_flow.md) for the full call graph and service bounda
 Renderers extend `heart.renderers.BaseRenderer` (or a specialization) and draw into the surface supplied by the loop. Configuration modules typically:
 
 - Call `loop.add_mode(<label or renderer>)` to register selectable modes.
-- Attach renderers with `mode.add_renderer(...)` to run them sequentially each frame.
+- Attach renderers with `mode.resolve_renderer(loop.context_container, RendererClass)` to run them sequentially each frame while leveraging dependency injection.
 - Wrap renderers in `heart.navigation.MultiScene` or `heart.navigation.ComposedRenderer` to control scheduling and overlays.
 
 `lib_2025.py` demonstrates how to mix ambient animations (`WaterCube`), interactive scenes, and a low-power sleep mode managed through `loop.app_controller.add_sleep_mode()`.

--- a/src/heart/programs/configurations/halloween_2024.py
+++ b/src/heart/programs/configurations/halloween_2024.py
@@ -34,7 +34,7 @@ def configure(loop: GameLoop) -> None:
     # PacMan
     mode = loop.add_mode()
     mode.add_renderer(RandomPixel(color=Color(187, 10, 30), num_pixels=50))
-    mode.add_renderer(PacmanGhostRenderer())
+    mode.resolve_renderer(loop.context_container, PacmanGhostRenderer)
     mode.add_renderer(Border(width=2, color=Color(187, 10, 30)))
 
     # SpookyEye
@@ -63,7 +63,7 @@ def configure(loop: GameLoop) -> None:
 
     mode = loop.add_mode()
     # MANDELBROT
-    mode.add_renderer(MandelbrotMode())
+    mode.resolve_renderer(loop.context_container, MandelbrotMode)
 
     width = 64
     height = 64
@@ -90,7 +90,7 @@ def configure(loop: GameLoop) -> None:
     # PacMan
     mode = loop.add_mode()
     mode.add_renderer(RandomPixel(color=Color(187, 10, 30), num_pixels=50))
-    mode.add_renderer(PacmanGhostRenderer())
+    mode.resolve_renderer(loop.context_container, PacmanGhostRenderer)
     mode.add_renderer(Border(width=2, color=Color(187, 10, 30)))
 
     # SpookyEye

--- a/src/heart/programs/configurations/heart_rate.py
+++ b/src/heart/programs/configurations/heart_rate.py
@@ -5,5 +5,5 @@ from heart.renderers.max_bpm_screen import MaxBpmScreen
 def configure(loop: GameLoop) -> None:
     mode = loop.add_mode("heart_rate")
 
-    mode.add_renderer(MaxBpmScreen())
+    mode.resolve_renderer(loop.context_container, MaxBpmScreen)
     # mode.add_renderer(MetadataScreen())

--- a/src/heart/programs/configurations/lib_2024.py
+++ b/src/heart/programs/configurations/lib_2024.py
@@ -10,7 +10,7 @@ from heart.renderers.text import TextRendering
 
 def configure(loop: GameLoop) -> None:
     kirby_mode = loop.add_mode(KirbyScene.title_scene())
-    kirby_mode.add_renderer(KirbyScene())
+    kirby_mode.resolve_renderer(loop.context_container, KirbyScene)
 
     modelbrot = loop.add_mode(
         ComposedRenderer(
@@ -26,10 +26,10 @@ def configure(loop: GameLoop) -> None:
             ]
         )
     )
-    modelbrot.add_renderer(MandelbrotMode())
+    modelbrot.resolve_renderer(loop.context_container, MandelbrotMode)
 
     hilbert_mode = loop.add_mode("hilbert")
-    hilbert_mode.add_renderer(HilbertScene())
+    hilbert_mode.resolve_renderer(loop.context_container, HilbertScene)
 
     mode = loop.add_mode("friend\nbeacon")
     text = ["Lost my\nfriends\nagain"]

--- a/src/heart/programs/configurations/lib_2025.py
+++ b/src/heart/programs/configurations/lib_2025.py
@@ -39,7 +39,7 @@ def pattern_numpy(t: float, X: np.ndarray, Y: np.ndarray) -> np.ndarray:
 
 def configure(loop: GameLoop) -> None:
     kirby_mode = loop.add_mode(KirbyScene.title_scene())
-    kirby_mode.add_renderer(KirbyScene())
+    kirby_mode.resolve_renderer(loop.context_container, KirbyScene)
 
     modelbrot = loop.add_mode(
         ComposedRenderer(
@@ -55,13 +55,13 @@ def configure(loop: GameLoop) -> None:
             ]
         )
     )
-    modelbrot.add_renderer(MandelbrotMode())
+    modelbrot.resolve_renderer(loop.context_container, MandelbrotMode)
 
     sphere_mode = loop.add_mode("3d fractal")
     sphere_mode.add_renderer(FractalScene(loop.device))
 
     hilbert_mode = loop.add_mode("hilbert")
-    hilbert_mode.add_renderer(HilbertScene())
+    hilbert_mode.resolve_renderer(loop.context_container, HilbertScene)
 
     mario_mode = loop.add_mode(
         ComposedRenderer(
@@ -127,7 +127,7 @@ def configure(loop: GameLoop) -> None:
             ]
         )
     )
-    heart_rate_mode.add_renderer(CombinedBpmScreen())
+    heart_rate_mode.resolve_renderer(loop.context_container, CombinedBpmScreen)
 
     water_mode = loop.add_mode(
         ComposedRenderer(
@@ -147,7 +147,7 @@ def configure(loop: GameLoop) -> None:
     water_mode.resolve_renderer(loop.context_container, WaterCube)
 
     artist_mode = loop.add_mode(ArtistScene.title_scene())
-    artist_mode.add_renderer(ArtistScene())
+    artist_mode.resolve_renderer(loop.context_container, ArtistScene)
 
     friend_beacon_mode = loop.add_mode("friend\nbeacon")
     friend_beacon_mode.add_renderer(

--- a/src/heart/programs/configurations/mandlebrot.py
+++ b/src/heart/programs/configurations/mandlebrot.py
@@ -4,4 +4,4 @@ from heart.renderers.mandelbrot.scene import MandelbrotMode
 
 def configure(loop: GameLoop) -> None:
     mode = loop.add_mode()
-    mode.add_renderer(MandelbrotMode())
+    mode.resolve_renderer(loop.context_container, MandelbrotMode)

--- a/src/heart/programs/configurations/pacman.py
+++ b/src/heart/programs/configurations/pacman.py
@@ -8,5 +8,5 @@ from heart.renderers.random_pixel import RandomPixel
 def configure(loop: GameLoop) -> None:
     mode = loop.add_mode()
     mode.add_renderer(RandomPixel(color=Color(187, 10, 30), num_pixels=50))
-    mode.add_renderer(PacmanGhostRenderer())
+    mode.resolve_renderer(loop.context_container, PacmanGhostRenderer)
     mode.add_renderer(Border(width=2, color=Color(187, 10, 30)))


### PR DESCRIPTION
## Summary
- prefer dependency-injected renderer wiring in program configurations by replacing direct add_renderer calls
- update documentation to highlight resolve_renderer usage alongside configuration examples

## Testing
- make format
- make test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f2e936af0832197194992ef151b6f)