### PR TITLE
Migrate renderers to StatefulBaseRenderer

### DIFF
--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -467,6 +467,9 @@ class GameLoop:
     def process_renderer(self, renderer: "BaseRenderer") -> pygame.Surface | None:
         try:
             start_ns = time.perf_counter_ns()
+            if self.clock is None:
+                raise RuntimeError("GameLoop clock is not initialized")
+            clock = self.clock
             if renderer.device_display_mode == DeviceDisplayMode.OPENGL:
                 if self._last_render_mode != pygame.OPENGL | pygame.DOUBLEBUF:
                     logger.info("Switching to OPENGL mode")
@@ -503,13 +506,13 @@ class GameLoop:
             if not renderer.initialized:
                 renderer.initialize(
                     window=screen,
-                    clock=self.clock,
+                    clock=clock,
                     peripheral_manager=self.peripheral_manager,
                     orientation=self.device.orientation,
                 )
             renderer._internal_process(
                 window=screen,
-                clock=self.clock,
+                clock=clock,
                 peripheral_manager=self.peripheral_manager,
                 orientation=self.device.orientation,
             )

--- a/src/heart/navigation.py
+++ b/src/heart/navigation.py
@@ -9,7 +9,7 @@ from heart.device import Orientation
 from heart.display.color import Color
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.switch import SwitchState
-from heart.renderers import AtomicBaseRenderer, BaseRenderer
+from heart.renderers import BaseRenderer, StatefulBaseRenderer
 from heart.renderers.color import RenderColor
 from heart.renderers.slide_transition import (SlideTransitionProvider,
                                               SlideTransitionRenderer)
@@ -148,7 +148,7 @@ class GameModeState:
         self.previous_mode_index = mode_index
         return self.renderers[mode_index]
 
