### PR TITLE
Remove unused magnetometer stub

### DIFF
--- a/src/heart/firmware_io/accel.py
+++ b/src/heart/firmware_io/accel.py
@@ -58,7 +58,6 @@ class SensorReader:
 
         self._last_accel: tuple | None = None
         self._last_gyro: tuple | None = None
-        self._last_mag: tuple | None = None
 
     def read(self):
         for sensor in self.sensors:
@@ -74,13 +73,6 @@ class SensorReader:
                 if self._changed_enough(gyro, self._last_gyro, self.min_change):
                     self._last_gyro = gyro
                     yield form_tuple_payload(constants.GYROSCOPE, gyro)
-
-            # TODO: Can be turned on when we have a use for it
-            # if hasattr(sensor, "magnetic"):
-            #     mag = sensor.magnetic
-            #     if self._changed_enough(mag, self._last_mag, self.min_change):
-            #         self._last_mag = mag
-            # yield form_tuple_payload(constants.MAGNETIC, mag)
 
     def _changed_enough(self, new: tuple, old: tuple | None, min_change: float) -> bool:
         """Return *True* if any axis differs by more than *min_change*."""


### PR DESCRIPTION
### Motivation
- Remove dead magnetometer state and unused commented code to reduce maintenance noise and clarify `SensorReader` responsibilities.
- The magnetometer code was only present as a commented stub and the `_last_mag` field was never used.

### Description
- Deleted the unused `_last_mag` attribute from `SensorReader` in `src/heart/firmware_io/accel.py`.
- Removed the commented-out magnetometer read and emit logic from `SensorReader.read`.
- Re-formatted the code with `make format` to keep style consistent.

### Testing
- Ran `make format` which completed successfully.
- Ran `make test` and the test suite completed successfully with `127 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aa91642988321bc583c7ddc3fd654)