### PR TITLE
Reuse render executor for binary surface merges

### DIFF
--- a/docs/research/render_executor_reuse.md
+++ b/docs/research/render_executor_reuse.md
@@ -1,0 +1,20 @@
+# Render executor reuse for binary surface merges
+
+## Problem
+
+`GameLoop._render_surfaces_binary` created a new `ThreadPoolExecutor` on every frame. That
+per-frame allocation adds thread startup and teardown overhead to a hot loop in the
+rendering path.
+
+## Approach
+
+Reuse a single executor instance across frames and shut it down when the game loop exits.
+This preserves the existing parallel merge strategy but avoids repeated thread creation.
+
+## Sources
+
+- `src/heart/environment.py` (`GameLoop._render_surfaces_binary`, executor lifecycle)
+
+## Materials
+
+- Python standard library `concurrent.futures.ThreadPoolExecutor` documentation


### PR DESCRIPTION
### Motivation

- Avoid per-frame thread startup/teardown overhead caused by creating a new `ThreadPoolExecutor` on every binary render pass.  
- Improve rendering performance and reduce CPU churn in the hot rendering loop.  
- Keep the existing parallel merge strategy while reducing allocation costs.  

### Description

- Introduce a long-lived `self._render_executor` on `GameLoop` and a lazy accessor `_get_render_executor()` that returns a shared `ThreadPoolExecutor`.  
- Replace the per-frame `with ThreadPoolExecutor()` usage in `_render_surfaces_binary` with the shared executor returned by `_get_render_executor()`.  
- Shutdown and clear the executor during `GameLoop` shutdown in the loop `finally` block to ensure clean teardown.  
- Add a research note at `docs/research/render_executor_reuse.md` describing the change and rationale.  

### Testing

- Ran `make format` to apply project formatting rules and the command completed successfully.  
- Ran the test suite via `make test` which resulted in all automated tests passing (`134 passed, 1 skipped`).  
- No new unit tests were required for the executor lifecycle; existing rendering tests exercised the modified code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ac474b6a083219b174b8e1071d813)