### PR TITLE
Improve render loop image handoff

### DIFF
--- a/docs/research/rendering-output-performance.md
+++ b/docs/research/rendering-output-performance.md
@@ -1,0 +1,18 @@
+# Rendering Output Performance Notes
+
+## Problem
+
+`GameLoop._one_loop` in `src/heart/environment.py` converted the display surface into
+NumPy arrays (`pygame.surfarray.array3d` plus a transpose) every frame before sending
+images to the device. That conversion allocated large arrays on every loop even when
+we already had a PIL image from the render pipeline.
+
+## Adjustment
+
+Reuse the `Image` returned by `__finalize_rendering` for device output, converting it
+to RGB only when needed. The legacy NumPy conversion remains as a fallback for cases
+where a render surface was not produced.
+
+## Materials
+
+- `src/heart/environment.py` (`GameLoop._one_loop`)

--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -644,11 +644,19 @@ class GameLoop:
 
         if len(renderers) > 0:
             pygame.display.flip()
-            # Convert screen to PIL Image
-            screen_array = pygame.surfarray.array3d(self.screen)
-            transposed_array = np.transpose(screen_array, (1, 0, 2))
-            pil_image = Image.fromarray(transposed_array)
-            self.device.set_image(pil_image)
+            if render_image is not None:
+                device_image = (
+                    render_image.convert("RGB")
+                    if render_image.mode != "RGB"
+                    else render_image
+                )
+                self.device.set_image(device_image)
+            else:
+                # Fallback to a screen capture if we did not render an image.
+                screen_array = pygame.surfarray.array3d(self.screen)
+                transposed_array = np.transpose(screen_array, (1, 0, 2))
+                pil_image = Image.fromarray(transposed_array)
+                self.device.set_image(pil_image)
 
     def _handle_events(self) -> None:
         try:


### PR DESCRIPTION
### Motivation

- Avoid allocating large NumPy arrays every frame in `GameLoop._one_loop` when a PIL `Image` is already available from the render pipeline. 
- Reduce per-frame memory churn and CPU overhead caused by `pygame.surfarray.array3d` + transpose conversions. 
- Preserve existing behavior for cases where no render surface is produced so device output remains correct. 

### Description

- Reuse the `Image` returned by `__finalize_rendering` in `GameLoop._one_loop` and pass it straight to the device after converting to `RGB` only when necessary. 
- Keep a fallback path that uses `pygame.surfarray.array3d` and `Image.fromarray` when no render image was produced. 
- Updated `src/heart/environment.py` to implement the new handoff and added `docs/research/rendering-output-performance.md` documenting the change. 

### Testing

- Ran `make format` and it completed with all checks passing. 
- Ran `make test` and the test suite completed with `131 passed, 1 skipped` in the CI environment. 
- Verified that the new fallback path still produces identical device output when `render_image` is absent. 
- No new automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ab763a05c8321aca12987a1a58138)