### PR TITLE
Refactor channel diffusion: move state updates to provider

### DIFF
--- a/docs/research/channel_diffusion_renderer_roles.md
+++ b/docs/research/channel_diffusion_renderer_roles.md
@@ -1,0 +1,20 @@
+# Channel diffusion renderer role split
+
+## Summary
+
+Channel diffusion rendering now separates state updates from pixel output. The
+state update logic lives in a provider, while the renderer focuses on converting
+the current state grid into pixels for the display surface.
+
+## Notes
+
+- State initialization and diffusion updates moved into
+  `heart.renderers.channel_diffusion.provider.ChannelDiffusionStateProvider`.
+- `heart.renderers.channel_diffusion.renderer.ChannelDiffusionRenderer` now
+  delegates state updates to the provider before blitting pixels.
+
+## Materials
+
+- `src/heart/renderers/channel_diffusion/provider.py`
+- `src/heart/renderers/channel_diffusion/renderer.py`
+- `src/heart/renderers/channel_diffusion/state.py`

--- a/src/heart/renderers/channel_diffusion/__init__.py
+++ b/src/heart/renderers/channel_diffusion/__init__.py
@@ -1,3 +1,5 @@
+from heart.renderers.channel_diffusion.provider import \
+    ChannelDiffusionStateProvider  # noqa: F401
 from heart.renderers.channel_diffusion.renderer import \
     ChannelDiffusionRenderer  # noqa: F401
 from heart.renderers.channel_diffusion.state import \

--- a/src/heart/renderers/channel_diffusion/provider.py
+++ b/src/heart/renderers/channel_diffusion/provider.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import numpy as np
+
+from heart.renderers.channel_diffusion.state import ChannelDiffusionState
+
+
+class ChannelDiffusionStateProvider:
+    def initial_state(self, *, width: int, height: int) -> ChannelDiffusionState:
+        grid = np.zeros((width, height, 3), dtype=np.uint8)
+        grid[width // 2, height // 2] = np.array([255, 255, 255], dtype=np.uint8)
+        return ChannelDiffusionState(grid=grid)
+
+    def next_state(self, state: ChannelDiffusionState) -> ChannelDiffusionState:
+        grid = state.grid.astype(np.int32)
+
+        red = grid[:, :, 0]
+        green = grid[:, :, 1]
+        blue = grid[:, :, 2]
+
+        new_grid = np.zeros_like(grid)
+
+        center = self._compute_center_after_fade(grid)
+        new_grid += center
+
+        new_grid[:, :-1, 1] += green[:, 1:]
+        new_grid[:, 1:, 1] += green[:, :-1]
+
+        new_grid[:-1, :, 2] += blue[1:, :]
+        new_grid[1:, :, 2] += blue[:-1, :]
+
+        new_grid[:-1, :-1, 0] += red[1:, 1:]
+        new_grid[1:, :-1, 0] += red[:-1, 1:]
+        new_grid[:-1, 1:, 0] += red[1:, :-1]
+        new_grid[1:, 1:, 0] += red[:-1, :-1]
+
+        clipped_grid = np.clip(new_grid, 0, 255).astype(np.uint8)
+        return ChannelDiffusionState(grid=clipped_grid)
+
+    def _compute_center_after_fade(self, grid: np.ndarray) -> np.ndarray:
+        brightness = grid.max(axis=2)
+        return grid - (brightness // 2)[:, :, None]


### PR DESCRIPTION
### Motivation
- Ensure renderers only convert state to pixels while state logic and event-driven updates live elsewhere.  
- Make `state` objects the single source of truth for renderer data snapshots.  
- Move channel-diffusion update logic into a provider so it can be reused, tested, and observed independently.  

### Description
- Add `ChannelDiffusionStateProvider` in `src/heart/renderers/channel_diffusion/provider.py` with `initial_state`, `next_state`, and `_compute_center_after_fade`.  
- Update `ChannelDiffusionRenderer` in `src/heart/renderers/channel_diffusion/renderer.py` to accept a provider, delegate initialization to `provider.initial_state`, call `provider.next_state` for updates, and only blit the current `grid` to the surface.  
- Export the provider from `src/heart/renderers/channel_diffusion/__init__.py` and add a research note at `docs/research/channel_diffusion_renderer_roles.md` describing the role split.  
- Apply code formatting changes via the repository tooling (`make format`).  

### Testing
- Ran `make format` and formatting checks completed successfully.  
- Ran the test suite with `make test` and observed `127 passed, 1 skipped`.  
- The channel diffusion behavior is covered by `tests/display/test_channel_diffusion_renderer.py` which now passes.  
- No new automated tests were added in this PR; changes preserved existing coverage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aaba8b3308321a736f99121475469)