### PR TITLE
Harden harness Python version checks and update sync docs

### DIFF
--- a/docs/sync_harness.md
+++ b/docs/sync_harness.md
@@ -59,9 +59,10 @@ build command.
 ## Harness check helper
 
 `scripts/check_harness.sh` verifies the core tooling expected by the sync and
-build harness. It confirms required commands like `uv` and `rsync` exist, reports
-optional helpers (for example `spellcheck`), and flags missing files such as
-`.syncignore`.
+build harness. It confirms required commands like `uv`, `uvx`, and `rsync` exist,
+checks the active Python interpreter meets the minimum version, reports optional
+helpers (for example `spellcheck`), and flags missing files such as `.syncignore`
+and `uv.lock`.
 
 ## Notes
 

--- a/scripts/check_harness.sh
+++ b/scripts/check_harness.sh
@@ -52,7 +52,7 @@ if [[ -z "${PYTHON_CMD}" ]]; then
   exit 1
 fi
 
-python_version=$(
+if ! python_version=$(
   "${PYTHON_CMD}" - <<PYTHON
 import sys
 required = (3, 11)
@@ -61,9 +61,8 @@ print(version)
 if sys.version_info < required:
     raise SystemExit(1)
 PYTHON
-)
-if [[ $? -ne 0 ]]; then
-  echo "Error: ${PYTHON_CMD} ${python_version} is below required ${PYTHON_MIN_VERSION}" >&2
+); then
+  echo "Error: ${PYTHON_CMD} ${python_version:-unknown} is below required ${PYTHON_MIN_VERSION}" >&2
   exit 1
 fi
 


### PR DESCRIPTION
### Motivation
- Avoid early script termination from `set -e` when validating the active Python interpreter during harness checks.  
- Surface missing tooling and repository artifacts earlier so builds and sync hooks fail fast with clear diagnostics.  
- Make the sync/harness guidance accurate about what the harness check verifies.  

### Description
- Modify `scripts/check_harness.sh` to run the Python probe inside a guarded assignment (`if ! python_version=$(...) ; then ... fi`) so version validation does not trigger `set -e` unexpectedly.  
- Improve the Python-version error message to include a safe fallback when the probe yields no output.  
- Update `docs/sync_harness.md` to document that `scripts/check_harness.sh` checks for `uv`, `uvx`, `rsync`, validates the active Python interpreter meets the minimum version, and flags missing files such as `.syncignore` and `uv.lock`.  

### Testing
- Ran `make format` and the formatting checks completed successfully.  
- Ran `make test` and the full test suite passed with `138 passed, 1 skipped`.  
- Verified the modified `scripts/check_harness.sh` and `docs/sync_harness.md` were staged and committed as part of the change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ac8b068588321a8081aa10bd1f8c9)