### PR TITLE
Optimize pixel border rendering

### DIFF
--- a/docs/research/border_renderer_fill.md
+++ b/docs/research/border_renderer_fill.md
@@ -1,0 +1,17 @@
+# Border renderer fill optimization
+
+## Technical problem
+
+The border renderer in `src/heart/renderers/pixels/renderer.py` drew every border pixel
+with nested `set_at` loops. That path executes per-pixel Python calls each frame, which
+adds overhead during render updates.
+
+## Change summary
+
+Use `Surface.fill` with rectangular regions to draw the border in four operations.
+`pygame` handles the pixel writes internally, reducing Python-level work while
+keeping the same border output.
+
+## Materials
+
+- `src/heart/renderers/pixels/renderer.py`

--- a/src/heart/renderers/pixels/renderer.py
+++ b/src/heart/renderers/pixels/renderer.py
@@ -31,15 +31,22 @@ class Border(StatefulBaseRenderer[BorderState]):
     ) -> None:
         width, height = window.get_size()
         color_value = self.state.color._as_tuple()
-        for x in range(width):
-            for y in range(self.width):
-                window.set_at((x, y), color_value)
-                window.set_at((x, height - 1 - y), color_value)
-
-        for y in range(height):
-            for x in range(self.width):
-                window.set_at((x, y), color_value)
-                window.set_at((width - 1 - x, y), color_value)
+        border_width = max(0, self.width)
+        if border_width == 0:
+            return
+        clamped_width = min(border_width, min(width, height))
+        if clamped_width == 0:
+            return
+        window.fill(color_value, pygame.Rect(0, 0, width, clamped_width))
+        window.fill(
+            color_value,
+            pygame.Rect(0, height - clamped_width, width, clamped_width),
+        )
+        window.fill(color_value, pygame.Rect(0, 0, clamped_width, height))
+        window.fill(
+            color_value,
+            pygame.Rect(width - clamped_width, 0, clamped_width, height),
+        )
 
     def set_color(self, color: Color) -> None:
         self._provider.set_color(color)


### PR DESCRIPTION
### Motivation
- The border renderer used nested `set_at` loops that performed per-pixel Python calls and added overhead each frame.
- Reduce Python-level work by delegating pixel writes to `pygame` internals where possible. 
- Ensure the requested border width is clamped to the drawable surface bounds to avoid drawing outside the surface.

### Description
- Replace nested per-pixel `window.set_at` loops in `Border.real_process` with four `Surface.fill` rectangle blits. 
- Clamp `self.width` using `max`/`min` and early-return when the effective border width is zero. 
- Add a short research note at `docs/research/border_renderer_fill.md` explaining the motivation and approach. 

### Testing
- Ran `make format` to apply formatting and style fixes and it completed successfully. 
- Ran `make test` and the full test suite passed with `142 passed, 1 skipped` (note: `pytest-benchmark` emitted a warning about `xdist` preventing reliable benchmarks). 
- No automated tests failed as a result of these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad2099e0083219e37eb0e0d7feabe)