### PR TITLE
Add channel diffusion renderer mode

### DIFF
--- a/docs/channel_diffusion.md
+++ b/docs/channel_diffusion.md
@@ -1,0 +1,17 @@
+# Channel diffusion mode
+
+This mode starts with a single white pixel centered on the display and iteratively redistributes the color channels to neighboring tiles.
+
+## Update rule
+
+- For each pixel, send its green component to the squares directly above and below.
+- Send the blue component to the squares directly left and right.
+- Send the red component to all diagonal squares.
+- Reduce the originating pixel by half of its brightness (computed from the maximum channel value) before clipping negative values to zero.
+- Clip any channel that would exceed 255 after aggregation.
+
+The renderer operates on the full device surface so the redistribution covers the entire display.
+
+## Implementation notes
+
+The mode is implemented in `ChannelDiffusionRenderer` (`src/heart/renderers/channel_diffusion/renderer.py`). The renderer maintains a grid of RGB values, applies the redistribution with NumPy slicing, clips the accumulated values, and blits the result to the active surface. The program entry point is exposed through `channel_diffusion.configure` (`src/heart/programs/configurations/channel_diffusion.py`).

--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -465,6 +465,10 @@ class GameLoop:
     #     # return isinstance(renderer, FlameRenderer)
 
     def process_renderer(self, renderer: "BaseRenderer") -> pygame.Surface | None:
+        clock = self.clock
+        if clock is None:
+            raise RuntimeError("GameLoop clock is not initialized")
+
         try:
             start_ns = time.perf_counter_ns()
             if renderer.device_display_mode == DeviceDisplayMode.OPENGL:
@@ -503,13 +507,13 @@ class GameLoop:
             if not renderer.initialized:
                 renderer.initialize(
                     window=screen,
-                    clock=self.clock,
+                    clock=clock,
                     peripheral_manager=self.peripheral_manager,
                     orientation=self.device.orientation,
                 )
             renderer._internal_process(
                 window=screen,
-                clock=self.clock,
+                clock=clock,
                 peripheral_manager=self.peripheral_manager,
                 orientation=self.device.orientation,
             )

--- a/src/heart/programs/configurations/channel_diffusion.py
+++ b/src/heart/programs/configurations/channel_diffusion.py
@@ -1,0 +1,7 @@
+from heart.environment import GameLoop
+from heart.renderers.channel_diffusion import ChannelDiffusionRenderer
+
+
+def configure(loop: GameLoop) -> None:
+    mode = loop.add_mode()
+    mode.add_renderer(ChannelDiffusionRenderer())

--- a/src/heart/renderers/channel_diffusion/__init__.py
+++ b/src/heart/renderers/channel_diffusion/__init__.py
@@ -1,0 +1,4 @@
+from heart.renderers.channel_diffusion.renderer import \
+    ChannelDiffusionRenderer  # noqa: F401
+from heart.renderers.channel_diffusion.state import \
+    ChannelDiffusionState  # noqa: F401

