### PR TITLE
Optimize HSV cache lookups

### DIFF
--- a/docs/research/hsv_cache_vectorization.md
+++ b/docs/research/hsv_cache_vectorization.md
@@ -1,0 +1,33 @@
+# HSV cache vectorization notes
+
+## Summary
+
+The HSV conversion helpers in `src/heart/environment.py` were spending time looping
+pixel-by-pixel to update the shared HSV-to-BGR cache and to re-apply cached
+values. That per-element Python overhead shows up during frequent render passes,
+so the cache update path was refactored to rely on NumPy unique/value grouping
+before touching the ordered dictionary.
+
+## Observations
+
+- `_convert_bgr_to_hsv` previously iterated over every HSV/BGR pair to update
+  `HSV_TO_BGR_CACHE`, moving items to the end or inserting new entries one at a
+  time.
+- `_convert_hsv_to_bgr` looped over every pixel to apply cached values and keep
+  the LRU ordering current.
+- Most frames reuse a small set of HSV values, so grouping by unique HSV tuples
+  allows the cache to be updated with fewer Python-level iterations while
+  preserving the LRU ordering based on the last occurrence.
+
+## Implementation notes
+
+- `np.unique(..., axis=0, return_inverse=True)` is used to identify distinct HSV
+  values for a frame and provide a stable mapping back to the flattened array.
+- Last-occurrence positions are tracked with `np.maximum.at` so that the cache
+  can still be ordered by most recent use, matching the previous behaviour.
+- Cache application now fills the flattened result array for each cached HSV
+  tuple instead of writing per pixel.
+
+## Materials
+
+- `src/heart/environment.py` (`_convert_bgr_to_hsv`, `_convert_hsv_to_bgr`)


### PR DESCRIPTION
### Motivation

- Reduce per-pixel Python overhead in the HSV/BGR conversion paths used during rendering to improve runtime performance.
- Avoid expensive Python loops that update and apply `HSV_TO_BGR_CACHE` on every frame by leveraging NumPy vectorized operations.
- Preserve previous semantics including the LRU ordering of `HSV_TO_BGR_CACHE` and special-case colour calibrations.

### Description

- Replace per-pixel updates in `_convert_bgr_to_hsv` with a vectorized approach that uses `np.unique(..., axis=0, return_inverse=True)` and `np.maximum.at` to compute last-occurrence positions and update `HSV_TO_BGR_CACHE` by unique HSV keys.
- Vectorize parts of `_convert_hsv_to_bgr` by applying calibration masks in bulk and filling the flattened result array for cached HSV tuples, then reorder the LRU entries according to last occurrence.
- Add a research note `docs/research/hsv_cache_vectorization.md` that documents the refactor and rationale.
- Changes applied to `src/heart/environment.py` and new documentation added at `docs/research/hsv_cache_vectorization.md`.

### Testing

- Ran `make format` and formatting checks completed successfully.
- Ran `make test` and the test suite completed with `127 passed, 1 skipped` in the CI environment.
- Existing unit tests exercising `_convert_bgr_to_hsv` and `_convert_hsv_to_bgr` passed, confirming behaviour is preserved.
- No additional automated benchmarks were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ab485bd5883218b39539c2df023b3)