### PR TITLE
Remove unused renderer scaffolding from GameLoop

### DIFF
--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -16,8 +16,6 @@ from PIL import Image
 
 from heart import DeviceDisplayMode
 from heart.device import Device
-# from heart.renderers.flame import FlameRenderer
-# from heart.renderers.free_text import FreeTextRenderer
 from heart.device.beats import WebSocket
 from heart.navigation import AppController, ComposedRenderer, MultiScene
 from heart.peripheral.core import events
@@ -302,18 +300,10 @@ class GameLoop:
 
         self._active_mode_index = 0
 
-        # Phone text display state
-        self._phone_text_display_started_at: float | None = None
-        self._phone_text_duration = 5.0  # Display phone text for 5 seconds
-        # self._phone_text_renderer: FreeTextRenderer | None = None
-
         # Lampe controller
         self.feedback_buffer: np.ndarray | None = None
         self.tmp_float: np.ndarray | None = None
         self.edge_thresh = 1
-
-        # self._flame_renderer: FlameRenderer | None = None
-        self._flame_bpm_threshold = 150.0
 
         pygame.display.set_mode(
             (
@@ -398,71 +388,10 @@ class GameLoop:
         self.clock = clock
         self.peripheral_manager.clock.on_next(self.clock)
 
-
-    # def _on_phone_text_message(self, _: "Input") -> None:
-    #     self._phone_text_display_started_at = time.monotonic()
-    #     self._ensure_phone_text_renderer()
-
-    # def _ensure_phone_text_renderer(self) -> FreeTextRenderer:
-    #     if self._phone_text_renderer is None:
-    #         self._phone_text_renderer = FreeTextRenderer()
-    #     return self._phone_text_renderer
-
-    # def _ensure_flame_renderer(self) -> FlameRenderer:
-    #     if self._flame_renderer is None:
-    #         self._flame_renderer = FlameRenderer()
-    #         setattr(self._flame_renderer, "is_flame_renderer", True)
-    #     return self._flame_renderer
-
     def _select_renderers(self) -> list["BaseRenderer"]:
-        # if self._should_show_phone_text():
-        #     return [self._ensure_phone_text_renderer()]
-
         base_renderers = self.app_controller.get_renderers()
         renderers = list(base_renderers) if base_renderers else []
-        # if self._should_add_flame_renderer(renderers):
-        #     renderers.append(self._ensure_flame_renderer())
         return renderers
-
-    # def _should_show_phone_text(self) -> bool:
-    #     if self._phone_text_display_started_at is None:
-    #         return False
-    #     elapsed = time.monotonic() - self._phone_text_display_started_at
-    #     if elapsed > self._phone_text_duration:
-    #         self._phone_text_display_started_at = None
-    #         return False
-    #     return True
-
-    # def _should_add_flame_renderer(
-    #     self, renderers: list["BaseRenderer"]
-    # ) -> bool:
-    #     if any(self._is_flame_renderer(renderer) for renderer in renderers):
-    #         return False
-
-    #     entries: Any = {}
-
-    #     if len(entries) < 5:
-    #         return False
-
-    #     bpm_values: list[int] = []
-    #     for entry in entries.values():
-    #         data = entry.data
-    #         if isinstance(data, Mapping):
-    #             bpm = data.get("bpm")
-    #             if isinstance(bpm, (int, float)) and bpm > 0:
-    #                 bpm_values.append(int(bpm))
-
-    #     if len(bpm_values) < 5:
-    #         return False
-
-    #     average_bpm = sum(bpm_values) / len(bpm_values)
-    #     return average_bpm > self._flame_bpm_threshold
-
-    # @staticmethod
-    # def _is_flame_renderer(renderer: "BaseRenderer") -> bool:
-    #     if getattr(renderer, "is_flame_renderer", False):
-    #         return True
-    #     # return isinstance(renderer, FlameRenderer)
 
     def process_renderer(self, renderer: "BaseRenderer") -> pygame.Surface | None:
         clock = self.clock


### PR DESCRIPTION
### Motivation

- Remove dead/commented renderer scaffolding and unused state from the `GameLoop` implementation to reduce noise and maintenance burden.
- Eliminate outdated references to `FlameRenderer` and `FreeTextRenderer` and the phone-text display state that are not exercised by the codebase.

### Description

- Deleted commented imports for `FlameRenderer` and `FreeTextRenderer` and removed the phone-text and flame-related state fields from `src/heart/environment.py`.
- Removed commented helper methods and checks (`_on_phone_text_message`, `_ensure_phone_text_renderer`, `_ensure_flame_renderer`, `_should_show_phone_text`, `_should_add_flame_renderer`, and `_is_flame_renderer`) and cleared the related commented branches in `_select_renderers`.
- Kept runtime behavior unchanged; this is a removal of dead code and scaffolding only.

### Testing

- Ran `make format` to apply repository formatting rules and it completed successfully.
- Ran `make test` and the test suite passed with `127 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aab25a9748321a5ab15f6d4d5cd70)