### PR TITLE
Add property tests and _advance_state helper for Combined BPM provider

### DIFF
--- a/docs/renderers/combined_bpm_screen_provider_testing.md
+++ b/docs/renderers/combined_bpm_screen_provider_testing.md
@@ -1,0 +1,11 @@
+# Combined BPM Screen Provider Property Testing
+
+## Problem statement
+
+State transitions in the combined BPM screen provider depend on elapsed timing data. This update documents the property-based tests that verify the provider switches between metadata and max BPM phases at the configured thresholds so renderer sequencing stays consistent.
+
+## Materials
+
+- `src/heart/renderers/combined_bpm_screen/provider.py`
+- `src/heart/renderers/combined_bpm_screen/state.py`
+- `tests/renderers/test_combined_bpm_screen_provider.py`

--- a/src/heart/renderers/combined_bpm_screen/provider.py
+++ b/src/heart/renderers/combined_bpm_screen/provider.py
@@ -34,19 +34,7 @@ class CombinedBpmScreenStateProvider(ObservableProvider[CombinedBpmScreenState])
         def advance_state(
             state: CombinedBpmScreenState, clock: Clock
         ) -> CombinedBpmScreenState:
-            elapsed_time = state.elapsed_time_ms + clock.get_time()
-            showing_metadata = state.showing_metadata
-
-            if showing_metadata and elapsed_time >= self._metadata_duration_ms:
-                showing_metadata = False
-                elapsed_time = 0
-            elif (not showing_metadata) and elapsed_time >= self._max_bpm_duration_ms:
-                showing_metadata = True
-                elapsed_time = 0
-
-            return CombinedBpmScreenState(
-                elapsed_time_ms=elapsed_time, showing_metadata=showing_metadata
-            )
+            return self._advance_state(state=state, elapsed_ms=clock.get_time())
 
         return (
             self._peripheral_manager.game_tick.pipe(
@@ -56,4 +44,21 @@ class CombinedBpmScreenStateProvider(ObservableProvider[CombinedBpmScreenState])
                 ops.start_with(initial_state),
                 ops.share(),
             )
+        )
+
+    def _advance_state(
+        self, *, state: CombinedBpmScreenState, elapsed_ms: int
+    ) -> CombinedBpmScreenState:
+        elapsed_time = state.elapsed_time_ms + elapsed_ms
+        showing_metadata = state.showing_metadata
+
+        if showing_metadata and elapsed_time >= self._metadata_duration_ms:
+            showing_metadata = False
+            elapsed_time = 0
+        elif (not showing_metadata) and elapsed_time >= self._max_bpm_duration_ms:
+            showing_metadata = True
+            elapsed_time = 0
+
+        return CombinedBpmScreenState(
+            elapsed_time_ms=elapsed_time, showing_metadata=showing_metadata
         )

--- a/tests/renderers/test_combined_bpm_screen_provider.py
+++ b/tests/renderers/test_combined_bpm_screen_provider.py
@@ -1,0 +1,71 @@
+"""Property-based tests for the combined BPM screen provider."""
+
+from __future__ import annotations
+
+from hypothesis import assume, given
+from hypothesis import strategies as st
+
+from heart.peripheral.core.manager import PeripheralManager
+from heart.renderers.combined_bpm_screen.provider import \
+    CombinedBpmScreenStateProvider
+from heart.renderers.combined_bpm_screen.state import CombinedBpmScreenState
+
+
+@st.composite
+def _timing_inputs(draw: st.DrawFn) -> tuple[int, int, int, int, bool]:
+    metadata_duration = draw(st.integers(min_value=1, max_value=20000))
+    max_bpm_duration = draw(st.integers(min_value=1, max_value=20000))
+    elapsed_time = draw(st.integers(min_value=0, max_value=20000))
+    delta = draw(st.integers(min_value=0, max_value=20000))
+    showing_metadata = draw(st.booleans())
+    return metadata_duration, max_bpm_duration, elapsed_time, delta, showing_metadata
+
+
+class TestCombinedBpmScreenProviderTransitions:
+    """Property tests for combined BPM transitions to keep screen toggles reliable."""
+
+    @given(data=_timing_inputs())
+    def test_advance_state_holds_until_threshold(
+        self, data: tuple[int, int, int, int, bool]
+    ) -> None:
+        """Verify elapsed time accumulates when below thresholds so screen phases stay steady."""
+        metadata_duration, max_bpm_duration, elapsed_time, delta, showing_metadata = data
+        provider = CombinedBpmScreenStateProvider(
+            peripheral_manager=PeripheralManager(),
+            metadata_duration_ms=metadata_duration,
+            max_bpm_duration_ms=max_bpm_duration,
+        )
+        total = elapsed_time + delta
+        threshold = metadata_duration if showing_metadata else max_bpm_duration
+        assume(total < threshold)
+        state = CombinedBpmScreenState(
+            elapsed_time_ms=elapsed_time, showing_metadata=showing_metadata
+        )
+
+        result = provider._advance_state(state=state, elapsed_ms=delta)
+
+        assert result.elapsed_time_ms == total
+        assert result.showing_metadata == showing_metadata
+
+    @given(data=_timing_inputs())
+    def test_advance_state_flips_on_threshold(
+        self, data: tuple[int, int, int, int, bool]
+    ) -> None:
+        """Verify exceeding thresholds flips screen phases so render cycles stay predictable."""
+        metadata_duration, max_bpm_duration, elapsed_time, delta, showing_metadata = data
+        provider = CombinedBpmScreenStateProvider(
+            peripheral_manager=PeripheralManager(),
+            metadata_duration_ms=metadata_duration,
+            max_bpm_duration_ms=max_bpm_duration,
+        )
+        total = elapsed_time + delta
+        threshold = metadata_duration if showing_metadata else max_bpm_duration
+        assume(total >= threshold)
+        state = CombinedBpmScreenState(
+            elapsed_time_ms=elapsed_time, showing_metadata=showing_metadata
+        )
+
+        result = provider._advance_state(state=state, elapsed_ms=delta)
+
+        assert result.elapsed_time_ms == 0
+        assert result.showing_metadata is not showing_metadata


### PR DESCRIPTION
### Motivation
- Make the combined BPM screen provider's timing transition behaviour easier to test by extracting the state-advance logic into a dedicated helper so property tests can exercise it directly.
- Verify that the provider flips between metadata and max-BPM phases at the configured thresholds to keep renderer sequencing deterministic.

### Description
- Extracted the inline timing logic into a new helper method `CombinedBpmScreenStateProvider._advance_state` and updated `observable` to call it.
- Added property-based tests in `tests/renderers/test_combined_bpm_screen_provider.py` using Hypothesis to assert both hold-until-threshold and flip-on-threshold behaviours.
- Added a documentation note at `docs/renderers/combined_bpm_screen_provider_testing.md` describing the property testing intent and materials.
- Ran formatting changes via `make format` as part of the change.

### Testing
- Ran `make format` to apply repository formatting rules and the invocation completed successfully.
- Ran `make test` and the test suite completed with `142 passed, 1 skipped` including the new property tests which passed.
- The new tests exercise both accumulation and threshold-flip behaviours of `_advance_state` under randomized inputs via Hypothesis.
- No failing automated tests were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694acac28e1483218a0870bb42f22601)