### PR TITLE
Refactor renderer state updates to use providers

### DIFF
--- a/src/heart/renderers/pixels/renderer.py
+++ b/src/heart/renderers/pixels/renderer.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Callable
+
 import pygame
 
 from heart import DeviceDisplayMode
@@ -55,26 +59,33 @@ class Border(StatefulBaseRenderer[BorderState]):
 
 
 class Rain(StatefulBaseRenderer[RainState]):
-    def __init__(self, provider: RainStateProvider | None = None) -> None:
-        self.provider = provider or RainStateProvider()
+    def __init__(
+        self,
+        provider_factory: Callable[..., RainStateProvider] | None = None,
+    ) -> None:
+        self._provider_factory = provider_factory or RainStateProvider
+        self._provider: RainStateProvider | None = None
         super().__init__()
         self.device_display_mode = DeviceDisplayMode.FULL
         self.l = 8
         self.starting_color = Color(r=173, g=216, b=230)
 
-    def _create_initial_state(
+    def initialize(
         self,
         window: pygame.Surface,
         clock: pygame.time.Clock,
         peripheral_manager: PeripheralManager,
         orientation: Orientation,
-    ) -> RainState:
-        return self.provider.create_initial_state(
-            window=window,
-            clock=clock,
-            peripheral_manager=peripheral_manager,
-            orientation=orientation,
-        )
+    ) -> None:
+        if self.builder is None:
+            width, height = window.get_size()
+            self._provider = self._provider_factory(
+                width=width,
+                height=height,
+                peripheral_manager=peripheral_manager,
+            )
+            self.builder = self._provider
+        super().initialize(window, clock, peripheral_manager, orientation)
 
     def real_process(
         self,
@@ -82,7 +93,6 @@ class Rain(StatefulBaseRenderer[RainState]):
         clock: pygame.time.Clock,
         orientation: Orientation,
     ) -> None:
-        width, height = window.get_size()
         new_y = self.state.current_y + 1
         starting_point = self.state.starting_point
 
@@ -90,34 +100,35 @@ class Rain(StatefulBaseRenderer[RainState]):
             color = self.starting_color.dim(fraction=i / self.l)
             window.set_at((starting_point, new_y - i), color)
 
-        next_state = self.provider.next_state(
-            state=self.state, width=width, height=height
-        )
-        if next_state != self.state:
-            self.set_state(next_state)
-
 
 class Slinky(StatefulBaseRenderer[SlinkyState]):
-    def __init__(self, provider: SlinkyStateProvider | None = None) -> None:
-        self.provider = provider or SlinkyStateProvider()
+    def __init__(
+        self,
+        provider_factory: Callable[..., SlinkyStateProvider] | None = None,
+    ) -> None:
+        self._provider_factory = provider_factory or SlinkyStateProvider
+        self._provider: SlinkyStateProvider | None = None
         super().__init__()
         self.device_display_mode = DeviceDisplayMode.FULL
         self.l = 10
         self.starting_color = Color(r=255, g=165, b=0)
 
-    def _create_initial_state(
+    def initialize(
         self,
         window: pygame.Surface,
         clock: pygame.time.Clock,
         peripheral_manager: PeripheralManager,
         orientation: Orientation,
-    ) -> SlinkyState:
-        return self.provider.create_initial_state(
-            window=window,
-            clock=clock,
-            peripheral_manager=peripheral_manager,
-            orientation=orientation,
-        )
+    ) -> None:
+        if self.builder is None:
+            width, height = window.get_size()
+            self._provider = self._provider_factory(
+                width=width,
+                height=height,
+                peripheral_manager=peripheral_manager,
+            )
+            self.builder = self._provider
+        super().initialize(window, clock, peripheral_manager, orientation)
 
     def real_process(
         self,
@@ -125,7 +136,6 @@ class Slinky(StatefulBaseRenderer[SlinkyState]):
         clock: pygame.time.Clock,
         orientation: Orientation,
     ) -> None:
-        width, height = window.get_size()
         new_y = self.state.current_y + 1
         starting_point = self.state.starting_point
 
