### PR TITLE
Centralize reactivex thread scheduling

### DIFF
--- a/docs/code_flow.md
+++ b/docs/code_flow.md
@@ -42,6 +42,7 @@ flowchart LR
     subgraph Inputs["Peripheral & Signal Services"]
         direction TB
         PeripheralMgr["PeripheralManager\n(background threads)"]
+        RxScheduler["Reactivex Thread Pool\n(shared scheduler)"]
         Switch["Switch / BluetoothSwitch"]
         Gamepad["Gamepad"]
         Sensors["Accelerometer / Phyphox"]
@@ -69,16 +70,16 @@ flowchart LR
     DisplaySvc --> Capture --> DeviceBridge --> LedMatrix
     Capture --> AverageMirror --> SingleLED
 
-    Loop --> PeripheralMgr
-    PeripheralMgr --> Switch --> AppRouter
-    PeripheralMgr --> Gamepad --> AppRouter
-    PeripheralMgr --> Sensors --> AppRouter
-    PeripheralMgr --> HeartRate --> AppRouter
-    PeripheralMgr --> PhoneText --> AppRouter
+    Loop --> PeripheralMgr --> RxScheduler
+    RxScheduler --> Switch --> AppRouter
+    RxScheduler --> Gamepad --> AppRouter
+    RxScheduler --> Sensors --> AppRouter
+    RxScheduler --> HeartRate --> AppRouter
+    RxScheduler --> PhoneText --> AppRouter
 
     class CLI,Registry,Configurer,ModeServices,FrameComposer service;
     class Loop,AppRouter orchestrator;
