### PR TITLE
Optimize render loop surface blit

### DIFF
--- a/docs/performance/render_loop.md
+++ b/docs/performance/render_loop.md
@@ -1,0 +1,17 @@
+# Render Loop Surface Copy Optimization
+
+## Technical problem
+
+The render loop converted the rendered `pygame.Surface` into a Pillow image, then
+rebuilt a new `pygame.Surface` from that Pillow image before blitting it to the
+screen. This duplicated buffer copies every frame and added unnecessary per-frame
+allocation work in `heart.environment.GameLoop._one_loop`.
+
+## Change summary
+
+- The loop now blits the renderer-produced `pygame.Surface` directly to the screen.
+- The Pillow conversion is still performed, but only for the device image path.
+
+## Materials
+
+None.

--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -635,12 +635,8 @@ class GameLoop:
             renderers
         )
         render_image = self.__finalize_rendering(result) if result else None
-        if render_image is not None:
-            pixel_bytes = render_image.tobytes()
-            surface = pygame.image.frombytes(
-                pixel_bytes, render_image.size, RGBA_IMAGE_FORMAT
-            )
-            self.screen.blit(surface, (0, 0))
+        if result is not None:
+            self.screen.blit(result, (0, 0))
 
         if len(renderers) > 0:
             pygame.display.flip()


### PR DESCRIPTION
### Motivation
- Reduce per-frame memory copies and allocations in the main render loop to improve runtime performance.
- Avoid reconstructing a `pygame.Surface` from a Pillow image when the renderer already produces a `pygame.Surface`.
- Keep the Pillow conversion only for the device image path where a `PIL.Image` is required.

### Description
- Replace the round-trip conversion in `GameLoop._one_loop` by blitting the renderer-produced `pygame.Surface` directly to the screen (`self.screen.blit(result, (0, 0))`).
- Preserve the Pillow conversion path used to produce the device image sent to `self.device.set_image` when needed.
- Add a short design note at `docs/performance/render_loop.md` describing the buffer-copy issue and the optimization.
- Files changed: `src/heart/environment.py` and new `docs/performance/render_loop.md`.

### Testing
- Ran `make format` to apply code formatting and linting fixes and it completed successfully.
- Ran `make test` and the test suite completed with `134 passed, 1 skipped` in ~16s.
- Verified existing renderer-related unit tests exercising `GameLoop` render variants still pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ac45ddd988321a4bdbd0d5a8fe1e0)