### PR TITLE
Add locking to sync harness

### DIFF
--- a/docs/research/sync_harness_locking.md
+++ b/docs/research/sync_harness_locking.md
@@ -1,0 +1,17 @@
+# Sync harness locking for overlapping triggers
+
+## Summary
+
+The sync harness in `sync.sh` now serializes sync runs with a lock keyed to the
+source and destination paths. When multiple filesystem events fire in quick
+succession, the lock prevents overlapping builds or rsync transfers and logs a
+skip instead.
+
+## Materials
+
+- `sync.sh`
+
+## Notes
+
+- `flock` is used when available to hold a per-sync lock file.
+- When `flock` is unavailable, the script falls back to a directory-based lock.

--- a/docs/sync_harness.md
+++ b/docs/sync_harness.md
@@ -11,6 +11,7 @@ host while optionally running build or harness steps before and after each sync.
   - `inotifywait` (Linux via `inotify-tools`).
 - Optional `spellcheck` command available on `PATH`.
 - Optional `sshpass` when using `REMOTE_PASS` for password-based SSH.
+- Optional `flock` (or a filesystem that supports directory locks) to prevent overlapping sync runs.
 
 ## Quick start
 
@@ -49,3 +50,5 @@ export SYNC_POST_SYNC_CMD="make test"
 - Use `--skip-spellcheck` if the `spellcheck` tool is not installed.
 - Use `--dry-run` to preview changes before syncing.
 - If a hook fails, the script exits with the hook's non-zero status.
+- Overlapping sync triggers are de-duplicated; a running sync holds a lock so the next
+  event logs a skip instead of running concurrently.


### PR DESCRIPTION
### Motivation

- Prevent overlapping sync runs from executing concurrent `rsync` transfers and pre/post hooks when file-watcher events fire in quick succession.
- Reduce risk of partial or conflicting builds by serializing sync operations for a given source/destination pair.
- Surface a clear, observable skip when a run is already in progress instead of attempting concurrent work.
- Record the design and behaviour in documentation so maintainers understand the locking fallback strategy.

### Description

- Compute a per-source/destination lock identifier with `cksum` and derive a lock path under `${TMPDIR:-/tmp}` as `heart-sync-<id>.lock`.
- Add a `with_lock` helper that uses `flock` if available and falls back to an atomic directory-based lock with `trap` cleanup, and introduce `_sync_once` to hold the critical section.
- Update `sync.sh` to call `with_lock _sync_once` so runs are de-duplicated and log a skip when another sync holds the lock.
- Update `docs/sync_harness.md` and add `docs/research/sync_harness_locking.md` describing the lock behaviour and fallback.

### Testing

- Ran `make test` and the test suite completed successfully with `127 passed, 1 skipped`.
- Ran `make format` which failed due to a `mypy` type-check error in `src/heart/utilities/reactivex_threads.py:23` that is unrelated to the sync harness changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aa91e83348321a311a6774f03a56f)