-class GameModes(AtomicBaseRenderer[GameModeState]):
+class GameModes(StatefulBaseRenderer[GameModeState]):
     """GameModes represents a collection of modes in the game loop where different
     renderers can be added.
 
@@ -275,14 +275,14 @@ class MultiSceneState:
     current_button_value: int = 0
     offset_of_button_value: int | None = None
 
-class MultiScene(AtomicBaseRenderer[MultiSceneState]):
-    def __init__(self, scenes: list[AtomicBaseRenderer]) -> None:
+class MultiScene(StatefulBaseRenderer[MultiSceneState]):
+    def __init__(self, scenes: list[StatefulBaseRenderer]) -> None:
         super().__init__()
         self.scenes = scenes
 
     def get_renderers(
         self
-    ) -> list[AtomicBaseRenderer]:
+    ) -> list[StatefulBaseRenderer]:
         index = (self.state.current_button_value - (self.state.offset_of_button_value or 0)) % len(self.scenes)
         return [
             *self.scenes[index].get_renderers()

--- a/src/heart/renderers/combined_bpm_screen/renderer.py
+++ b/src/heart/renderers/combined_bpm_screen/renderer.py
@@ -8,7 +8,7 @@ from reactivex.disposable import Disposable
 from heart import DeviceDisplayMode
 from heart.device import Orientation
 from heart.peripheral.core.manager import PeripheralManager
-from heart.renderers import AtomicBaseRenderer
+from heart.renderers import StatefulBaseRenderer
 from heart.renderers.combined_bpm_screen.provider import (
     DEFAULT_MAX_BPM_DURATION_MS, DEFAULT_METADATA_DURATION_MS,
     CombinedBpmScreenStateProvider)
@@ -17,7 +17,7 @@ from heart.renderers.max_bpm_screen import MaxBpmScreen
 from heart.renderers.metadata_screen import MetadataScreen
 
 
-class CombinedBpmScreen(AtomicBaseRenderer[CombinedBpmScreenState]):
+class CombinedBpmScreen(StatefulBaseRenderer[CombinedBpmScreenState]):
     def __init__(
         self,
         metadata_duration_ms: int = DEFAULT_METADATA_DURATION_MS,
@@ -31,7 +31,7 @@ class CombinedBpmScreen(AtomicBaseRenderer[CombinedBpmScreenState]):
 
         self.is_flame_renderer = True
 
-        AtomicBaseRenderer.__init__(self)
+        super().__init__()
         self.device_display_mode = DeviceDisplayMode.FULL
 
         self._provider: CombinedBpmScreenStateProvider | None = None

--- a/src/heart/renderers/flame/renderer.py
+++ b/src/heart/renderers/flame/renderer.py
@@ -10,7 +10,7 @@ from reactivex.disposable import Disposable
 from heart import DeviceDisplayMode
 from heart.device import Orientation
 from heart.peripheral.core.manager import PeripheralManager
-from heart.renderers import AtomicBaseRenderer
+from heart.renderers import StatefulBaseRenderer
 from heart.renderers.flame.provider import FlameStateProvider
 from heart.renderers.flame.state import FlameState
 
@@ -228,7 +228,7 @@ class FlameGenerator:
         raise ValueError("side must be 'bottom', 'top', 'left' or 'right'")
 
 
-class FlameRenderer(AtomicBaseRenderer[FlameState]):
+class FlameRenderer(StatefulBaseRenderer[FlameState]):
     """Display animated flames on all four sides of the screen."""
 
     def __init__(self) -> None:

--- a/src/heart/renderers/free_text/renderer.py
+++ b/src/heart/renderers/free_text/renderer.py
@@ -6,12 +6,12 @@ from reactivex.disposable import Disposable
 from heart import DeviceDisplayMode
 from heart.device import Orientation
 from heart.peripheral.core.manager import PeripheralManager
-from heart.renderers import AtomicBaseRenderer
+from heart.renderers import StatefulBaseRenderer
 from heart.renderers.free_text.provider import FreeTextStateProvider
 from heart.renderers.free_text.state import FreeTextRendererState
 
 
-class FreeTextRenderer(AtomicBaseRenderer[FreeTextRendererState]):
+class FreeTextRenderer(StatefulBaseRenderer[FreeTextRendererState]):
     """Render the most recent text message that arrived via *PhoneText*."""
 
     def __init__(self) -> None:

--- a/src/heart/renderers/hilbert_curve/renderer.py
+++ b/src/heart/renderers/hilbert_curve/renderer.py
@@ -7,12 +7,12 @@ import pygame
 from heart import DeviceDisplayMode
 from heart.device import Orientation
 from heart.peripheral.core.manager import PeripheralManager
-from heart.renderers import AtomicBaseRenderer
+from heart.renderers import StatefulBaseRenderer
 from heart.renderers.hilbert_curve.provider import HilbertCurveProvider
 from heart.renderers.hilbert_curve.state import HilbertCurveState
 
 
-class HilbertScene(AtomicBaseRenderer[HilbertCurveState]):
+class HilbertScene(StatefulBaseRenderer[HilbertCurveState]):
     def __init__(self, provider: HilbertCurveProvider | None = None) -> None:
         self.provider = provider or HilbertCurveProvider()
         self.device_display_mode = DeviceDisplayMode.MIRRORED

--- a/src/heart/renderers/max_bpm_screen/renderer.py
+++ b/src/heart/renderers/max_bpm_screen/renderer.py
@@ -9,7 +9,7 @@ from heart.assets.loader import Loader
 from heart.device import Orientation
 from heart.navigation import ComposedRenderer
 from heart.peripheral.core.manager import PeripheralManager
-from heart.renderers import AtomicBaseRenderer
+from heart.renderers import StatefulBaseRenderer
 from heart.renderers.flame import FlameRenderer
 from heart.renderers.max_bpm_screen.provider import (AVATAR_MAPPINGS,
                                                      AvatarBpmStateProvider)
@@ -26,7 +26,7 @@ class MaxBpmScreen(ComposedRenderer):
         self.is_flame_renderer = True
 
 
-class AvatarBpmRenderer(AtomicBaseRenderer[AvatarBpmRendererState]):
+class AvatarBpmRenderer(StatefulBaseRenderer[AvatarBpmRendererState]):
     def __init__(self) -> None:
         super().__init__()
         self.device_display_mode = DeviceDisplayMode.MIRRORED

--- a/src/heart/renderers/metadata_screen/renderer.py
+++ b/src/heart/renderers/metadata_screen/renderer.py
@@ -11,7 +11,7 @@ from heart.assets.loader import Loader
 from heart.device import Orientation
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.heart_rates import battery_status, current_bpms
-from heart.renderers import AtomicBaseRenderer
+from heart.renderers import StatefulBaseRenderer
 from heart.renderers.metadata_screen.provider import \
     MetadataScreenStateProvider
 from heart.renderers.metadata_screen.state import (DEFAULT_HEART_COLORS,
@@ -21,7 +21,7 @@ from heart.utilities.logging import get_logger
 logger = get_logger("HeartRateManager")
 
 
-class MetadataScreen(AtomicBaseRenderer[MetadataScreenState]):
+class MetadataScreen(StatefulBaseRenderer[MetadataScreenState]):
     def __init__(self, colors: Iterable[str] | None = None) -> None:
         self.colors = list(colors) if colors is not None else list(DEFAULT_HEART_COLORS)
 
@@ -35,7 +35,7 @@ class MetadataScreen(AtomicBaseRenderer[MetadataScreenState]):
 
         self.avatar_images: Dict[str, Surface] = {}
 
-        AtomicBaseRenderer.__init__(self)
+        super().__init__()
         self.device_display_mode = DeviceDisplayMode.FULL
 
         self._provider: MetadataScreenStateProvider | None = None

--- a/src/heart/renderers/pacman/renderer.py
+++ b/src/heart/renderers/pacman/renderer.py
@@ -6,12 +6,12 @@ from heart import DeviceDisplayMode
 from heart.assets.loader import Loader
 from heart.device import Orientation
 from heart.peripheral.core.manager import PeripheralManager
-from heart.renderers import AtomicBaseRenderer
+from heart.renderers import StatefulBaseRenderer
 from heart.renderers.pacman.provider import PacmanGhostStateProvider
 from heart.renderers.pacman.state import PacmanGhostState
 
 
-class PacmanGhostRenderer(AtomicBaseRenderer[PacmanGhostState]):
+class PacmanGhostRenderer(StatefulBaseRenderer[PacmanGhostState]):
     def __init__(self, builder: PacmanGhostStateProvider | None = None) -> None:
         self._builder = builder or PacmanGhostStateProvider()
         super().__init__()

--- a/src/heart/renderers/pixels/renderer.py
+++ b/src/heart/renderers/pixels/renderer.py
@@ -6,17 +6,17 @@ from heart import DeviceDisplayMode
 from heart.device import Orientation
 from heart.display.color import Color
 from heart.peripheral.core.manager import PeripheralManager
-from heart.renderers import AtomicBaseRenderer
+from heart.renderers import StatefulBaseRenderer
 from heart.renderers.pixels.provider import (BorderStateProvider,
                                              RainStateProvider,
                                              SlinkyStateProvider)
 from heart.renderers.pixels.state import BorderState, RainState, SlinkyState
 
 
-class Border(AtomicBaseRenderer[BorderState]):
+class Border(StatefulBaseRenderer[BorderState]):
     def __init__(self, width: int, color: Color | None = None, provider: BorderStateProvider | None = None) -> None:
         self.provider = provider or BorderStateProvider(color)
-        AtomicBaseRenderer.__init__(self)
+        super().__init__()
         self.device_display_mode = DeviceDisplayMode.FULL
         self.width = width
 
@@ -56,10 +56,10 @@ class Border(AtomicBaseRenderer[BorderState]):
         self.update_state(color=color)
 
 
-class Rain(AtomicBaseRenderer[RainState]):
+class Rain(StatefulBaseRenderer[RainState]):
     def __init__(self, provider: RainStateProvider | None = None) -> None:
         self.provider = provider or RainStateProvider()
-        AtomicBaseRenderer.__init__(self)
+        super().__init__()
         self.device_display_mode = DeviceDisplayMode.FULL
         self.l = 8
         self.starting_color = Color(r=173, g=216, b=230)
@@ -104,10 +104,10 @@ class Rain(AtomicBaseRenderer[RainState]):
             self.update_state(current_y=new_y)
 
 
-class Slinky(AtomicBaseRenderer[SlinkyState]):
+class Slinky(StatefulBaseRenderer[SlinkyState]):
     def __init__(self, provider: SlinkyStateProvider | None = None) -> None:
         self.provider = provider or SlinkyStateProvider()
-        AtomicBaseRenderer.__init__(self)
+        super().__init__()
         self.device_display_mode = DeviceDisplayMode.FULL
         self.l = 10
         self.starting_color = Color(r=255, g=165, b=0)

--- a/src/heart/renderers/slide_transition/renderer.py
+++ b/src/heart/renderers/slide_transition/renderer.py
@@ -6,7 +6,7 @@ import pygame
 from heart import DeviceDisplayMode
 from heart.device import Orientation, Rectangle
 from heart.peripheral.core.manager import PeripheralManager
-from heart.renderers import AtomicBaseRenderer
+from heart.renderers import StatefulBaseRenderer
 from heart.renderers.slide_transition.provider import SlideTransitionProvider
 from heart.renderers.slide_transition.state import SlideTransitionState
 from heart.utilities.logging import get_logger
@@ -16,13 +16,13 @@ logger = get_logger(__name__)
 log_controller = get_logging_controller()
 
 
-class SlideTransitionRenderer(AtomicBaseRenderer[SlideTransitionState]):
+class SlideTransitionRenderer(StatefulBaseRenderer[SlideTransitionState]):
     """Slides renderer_B into view while renderer_A moves out."""
 
     def __init__(self, provider: SlideTransitionProvider) -> None:
         self.provider = provider
         self.device_display_mode = DeviceDisplayMode.MIRRORED
-        AtomicBaseRenderer.__init__(self)
+        super().__init__()
 
     def _create_initial_state(
         self,

--- a/src/heart/renderers/sliding_image/renderer.py
+++ b/src/heart/renderers/sliding_image/renderer.py
@@ -8,14 +8,14 @@ from heart import DeviceDisplayMode
 from heart.assets.loader import Loader
 from heart.device import Orientation
 from heart.peripheral.core.manager import PeripheralManager
-from heart.renderers import AtomicBaseRenderer, BaseRenderer
+from heart.renderers import BaseRenderer, StatefulBaseRenderer
 from heart.renderers.sliding_image.provider import (
     SlidingImageStateProvider, SlidingRendererStateProvider)
 from heart.renderers.sliding_image.state import (SlidingImageState,
                                                  SlidingRendererState)
 
 
-class SlidingImage(AtomicBaseRenderer[SlidingImageState]):
+class SlidingImage(StatefulBaseRenderer[SlidingImageState]):
     """Render a 256×64 image that continuously slides horizontally."""
 
     def __init__(
@@ -98,7 +98,7 @@ class SlidingImage(AtomicBaseRenderer[SlidingImageState]):
         super().reset()
 
 
-class SlidingRenderer(AtomicBaseRenderer[SlidingRendererState]):
+class SlidingRenderer(StatefulBaseRenderer[SlidingRendererState]):
     """Wrap another renderer and slide its output horizontally."""
 
     def __init__(

--- a/src/heart/renderers/spritesheet/renderer.py
+++ b/src/heart/renderers/spritesheet/renderer.py
@@ -6,13 +6,13 @@ from heart import DeviceDisplayMode
 from heart.device import Orientation
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.switch import SwitchState
-from heart.renderers import AtomicBaseRenderer
+from heart.renderers import StatefulBaseRenderer
 from heart.renderers.spritesheet.provider import SpritesheetProvider
 from heart.renderers.spritesheet.state import (FrameDescription,
                                                SpritesheetLoopState)
 
 
-class SpritesheetLoop(AtomicBaseRenderer[SpritesheetLoopState]):
+class SpritesheetLoop(StatefulBaseRenderer[SpritesheetLoopState]):
     def __init__(
         self,
         provider: SpritesheetProvider | str | None = None,

--- a/src/heart/renderers/spritesheet_random/renderer.py
+++ b/src/heart/renderers/spritesheet_random/renderer.py
@@ -8,7 +8,7 @@ from heart.assets.loader import Loader
 from heart.device import Orientation
 from heart.display.models import KeyFrame
 from heart.peripheral.core.manager import PeripheralManager
-from heart.renderers import AtomicBaseRenderer
+from heart.renderers import StatefulBaseRenderer
 from heart.renderers.spritesheet_random.provider import \
     SpritesheetLoopRandomProvider
 from heart.renderers.spritesheet_random.state import (
@@ -17,7 +17,7 @@ from heart.renderers.spritesheet_random.state import (
 logger = logging.getLogger(__name__)
 
 
-class SpritesheetLoopRandom(AtomicBaseRenderer[SpritesheetLoopRandomState]):
+class SpritesheetLoopRandom(StatefulBaseRenderer[SpritesheetLoopRandomState]):
     def __init__(
         self,
         screen_width: int,
@@ -50,7 +50,7 @@ class SpritesheetLoopRandom(AtomicBaseRenderer[SpritesheetLoopRandomState]):
         self.y = 30
         self.provider = provider or SpritesheetLoopRandomProvider(sheet_file_path)
 
-        AtomicBaseRenderer.__init__(self)
+        super().__init__()
         self.device_display_mode = DeviceDisplayMode.FULL
 
     def __duration_scale_factor(self) -> float:

--- a/src/heart/renderers/text/renderer.py
+++ b/src/heart/renderers/text/renderer.py
@@ -3,12 +3,12 @@ import pygame
 from heart.device import Orientation
 from heart.display.color import Color
 from heart.peripheral.core.manager import PeripheralManager
-from heart.renderers import AtomicBaseRenderer
+from heart.renderers import StatefulBaseRenderer
 from heart.renderers.text.provider import TextRenderingProvider
 from heart.renderers.text.state import TextRenderingState
 
 
-class TextRendering(AtomicBaseRenderer[TextRenderingState]):
+class TextRendering(StatefulBaseRenderer[TextRenderingState]):
     def __init__(
         self,
         text: list[str],

--- a/src/heart/renderers/three_d_glasses/renderer.py
+++ b/src/heart/renderers/three_d_glasses/renderer.py
@@ -15,7 +15,7 @@ import pygame
 from heart.assets.loader import Loader
 from heart.device import Orientation
 from heart.peripheral.core.manager import PeripheralManager
-from heart.renderers import AtomicBaseRenderer
+from heart.renderers import StatefulBaseRenderer
 from heart.renderers.three_d_glasses.provider import ThreeDGlassesStateProvider
 from heart.renderers.three_d_glasses.state import ThreeDGlassesState
 
@@ -30,7 +30,7 @@ class _ChannelProfile:
     cyan_gain: float
 
 
-class ThreeDGlassesRenderer(AtomicBaseRenderer[ThreeDGlassesState]):
+class ThreeDGlassesRenderer(StatefulBaseRenderer[ThreeDGlassesState]):
     """Render a sequence of images with a red/blue anaglyph effect."""
 
     def __init__(

--- a/src/heart/renderers/three_fractal/renderer.py
+++ b/src/heart/renderers/three_fractal/renderer.py
@@ -15,7 +15,7 @@ from heart.display.shaders.util import _UNIFORMS, get_global, set_global_float
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.gamepad.peripheral_mappings import (BitDoLite2,
                                                           BitDoLite2Bluetooth)
-from heart.renderers import AtomicBaseRenderer, BaseRenderer
+from heart.renderers import BaseRenderer, StatefulBaseRenderer
 from heart.renderers.three_fractal.state import FractalSceneState
 from heart.utilities.env import Configuration
 
@@ -809,7 +809,7 @@ class FractalRuntime(BaseRenderer):
         self.mode = "auto"
 
 
-class FractalScene(AtomicBaseRenderer[FractalSceneState]):
+class FractalScene(StatefulBaseRenderer[FractalSceneState]):
     def __init__(
         self, provider: "FractalSceneProvider" | None = None
     ) -> None:

--- a/src/heart/renderers/yolisten/renderer.py
+++ b/src/heart/renderers/yolisten/renderer.py
@@ -10,7 +10,7 @@ from heart import DeviceDisplayMode
 from heart.device import Orientation
 from heart.display.color import Color
 from heart.peripheral.core.manager import PeripheralManager
-from heart.renderers import AtomicBaseRenderer
+from heart.renderers import StatefulBaseRenderer
 from heart.renderers.yolisten.provider import YoListenStateProvider
 from heart.renderers.yolisten.state import YoListenState
 
@@ -18,7 +18,7 @@ PHYPOX_URL = "http://192.168.1.50/get?accY&accX&accZ&dB"
 logger = logging.getLogger(__name__)
 
 
-class YoListenRenderer(AtomicBaseRenderer[YoListenState]):
+class YoListenRenderer(StatefulBaseRenderer[YoListenState]):
     def __init__(self, color: Color = Color(255, 0, 0), provider: YoListenStateProvider | None = None) -> None:
         self.base_color = color
         self.words = ["YO", "LISTEN", "Y'HEAR", "THAT"]
@@ -59,7 +59,7 @@ class YoListenRenderer(AtomicBaseRenderer[YoListenState]):
         self.test_mode = False
         self.phyphox_db = 50.0
         self.provider = provider or YoListenStateProvider(color)
-        AtomicBaseRenderer.__init__(self)
+        super().__init__()
 
         self.device_display_mode = DeviceDisplayMode.FULL
 

--- a/tests/navigation/test_composed_renderer_initialization.py
+++ b/tests/navigation/test_composed_renderer_initialization.py
@@ -5,10 +5,10 @@ import pygame
 from heart.device import Rectangle
 from heart.navigation import ComposedRenderer
 from heart.peripheral.core.manager import PeripheralManager
-from heart.renderers import AtomicBaseRenderer
+from heart.renderers import StatefulBaseRenderer
 
 
-class _ColdAtomicRenderer(AtomicBaseRenderer[int]):
+class _ColdAtomicRenderer(StatefulBaseRenderer[int]):
     """Atomic renderer without warmup that still requires initialization."""
 
     def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- update renderer subclasses to use StatefulBaseRenderer while preserving existing state initialization
- add central subscription cleanup and optional builder support in the renderer base class
- guard game loop rendering against missing clocks to satisfy type checks

## Testing
- make format
- make test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f8cb678e4832197f8aec0b25c9677)