### PR TITLE
Remove unused isolated rendering helper re-export

### DIFF
--- a/experimental/isolated_rendering/src/isolated_rendering/__init__.py
+++ b/experimental/isolated_rendering/src/isolated_rendering/__init__.py
@@ -1,3 +1,3 @@
 """Isolated rendering service for the heart LED matrix."""
 
-from .client import MatrixClient as MatrixClient, send_image as send_image
+from .client import MatrixClient as MatrixClient

--- a/experimental/isolated_rendering/src/isolated_rendering/client.py
+++ b/experimental/isolated_rendering/src/isolated_rendering/client.py
@@ -1,3 +1,3 @@
 """Compatibility re-export for isolated rendering helpers."""
 
-from heart.device.isolated_render import MatrixClient as MatrixClient, send_image as send_image
+from heart.device.isolated_render import MatrixClient as MatrixClient

--- a/src/heart/device/isolated_render.py
+++ b/src/heart/device/isolated_render.py
@@ -59,15 +59,3 @@ class MatrixClient:
             finally:
                 sock.settimeout(None)
 
-
-def send_image(
-    image: Image.Image,
-    *,
-    socket_path: Optional[str] = None,
-    tcp_address: Optional[Tuple[str, int]] = None,
-) -> None:
-    client = MatrixClient(socket_path=socket_path, tcp_address=tcp_address)
-    try:
-        client.send_image(image)
-    finally:
-        client.close()


### PR DESCRIPTION
### Motivation

- Remove dead/unused helper that duplicated `MatrixClient.send_image` and caused an import-time API mismatch.  
- Prevent spurious import errors in the experimental isolated rendering package by aligning re-exports with the core implementation.  
- Keep the public API surface minimal and avoid dangling convenience functions that encourage duplicate resource management.  

### Description

- Delete the top-level `send_image` helper function from `src/heart/device/isolated_render.py`.  
- Update `experimental/isolated_rendering/src/isolated_rendering/client.py` to stop importing `send_image` and only import `MatrixClient`.  
- Update `experimental/isolated_rendering/src/isolated_rendering/__init__.py` to re-export only `MatrixClient`.  

### Testing

- Ran `make format` to apply formatting checks and fixes and it completed successfully.  
- Ran `make test` and the test suite passed with `127 passed, 1 skipped`.  
- Verified that the previous import error caused by the stale re-export was resolved by the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ab46e175483218b78cea5ac4b4c6b)