### PR TITLE
Improve harness build checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ check:
 test:
 	@uv run pytest
 
-build:
+build: check-harness
 	@uv build $(BUILD_ARGS)
 
 check-harness:

--- a/docs/research/harness_build_checks.md
+++ b/docs/research/harness_build_checks.md
@@ -1,0 +1,38 @@
+# Harness and build checks research note
+
+## Problem statement
+
+Local builds and sync workflows depend on a small set of command-line tools and
+expected repository files. The project did not surface missing prerequisites or
+version mismatches early, which made harness setup and packaging builds harder to
+diagnose.
+
+## Observations
+
+- The harness check script verifies only a subset of required tools and does not
+  validate the Python version needed by the project.
+- Build and format steps use `uv` tooling, so `uvx` is a practical dependency
+  even when `uv` is present.
+- The build pipeline assumes `uv.lock` exists, but that file may be absent on a
+  fresh checkout.
+
+## Proposed adjustments
+
+- Extend `scripts/check_harness.sh` to validate Python >= 3.11, verify `uvx`, and
+  report missing repository artifacts that the harness expects.
+- Tie `make build` to the harness check so packaging failures appear before
+  running `uv build`.
+
+## Source locations reviewed
+
+- `scripts/check_harness.sh`
+- `Makefile`
+- `sync.sh`
+- `pyproject.toml`
+
+## Materials
+
+- Shell environment with `bash`
+- `python3` (>= 3.11)
+- `uv`/`uvx`
+- `rsync`

--- a/scripts/check_harness.sh
+++ b/scripts/check_harness.sh
@@ -2,8 +2,10 @@
 set -euo pipefail
 
 REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-REQUIRED_CMDS=(uv rsync)
-OPTIONAL_CMDS=(spellcheck sshpass fswatch inotifywait)
+REQUIRED_CMDS=(uv uvx rsync)
+OPTIONAL_CMDS=(spellcheck sshpass fswatch inotifywait flock)
+PYTHON_CANDIDATES=(python3 python)
+PYTHON_MIN_VERSION="3.11"
 missing_required=()
 
 if [[ ! -f "${REPO_ROOT}/pyproject.toml" ]]; then
@@ -14,6 +16,14 @@ fi
 if [[ ! -f "${REPO_ROOT}/sync.sh" ]]; then
   echo "Error: expected to find sync.sh in ${REPO_ROOT}" >&2
   exit 1
+fi
+
+if [[ ! -x "${REPO_ROOT}/sync.sh" ]]; then
+  echo "Warning: sync.sh is not executable; run chmod +x ${REPO_ROOT}/sync.sh" >&2
+fi
+
+if [[ ! -f "${REPO_ROOT}/uv.lock" ]]; then
+  echo "Warning: uv.lock is missing; run 'uv sync' to generate it." >&2
 fi
 
 echo "Checking harness prerequisites in ${REPO_ROOT}"
@@ -29,7 +39,38 @@ if [[ ${#missing_required[@]} -gt 0 ]]; then
   exit 1
 fi
 
+PYTHON_CMD=""
+for candidate in "${PYTHON_CANDIDATES[@]}"; do
+  if command -v "${candidate}" >/dev/null 2>&1; then
+    PYTHON_CMD="${candidate}"
+    break
+  fi
+done
+
+if [[ -z "${PYTHON_CMD}" ]]; then
+  echo "Missing required tool: python (>=${PYTHON_MIN_VERSION})" >&2
+  exit 1
+fi
+
+python_version=$(
+  "${PYTHON_CMD}" - <<PYTHON
+import sys
+required = (3, 11)
+version = ".".join(str(part) for part in sys.version_info[:3])
+print(version)
+if sys.version_info < required:
+    raise SystemExit(1)
+PYTHON
+)
+if [[ $? -ne 0 ]]; then
+  echo "Error: ${PYTHON_CMD} ${python_version} is below required ${PYTHON_MIN_VERSION}" >&2
+  exit 1
+fi
+
+echo "Python available: ${PYTHON_CMD} ${python_version}"
 echo "Required tools available: ${REQUIRED_CMDS[*]}"
+echo "uv version: $(uv --version)"
+echo "uvx version: $(uvx --version)"
 
 for cmd in "${OPTIONAL_CMDS[@]}"; do
   if command -v "${cmd}" >/dev/null 2>&1; then
@@ -44,4 +85,3 @@ if [[ -f "${REPO_ROOT}/.syncignore" ]]; then
 else
   echo "No .syncignore file found in ${REPO_ROOT}"
 fi
-


### PR DESCRIPTION
### Motivation

- Surface missing tooling and repository artifacts earlier to make local setup failures easier to diagnose.  
- Ensure the harness verifies the Python runtime meets the project requirement (`>= 3.11`).  
- Fail fast on packaging/build steps by running harness checks before invoking `uv build`.

### Description

- Extend `scripts/check_harness.sh` to require `uvx`, include `flock` as an optional tool, and check for `python` candidates (`python3|python`).
- Add a Python runtime version check that enforces `>= 3.11` and prints the resolved Python and `uv`/`uvx` versions.  
- Emit warnings when expected repo artifacts are missing or not executable (for example `uv.lock` and `sync.sh`).
- Make the `Makefile` `build` target depend on `check-harness` and add a research note under `docs/research/harness_build_checks.md` documenting findings.

### Testing

- Ran `make format` to apply formatting and tool checks, which completed successfully.  
- Ran `make test`, which executed the test suite and reported `127 passed, 1 skipped`.  
- Verified the harness script runs and reports missing/available tools during CI-local verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ab58b9cc08321bf4438175b68f8b1)