### PR TITLE
Add Makefile `build` target and document sync harness build hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 PYTHON_SOURCES = src tests
 DOCS_SOURCES = docs
 TOOLS = ruff isort docformatter mdformat mypy
-.PHONY: install pi_install format check test
+BUILD_ARGS ?=
+.PHONY: install pi_install format check test build
 
 install:
 	@uv sync --all-extras --group dev
@@ -23,6 +24,9 @@ check:
 
 test:
 	@uv run pytest
+
+build:
+	@uv build $(BUILD_ARGS)
 
 pi_install:
 	@sudo bash src/heart/manage/install_rgb_matrix.sh

--- a/docs/research/build_harness_make_target.md
+++ b/docs/research/build_harness_make_target.md
@@ -1,0 +1,16 @@
+# Build harness: Makefile build target
+
+## Summary
+
+The build harness referenced `make build` in documentation, but the Makefile did not provide
+that target. This left build hooks in `sync.sh` without a default build action.
+
+## Changes
+
+- Added a `build` target to the Makefile that runs `uv build` and supports `BUILD_ARGS`.
+- Documented the `make build` behaviour in the sync harness guide so hook usage is explicit.
+
+## Materials
+
+- `Makefile`
+- `docs/sync_harness.md`

--- a/docs/sync_harness.md
+++ b/docs/sync_harness.md
@@ -53,6 +53,9 @@ Example with multiple hooks:
   --post-sync "make test" --post-sync "scripts/check_harness.sh" --once
 ```
 
+`make build` runs `uv build`. Use `BUILD_ARGS` to pass extra arguments to the
+build command.
+
 ## Notes
 
 - Use `--skip-spellcheck` if the `spellcheck` tool is not installed.


### PR DESCRIPTION
### Motivation
- Documentation and the sync harness referenced `make build` but the Makefile did not provide a `build` target, leaving build hooks without a default action. 
- Provide a simple, consistent way for the developer harness to invoke the project build via `uv build`. 
- Allow callers to pass additional build arguments from the Makefile without editing scripts. 

### Description
- Added a `build` target to the `Makefile` that runs `uv build` and honors a `BUILD_ARGS` variable. 
- Introduced `BUILD_ARGS ?=` and added `build` to the `.PHONY` list in the `Makefile`. 
- Updated `docs/sync_harness.md` to document that `make build` runs `uv build` and that `BUILD_ARGS` can be used to pass extra arguments. 
- Added `docs/research/build_harness_make_target.md` capturing the rationale and changes made. 

### Testing
- Ran `make format` and the repository formatting checks completed successfully. 
- Ran `make test` (Pytest via `uv run pytest`) and the test suite completed with `127 passed, 1 skipped` in ~18s, with a benchmark warning about xdist concurrency. 
- Verified `make build` target invokes `uv build` locally (manual behavior exercised via the introduced target during testing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ab0d5a374832193f8f6a3466a0484)