### PR TITLE
Remove dead-code guard from peripheral registry

### DIFF
--- a/src/heart/peripheral/registry.py
+++ b/src/heart/peripheral/registry.py
@@ -9,9 +9,6 @@ from typing import Callable
 
 from heart.peripheral.configuration import PeripheralConfiguration
 
-if False:  # pragma: no cover - for type checkers only
-    pass
-
 ConfigurationFactory = Callable[[], PeripheralConfiguration]
 
 


### PR DESCRIPTION
### Motivation

- Eliminate an unused defensive `if False: pass` guard that served no runtime or type-checking purpose.
- Keep the codebase clean and reduce misleading dead code in the peripheral configuration discovery logic.

### Description

- Removed the redundant `if False: pass` block from `src/heart/peripheral/registry.py`.
- Preserved the `ConfigurationFactory` alias and the `PeripheralConfigurationRegistry` behaviour that dynamically loads configuration modules.
- Change is limited to a single-file cleanup with no behaviour changes.

### Testing

- Ran `make format` and the formatter reported all checks passed.
- Executed `make test` which completed with `127 passed, 1 skipped`.
- No new tests were added or modified as this is a code cleanup only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aa6dce910832186999bb46e5f5e6b)