### PR TITLE
Fix reactivex scheduler typing

### DIFF
--- a/src/heart/utilities/reactivex_threads.py
+++ b/src/heart/utilities/reactivex_threads.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 from threading import Lock
+from typing import Any, cast
 
 from reactivex.scheduler import ThreadPoolScheduler
 
@@ -26,11 +27,13 @@ def background_scheduler(max_workers: int | None = None) -> ThreadPoolScheduler:
                     if max_workers is not None
                     else Configuration.reactivex_background_max_workers()
                 )
-                _EXECUTOR = ThreadPoolExecutor(
+                executor = ThreadPoolExecutor(
                     max_workers=resolved_workers,
                     thread_name_prefix="heart-rx",
                 )
-                _SCHEDULER = ThreadPoolScheduler(_EXECUTOR)
+                _EXECUTOR = executor
+                _SCHEDULER = ThreadPoolScheduler(cast(Any, executor))
+    assert _SCHEDULER is not None
     return _SCHEDULER
 
 
@@ -45,9 +48,11 @@ def input_scheduler(max_workers: int | None = None) -> ThreadPoolScheduler:
                     if max_workers is not None
                     else Configuration.reactivex_input_max_workers()
                 )
-                _INPUT_EXECUTOR = ThreadPoolExecutor(
+                executor = ThreadPoolExecutor(
                     max_workers=resolved_workers,
                     thread_name_prefix="heart-rx-input",
                 )
-                _INPUT_SCHEDULER = ThreadPoolScheduler(_INPUT_EXECUTOR)
+                _INPUT_EXECUTOR = executor
+                _INPUT_SCHEDULER = ThreadPoolScheduler(cast(Any, executor))
+    assert _INPUT_SCHEDULER is not None
     return _INPUT_SCHEDULER


### PR DESCRIPTION
### Motivation
- Resolve Pyright type errors raised from constructing `ThreadPoolScheduler` with a `ThreadPoolExecutor` in `src/heart/utilities/reactivex_threads.py`.
- Ensure the shared scheduler factories return non-`None` typed values for callers and static analysis.
- Centralize the executor creation pattern to make typing and runtime behaviour clearer.

### Description
- Import `Any` and `cast` from `typing` and use a local `executor` variable when creating the `ThreadPoolExecutor` to satisfy type checking.
- Assign the module-level `_EXECUTOR` / `_INPUT_EXECUTOR` from the local `executor` and construct `ThreadPoolScheduler` with `cast(Any, executor)` to avoid type mismatch errors.
- Add `assert` statements before returning from `background_scheduler` and `input_scheduler` to communicate non-`None` return values to the type checker.
- Changes applied in `src/heart/utilities/reactivex_threads.py` only.

### Testing
- Ran `make format` and formatting checks completed successfully.
- Ran `make test` and the test suite completed with `127 passed, 1 skipped`.
- No additional automated tests were added or modified for this change.
- All automated checks reported as succeeding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aac55ab508321bfe8d35fffece49a)