-    class PeripheralMgr,Switch,Gamepad,Sensors,HeartRate,PhoneText input;
+    class PeripheralMgr,RxScheduler,Switch,Gamepad,Sensors,HeartRate,PhoneText input;
     class DisplaySvc,LocalScreen,Capture,DeviceBridge,LedMatrix,AverageMirror,SingleLED output;
 ```
 

--- a/docs/research/reactivex_thread_management.md
+++ b/docs/research/reactivex_thread_management.md
@@ -1,0 +1,28 @@
+# Centralized reactivex thread management
+
+## Overview
+
+Reactive peripherals currently schedule background polling and IO work with
+per-subscription thread creation. This change introduces a shared scheduler so
+ReactiVex work runs on a single, named thread pool that is managed in one
+place, making thread usage easier to audit and tune.
+
+## Materials
+
+- `src/heart/utilities/reactivex_threads.py`
+- `src/heart/peripheral/keyboard.py`
+- `src/heart/peripheral/switch.py`
+- `src/heart/peripheral/gamepad/gamepad.py`
+
+## Implementation
+
+- `background_scheduler` in `src/heart/utilities/reactivex_threads.py` lazily
+  constructs a `ThreadPoolScheduler` backed by a named `ThreadPoolExecutor`.
+- Peripheral pollers now request the shared scheduler instead of instantiating
+  `NewThreadScheduler` directly, keeping reactivex thread creation centralized.
+
+## Expected impact
+
+Using a shared scheduler reduces scattered thread creation in input peripherals,
+while still allowing those observables to run asynchronously. The scheduler is
+now the single place to adjust thread pool sizing if future tuning is needed.

--- a/src/heart/peripheral/gamepad/gamepad.py
+++ b/src/heart/peripheral/gamepad/gamepad.py
@@ -10,11 +10,11 @@ import pygame.joystick
 import reactivex
 from pygame.event import Event
 from reactivex import operators as ops
-from reactivex.scheduler import NewThreadScheduler
 
 from heart.peripheral.core import Peripheral, events
 from heart.utilities.env import Configuration
 from heart.utilities.logging import get_logger
+from heart.utilities.reactivex_threads import background_scheduler
 
 logger = get_logger(__name__)
 
@@ -246,12 +246,13 @@ class Gamepad(Peripheral[Any]):
         time.sleep(1.5)
 
         # check every 1 second for controller state, so that we can attempt to connect
-        reactivex.interval(timedelta(seconds=1)).subscribe(
+        scheduler = background_scheduler()
+        reactivex.interval(timedelta(seconds=1), scheduler=scheduler).subscribe(
             on_next=self._read_from_gamepad,
-            scheduler=NewThreadScheduler()
+            scheduler=scheduler,
         )
 
         # Query the controller state frequently
-        reactivex.interval(timedelta(milliseconds=20)).pipe(
-            ops.observe_on(NewThreadScheduler()),
+        reactivex.interval(timedelta(milliseconds=20), scheduler=scheduler).pipe(
+            ops.observe_on(scheduler),
         ).subscribe(on_next=lambda x: self._update())

--- a/src/heart/peripheral/keyboard.py
+++ b/src/heart/peripheral/keyboard.py
@@ -7,10 +7,10 @@ from typing import Any, Iterator, Self, cast
 import pygame
 import reactivex
 from reactivex import operators as ops
-from reactivex.scheduler import NewThreadScheduler
 
 from heart.peripheral.core import Peripheral
 from heart.utilities.env import Configuration
+from heart.utilities.reactivex_threads import background_scheduler
 
 
 @dataclass
@@ -32,10 +32,13 @@ class KeyboardKey(Peripheral[KeyTimeline]):
 
         # Start running the key checker
         if not (Configuration.is_pi() and not Configuration.is_x11_forward()):
-            check_for_input = reactivex.interval(timedelta(milliseconds=10))
+            scheduler = background_scheduler()
+            check_for_input = reactivex.interval(
+                timedelta(milliseconds=10), scheduler=scheduler
+            )
             check_for_input.subscribe(
                 on_next=lambda _: self._check_if_pressed(),
-                scheduler=NewThreadScheduler()
+                scheduler=scheduler,
             )
 
     @classmethod

--- a/src/heart/peripheral/switch.py
+++ b/src/heart/peripheral/switch.py
@@ -12,13 +12,13 @@ from reactivex import create
 from reactivex import operators as ops
 from reactivex.abc import ObserverBase, SchedulerBase
 from reactivex.disposable import Disposable
-from reactivex.scheduler import NewThreadScheduler
 
 from heart.peripheral.bluetooth import UartListener
 from heart.peripheral.core import Peripheral, PeripheralInfo, PeripheralTag
 from heart.peripheral.keyboard import KeyboardKey
 from heart.utilities.env import Configuration, get_device_ports
 from heart.utilities.logging import get_logger
+from heart.utilities.reactivex_threads import background_scheduler
 
 logger = get_logger(__name__)
 
@@ -177,7 +177,7 @@ class Switch(BaseSwitch):
         source = create(self._read_from_switch)
         source.subscribe(
             on_next=self.update_due_to_data,
-            scheduler=NewThreadScheduler()
+            scheduler=background_scheduler(),
         )
 
 class BluetoothSwitch(BaseSwitch):

--- a/src/heart/utilities/reactivex_threads.py
+++ b/src/heart/utilities/reactivex_threads.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Lock
+
+from reactivex.scheduler import ThreadPoolScheduler
+
+_SCHEDULER_LOCK = Lock()
+_SCHEDULER: ThreadPoolScheduler | None = None
+_EXECUTOR: ThreadPoolExecutor | None = None
+
+
+def background_scheduler(max_workers: int = 4) -> ThreadPoolScheduler:
+    """Return the shared scheduler for background reactivex work."""
+    global _SCHEDULER, _EXECUTOR
+    if _SCHEDULER is None:
+        with _SCHEDULER_LOCK:
+            if _SCHEDULER is None:
+                _EXECUTOR = ThreadPoolExecutor(
+                    max_workers=max_workers,
+                    thread_name_prefix="heart-rx",
+                )
+                _SCHEDULER = ThreadPoolScheduler(_EXECUTOR)
+    return _SCHEDULER


### PR DESCRIPTION
### Motivation

- Reduce scattered per-subscription thread creation for ReactiVex-based background work by providing a single place to manage thread resources. 
- Make background threading behaviour easier to audit and tune by using a named thread pool instead of `NewThreadScheduler` per call site. 
- Improve consistency across input peripherals (keyboard, switch, gamepad) so their polling/IO runs on a shared scheduler. 

### Description

- Add a shared scheduler utility `background_scheduler()` in `src/heart/utilities/reactivex_threads.py` that lazily constructs a `ThreadPoolScheduler` backed by a `ThreadPoolExecutor`. 
- Update `src/heart/peripheral/keyboard.py`, `src/heart/peripheral/switch.py`, and `src/heart/peripheral/gamepad/gamepad.py` to use `background_scheduler()` for interval and subscription scheduling instead of creating `NewThreadScheduler` instances. 
- Add documentation `docs/research/reactivex_thread_management.md` describing the change and update the runtime diagram in `docs/code_flow.md`, then regenerate `docs/code_flow.svg` with `scripts/render_code_flow.py`. 

### Testing

- Ran `make format` to apply repository formatting rules, which completed successfully. 
- Regenerated the runtime diagram with `python scripts/render_code_flow.py --output docs/code_flow.svg` without errors. 
- Ran the test suite with `make test`, which completed with `127 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aa7541078832199bb996368bc3a50)