### PR TITLE
Improve firmware update harness validation

### DIFF
--- a/docs/research/firmware_update_harness.md
+++ b/docs/research/firmware_update_harness.md
@@ -1,0 +1,22 @@
+# Firmware update harness: configuration validation and file handling
+
+## Summary
+
+The firmware update harness in `src/heart/manage/update.py` now validates driver
+settings early, ensures required driver files exist before mounting devices, and
+uses portable filesystem operations in place of shell `cp`/`rm` calls. These
+changes reduce partial updates when settings are malformed or driver assets are
+missing, and they improve error messages for maintenance workflows.
+
+## Materials
+
+- `src/heart/manage/update.py`
+
+## Notes
+
+- `DriverConfig` centralizes parsing of `settings.toml` keys so missing values
+  fail fast with a clear list of required keys.
+- `_ensure_driver_files` verifies `boot.py`, `code.py`, and `settings.toml`
+  before any device copy steps, reducing partially configured devices.
+- `copy_file` and `load_driver_libs` now rely on `shutil` to keep filesystem
+  operations portable and reduce reliance on shell subprocesses.


### PR DESCRIPTION
### Motivation

- Harden the firmware update flow to avoid partially-applied driver updates when configuration or assets are malformed.
- Fail fast and give clearer diagnostics when required driver settings or files are missing.
- Replace fragile shell `cp`/`rm` behavior with portable Python filesystem operations for cross-platform reliability.
- Centralize parsing and validation of driver configuration to improve maintainability and testability.

### Description

- Add a `DriverConfig` dataclass and `_load_driver_config` helper to parse and validate `settings.toml` and fail fast on missing keys.  
- Introduce `_parse_board_id`, `_parse_csv`, and `_ensure_driver_files` plus constants `DRIVER_FILES` and `DRIVER_SETTINGS_FILENAME` to verify required assets (`boot.py`, `code.py`, `settings.toml`) before copying.  
- Replace subprocess-based file ops with `shutil` APIs (`shutil.rmtree`, `shutil.copytree`, `shutil.copy2`) and improve `copy_file` and `load_driver_libs` to use these portable operations.  
- Add documentation `docs/research/firmware_update_harness.md` that explains the changes and rationale.

### Testing

- Ran `make format` and the repository formatting/lint checks completed successfully.  
- Ran `make test` and the test suite completed with `127 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aa256ade88321820a8b8f346a3489)