### PR TITLE
Add harness check helper and Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYTHON_SOURCES = src tests
 DOCS_SOURCES = docs
 TOOLS = ruff isort docformatter mdformat mypy
 BUILD_ARGS ?=
-.PHONY: install pi_install format check test build
+.PHONY: install pi_install format check test build check-harness
 
 install:
 	@uv sync --all-extras --group dev
@@ -27,6 +27,9 @@ test:
 
 build:
 	@uv build $(BUILD_ARGS)
+
+check-harness:
+	@bash scripts/check_harness.sh
 
 pi_install:
 	@sudo bash src/heart/manage/install_rgb_matrix.sh

--- a/docs/research/harness_build_check_helper.md
+++ b/docs/research/harness_build_check_helper.md
@@ -1,0 +1,23 @@
+______________________________________________________________________
+
+## title: Harness check helper for build tooling
+
+## Summary
+
+This note captures the new harness check helper that validates core tooling for
+sync and build workflows before running hooks.
+
+## Changes
+
+- Added `scripts/check_harness.sh` to verify required commands like `uv` and
+  `rsync`, report optional helpers, and confirm expected files exist.
+- Added a `make check-harness` target to make the helper easy to run from the
+  standard build interface.
+- Documented the helper in `docs/sync_harness.md` so hook recipes point to a
+  real script.
+
+## Materials
+
+- `scripts/check_harness.sh`
+- `Makefile`
+- `docs/sync_harness.md`

--- a/docs/sync_harness.md
+++ b/docs/sync_harness.md
@@ -56,6 +56,13 @@ Example with multiple hooks:
 `make build` runs `uv build`. Use `BUILD_ARGS` to pass extra arguments to the
 build command.
 
+## Harness check helper
+
+`scripts/check_harness.sh` verifies the core tooling expected by the sync and
+build harness. It confirms required commands like `uv` and `rsync` exist, reports
+optional helpers (for example `spellcheck`), and flags missing files such as
+`.syncignore`.
+
 ## Notes
 
 - Use `--skip-spellcheck` if the `spellcheck` tool is not installed.

--- a/scripts/check_harness.sh
+++ b/scripts/check_harness.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+REQUIRED_CMDS=(uv rsync)
+OPTIONAL_CMDS=(spellcheck sshpass fswatch inotifywait)
+missing_required=()
+
+if [[ ! -f "${REPO_ROOT}/pyproject.toml" ]]; then
+  echo "Error: expected to find pyproject.toml in ${REPO_ROOT}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${REPO_ROOT}/sync.sh" ]]; then
+  echo "Error: expected to find sync.sh in ${REPO_ROOT}" >&2
+  exit 1
+fi
+
+echo "Checking harness prerequisites in ${REPO_ROOT}"
+
+for cmd in "${REQUIRED_CMDS[@]}"; do
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    missing_required+=("${cmd}")
+  fi
+done
+
+if [[ ${#missing_required[@]} -gt 0 ]]; then
+  echo "Missing required tools: ${missing_required[*]}" >&2
+  exit 1
+fi
+
+echo "Required tools available: ${REQUIRED_CMDS[*]}"
+
+for cmd in "${OPTIONAL_CMDS[@]}"; do
+  if command -v "${cmd}" >/dev/null 2>&1; then
+    echo "Optional tool available: ${cmd}"
+  else
+    echo "Optional tool missing: ${cmd}"
+  fi
+done
+
+if [[ -f "${REPO_ROOT}/.syncignore" ]]; then
+  echo "Found .syncignore at ${REPO_ROOT}/.syncignore"
+else
+  echo "No .syncignore file found in ${REPO_ROOT}"
+fi
+


### PR DESCRIPTION
### Motivation

- Provide an automated helper to verify the developer harness and build tooling before running sync or build hooks.  
- Surface missing required tools and optional helpers so pre/post-sync hooks are less likely to fail unexpectedly.  
- Make the validation easy to run from the standard build interface so contributors can quickly confirm their environment.  
- Record the change in docs and research notes so the behaviour and rationale are discoverable.

### Description

- Add `scripts/check_harness.sh` which validates required commands (`uv`, `rsync`), reports optional helpers, and checks for expected repository files like `pyproject.toml` and `sync.sh`.  
- Add a `check-harness` phony target to the `Makefile` that runs `bash scripts/check_harness.sh`.  
- Update `docs/sync_harness.md` to document the new helper and add `docs/research/harness_build_check_helper.md` to record the change.  
- Ensure the helper script is executable and included in repository materials.

### Testing

- Ran `make format` and the formatting/linting steps completed successfully.  
- Ran `make test` and the Pytest suite completed successfully with `127 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ab4751a8883219741469a3982f863)