### PR TITLE
Support multiple pre/post sync hooks in sync harness

### DIFF
--- a/docs/sync_harness.md
+++ b/docs/sync_harness.md
@@ -34,8 +34,8 @@ script. Hooks run from the source directory.
 
 | Option | Environment variable | Purpose |
 | --- | --- | --- |
-| `--pre-sync CMD` | `SYNC_PRE_SYNC_CMD` | Run a command before each sync. |
-| `--post-sync CMD` | `SYNC_POST_SYNC_CMD` | Run a command after each sync. |
+| `--pre-sync CMD` | `SYNC_PRE_SYNC_CMD` | Run a command before each sync. Repeat the option to run multiple commands. |
+| `--post-sync CMD` | `SYNC_POST_SYNC_CMD` | Run a command after each sync. Repeat the option to run multiple commands. |
 
 Example with environment variables:
 
@@ -43,6 +43,13 @@ Example with environment variables:
 export SYNC_PRE_SYNC_CMD="make format"
 export SYNC_POST_SYNC_CMD="make test"
 ./sync.sh --once
+```
+
+Example with multiple hooks:
+
+```bash
+./sync.sh --pre-sync "make format" --pre-sync "make build" \
+  --post-sync "make test" --post-sync "scripts/check_harness.sh" --once
 ```
 
 ## Notes


### PR DESCRIPTION
### Motivation
- Allow the sync harness to run multiple build or verification steps before and after each rsync run to better support complex build workflows.
- Make it possible to specify several hooks via CLI or environment variables so users can compose formatting, build, and test commands without editing the script.

### Description
- Updated `sync.sh` to accept repeated `--pre-sync` and `--post-sync` options and to read `SYNC_PRE_SYNC_CMD` / `SYNC_POST_SYNC_CMD` into arrays (`PRE_SYNC_CMDS` / `POST_SYNC_CMDS`).
- Added `run_hooks` which executes multiple hook commands sequentially from the source directory and replaced single-hook calls with this new function in `_sync_once`.
- Extended the help text in `sync.sh` and updated `docs/sync_harness.md` with guidance and an example showing multiple hooks.
- Preserved existing behaviour for spellcheck, locking, and rsync flags while printing each configured hook on startup for visibility.

### Testing
- Ran `make test` and the full Pytest suite completed with `127 passed, 1 skipped`.
- Ran formatting/type checks with `make format` which reported type errors from the static checker in `src/heart/utilities/reactivex_threads.py` and therefore did not fully succeed.
- Verified the modified `sync.sh` exercises multiple hooks locally by invoking `--pre-sync`/`--post-sync` multiple times during manual runs (examples added to docs).
- Ensured the repository was formatted with the project tooling where possible before committing the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aab3011d483218cc8fd8ddb0a53c5)