### PR TITLE
Remove unused debugging timestamp fields

### DIFF
--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -296,8 +296,6 @@ class GameLoop:
         self._current_offset_on_change = 0
         self.renderers_cache: list["BaseRenderer"] | None = None
 
-        self.time_last_debugging_press: float | None = None
-
         self._active_mode_index = 0
 
         # Lampe controller

--- a/src/heart/navigation.py
+++ b/src/heart/navigation.py
@@ -105,7 +105,6 @@ class GameModeState:
     last_long_button_value = 0
     mode_offset = 0
     _active_mode_index = 0
-    time_last_debugging_press = None
 
     previous_mode_index = 0
     sliding_transition = None


### PR DESCRIPTION
### Motivation

- Remove dead/unused debug state to simplify navigation and loop state and avoid lingering unused fields. 
- Clean up code where a debug timestamp field was declared but never read or used. 

### Description

- Deleted the unused `time_last_debugging_press` field from `GameModeState` in `src/heart/navigation.py`. 
- Deleted the unused `time_last_debugging_press` attribute from `GameLoop` in `src/heart/environment.py`. 
- Restored the required `Container` import in `src/heart/navigation.py` so `resolve_renderer` continues to type-check correctly. 
- Ran formatting to satisfy the repository style rules. 

### Testing

- Ran `make format` and the formatting/lint checks passed. 
- Ran `make test` and the test suite completed successfully with `127 passed, 1 skipped`. 
- No new tests were added for this change. 
- All automated checks related to this change passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ab1017918832188e54a602b782918)