### PR TITLE
Add property-based tests for sliding state providers

### DIFF
--- a/docs/research/sliding_state_provider_property_tests.md
+++ b/docs/research/sliding_state_provider_property_tests.md
@@ -1,0 +1,11 @@
+# Sliding state provider property tests
+
+## Summary
+
+Document the property-based checks added to keep sliding renderer state transitions consistent. The tests focus on width selection and offset wraparound so renderers continue to scroll predictably.
+
+## Materials
+
+- `src/heart/renderers/sliding_image/provider.py`
+- `src/heart/renderers/sliding_image/state.py`
+- `tests/renderers/test_sliding_state_provider.py`

--- a/tests/renderers/test_sliding_state_provider.py
+++ b/tests/renderers/test_sliding_state_provider.py
@@ -1,0 +1,95 @@
+"""Property-based tests for sliding renderer state providers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from heart.peripheral.core.manager import PeripheralManager
+from heart.renderers.sliding_image.provider import (
+    SlidingImageStateProvider, SlidingRendererStateProvider)
+from heart.renderers.sliding_image.state import (SlidingImageState,
+                                                 SlidingRendererState)
+
+
+@dataclass(frozen=True)
+class _ProviderSpec:
+    provider_cls: type[SlidingImageStateProvider | SlidingRendererStateProvider]
+    state_cls: type[SlidingImageState | SlidingRendererState]
+
+    def build_state(self, *, offset: int, speed: int, width: int):
+        if self.state_cls is SlidingImageState:
+            return self.state_cls(offset=offset, speed=speed, width=width, image=None)
+        return self.state_cls(offset=offset, speed=speed, width=width)
+
+
+PROVIDER_SPECS = [
+    _ProviderSpec(SlidingImageStateProvider, SlidingImageState),
+    _ProviderSpec(SlidingRendererStateProvider, SlidingRendererState),
+]
+
+
+@st.composite
+def _advance_inputs(draw: st.DrawFn) -> tuple[int, int, int]:
+    offset = draw(st.integers(min_value=-512, max_value=512))
+    speed = draw(st.integers(min_value=1, max_value=32))
+    width = draw(st.integers(min_value=-10, max_value=256))
+    return offset, speed, width
+
+
+@st.composite
+def _width_inputs(draw: st.DrawFn) -> tuple[int, int, int, int]:
+    offset = draw(st.integers(min_value=-512, max_value=512))
+    speed = draw(st.integers(min_value=1, max_value=32))
+    state_width = draw(st.integers(min_value=-10, max_value=256))
+    provider_width = draw(st.integers(min_value=-10, max_value=256))
+    return offset, speed, state_width, provider_width
+
+
+class TestSlidingStateProviderTransitions:
+    """Property checks for sliding provider transitions to preserve wraparound consistency."""
+
+    @pytest.mark.parametrize("spec", PROVIDER_SPECS)
+    @given(data=_width_inputs())
+    def test_advance_state_uses_expected_width(self, spec: _ProviderSpec, data) -> None:
+        """Verify width selection follows state or provider so scrolling remains predictable."""
+        offset, speed, state_width, provider_width = data
+        provider = spec.provider_cls(
+            peripheral_manager=PeripheralManager(),
+            speed=speed,
+            width=provider_width,
+        )
+        state = spec.build_state(offset=offset, speed=speed, width=state_width)
+        expected_width = state_width if state_width != 0 else provider_width
+
+        result = provider.advance_state(state)
+
+        assert result.width == expected_width
+        assert result.speed == speed
+        if expected_width <= 0:
+            assert result.offset == offset
+        else:
+            assert result.offset == (offset + speed) % expected_width
+
+    @pytest.mark.parametrize("spec", PROVIDER_SPECS)
+    @given(data=_advance_inputs())
+    def test_reset_state_clears_offset(self, spec: _ProviderSpec, data) -> None:
+        """Verify resets zero the offset so replays start at the leading edge reliably."""
+        offset, speed, width = data
+        provider = spec.provider_cls(
+            peripheral_manager=PeripheralManager(),
+            speed=speed,
+            width=width,
+        )
+        state = spec.build_state(offset=offset, speed=speed, width=width)
+
+        result = provider.reset_state(state)
+
+        assert result.offset == 0
+        assert result.speed == speed
+        assert result.width == width
+        if isinstance(result, SlidingImageState):
+            assert result.image is None


### PR DESCRIPTION
### Motivation

- Increase confidence in renderer state transitions by exercising `SlidingImageStateProvider` and `SlidingRendererStateProvider` with property-based checks. 
- Capture edge cases around width selection and offset wraparound so scrolling behaviour remains deterministic across inputs. 

### Description

- Add `tests/renderers/test_sliding_state_provider.py` which defines Hypothesis strategies and parameterised specs to exercise provider transitions over broad input ranges. 
- Introduce `_ProviderSpec` to unify testing for `SlidingImageStateProvider` and `SlidingRendererStateProvider` and add `_advance_inputs` and `_width_inputs` strategies. 
- Adjust width selection expectation in the test to use `state_width != 0` when deriving the `expected_width` to reflect provider/state semantics. 
- Add documentation `docs/research/sliding_state_provider_property_tests.md` describing the new checks and referenced source files. 

### Testing

- Ran formatting with `make format` which completed successfully. 
- Ran the test suite with `make test`; an initial failure was diagnosed, a test expectation was corrected, and the full suite then passed. 
- Final automated result: `138 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ac4674f5483218a9205b903002d16)