### PR TITLE
Enable mypy strict mode in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ packages = [
 warn_unused_configs = true
 warn_unused_ignores = true
 check_untyped_defs = true
+strict = true
 color_output = false
 error_summary = false
 show_error_context = false


### PR DESCRIPTION
### Motivation
- Increase type-checking rigor by enabling strict mypy checks across the project to catch more issues at development time.
- Align static analysis with repository quality goals and make type expectations explicit in configuration.

### Description
- Add `strict = true` to the `[tool.mypy]` section in `pyproject.toml` to enable strict mypy mode.
- Commit the configuration change so CI and local runs will pick up the stricter settings.

### Testing
- Ran `make format`, which attempted to run the repository build but failed due to inability to fetch `uv-build` from PyPI (network/tunnel error).
- Ran `make test`, which also failed for the same reason while resolving build-system requirements for the project.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aa153de0c83219ee1545d985315c1)