@@ -141,9 +151,3 @@ class Slinky(StatefulBaseRenderer[SlinkyState]):
                 more_dim = self.starting_color.dim(fraction=(i + 1) / self.l)
                 window.set_at((starting_point + 1, new_y + i), more_dim)
                 window.set_at((starting_point - 1, new_y - i), more_dim)
-
-        next_state = self.provider.next_state(
-            state=self.state, width=width, height=height
-        )
-        if next_state != self.state:
-            self.set_state(next_state)

--- a/src/heart/renderers/sliding_image/state.py
+++ b/src/heart/renderers/sliding_image/state.py
@@ -12,25 +12,9 @@ class SlidingImageState:
     width: int = 0
     image: pygame.Surface | None = None
 
-    def advance(self) -> "SlidingImageState":
-        if self.width <= 0:
-            return self
-
-        offset = (self.offset + self.speed) % self.width
-        return SlidingImageState(
-            offset=offset, speed=self.speed, width=self.width, image=self.image
-        )
-
 
 @dataclass(frozen=True)
 class SlidingRendererState:
     offset: int = 0
     speed: int = 1
     width: int = 0
-
-    def advance(self) -> "SlidingRendererState":
-        if self.width <= 0:
-            return self
-
-        offset = (self.offset + self.speed) % self.width
-        return SlidingRendererState(offset=offset, speed=self.speed, width=self.width)

--- a/tests/display/test_sliding_image_renderer.py
+++ b/tests/display/test_sliding_image_renderer.py
@@ -26,13 +26,13 @@ def test_reset_preserves_cached_surface(monkeypatch, orientation, manager, stub_
 
     window.fill((0, 0, 0, 0))
     offset_before = renderer.state.offset
+    manager.game_tick.on_next(True)
     renderer.process(window, clock, manager, orientation)
     processed_state = renderer.state
     assert processed_state.offset == (
         offset_before + processed_state.speed
     ) % processed_state.width
     assert window.get_at((0, 0))[:3] == (10, 20, 30)
-
 
     renderer.reset()
 
@@ -44,6 +44,7 @@ def test_reset_preserves_cached_surface(monkeypatch, orientation, manager, stub_
 
     window.fill((0, 0, 0, 0))
     offset_before_second = renderer.state.offset
+    manager.game_tick.on_next(True)
     renderer.process(window, clock, manager, orientation)
     after_second_process_state = renderer.state
     assert after_second_process_state.offset == (


### PR DESCRIPTION
### Motivation
- Enforce clear separation of concerns so renderers only convert state to pixels, state objects remain passive data, and providers drive state changes from event streams.
- Make sliding image animation and pixel effects driven by the global `game_tick` stream instead of renderer-local mutation for more consistent timing and easier resets.
- Allow explicit reset signals for sliding providers to preserve cached surfaces across scene transitions.
- Simplify renderers to rely on `StatefulBaseRenderer` subscription semantics rather than manually advancing state.

### Description
- Converted `SlidingImage`/`SlidingRenderer` to rely on a `Sliding*StateProvider` builder observable and removed in-renderer advancement logic, delegating advancement and reset handling to the providers.
- Removed `advance` helpers from `SlidingImageState` and `SlidingRendererState` dataclasses so states are pure data objects and moved advance/reset logic into `src/heart/renderers/sliding_image/provider.py` which now exposes a `request_reset` hook backed by a `Subject`.
- Reworked pixel effect providers in `src/heart/renderers/pixels/provider.py` (`RainStateProvider` and `SlinkyStateProvider`) to implement `ObservableProvider` and emit state from `peripheral_manager.game_tick` using Rx operators, and updated the corresponding renderers to construct providers in `initialize` and set them as `builder`.
- Updated `tests/display/test_sliding_image_renderer.py` to advance the provider-driven state via `manager.game_tick.on_next(True)` and kept the cached surface assertion to ensure resets preserve the image.

### Testing
- Ran code formatting with `make format` and received no issues (fixed and validated changes). 
- Ran the full test suite with `make test` and observed all automated tests pass: `127 passed, 1 skipped`.
- The updated sliding image test `tests/display/test_sliding_image_renderer.py` now passes under the provider-driven game tick model.
- No automated tests failed after the refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ab109ed388321a94de668b7d2f4d2)