### PR TITLE
Treat OPENGL like FULL when sizing renderer input surfaces

### DIFF
--- a/src/heart/renderers/__init__.py
+++ b/src/heart/renderers/__init__.py
@@ -57,12 +57,8 @@ class BaseRenderer:
             case DeviceDisplayMode.MIRRORED:
                 layout: Layout = orientation.layout
                 screen_size = (window_x // layout.columns, window_y // layout.rows)
-            case DeviceDisplayMode.FULL:
+            case DeviceDisplayMode.FULL | DeviceDisplayMode.OPENGL:
                 # The screen is the full size of the device
-                screen_size = (window_x, window_y)
-            case DeviceDisplayMode.OPENGL:
-                # todo: this is actually completely unused for this dispaly mode
-                #  so there's some smell here but providing this dummy val for now
                 screen_size = (window_x, window_y)
         screen = pygame.Surface(screen_size, pygame.SRCALPHA)
         return screen
@@ -291,12 +287,8 @@ class AtomicBaseRenderer(Generic[StateT]):
             case DeviceDisplayMode.MIRRORED:
                 layout: Layout = orientation.layout
                 screen_size = (window_x // layout.columns, window_y // layout.rows)
-            case DeviceDisplayMode.FULL:
+            case DeviceDisplayMode.FULL | DeviceDisplayMode.OPENGL:
                 # The screen is the full size of the device
-                screen_size = (window_x, window_y)
-            case DeviceDisplayMode.OPENGL:
-                # todo: this is actually completely unused for this dispaly mode
-                #  so there's some smell here but providing this dummy val for now
                 screen_size = (window_x, window_y)
         screen = pygame.Surface(screen_size, pygame.SRCALPHA)
         return screen
@@ -370,4 +362,3 @@ class StatefulBaseRenderer(AtomicBaseRenderer[StateT], Generic[StateT]):
             self._subscription.dispose()
             self._subscription = None
         super().reset()
-


### PR DESCRIPTION
### Motivation

- Simplify renderer input surface sizing by removing a redundant OpenGL-specific branch.
- Treat `DeviceDisplayMode.OPENGL` the same as `DeviceDisplayMode.FULL` because OpenGL renderers use the full device frame.
- Reduce code duplication and remove a misleading comment about the OPENGL path being unused.

### Description

- Updated `_get_input_screen` in `src/heart/renderers/__init__.py` for both `BaseRenderer` and `AtomicBaseRenderer` to use `case DeviceDisplayMode.FULL | DeviceDisplayMode.OPENGL` and removed the separate `OPENGL` branch.
- Kept the behavior of full-frame sizing intact by using `(window_x, window_y)` for both modes.
- No other functional changes were made.

### Testing

- Ran `make format`, which reported mypy/type-check issues in unrelated files and therefore failed (these are pre-existing errors, not introduced by this change). 
- Ran `make test`, which passed (`127 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aa41abd7c8321989cd5cf1ce8bfc1)