### PR TITLE
Refactor random pixel renderer state flow

### DIFF
--- a/docs/research/random_pixel_renderer_roles.md
+++ b/docs/research/random_pixel_renderer_roles.md
@@ -1,0 +1,22 @@
+# Random pixel renderer role separation
+
+The random pixel renderer mixed responsibilities by generating pixel positions
+and per-frame colors inside the renderer. That made the renderer own state
+mutation instead of limiting it to drawing. The renderer has been adjusted so
+pixel locations and color are emitted from the provider and stored in state,
+while the renderer only turns that state into pixels.
+
+## Notes
+
+- `RandomPixelStateProvider` now subscribes to the game tick stream and emits
+  updated pixel coordinates (and random colors when no fixed color is set).
+- `RandomPixelState` stores the current pixel coordinates alongside the color
+  for the frame.
+- `RandomPixel` renders whatever coordinates and color are in state without
+  computing new positions at draw time.
+
+## Sources
+
+- `src/heart/renderers/random_pixel/provider.py`
+- `src/heart/renderers/random_pixel/state.py`
+- `src/heart/renderers/random_pixel/renderer.py`

--- a/src/heart/renderers/random_pixel/provider.py
+++ b/src/heart/renderers/random_pixel/provider.py
@@ -1,22 +1,70 @@
 from __future__ import annotations
 
+import random
 from dataclasses import replace
 
 import reactivex
+from reactivex import operators as ops
 from reactivex.subject import BehaviorSubject
 
 from heart.display.color import Color
+from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import ObservableProvider
 from heart.renderers.random_pixel.state import RandomPixelState
 
 
 class RandomPixelStateProvider(ObservableProvider[RandomPixelState]):
-    def __init__(self, initial_color: Color | None = None) -> None:
-        self._state = BehaviorSubject(RandomPixelState(color=initial_color))
+    def __init__(
+        self,
+        *,
+        width: int,
+        height: int,
+        num_pixels: int,
+        peripheral_manager: PeripheralManager,
+        initial_color: Color | None = None,
+        rng: random.Random | None = None,
+    ) -> None:
+        self._width = width
+        self._height = height
+        self._num_pixels = num_pixels
+        self._peripheral_manager = peripheral_manager
+        self._rng = rng or random.Random()
+        self._color = BehaviorSubject(initial_color)
 
     def observable(self) -> reactivex.Observable[RandomPixelState]:
-        return self._state
+        initial_color = self._color.value or Color.random()
+        initial_state = RandomPixelState(
+            color=initial_color, pixels=self._random_pixels()
+        )
+
+        color_updates = self._color.pipe(
+            ops.map(lambda color: ("color", color)),
+        )
+        tick_updates = self._peripheral_manager.game_tick.pipe(
+            ops.map(lambda _: ("tick", None)),
+        )
+
+        return reactivex.merge(color_updates, tick_updates).pipe(
+            ops.scan(self._advance_state, seed=initial_state),
+            ops.share(),
+        )
 
     def set_color(self, color: Color | None) -> None:
-        current_state = self._state.value
-        self._state.on_next(replace(current_state, color=color))
+        self._color.on_next(color)
+
+    def _advance_state(
+        self, state: RandomPixelState, event: tuple[str, Color | None]
+    ) -> RandomPixelState:
+        kind, value = event
+        if kind == "color":
+            next_color = value or Color.random()
+            return replace(state, color=next_color)
+
+        next_color = self._color.value or Color.random()
+        return RandomPixelState(color=next_color, pixels=self._random_pixels())
+
+    def _random_pixels(self) -> tuple[tuple[int, int], ...]:
+        return tuple(
+            (self._rng.randrange(self._width), self._rng.randrange(self._height))
+            for _ in range(self._num_pixels)
+        )

--- a/src/heart/renderers/random_pixel/renderer.py
+++ b/src/heart/renderers/random_pixel/renderer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import random
 from typing import Callable
 
 import pygame
@@ -8,6 +7,7 @@ import pygame
 from heart import DeviceDisplayMode
 from heart.device import Orientation
 from heart.display.color import Color
+from heart.peripheral.core.manager import PeripheralManager
 from heart.renderers import StatefulBaseRenderer
 from heart.renderers.random_pixel.provider import RandomPixelStateProvider
 from heart.renderers.random_pixel.state import RandomPixelState
