### PR TITLE
Stabilize stream cube rotation across image updates

### DIFF
--- a/experimental/beats/src/components/stream.tsx
+++ b/experimental/beats/src/components/stream.tsx
@@ -1,7 +1,7 @@
 import { useStreamedImage } from "@/actions/ws/providers/ImageProvider";
 import { useWS } from "@/actions/ws/websocket";
 import { Antenna } from "lucide-react";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 import { StreamCube } from "./stream-cube";
 import { Separator } from "./ui/separator";
@@ -48,6 +48,9 @@ export function Stream() {
   const ws = useWS();
   const { imgURL, isActive, fps } = useStreamedImage();
   const [useImageFallback, setUseImageFallback] = useState(false);
+  const handleContextError = useCallback(() => {
+    setUseImageFallback(true);
+  }, []);
 
   return (
     <div className="flex h-full flex-col select-none">
@@ -57,7 +60,7 @@ export function Stream() {
         ) : (
           <StreamCube
             imgURL={imgURL}
-            onContextError={() => setUseImageFallback(true)}
+            onContextError={handleContextError}
           />
         )}
       </div>


### PR DESCRIPTION
### Motivation
- The WebGL cube in the beats stream was losing its rotation state and restarting whenever a new image frame or prop change caused the parent to re-render.  
- The reset was caused by passing a new inline `onContextError` callback each render, which could trigger reinitialization of the `StreamCube` scene.  

### Description
- Memoize the context-error handler using `useCallback` and pass the stable `handleContextError` to `StreamCube` to avoid changing the prop identity.  
- Update imports to include `useCallback` and replace the inline arrow function with the memoized `handleContextError` in `experimental/beats/src/components/stream.tsx`.  

### Testing
- Ran `make format` and the formatter completed without changes reported.  
- Ran `make test` and the suite completed successfully with `127 passed, 1 skipped` (duration ~15s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a9950bb588321a3dc79f8893db9d9)