### PR TITLE
Improve firmware update harness validation

### DIFF
--- a/docs/research/firmware_update_harness.md
+++ b/docs/research/firmware_update_harness.md
@@ -2,11 +2,12 @@
 
 ## Summary
 
-The firmware update harness in `src/heart/manage/update.py` now validates driver
-settings early, ensures required driver files exist before mounting devices, and
-uses portable filesystem operations in place of shell `cp`/`rm` calls. These
-changes reduce partial updates when settings are malformed or driver assets are
-missing, and they improve error messages for maintenance workflows.
+The firmware update harness in `src/heart/manage/update.py` validates driver
+settings early, accepts both list and comma-delimited formats for driver
+libraries and board IDs, and confirms the media mount root exists before
+searching for CircuitPython volumes. These checks reduce partial updates when
+settings are malformed or removable storage is missing, while improving error
+messages for maintenance workflows.
 
 ## Materials
 
@@ -16,7 +17,9 @@ missing, and they improve error messages for maintenance workflows.
 
 - `DriverConfig` centralizes parsing of `settings.toml` keys so missing values
   fail fast with a clear list of required keys.
-- `_ensure_driver_files` verifies `boot.py`, `code.py`, and `settings.toml`
-  before any device copy steps, reducing partially configured devices.
-- `copy_file` and `load_driver_libs` now rely on `shutil` to keep filesystem
-  operations portable and reduce reliance on shell subprocesses.
+- `_parse_csv` now supports TOML list values alongside comma-separated strings,
+  keeping `CIRCUIT_PY_DRIVER_LIBS` and `VALID_BOARD_IDS` flexible for future
+  driver settings.
+- `_mount_points` validates the media root early and narrows the search to
+  directories, so missing volumes produce actionable errors before any file
+  copies begin.


### PR DESCRIPTION
### Motivation
- Harden the firmware update harness to fail fast on malformed driver settings and avoid partially-applied updates.
- Accept more flexible `settings.toml` input formats (TOML lists or comma-delimited strings) to reduce configuration friction.
- Ensure the removable-media root is present and enumerate only directories to avoid noisy errors when no volumes are mounted.
- Make validation and error messages more actionable for maintenance workflows.

### Description
- Replace the simple CSV parser with `_parse_csv(value, *, field_name)` that accepts both `list` and comma-delimited `str` inputs and normalizes entries.
- Add `_require_string()` and use it in `_load_driver_config()` so `CIRCUIT_PY_UF2_URL`, `CIRCUIT_PY_UF2_CHECKSUM`, and `CIRCUIT_PY_BOOT_NAME` are validated as non-empty strings, and surface validation errors cleanly.
- Add `_mount_points(media_directory)` to validate the media root exists and return only directory entries, then narrow CircuitPython scanning to these mount points.
- Update `docs/research/firmware_update_harness.md` to document the new validation behavior and supported input formats.

### Testing
- Ran formatting with `make format` and the formatter reported all checks passed.
- Ran the full test suite with `make test` and the automated tests completed successfully with `127 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aa415e3108321bc9889a39ca9a6b7)