### PR TITLE
Remove unused mandelbrot scene fields

### DIFF
--- a/src/heart/renderers/mandelbrot/scene.py
+++ b/src/heart/renderers/mandelbrot/scene.py
@@ -11,7 +11,7 @@ import numpy as np
 import pygame
 from numba import jit, prange
 
-from heart.device import Cube, Layout, Orientation, Rectangle
+from heart.device import Cube, Orientation, Rectangle
 from heart.environment import DeviceDisplayMode
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.gamepad import GamepadIdentifier
@@ -38,9 +38,6 @@ class MandelbrotMode(BaseRenderer):
         self.individual_screen_width: int | None = None
         self.individual_screen_height: int | None = None
         self.screens: dict[tuple[int, int], pygame.Surface] = {}
-        self.layout: Layout | None = None
-        self.orientation: Orientation | None = None
-
         # sharable app state
         self.state: AppState | None = None
         self.palettes = self._generate_palettes()
@@ -56,8 +53,6 @@ class MandelbrotMode(BaseRenderer):
             -0.7446419526560056,
             0.11883810795259032,
         )
-        self.last_switch_value = None
-
         # input properties
         self.time_initialized = None
         self.gamepad = None
@@ -81,7 +76,6 @@ class MandelbrotMode(BaseRenderer):
         self.clock = clock
         self.height = window.get_height()
         self.width = window.get_width()
-        self.layout = orientation.layout
         screen_cols = orientation.layout.columns
         screen_rows = orientation.layout.rows
         self.screens = {


### PR DESCRIPTION
### Motivation

- Remove dead/unused state in the Mandelbrot renderer to reduce surface area and avoid misleading fields.
- Eliminate a redundant assignment that duplicated information already available via the `orientation` parameter.
- Simplify imports by dropping an unused `Layout` symbol.

### Description

- Deleted unused attributes `self.layout`, `self.orientation`, and `self.last_switch_value` from `MandelbrotMode` in `src/heart/renderers/mandelbrot/scene.py`.
- Removed the redundant `self.layout = orientation.layout` assignment in `initialize` and adjusted code to read `orientation.layout` directly.
- Tidied the import line by removing `Layout` from `from heart.device import ...`.
- Changes are limited to `src/heart/renderers/mandelbrot/scene.py` and do not alter runtime behaviour.

### Testing

- Ran `make format` and the formatter reported all checks passed.
- Ran the test suite with `make test` and observed: `127 passed, 1 skipped`.
- No new tests were added or modified.
- All automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aad84104c83218a8be259a63a5c0a)