### PR TITLE
Add Peripherals > Snapshots tab to Beats UI

### DIFF
--- a/docs/beats-peripheral-snapshots.md
+++ b/docs/beats-peripheral-snapshots.md
@@ -1,0 +1,12 @@
+# Beats peripheral snapshot tab
+
+## Overview
+
+The Beats renderer now includes a Peripherals > Snapshots tab that surfaces the most recent data payload captured for each connected peripheral. This fills the gap between the event log and the hierarchical tree view by providing a quick, per-peripheral snapshot of the latest payload, tag metadata, and update timestamp.
+
+## Materials
+
+- `experimental/beats/src/actions/ws/providers/PeripheralProvider.tsx`
+- `experimental/beats/src/actions/peripherals/peripheral_snapshots.tsx`
+- `experimental/beats/src/routes/peripherals/snapshots.tsx`
+- `experimental/beats/src/components/app-sidebar.tsx`

--- a/experimental/beats/src/actions/peripherals/peripheral_snapshots.tsx
+++ b/experimental/beats/src/actions/peripherals/peripheral_snapshots.tsx
@@ -1,0 +1,71 @@
+import { useConnectedPeripherals } from "../ws/providers/PeripheralProvider";
+
+function formatTimestamp(timestamp: number) {
+  return new Date(timestamp).toLocaleTimeString();
+}
+
+export function PeripheralSnapshots() {
+  const peripherals = useConnectedPeripherals();
+  const items = Object.entries(peripherals).sort(([, left], [, right]) => right.ts - left.ts);
+
+  return (
+    <div className="flex h-full flex-col select-none p-3">
+      <h2 className="text-sm font-bold mb-2 text-muted-foreground uppercase">
+        Latest Peripheral Data
+      </h2>
+
+      <div className="overflow-auto border rounded-md p-2 bg-black/20 max-h-screen overflow-y-auto scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-gray-100 mb-10">
+        {items.length === 0 ? (
+          <div className="text-xs text-muted-foreground">
+            No peripheral snapshots have been captured yet.
+          </div>
+        ) : (
+          <table className="w-full text-xs font-mono">
+            <thead className="text-muted-foreground border-b">
+              <tr>
+                <th className="py-1 px-2 text-left">Peripheral</th>
+                <th className="py-1 px-2 text-left">Last Update</th>
+                <th className="py-1 px-2 text-left">Tags</th>
+                <th className="py-1 px-2 text-left">Payload</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map(([id, peripheral]) => (
+                <tr
+                  key={id}
+                  className="hover:bg-white/5 border-b border-white/5 align-top"
+                >
+                  <td className="py-1 px-2 whitespace-nowrap">
+                    {peripheral.info.id ?? "unknown"}
+                  </td>
+                  <td className="py-1 px-2 whitespace-nowrap">
+                    {formatTimestamp(peripheral.ts)}
+                  </td>
+                  <td className="py-1 px-2">
+                    {peripheral.info.tags.length > 0 ? (
+                      <ul className="space-y-1">
+                        {peripheral.info.tags.map((tag, index) => (
+                          <li key={`${tag.name}-${index}`}>
+                            <span className="text-muted-foreground">{tag.variant}/</span>
+                            {tag.name}
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <span className="text-muted-foreground">No tags</span>
+                    )}
+                  </td>
+                  <td className="py-1 px-2">
+                    <pre className="whitespace-pre-wrap">
+                      {JSON.stringify(peripheral.last_data ?? {}, null, 2)}
+                    </pre>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/experimental/beats/src/actions/ws/providers/PeripheralProvider.tsx
+++ b/experimental/beats/src/actions/ws/providers/PeripheralProvider.tsx
@@ -30,6 +30,7 @@ export function PeripheralProvider({ children }: { children: React.ReactNode }) 
         [info.id]: {
           ts: Date.now(),
           info,
+          last_data: data,
         },
       }));
     });

--- a/experimental/beats/src/components/app-sidebar.tsx
+++ b/experimental/beats/src/components/app-sidebar.tsx
@@ -53,6 +53,10 @@ const items = {
                   title: "Events",
                   url: "/peripherals/events",
               },
+              {
+                  title: "Snapshots",
+                  url: "/peripherals/snapshots",
+              },
             ],
         },
     ]

--- a/experimental/beats/src/routes/peripherals/snapshots.tsx
+++ b/experimental/beats/src/routes/peripherals/snapshots.tsx
@@ -1,0 +1,10 @@
+import { PeripheralSnapshots } from "@/actions/peripherals/peripheral_snapshots";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/peripherals/snapshots")({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return <PeripheralSnapshots />;
+}


### PR DESCRIPTION
### Motivation
- Provide a quick, per-peripheral snapshot view that surfaces the most recent payload and metadata, filling the gap between the event log and hierarchical tree view.
- Persist the latest payload in the peripheral provider so UI views can display the most recent data without replaying event streams.

### Description
- Persist `last_data` in the peripheral map inside `experimental/beats/src/actions/ws/providers/PeripheralProvider.tsx` when peripheral messages arrive.
- Add a new `PeripheralSnapshots` component at `experimental/beats/src/actions/peripherals/peripheral_snapshots.tsx` that renders a table of peripherals with timestamp, tags, and payload.
- Register a new route at `experimental/beats/src/routes/peripherals/snapshots.tsx` and add the `Snapshots` entry to the Peripherals menu in `experimental/beats/src/components/app-sidebar.tsx`.
- Add user-facing documentation at `docs/beats-peripheral-snapshots.md` describing the new tab and its touchpoints.

### Testing
- Ran `make format` and the repository formatting checks passed.
- Ran `make test` and the test suite completed with `127 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aa18fae6083218669e0e40141f91c)