### PR TITLE
Vectorize HSV round-trip hue calibration

### DIFF
--- a/docs/research/hsv_roundtrip_vectorization.md
+++ b/docs/research/hsv_roundtrip_vectorization.md
@@ -1,0 +1,26 @@
+# HSV round-trip calibration vectorization
+
+## Problem
+
+The numpy fallback for HSV conversion in `heart.environment` corrects hue values by
+checking nearby hues until the converted BGR values match the original image. The
+previous implementation processed each mismatched pixel in a nested Python loop,
+which scaled poorly when many pixels required adjustment.
+
+## Approach
+
+Vectorize the hue search by batching the candidate hue checks across all mismatched
+pixels for each offset. The updated loop keeps the same offsets and matching logic
+but uses array operations to compare candidate BGR values in bulk, reducing Python
+iteration overhead while preserving the calibrated round-trip behaviour.
+
+## Impact
+
+The per-frame fallback conversion now spends less time in Python when the hue
+calibration branch is exercised, improving throughput for renderer pipelines that
+rely on the numpy conversion path.
+
+## Materials
+
+- `src/heart/environment.py` (`_convert_bgr_to_hsv` hue calibration loop)
+- `tests/test_environment_core_logic.py` (HSV conversion round-trip coverage)


### PR DESCRIPTION
### Motivation

- The numpy fallback for HSV conversion used per-pixel Python loops when calibrating hue, which created unnecessary Python overhead for images with many mismatches.
- Reduce CPU time in the renderer color-conversion hot path to improve frame-throughput for pipelines that exercise the numpy path.
- Preserve the existing calibration semantics and cache behaviour so visual results remain unchanged.

### Description

- Replace the nested per-pixel hue search in `_convert_bgr_to_hsv` with a batched, vectorized loop that evaluates candidate hue offsets across all mismatched pixels.
- Keep the original offsets and matching rules while updating matched hues in bulk to retain behaviour.
- Add a research note at `docs/research/hsv_roundtrip_vectorization.md` describing the problem, approach, and impact.
- Applied repository formatting as part of the change (`make format`).

### Testing

- Ran `make format` which completed successfully.
- Ran `make test` and all automated tests passed: `138 passed, 1 skipped`.
- Existing unit tests in `tests/test_environment_core_logic.py` that exercise the HSV round-trip and cache behaviour passed unchanged.
- No new runtime or integration tests were added beyond the documentation note.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694acaad758083218a37557a3d2fde32)