@@ -19,18 +19,35 @@ class RandomPixel(StatefulBaseRenderer[RandomPixelState]):
         num_pixels: int = 1,
         color: Color | None = None,
         brightness: float = 1.0,
-        provider_factory: Callable[[Color | None], RandomPixelStateProvider] | None = None,
+        provider_factory: Callable[..., RandomPixelStateProvider] | None = None,
     ) -> None:
         self.num_pixels = num_pixels
         self.brightness = brightness
-        self._provider = (
-            provider_factory(color)
-            if provider_factory is not None
-            else RandomPixelStateProvider(initial_color=color)
-        )
+        self._initial_color = color
+        self._provider_factory = provider_factory or RandomPixelStateProvider
+        self._provider: RandomPixelStateProvider | None = None
 
-        super().__init__(builder=self._provider)
+        super().__init__()
         self.device_display_mode = DeviceDisplayMode.FULL
+
+    def initialize(
+        self,
+        window: pygame.Surface,
+        clock: pygame.time.Clock,
+        peripheral_manager: PeripheralManager,
+        orientation: Orientation,
+    ) -> None:
+        if self.builder is None:
+            width, height = window.get_size()
+            self._provider = self._provider_factory(
+                width=width,
+                height=height,
+                num_pixels=self.num_pixels,
+                peripheral_manager=peripheral_manager,
+                initial_color=self._initial_color,
+            )
+            self.builder = self._provider
+        super().initialize(window, clock, peripheral_manager, orientation)
 
     def real_process(
         self,
@@ -38,19 +55,14 @@ class RandomPixel(StatefulBaseRenderer[RandomPixelState]):
         clock: pygame.time.Clock,
         orientation: Orientation,
     ) -> None:
-        width, height = window.get_size()
         state = self.state
 
-        pixels = [
-            (random.randint(0, width - 1), random.randint(0, height - 1))
-            for _ in range(self.num_pixels)
-        ]
+        color_value = [int(x * self.brightness) for x in state.color._as_tuple()]
 
-        base_color = state.color or Color.random()
-        color_value = [int(x * self.brightness) for x in base_color._as_tuple()]
-
-        for x, y in pixels:
+        for x, y in state.pixels:
             window.set_at((x, y), color_value)
 
     def set_color(self, color: Color | None) -> None:
-        self._provider.set_color(color)
+        self._initial_color = color
+        if self._provider is not None:
+            self._provider.set_color(color)

--- a/src/heart/renderers/random_pixel/state.py
+++ b/src/heart/renderers/random_pixel/state.py
@@ -7,4 +7,5 @@ from heart.display.color import Color
 
 @dataclass(frozen=True)
 class RandomPixelState:
-    color: Color | None
+    color: Color
+    pixels: tuple[tuple[int, int], ...]


### PR DESCRIPTION
### Motivation

- Move random pixel position generation out of the renderer so the renderer only converts state into pixels and the provider owns state mutation and timing. 
- Make the random-pixel pipeline consistent with other renderers that follow the `provider`/`state`/`renderer` split. 

### Description

- Changed `RandomPixelState` to include explicit `color` and `pixels` fields so state carries both the color and the pixel coordinates for a frame (`src/heart/renderers/random_pixel/state.py`).
- Implemented `RandomPixelStateProvider` to drive state updates from the shared game tick and color updates and to emit new `RandomPixelState` snapshots (`src/heart/renderers/random_pixel/provider.py`).
- Updated `RandomPixel` to defer provider construction to `initialize`, use the provider as the `builder`, and render pixels from the provider-supplied state only (`src/heart/renderers/random_pixel/renderer.py`).
- Added documentation notes describing the role split in `docs/research/random_pixel_renderer_roles.md` and adjusted the provider/renderer API (provider now requires `width`, `height`, `num_pixels`, and `peripheral_manager` when constructed).

### Testing

- Ran `make format` and formatting checks passed. 
- Ran `make test` and the test suite succeeded with `127 passed, 1 skipped`. 
- Existing display and stateful-renderer tests exercised the change surface (no regressions observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aad943ca0832197da0742afdfb856)