### PR TITLE
Improve harness config reporting and shared checks

### DIFF
--- a/docs/research/harness_build_config_visibility.md
+++ b/docs/research/harness_build_config_visibility.md
@@ -1,0 +1,24 @@
+______________________________________________________________________
+
+## title: Harness config visibility and shared checks
+
+## Summary
+
+This note records harness updates that make sync/build configuration easier to
+inspect while keeping common tooling checks in one place.
+
+## Changes
+
+- Centralized shared harness helpers for command and file checks so sync and
+  build validation follow the same expectations.
+- Added a `--print-config` mode to `sync.sh` so the resolved watcher, hooks, and
+  rsync arguments can be reviewed without running a sync.
+- Extended the harness check helper to report tool versions and to verify the
+  Makefile is present for build workflows.
+
+## Materials
+
+- `scripts/harness_utils.sh`
+- `scripts/check_harness.sh`
+- `sync.sh`
+- `docs/sync_harness.md`

--- a/docs/sync_harness.md
+++ b/docs/sync_harness.md
@@ -37,6 +37,7 @@ script. Hooks run from the source directory.
 | `--pre-sync CMD` | `SYNC_PRE_SYNC_CMD` | Run a command before each sync. Repeat the option to run multiple commands. |
 | `--post-sync CMD` | `SYNC_POST_SYNC_CMD` | Run a command after each sync. Repeat the option to run multiple commands. |
 | `--skip-noop` | `SYNC_SKIP_NOOP` | Skip hooks and rsync when a dry-run reports no changes. |
+| `--print-config` | N/A | Print the resolved configuration and exit. |
 
 Example with environment variables:
 
@@ -68,6 +69,7 @@ optional helpers (for example `spellcheck`), and flags missing files such as
 - Use `--skip-spellcheck` if the `spellcheck` tool is not installed.
 - Use `--dry-run` to preview changes before syncing.
 - Use `--skip-noop` to avoid running hooks when no files would transfer.
+- Use `--print-config` to verify resolved settings without running hooks or rsync.
 - If a hook fails, the script exits with the hook's non-zero status.
 - Overlapping sync triggers are coalesced; a running sync holds a lock and records a
   pending run so changes that land mid-sync are picked up once the current pass finishes.

--- a/scripts/harness_utils.sh
+++ b/scripts/harness_utils.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+harness_command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+harness_require_file() {
+  local path=$1
+
+  if [[ ! -f "$path" ]]; then
+    echo "Error: expected to find ${path}" >&2
+    return 1
+  fi
+}
+
+harness_collect_missing_commands() {
+  local -n missing_ref=$1
+  shift
+  local cmd
+
+  for cmd in "$@"; do
+    if ! harness_command_exists "$cmd"; then
+      missing_ref+=("$cmd")
+    fi
+  done
+}
+
+harness_report_optional_commands() {
+  local cmd
+
+  for cmd in "$@"; do
+    if harness_command_exists "$cmd"; then
+      echo "Optional tool available: ${cmd}"
+    else
+      echo "Optional tool missing: ${cmd}"
+    fi
+  done
+}
+
+harness_report_tool_versions() {
+  local cmd
+
+  for cmd in "$@"; do
+    if ! harness_command_exists "$cmd"; then
+      continue
+    fi
+
+    case "$cmd" in
+      rsync)
+        echo "Tool version: $(rsync --version | head -n 1)"
+        ;;
+      uv)
+        echo "Tool version: $(uv --version)"
+        ;;
+      *)
+        echo "Tool version: $("$cmd" --version | head -n 1)"
+        ;;
+    esac
+  done
+}


### PR DESCRIPTION
### Motivation
- Centralize harness checks and file validations so sync and build tooling follow the same expectations.  
- Make the resolved `sync.sh` configuration visible to avoid surprises when running hooks or rsync.  
- Surface tool versions and verify the presence of the `Makefile` so build workflows can be validated before execution.  
- Improve developer ergonomics for local sync/build operations and troubleshooting.

### Description
- Add `scripts/harness_utils.sh` which provides reusable helpers for command checks, file requirements, missing-command collection, optional tool reporting, and basic tool version output.  
- Update `scripts/check_harness.sh` to source the new helpers, verify required files (including `Makefile`), collect missing required commands, and report tool versions and optional tools.  
- Update `sync.sh` to source the harness helpers, use them for command availability checks, and add a `--print-config` mode that prints resolved settings (watcher, hooks, rsync args, etc.) and exits.  
- Documentation updates include adding `docs/research/harness_build_config_visibility.md` and updating `docs/sync_harness.md` to document the `--print-config` option.

### Testing
- Ran `make format` and the formatting step completed successfully.  
- Ran `make test` and the test suite completed with `127 passed, 1 skipped`.  
- Executed the updated `scripts/check_harness.sh` and `sync.sh` in local runs during development to confirm expected output and behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ab5edb420832191fd5e4ffdb53df7)