### PR TITLE
Ensure renderer clock is initialized before processing

### DIFF
--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -465,6 +465,10 @@ class GameLoop:
     #     # return isinstance(renderer, FlameRenderer)
 
     def process_renderer(self, renderer: "BaseRenderer") -> pygame.Surface | None:
+        clock = self.clock
+        if clock is None:
+            raise RuntimeError("GameLoop clock is not initialized")
+
         try:
             start_ns = time.perf_counter_ns()
             if renderer.device_display_mode == DeviceDisplayMode.OPENGL:
@@ -503,13 +507,13 @@ class GameLoop:
             if not renderer.initialized:
                 renderer.initialize(
                     window=screen,
-                    clock=self.clock,
+                    clock=clock,
                     peripheral_manager=self.peripheral_manager,
                     orientation=self.device.orientation,
                 )
             renderer._internal_process(
                 window=screen,
-                clock=self.clock,
+                clock=clock,
                 peripheral_manager=self.peripheral_manager,
                 orientation=self.device.orientation,
             )


### PR DESCRIPTION
## Summary
- add a guard to GameLoop renderer processing to ensure a clock is initialized
- reuse the validated clock when initializing and running renderers

## Testing
- make format


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f8cd202f8832199b155463eaa07d1)