### PR TITLE
Remove unused GamepadState stub

### DIFF
--- a/src/heart/peripheral/gamepad/gamepad.py
+++ b/src/heart/peripheral/gamepad/gamepad.py
@@ -1,7 +1,6 @@
 import subprocess
 import time
 from collections import defaultdict
-from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
 from typing import Any, Iterator, Self
@@ -24,10 +23,6 @@ class GamepadIdentifier(Enum):
     # so check that first when adding a controller type
     BIT_DO_LITE_2 = "8BitDo Lite 2"
     SWITCH_PRO = "Nintendo Switch Pro Controller"
-
-@dataclass
-class GamepadState:
-    pass
 
 class Gamepad(Peripheral[Any]):
     EVENT_BUTTON = "gamepad.button"


### PR DESCRIPTION
### Motivation
- Remove dead code that served no runtime purpose and introduced an unnecessary dependency on `dataclasses`.
- Reduce maintenance burden and avoid confusion from an unused `GamepadState` placeholder.

### Description
- Delete the `GamepadState` dataclass stub from `src/heart/peripheral/gamepad/gamepad.py`.
- Remove the now-unneeded `dataclasses` import from the same module.
- Leave the functional `Gamepad` implementation unchanged aside from the dead-code removal.

### Testing
- Ran `make format` which completed successfully.
- Ran `make test` which resulted in `127 passed, 1 skipped` and no failures.
- Verified the module still imports cleanly and the repository lint/format checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aaa4e3f248321afdd0d7537160a39)