### PR TITLE
Align pixel and Pacman renderers with provider-driven state streams

### DIFF
--- a/docs/research/renderer_state_provider_review.md
+++ b/docs/research/renderer_state_provider_review.md
@@ -1,0 +1,27 @@
+# Renderer state/provider boundary review
+
+## Summary
+
+- Shifted the pixel-family renderers (Border, Rain, Slinky) so providers emit
+  immutable state updates from the game-tick stream, while renderers only draw
+  based on the current state snapshot.
+- Updated the Pacman ghost renderer to receive state updates from its provider
+  instead of mutating state during rendering.
+
+## Findings
+
+- `RainStateProvider` and `SlinkyStateProvider` now own the per-tick updates via
+  `PeripheralManager.game_tick`, keeping animation progression inside the
+  provider layer.
+- `BorderStateProvider` owns color changes through a subject so renderer color
+  updates remain a state update rather than a renderer mutation.
+- `PacmanGhostStateProvider` now advances positions and sprite variants through
+  the tick stream, and the renderer only swaps cached sprites when the state
+  indicates an asset change.
+
+## Materials
+
+- `src/heart/renderers/pixels/provider.py`
+- `src/heart/renderers/pixels/renderer.py`
+- `src/heart/renderers/pacman/provider.py`
+- `src/heart/renderers/pacman/renderer.py`

--- a/src/heart/renderers/pixels/renderer.py
+++ b/src/heart/renderers/pixels/renderer.py
@@ -12,9 +12,14 @@ from heart.renderers.pixels.state import BorderState, RainState, SlinkyState
 
 
 class Border(StatefulBaseRenderer[BorderState]):
-    def __init__(self, width: int, color: Color | None = None, provider: BorderStateProvider | None = None) -> None:
-        self.provider = provider or BorderStateProvider(color)
-        super().__init__()
+    def __init__(
+        self,
+        width: int,
+        color: Color | None = None,
+        provider: BorderStateProvider | None = None,
+    ) -> None:
+        self._provider = provider or BorderStateProvider(color)
+        super().__init__(builder=self._provider)
         self.device_display_mode = DeviceDisplayMode.FULL
         self.width = width
 
@@ -36,45 +41,37 @@ class Border(StatefulBaseRenderer[BorderState]):
                 window.set_at((x, y), color_value)
                 window.set_at((width - 1 - x, y), color_value)
 
-    def _create_initial_state(
-        self,
-        window: pygame.Surface,
-        clock: pygame.time.Clock,
-        peripheral_manager: PeripheralManager,
-        orientation: Orientation,
-    ) -> BorderState:
-        return self.provider.create_initial_state(
-            window=window,
-            clock=clock,
-            peripheral_manager=peripheral_manager,
-            orientation=orientation,
-        )
-
     def set_color(self, color: Color) -> None:
-        self.set_state(self.provider.update_color(self.state, color))
+        self._provider.set_color(color)
 
 
 class Rain(StatefulBaseRenderer[RainState]):
-    def __init__(self, provider: RainStateProvider | None = None) -> None:
-        self.provider = provider or RainStateProvider()
+    def __init__(
+        self,
+        provider: RainStateProvider | None = None,
+    ) -> None:
+        self._provider: RainStateProvider | None = provider
         super().__init__()
         self.device_display_mode = DeviceDisplayMode.FULL
         self.l = 8
         self.starting_color = Color(r=173, g=216, b=230)
 
-    def _create_initial_state(
+    def initialize(
         self,
         window: pygame.Surface,
         clock: pygame.time.Clock,
         peripheral_manager: PeripheralManager,
         orientation: Orientation,
-    ) -> RainState:
-        return self.provider.create_initial_state(
-            window=window,
-            clock=clock,
-            peripheral_manager=peripheral_manager,
-            orientation=orientation,
-        )
+    ) -> None:
+        if self.builder is None:
+            width, height = window.get_size()
+            self._provider = self._provider or RainStateProvider(
+                width=width,
+                height=height,
+                peripheral_manager=peripheral_manager,
+            )
+            self.builder = self._provider
+        super().initialize(window, clock, peripheral_manager, orientation)
 
     def real_process(
         self,
@@ -82,42 +79,38 @@ class Rain(StatefulBaseRenderer[RainState]):
         clock: pygame.time.Clock,
         orientation: Orientation,
     ) -> None:
