### PR TITLE
Add pre/post-sync hooks to `sync.sh` and document sync harness

### DIFF
--- a/docs/sync_harness.md
+++ b/docs/sync_harness.md
@@ -1,0 +1,51 @@
+# Synchronize a Build or Harness Workspace
+
+This guide explains how to use `sync.sh` to keep a local workspace aligned with a remote
+host while optionally running build or harness steps before and after each sync.
+
+## Materials
+
+- `rsync` installed locally.
+- Optional watcher:
+  - `fswatch` (macOS, Linux), or
+  - `inotifywait` (Linux via `inotify-tools`).
+- Optional `spellcheck` command available on `PATH`.
+- Optional `sshpass` when using `REMOTE_PASS` for password-based SSH.
+
+## Quick start
+
+Run a one-time sync of the current directory:
+
+```bash
+./sync.sh --once
+```
+
+Sync with a build step that runs before each upload:
+
+```bash
+./sync.sh --pre-sync "make build" --once
+```
+
+## Configure build and harness hooks
+
+Use pre- and post-sync hooks to add build or verification steps without editing the
+script. Hooks run from the source directory.
+
+| Option | Environment variable | Purpose |
+| --- | --- | --- |
+| `--pre-sync CMD` | `SYNC_PRE_SYNC_CMD` | Run a command before each sync. |
+| `--post-sync CMD` | `SYNC_POST_SYNC_CMD` | Run a command after each sync. |
+
+Example with environment variables:
+
+```bash
+export SYNC_PRE_SYNC_CMD="make format"
+export SYNC_POST_SYNC_CMD="make test"
+./sync.sh --once
+```
+
+## Notes
+
+- Use `--skip-spellcheck` if the `spellcheck` tool is not installed.
+- Use `--dry-run` to preview changes before syncing.
+- If a hook fails, the script exits with the hook's non-zero status.


### PR DESCRIPTION
### Motivation

- Provide a simple way to run build, test, or other harness commands around file synchronization to support iterative development workflows.
- Make it possible to perform pre-sync preparation (e.g. `make build`) and post-sync validation (e.g. `make test`) without editing the script.
- Surface configuration via both CLI flags and environment variables for CI and local use.

### Description

- Add `--pre-sync` and `--post-sync` CLI options to `sync.sh` and corresponding environment variables `SYNC_PRE_SYNC_CMD` and `SYNC_POST_SYNC_CMD`.
- Implement a `run_hook` helper that executes hooks from the source directory and invoke it before and after `run_rsync` in `sync_changes`.
- Preserve existing behaviour and flags while printing configured hook values at startup for visibility.
- Add `docs/sync_harness.md` documenting usage, required tools, and examples for hooking build/harness steps.

### Testing

- Ran `make format` to apply repository formatting rules and it completed successfully.
- Ran `make test` and the test suite completed successfully with `127 passed, 1 skipped`.
- Verified the modified `sync.sh` prints configured hooks and invokes pre/post hooks during a manual run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aa6ed661c83218a700cb66dc44bd2)