### PR TITLE
Remove unused PhoneText fields

### DIFF
--- a/src/heart/peripheral/phone_text.py
+++ b/src/heart/peripheral/phone_text.py
@@ -12,9 +12,6 @@ from typing import Any, Self
 
 from heart.peripheral.core import Peripheral
 
-# Target iPhone information
-TARGET_DEVICE_NAME = "SEBASTIEN's iPhone"
-
 adapter: ModuleType | None
 bz_peripheral: ModuleType | None
 
@@ -44,7 +41,6 @@ class PhoneText(Peripheral[str]):
         self._last_text: str | None = None  # full text as received
         self.new_text = False
         self._buffer = bytearray()  # assembly buffer for chunks
-        self._producer_id = id(self)
 
     # ---------------------------------------------------------------------
     # Peripheral API


### PR DESCRIPTION
### Motivation
- Remove dead/unused code in the PhoneText peripheral to reduce maintenance burden and avoid confusing leftovers.
- The `TARGET_DEVICE_NAME` constant and the `self._producer_id` attribute were not referenced anywhere and served no runtime purpose.

### Description
- Deleted the `TARGET_DEVICE_NAME` constant from `src/heart/peripheral/phone_text.py`.
- Removed the unused `self._producer_id = id(self)` initialization from `PhoneText.__init__`.
- Applied repository formatting to the modified file using `make format`.
- No public API or runtime behaviour of `PhoneText` was otherwise changed.

### Testing
- Ran `make format`, which completed successfully.
- Ran `make test`, which completed successfully with `127 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aa6119b948321b850c358ef04c51d)