--- a/src/heart/renderers/channel_diffusion/renderer.py
+++ b/src/heart/renderers/channel_diffusion/renderer.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import numpy as np
+import pygame
+
+from heart import DeviceDisplayMode
+from heart.device import Orientation
+from heart.peripheral.core.manager import PeripheralManager
+from heart.renderers import AtomicBaseRenderer
+from heart.renderers.channel_diffusion.state import ChannelDiffusionState
+
+
+class ChannelDiffusionRenderer(AtomicBaseRenderer[ChannelDiffusionState]):
+    def __init__(self) -> None:
+        super().__init__()
+        self.device_display_mode = DeviceDisplayMode.FULL
+        self.warmup = False
+
+    def _create_initial_state(
+        self,
+        window: pygame.Surface,
+        clock: pygame.time.Clock,
+        peripheral_manager: PeripheralManager,
+        orientation: Orientation,
+    ) -> ChannelDiffusionState:
+        width, height = window.get_size()
+        grid = np.zeros((width, height, 3), dtype=np.uint8)
+        grid[width // 2, height // 2] = np.array([255, 255, 255], dtype=np.uint8)
+        return ChannelDiffusionState(grid=grid)
+
+    def _compute_center_after_fade(self, grid: np.ndarray) -> np.ndarray:
+        brightness = grid.max(axis=2)
+        faded = grid - (brightness // 2)[:, :, None]
+        return faded
+
+    def real_process(
+        self,
+        window: pygame.Surface,
+        clock: pygame.time.Clock,
+        orientation: Orientation,
+    ) -> None:
+        grid = self.state.grid.astype(np.int32)
+
+        red = grid[:, :, 0]
+        green = grid[:, :, 1]
+        blue = grid[:, :, 2]
+
+        new_grid = np.zeros_like(grid)
+
+        center = self._compute_center_after_fade(grid)
+        new_grid += center
+
+        new_grid[:, :-1, 1] += green[:, 1:]
+        new_grid[:, 1:, 1] += green[:, :-1]
+
+        new_grid[:-1, :, 2] += blue[1:, :]
+        new_grid[1:, :, 2] += blue[:-1, :]
+
+        new_grid[:-1, :-1, 0] += red[1:, 1:]
+        new_grid[1:, :-1, 0] += red[:-1, 1:]
+        new_grid[:-1, 1:, 0] += red[1:, :-1]
+        new_grid[1:, 1:, 0] += red[:-1, :-1]
+
+        clipped_grid = np.clip(new_grid, 0, 255).astype(np.uint8)
+        self.set_state(ChannelDiffusionState(grid=clipped_grid))
+
+        pygame.surfarray.blit_array(window, clipped_grid)

--- a/src/heart/renderers/channel_diffusion/state.py
+++ b/src/heart/renderers/channel_diffusion/state.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class ChannelDiffusionState:
+    grid: np.ndarray

--- a/tests/display/test_channel_diffusion_renderer.py
+++ b/tests/display/test_channel_diffusion_renderer.py
@@ -1,0 +1,41 @@
+"""Tests for the channel diffusion renderer rule application."""
+
+import numpy as np
+import pygame
+
+from heart.device import Rectangle
+from heart.peripheral.core.manager import PeripheralManager
+from heart.renderers.channel_diffusion import ChannelDiffusionRenderer
+
+
+class TestChannelDiffusionRenderer:
+    """Validate channel diffusion spreads color energy predictably for troubleshooting."""
+
+    def test_single_white_pixel_spreads_channels(self, stub_clock_factory) -> None:
+        """Ensure a lone white pixel fans out by channel while dimming in place to keep the seed deterministic."""
+
+        renderer = ChannelDiffusionRenderer()
+        manager = PeripheralManager()
+        clock = stub_clock_factory(0)
+        orientation = Rectangle.with_layout(1, 1)
+        window = pygame.Surface((3, 3), pygame.SRCALPHA)
+
+        renderer.initialize(window, clock, manager, orientation)
+
+        initial_center = renderer.state.grid[1, 1]
+        np.testing.assert_array_equal(initial_center, np.array([255, 255, 255], dtype=np.uint8))
+
+        renderer.process(window, clock, manager, orientation)
+
+        expected = np.zeros((3, 3, 3), dtype=np.uint8)
+        expected[1, 1] = np.array([128, 128, 128], dtype=np.uint8)
+        expected[1, 0] = np.array([0, 255, 0], dtype=np.uint8)
+        expected[1, 2] = np.array([0, 255, 0], dtype=np.uint8)
+        expected[0, 1] = np.array([0, 0, 255], dtype=np.uint8)
+        expected[2, 1] = np.array([0, 0, 255], dtype=np.uint8)
+        expected[0, 0] = np.array([255, 0, 0], dtype=np.uint8)
+        expected[2, 0] = np.array([255, 0, 0], dtype=np.uint8)
+        expected[0, 2] = np.array([255, 0, 0], dtype=np.uint8)
+        expected[2, 2] = np.array([255, 0, 0], dtype=np.uint8)
+
+        np.testing.assert_array_equal(renderer.state.grid, expected)


### PR DESCRIPTION
## Summary
- add a channel diffusion renderer that seeds a central white pixel and redistributes color channels to neighbors while dimming the source
- register the new renderer as a game mode and document the rule set
- cover the diffusion behaviour with a unit test and tighten GameLoop clock handling

## Testing
- make format
- make test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fb50c89a083219850c8748865ad02)