### PR TITLE
Improve harness tool list handling and guardrails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,17 @@
 PYTHON_SOURCES = src tests
 DOCS_SOURCES = docs
-TOOLS := $(shell cat scripts/harness_tools.txt)
+TOOL_LIST_FILE = scripts/harness_tools.txt
+TOOLS := $(shell awk '/^[a-zA-Z0-9_-]+/ {print $$1}' $(TOOL_LIST_FILE))
 BUILD_ARGS ?=
 .PHONY: install pi_install format check test build check-harness
 
 install:
 	@uv sync --all-extras --group dev
-	@for tool in $(TOOLS); do uv tool install $$tool; done
+	@if [ -s "$(TOOL_LIST_FILE)" ]; then \
+		for tool in $(TOOLS); do uv tool install $$tool; done; \
+	else \
+		echo "Warning: $(TOOL_LIST_FILE) is missing or empty; skipping uv tool installs." >&2; \
+	fi
 
 format:
 	@uvx isort $(PYTHON_SOURCES)

--- a/docs/research/harness_tool_list_guardrails.md
+++ b/docs/research/harness_tool_list_guardrails.md
@@ -1,0 +1,24 @@
+# Harness tool list guardrails for build/install helpers
+
+## Problem statement
+
+The Makefile install target assumes the harness tool list exists and is populated,
+which can yield confusing errors if the file is missing or empty. The harness
+check script also skips tool validation silently when the list is empty.
+
+## Update summary
+
+- Filter the harness tool list in the Makefile so comment lines are ignored.
+- Emit a warning when the list is missing or empty and skip tool installs or
+  checks explicitly.
+
+## Source locations reviewed
+
+- `Makefile`
+- `scripts/check_harness.sh`
+- `scripts/harness_tools.txt`
+
+## Materials
+
+- `bash`
+- `make`

--- a/scripts/check_harness.sh
+++ b/scripts/check_harness.sh
@@ -75,6 +75,9 @@ echo "uvx version: $(uvx --version)"
 
 if [[ -f "${UV_TOOL_LIST_FILE}" ]]; then
   mapfile -t required_uv_tools < <(grep -E '^[a-zA-Z0-9_-]+' "${UV_TOOL_LIST_FILE}")
+  if [[ ${#required_uv_tools[@]} -eq 0 ]]; then
+    echo "Warning: ${UV_TOOL_LIST_FILE} has no tool entries; skipping uv tool checks." >&2
+  fi
 else
   required_uv_tools=()
   echo "Warning: ${UV_TOOL_LIST_FILE} not found; skipping uv tool checks." >&2

--- a/scripts/harness_tools.txt
+++ b/scripts/harness_tools.txt
@@ -1,3 +1,4 @@
+# uv tool installs for formatter/lint helpers used by Makefile targets.
 ruff
 isort
 docformatter


### PR DESCRIPTION
### Motivation
- The Makefile `install` target assumed `scripts/harness_tools.txt` existed and was non-empty, which produced confusing errors on fresh checkouts or when the file only contained comments. 
- The harness check script (`scripts/check_harness.sh`) skipped uv tool validation silently when the tool list had no entries. 
- Ignoring comment/blank lines when reading the tool list reduces accidental installs of empty entries and keeps `make install` deterministic. 

### Description
- Add `TOOL_LIST_FILE` and use `awk '/^[a-zA-Z0-9_-]+/ {print $$1}'` to filter valid tool names from `scripts/harness_tools.txt` in the `Makefile`. 
- Guard the `install` target to check `-s` on the tool list and emit a warning while skipping uv tool installs if the file is missing or empty. 
- Emit a clear warning in `scripts/check_harness.sh` when the uv tool list file exists but contains no tool entries, and retain the existing behavior when it is missing. 
- Add a short research note at `docs/research/harness_tool_list_guardrails.md` and add a header comment to `scripts/harness_tools.txt` to document intent. 

### Testing
- Ran `make format` which completed successfully. 
- Ran `make test` which completed successfully with `138 passed, 1 skipped`. 
- Verified `make install` path now warns and skips installs when `scripts/harness_tools.txt` is missing or empty (manual check via script behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694acaa3a4648321968bf4ff1a96eb69)