### PR TITLE
Batch blits in FrameAccumulator.flush

### DIFF
--- a/docs/research/frame_accumulator_batch_blits.md
+++ b/docs/research/frame_accumulator_batch_blits.md
@@ -1,0 +1,28 @@
+# Frame accumulator batched blits
+
+## Summary
+
+`FrameAccumulator.flush` now batches consecutive blit commands into a single
+`pygame.Surface.blits` call. This reduces Python-level dispatch overhead when
+renderers queue many blits per frame, while keeping the original command order
+intact by flushing pending blits before any fill command.
+
+## Observations
+
+- The accumulator can hold long runs of blit commands when renderers draw many
+  sprites or tiles.
+- Each `blit` call incurs Python overhead, so grouping them into a single
+  `blits` call is a low-risk way to reduce per-frame work.
+- Fill commands must preserve ordering relative to blits, so batching is limited
+  to consecutive blit segments.
+
+## Implementation notes
+
+- `flush` maintains a pending list of blit tuples in the order they were queued.
+- Before processing a fill command, any pending blits are flushed to preserve
+  rendering order.
+- After the loop, any remaining blits are flushed once.
+
+## Materials
+
+- `src/heart/renderers/internal/frame_accumulator.py`


### PR DESCRIPTION
### Motivation

- Reduce Python-level overhead when many sequential blit commands are queued by renderers. 
- Preserve original draw ordering while improving per-frame throughput for sprite/tile-heavy renderers. 
- Provide a low-risk optimization that leverages `pygame.Surface.blits` to perform many blits in a single call. 

### Description

- Replace per-command `blit` calls in `FrameAccumulator.flush` with a batched approach that accumulates consecutive blit tuples and calls `destination.blits` once for each consecutive block. 
- Ensure ordering is preserved by flushing any pending blits before processing a `fill` command. 
- Add a research note at `docs/research/frame_accumulator_batch_blits.md` describing the rationale and implementation. 
- Change is isolated to `src/heart/renderers/internal/frame_accumulator.py` and preserves existing public behaviour. 

### Testing

- Ran `make format` (formatting hooks completed successfully). 
- Ran the test suite with `make test` and observed `138 passed, 1 skipped` in ~32s. 
- Confirmed the new logic does not change visible behaviour by keeping command order intact during `flush`. 
- No additional failing tests were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694acab0aac88321b2316588a50fa7a4)