### PR TITLE
Add configurable rsync args to sync harness and consolidate Makefile tool installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,15 @@
 PYTHON_SOURCES = src tests
 DOCS_SOURCES = docs
+TOOLS = ruff isort docformatter mdformat mypy
 .PHONY: install pi_install format check test
 
 install:
 	@uv sync --all-extras --group dev
-	@uv tool install ruff
-	@uv tool install isort
-	@uv tool install docformatter
-	@uv tool install mdformat
-	@uv tool install mypy
+	@for tool in $(TOOLS); do uv tool install $$tool; done
 
 format:
 	@uvx isort $(PYTHON_SOURCES)
-	@uvx ruff check --fix
+	@uvx ruff check --fix $(PYTHON_SOURCES)
 	@uvx docformatter -i -r --config ./pyproject.toml $(DOCS_SOURCES)
 	@uvx mdformat $(DOCS_SOURCES)
 	@uv run mypy --config-file pyproject.toml

--- a/docs/research/harness_build_updates.md
+++ b/docs/research/harness_build_updates.md
@@ -1,0 +1,20 @@
+______________________________________________________________________
+
+## title: Harness and build updates (sync + Makefile)
+
+## Summary
+
+This note records updates to the developer harness and build helpers so contributors can tune
+sync behavior and keep tool installation consistent.
+
+## Changes
+
+- Added `--rsync-arg`/`SYNC_RSYNC_ARGS` support in `sync.sh` so callers can append custom rsync
+  flags without editing the script.
+- Consolidated Makefile tool installation into a single list so the install harness stays in
+  sync with the formatting/linting stack.
+
+## Materials
+
+- `sync.sh`
+- `Makefile`

--- a/sync.sh
+++ b/sync.sh
@@ -18,6 +18,7 @@ Options:
   -d, --destination DEST   Override rsync destination (default: ${DEFAULT_REMOTE_HOST}:${DEFAULT_REMOTE_DIR})
   -i, --ignore PATTERN     Additional rsync exclude pattern (may be supplied multiple times)
       --ignore-from FILE   Read rsync exclude patterns from FILE
+      --rsync-arg ARG      Additional rsync argument (may be supplied multiple times)
       --once               Perform a single sync and exit (no file watching)
       --watcher MODE       Watch implementation to use: auto, fswatch, inotifywait, poll (default: auto)
       --poll-interval SEC  Interval in seconds for polling when watcher=poll (default: 5)
@@ -30,7 +31,7 @@ Options:
 
 Environment variables:
   SYNC_SOURCE_DIR, SYNC_DESTINATION, SYNC_IGNORE_FILE,
-  SYNC_POLL_INTERVAL, SYNC_WATCHER, SYNC_DRY_RUN,
+  SYNC_POLL_INTERVAL, SYNC_WATCHER, SYNC_DRY_RUN, SYNC_RSYNC_ARGS,
   SYNC_PRE_SYNC_CMD, SYNC_POST_SYNC_CMD, SYNC_SKIP_NOOP,
   REMOTE_HOST, REMOTE_DIR, REMOTE_PASS
 
@@ -55,6 +56,7 @@ DRY_RUN=${SYNC_DRY_RUN:-false}
 SKIP_NOOP=${SYNC_SKIP_NOOP:-false}
 declare -a PRE_SYNC_CMDS=()
 declare -a POST_SYNC_CMDS=()
+declare -a EXTRA_RSYNC_ARGS=()
 SPELLCHECK_ENABLED=true
 RUN_ONCE=false
 
@@ -66,6 +68,10 @@ fi
 
 if [[ -n "${SYNC_POST_SYNC_CMD:-}" ]]; then
   POST_SYNC_CMDS+=("$SYNC_POST_SYNC_CMD")
+fi
+
+if [[ -n "${SYNC_RSYNC_ARGS:-}" ]]; then
+  read -r -a EXTRA_RSYNC_ARGS <<< "$SYNC_RSYNC_ARGS"
 fi
 
 while [[ $# -gt 0 ]]; do
@@ -84,6 +90,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --ignore-from)
       IGNORE_FILE="$2"
+      shift 2
+      ;;
+    --rsync-arg)
+      EXTRA_RSYNC_ARGS+=("$2")
       shift 2
       ;;
     --once)
@@ -201,6 +211,10 @@ done
 
 if [[ -n "$IGNORE_FILE" ]]; then
   RSYNC_FLAGS+=("--exclude-from=$IGNORE_FILE")
+fi
+
+if [[ ${#EXTRA_RSYNC_ARGS[@]} -gt 0 ]]; then
+  RSYNC_FLAGS+=("${EXTRA_RSYNC_ARGS[@]}")
 fi
 
 sync_changes() {


### PR DESCRIPTION
### Motivation

- Make the project sync helper more flexible by allowing callers to pass extra rsync flags without editing the script.  
- Keep tooling installation in the `Makefile` consistent and easy to maintain as the formatting/linting stack evolves.  
- Ensure formatting operations run only against Python sources where appropriate.  
- Document the harness changes for future contributors.

### Description

- Added `--rsync-arg` CLI option and `SYNC_RSYNC_ARGS` environment variable parsing to `sync.sh`, collected into `EXTRA_RSYNC_ARGS` and appended to `RSYNC_FLAGS`.  
- Updated `sync.sh` usage/help and argument parsing to support multiple `--rsync-arg` entries and space-separated `SYNC_RSYNC_ARGS`.  
- Introduced a `TOOLS` variable in the `Makefile` and replaced repeated `uv tool install` lines with a loop `for tool in $(TOOLS); do uv tool install $$tool; done`.  
- Scoped `ruff check --fix` to `$(PYTHON_SOURCES)` and added a short research note at `docs/research/harness_build_updates.md` describing the changes.

### Testing

- Ran `make format` which completed with "All checks passed!".  
- Ran `make test` (Pytest) and observed the suite complete with `127 passed, 1 skipped`.  
- Verified `git status` shows the expected changes to `Makefile`, `sync.sh`, and the new documentation file.  
- No automated tests were modified; only harness and documentation were updated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aaf9e58e48321aa6dbcae85b1a0ee)