-        width, height = window.get_size()
-        new_y = self.state.current_y + 1
+        new_y = self.state.current_y
         starting_point = self.state.starting_point
 
         for i in range(self.l):
             color = self.starting_color.dim(fraction=i / self.l)
             window.set_at((starting_point, new_y - i), color)
 
-        next_state = self.provider.next_state(
-            state=self.state, width=width, height=height
-        )
-        if next_state != self.state:
-            self.set_state(next_state)
-
 
 class Slinky(StatefulBaseRenderer[SlinkyState]):
     def __init__(self, provider: SlinkyStateProvider | None = None) -> None:
-        self.provider = provider or SlinkyStateProvider()
+        self._provider: SlinkyStateProvider | None = provider
         super().__init__()
         self.device_display_mode = DeviceDisplayMode.FULL
         self.l = 10
         self.starting_color = Color(r=255, g=165, b=0)
 
-    def _create_initial_state(
+    def initialize(
         self,
         window: pygame.Surface,
         clock: pygame.time.Clock,
         peripheral_manager: PeripheralManager,
         orientation: Orientation,
-    ) -> SlinkyState:
-        return self.provider.create_initial_state(
-            window=window,
-            clock=clock,
-            peripheral_manager=peripheral_manager,
-            orientation=orientation,
-        )
+    ) -> None:
+        if self.builder is None:
+            width, height = window.get_size()
+            self._provider = self._provider or SlinkyStateProvider(
+                width=width,
+                height=height,
+                peripheral_manager=peripheral_manager,
+            )
+            self.builder = self._provider
+        super().initialize(window, clock, peripheral_manager, orientation)
 
     def real_process(
         self,
@@ -125,8 +118,7 @@ class Slinky(StatefulBaseRenderer[SlinkyState]):
         clock: pygame.time.Clock,
         orientation: Orientation,
     ) -> None:
-        width, height = window.get_size()
-        new_y = self.state.current_y + 1
+        new_y = self.state.current_y
         starting_point = self.state.starting_point
 
         window.set_at((starting_point, new_y), self.starting_color)
@@ -141,9 +133,3 @@ class Slinky(StatefulBaseRenderer[SlinkyState]):
                 more_dim = self.starting_color.dim(fraction=(i + 1) / self.l)
                 window.set_at((starting_point + 1, new_y + i), more_dim)
                 window.set_at((starting_point - 1, new_y - i), more_dim)
-
-        next_state = self.provider.next_state(
-            state=self.state, width=width, height=height
-        )
-        if next_state != self.state:
-            self.set_state(next_state)


### PR DESCRIPTION
### Motivation

- Enforce the renderer/provider/state separation so renderers only convert state snapshots into pixels and do not own state evolution.
- Move time-based animation progression into providers that react to the shared event stream (the peripheral `game_tick`) to make updates deterministic and testable.
- Reduce in-renderer mutation and resource-management responsibilities to prevent subscription leaks and asset reload regressions.
- Improve testability and reuse by exposing observable state streams from providers.

### Description

- Reworked the pixel-family providers into observable providers: `src/heart/renderers/pixels/provider.py` now implements `BorderStateProvider`, `RainStateProvider`, and `SlinkyStateProvider` as `ObservableProvider` instances that emit immutable states (with `Border` using a `BehaviorSubject` for color updates and `Rain`/`Slinky` advancing on `PeripheralManager.game_tick`).
- Updated pixel renderers in `src/heart/renderers/pixels/renderer.py` to accept provider builders (passed to `StatefulBaseRenderer`) and to draw solely from the current `state` without mutating it or advancing animation ticks.
- Converted the Pacman provider to an `ObservableProvider` that advances ghost state on `game_tick` and modified `src/heart/renderers/pacman/renderer.py` so the renderer initializes the provider and reacts to `state.asset_version` for sprite caching instead of mutating state.
- Added a research note `docs/research/renderer_state_provider_review.md` summarising the boundary changes and listing the modified materials.

### Testing

- Ran `make format` and applied formatting fixes to updated files successfully.
- Ran the test suite via `make test`, with the full suite returning `127 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aafbf1f7c8321a4df1b0812cbe1e9)