### PR TITLE
Remove unused `_norm` helper from water_cube state

### DIFF
--- a/src/heart/modules/water_cube/state.py
+++ b/src/heart/modules/water_cube/state.py
@@ -1,4 +1,3 @@
-import math
 from dataclasses import dataclass
 from typing import Self, Tuple
 
@@ -25,13 +24,6 @@ _centre = (GRID - 1) / 2.0
 X_COORDS, Y_COORDS = np.meshgrid(np.arange(GRID), np.arange(GRID), indexing="ij")
 DX = X_COORDS - _centre
 DY = Y_COORDS - _centre
-
-
-def _norm(v: tuple[float, float, float]) -> tuple[float, float, float]:
-    length = math.hypot(v[0], v[1]) + abs(v[2])
-    if length == 0:
-        return (0.0, 0.0, 0.0)
-    return (v[0] / length, v[1] / length, v[2] / length)
 
 
 def _target_plane(g: Tuple[float, float, float]) -> np.ndarray:


### PR DESCRIPTION
### Motivation
- Remove dead/unused code in the water cube state module to reduce maintenance surface.
- The `_norm` helper and its `math` import were not referenced elsewhere and added noise to the file.

### Description
- Delete the unused `_norm` function from `src/heart/modules/water_cube/state.py`.
- Remove the now-unused `math` import from the same module.
- Run repository formatting to apply style fixes via `make format`.

### Testing
- Ran `make format` and it completed successfully.
- Ran the full test suite with `make test` and all tests passed (`127 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aae724d6483219fca9a3ed47e69fb)