### PR TITLE
Add Hypothesis property tests for SlideTransitionProvider state transitions

### DIFF
--- a/tests/renderers/test_slide_transition_provider.py
+++ b/tests/renderers/test_slide_transition_provider.py
@@ -1,0 +1,121 @@
+"""Property-based tests for the slide transition provider."""
+
+from __future__ import annotations
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from heart.peripheral.core.manager import PeripheralManager
+from heart.renderers import BaseRenderer
+from heart.renderers.slide_transition.provider import SlideTransitionProvider
+from heart.renderers.slide_transition.state import SlideTransitionState
+
+
+@st.composite
+def _advance_inputs(draw: st.DrawFn) -> tuple[int, int, int, int]:
+    direction = draw(st.sampled_from([-1, 1]))
+    slide_speed = draw(st.integers(min_value=1, max_value=64))
+    screen_width = draw(st.integers(min_value=1, max_value=256))
+    target_offset = -direction * screen_width
+    x_offset = draw(
+        st.integers(min_value=target_offset - 256, max_value=target_offset + 256)
+    )
+    return direction, slide_speed, screen_width, x_offset
+
+
+@st.composite
+def _steady_inputs(draw: st.DrawFn) -> tuple[int, int, int, int]:
+    direction = draw(st.sampled_from([-1, 1]))
+    slide_speed = draw(st.integers(min_value=1, max_value=64))
+    screen_width = draw(st.integers(min_value=1, max_value=256))
+    x_offset = draw(st.integers(min_value=-512, max_value=512))
+    return direction, slide_speed, screen_width, x_offset
+
+
+@st.composite
+def _screen_refresh_inputs(draw: st.DrawFn) -> tuple[int, int, int]:
+    direction = draw(st.sampled_from([-1, 1]))
+    slide_speed = draw(st.integers(min_value=1, max_value=64))
+    screen_width = draw(st.integers(min_value=1, max_value=256))
+    return direction, slide_speed, screen_width
+
+
+class TestSlideTransitionProviderStateTransitions:
+    """Property checks for slide transitions to keep renderer sequencing stable."""
+
+    @given(data=_advance_inputs())
+    def test_update_state_moves_toward_target(self, data: tuple[int, int, int, int]) -> None:
+        """Verify slide steps advance toward the target offset so scenes converge deterministically."""
+        direction, slide_speed, screen_width, x_offset = data
+        target_offset = -direction * screen_width
+        provider = SlideTransitionProvider(
+            BaseRenderer(),
+            BaseRenderer(),
+            direction=direction,
+            slide_speed=slide_speed,
+        )
+        state = SlideTransitionState(
+            peripheral_manager=PeripheralManager(),
+            x_offset=x_offset,
+            target_offset=target_offset,
+            sliding=True,
+            screen_w=screen_width,
+        )
+
+        result = provider.update_state(state=state, screen_width=screen_width)
+
+        assert abs(result.x_offset - target_offset) <= abs(x_offset - target_offset)
+        assert result.target_offset == target_offset
+        assert result.screen_w == screen_width
+        if result.x_offset == target_offset:
+            assert result.sliding is False
+        else:
+            assert abs(result.x_offset - x_offset) <= slide_speed
+            assert result.sliding is True
+
+    @given(data=_steady_inputs())
+    def test_update_state_keeps_idle_state(self, data: tuple[int, int, int, int]) -> None:
+        """Verify idle transitions stay unchanged so halted slides do not jitter."""
+        direction, slide_speed, screen_width, x_offset = data
+        provider = SlideTransitionProvider(
+            BaseRenderer(),
+            BaseRenderer(),
+            direction=direction,
+            slide_speed=slide_speed,
+        )
+        state = SlideTransitionState(
+            peripheral_manager=PeripheralManager(),
+            x_offset=x_offset,
+            target_offset=-direction * screen_width,
+            sliding=False,
+            screen_w=screen_width,
+        )
+
+        result = provider.update_state(state=state, screen_width=screen_width)
+
+        assert result == state
+
+    @given(data=_screen_refresh_inputs())
+    def test_update_state_refreshes_missing_target(self, data: tuple[int, int, int]) -> None:
+        """Verify missing targets refresh to screen width so transitions restart coherently."""
+        direction, slide_speed, screen_width = data
+        provider = SlideTransitionProvider(
+            BaseRenderer(),
+            BaseRenderer(),
+            direction=direction,
+            slide_speed=slide_speed,
+        )
+        state = SlideTransitionState(
+            peripheral_manager=PeripheralManager(),
+            x_offset=0,
+            target_offset=None,
+            sliding=False,
+            screen_w=screen_width,
+        )
+
+        result = provider.update_state(state=state, screen_width=screen_width)
+
+        assert result.target_offset == -direction * screen_width
+        assert result.screen_w == screen_width
+        assert result.x_offset == 0
+        assert result.sliding is False


### PR DESCRIPTION
### Motivation

- Add property-based tests to validate the state transition semantics of the slide transition provider so renderer slides behave deterministically.
- Ensure transitions advance toward targets, remain stable when idle, and refresh missing targets to avoid jitter or inconsistent restarts.

### Description

- Add `tests/renderers/test_slide_transition_provider.py` with Hypothesis-based property tests for `SlideTransitionProvider` and `SlideTransitionState` covering advance, idle, and target-refresh behaviours.
- Use strategies to generate varied `direction`, `slide_speed`, `screen_width`, and `x_offset` inputs to exercise edge cases and bounds.
- Implement assertions that verify distance-to-target non-increase, correct `target_offset` refresh, and `sliding` flag semantics.
- Run repository formatting with `make format` before committing the new tests.

### Testing

- Ran `make format` and formatting completed successfully.
- Ran the full test suite with `make test` as part of the change validation.
- Automated tests result: `134 passed, 1 skipped`.
- The new property tests executed under `Hypothesis` and passed within the CI-local test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ab7385d488321971951422bc7ed4e)