### PR TITLE
Remove unused peripheral helper code

### DIFF
--- a/src/heart/peripheral/gamepad/gamepad.py
+++ b/src/heart/peripheral/gamepad/gamepad.py
@@ -62,12 +62,6 @@ class Gamepad(Peripheral[Any]):
         self._tap_flag[button_id] = False
         return tapped
 
-    def was_released(self, button_id: int) -> bool:
-        return (
-            not self._pressed_curr_frame[button_id]
-            and self._pressed_prev_frame[button_id]
-        )
-
     def axis_value(self, axis_id: int, dead_zone: float = 0) -> float:
         axis_value = self._axis_curr_frame[self.axis_key(axis_id)]
         if abs(axis_value) < dead_zone:
@@ -82,9 +76,6 @@ class Gamepad(Peripheral[Any]):
         tapped_last_frame = self._axis_tapped_prev_frame[self.axis_key(axis_id)]
         self._axis_tapped_prev_frame[self.axis_key(axis_id)] = tapped
         return tapped and not tapped_last_frame
-
-    def get_dpad_value(self) -> tuple[float, float]:
-        return self._dpad_curr_frame
 
     def reset(self) -> None:
         if self.joystick is not None:

--- a/src/heart/peripheral/sensor.py
+++ b/src/heart/peripheral/sensor.py
@@ -1,7 +1,5 @@
-import collections
 import json
 import random
-import time
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, Iterator, Mapping, NoReturn, Self, cast
@@ -25,20 +23,6 @@ class Acceleration:
     z: float
 
 
-# TODO (lampe): This is fundamentally useless right now
-class Distribution:
-    def __init__(self) -> None:
-        self.historic_values: collections.deque[tuple[float, float]] = (
-            collections.deque([], maxlen=100)
-        )
-
-    def _get_time(self) -> float:
-        return time.monotonic()
-
-    def add_value(self, value: float) -> None:
-        self.historic_values.append((self._get_time(), value))
-
-
 class Accelerometer(Peripheral[Acceleration | None]):
     def __init__(
         self,
@@ -49,10 +33,6 @@ class Accelerometer(Peripheral[Acceleration | None]):
         self.acceleration_value: dict[str, float] | None = None
         self.port = port
         self.baudrate = baudrate
-
-        self.x_distribution = Distribution()
-        self.y_distribution = Distribution()
-        self.z_distribution = Distribution()
 
     def _event_stream(
         self
@@ -144,10 +124,6 @@ class Accelerometer(Peripheral[Acceleration | None]):
 
         input_event = vector.to_input()
         self.acceleration_value = cast(dict[str, float], input_event.data)
-
-        self.x_distribution.add_value(vector.x)
-        self.y_distribution.add_value(vector.y)
-        self.z_distribution.add_value(vector.z)
 
         raise NotImplementedError("")
 


### PR DESCRIPTION
### Motivation

- Remove dead and unused helper code in peripheral modules to reduce maintenance burden and clarify intent.
- Eliminate unused runtime state that was never consumed to avoid needless memory and complexity.

### Description

- Remove the unused `Distribution` helper class and its usages from `src/heart/peripheral/sensor.py` so accelerometer code no longer maintains unused historic state.
- Drop unused gamepad accessors (`was_released` and `get_dpad_value`) from `src/heart/peripheral/gamepad/gamepad.py` that had no callers.
- Keep behavior and public interfaces used by the rest of the codebase unchanged aside from removing the dead members.

### Testing

- Ran `make format` to apply repository formatting rules and the formatter completed successfully.
- Ran `make test` and the test suite completed with `127 passed, 1 skipped`.
- No additional automated tests were added or modified for this change.
- All existing tests continued to pass after the removals.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aafaa7e308321ad943fd89737898c)