### PR TITLE
Improve render RGBA conversion performance

### DIFF
--- a/docs/research/perf_finalize_rendering.md
+++ b/docs/research/perf_finalize_rendering.md
@@ -1,0 +1,24 @@
+# Research Note: Faster RGBA extraction in GameLoop
+
+## Context
+
+`GameLoop.__finalize_rendering` in `src/heart/environment.py` converts a
+`pygame.Surface` into a `PIL.Image` each frame. The previous approach relied on
+`pygame.surfarray` followed by NumPy stacking and transposition, which adds
+multiple Python-level array allocations per frame.
+
+## Change Summary
+
+Switched to `pygame.image.tostring` plus `Image.frombuffer` to build the RGBA
+image directly from SDL's pixel buffer. This keeps the conversion in C-backed
+code paths and avoids extra NumPy copies while keeping the same RGBA output.
+
+## Why This Matters
+
+The conversion runs every render loop iteration. Reducing Python-level array
+work lowers per-frame overhead and helps keep frame times stable when multiple
+renderers are active.
+
+## Materials
+
+- `src/heart/environment.py` (`GameLoop.__finalize_rendering`)

--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -504,7 +504,7 @@ class GameLoop:
             return None
 
     def __finalize_rendering(self, screen: pygame.Surface) -> Image.Image:
-        image_array = pygame.surfarray.pixels3d(screen)
+        image_bytes = pygame.image.tostring(screen, "RGBA")
 
         #     # Button Three
         #     ###
@@ -545,11 +545,15 @@ class GameLoop:
 
         #             image_array[:] = out.astype(np.uint8)
 
-        # TODO: This operation will be slow.
-        alpha = pygame.surfarray.pixels_alpha(screen)
-        rgba = np.dstack((image_array, alpha))
-        rgba = np.transpose(rgba, (1, 0, 2))
-        return Image.fromarray(rgba, RGBA_IMAGE_FORMAT)
+        return Image.frombuffer(
+            RGBA_IMAGE_FORMAT,
+            screen.get_size(),
+            image_bytes,
+            "raw",
+            RGBA_IMAGE_FORMAT,
+            0,
+            1,
+        )
 
     def merge_surfaces(
         self, surface1: pygame.Surface, surface2: pygame.Surface


### PR DESCRIPTION
### Motivation

- The per-frame conversion from `pygame.Surface` to `PIL.Image` previously performed multiple Python-level array allocations which increased frame overhead. 
- Reducing copies and keeping conversion in C-backed code paths should lower per-frame CPU work and improve render stability when many renderers are active. 

### Description

- Replace the `pygame.surfarray` + NumPy `dstack`/`transpose` pipeline in `GameLoop.__finalize_rendering` with `pygame.image.tostring` and `Image.frombuffer` to produce an RGBA `PIL.Image` directly. 
- Add a research note at `docs/research/perf_finalize_rendering.md` describing the motivation and approach for the optimization. 
- Run repository formatting as part of the change to keep style consistent with project tooling. 

### Testing

- Ran `make format` and it completed successfully. 
- Ran the test suite via `make test` and observed `127 passed, 1 skipped`. 
- The environment rendering tests that exercise `GameLoop` render paths passed in both `ITERATIVE` and `BINARY` variants.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ab5f64f4c8321af0256717e0cc20d)