### PR TITLE
Add property tests for HeartTitleScreen provider and extract advance helper

### DIFF
--- a/src/heart/renderers/heart_title_screen/provider.py
+++ b/src/heart/renderers/heart_title_screen/provider.py
@@ -26,15 +26,7 @@ class HeartTitleScreenStateProvider(ObservableProvider[HeartTitleScreenState]):
         def advance_state(
             state: HeartTitleScreenState, clock: Clock
         ) -> HeartTitleScreenState:
-            frame_ms = max(clock.get_time(), 0)
-            elapsed_ms = state.elapsed_ms + frame_ms
-            heart_up = state.heart_up
-
-            if elapsed_ms > DEFAULT_TIME_BETWEEN_FRAMES_MS:
-                elapsed_ms = 0.0
-                heart_up = not heart_up
-
-            return HeartTitleScreenState(heart_up=heart_up, elapsed_ms=elapsed_ms)
+            return self._advance_state(state=state, frame_ms=clock.get_time())
 
         return (
             self._peripheral_manager.game_tick.pipe(
@@ -45,3 +37,16 @@ class HeartTitleScreenStateProvider(ObservableProvider[HeartTitleScreenState]):
                 ops.share(),
             )
         )
+
+    def _advance_state(
+        self, *, state: HeartTitleScreenState, frame_ms: float
+    ) -> HeartTitleScreenState:
+        safe_frame_ms = max(frame_ms, 0.0)
+        elapsed_ms = state.elapsed_ms + safe_frame_ms
+        heart_up = state.heart_up
+
+        if elapsed_ms > DEFAULT_TIME_BETWEEN_FRAMES_MS:
+            elapsed_ms = 0.0
+            heart_up = not heart_up
+
+        return HeartTitleScreenState(heart_up=heart_up, elapsed_ms=elapsed_ms)

--- a/tests/renderers/test_heart_title_screen_provider.py
+++ b/tests/renderers/test_heart_title_screen_provider.py
@@ -1,0 +1,66 @@
+"""Property-based tests for heart title screen provider transitions."""
+
+from __future__ import annotations
+
+from hypothesis import assume, given
+from hypothesis import strategies as st
+
+from heart.peripheral.core.manager import PeripheralManager
+from heart.renderers.heart_title_screen.provider import (
+    DEFAULT_TIME_BETWEEN_FRAMES_MS, HeartTitleScreenStateProvider)
+from heart.renderers.heart_title_screen.state import HeartTitleScreenState
+
+
+@st.composite
+def _timing_inputs(draw: st.DrawFn) -> tuple[float, float, bool]:
+    elapsed_ms = draw(
+        st.floats(min_value=0, max_value=2000, allow_nan=False, allow_infinity=False)
+    )
+    frame_ms = draw(
+        st.floats(
+            min_value=-500,
+            max_value=2000,
+            allow_nan=False,
+            allow_infinity=False,
+        )
+    )
+    heart_up = draw(st.booleans())
+    return elapsed_ms, frame_ms, heart_up
+
+
+class TestHeartTitleScreenProviderTransitions:
+    """Group heart title provider checks so animation toggles remain deterministic."""
+
+    @given(data=_timing_inputs())
+    def test_advance_state_accumulates_below_threshold(
+        self, data: tuple[float, float, bool]
+    ) -> None:
+        """Verify elapsed time accumulates below the threshold so title pulses stay steady."""
+        elapsed_ms, frame_ms, heart_up = data
+        provider = HeartTitleScreenStateProvider(PeripheralManager())
+        state = HeartTitleScreenState(heart_up=heart_up, elapsed_ms=elapsed_ms)
+        safe_frame_ms = max(frame_ms, 0.0)
+        total = elapsed_ms + safe_frame_ms
+        assume(total <= DEFAULT_TIME_BETWEEN_FRAMES_MS)
+
+        result = provider._advance_state(state=state, frame_ms=frame_ms)
+
+        assert result.heart_up is heart_up
+        assert result.elapsed_ms == total
+
+    @given(data=_timing_inputs())
+    def test_advance_state_toggles_above_threshold(
+        self, data: tuple[float, float, bool]
+    ) -> None:
+        """Verify exceeding the threshold flips heart frames so animations keep pulsing."""
+        elapsed_ms, frame_ms, heart_up = data
+        provider = HeartTitleScreenStateProvider(PeripheralManager())
+        state = HeartTitleScreenState(heart_up=heart_up, elapsed_ms=elapsed_ms)
+        safe_frame_ms = max(frame_ms, 0.0)
+        total = elapsed_ms + safe_frame_ms
+        assume(total > DEFAULT_TIME_BETWEEN_FRAMES_MS)
+
+        result = provider._advance_state(state=state, frame_ms=frame_ms)
+
+        assert result.heart_up is not heart_up
+        assert result.elapsed_ms == 0.0


### PR DESCRIPTION
### Motivation

- Encapsulate the heart title frame-advance logic to make it easier to test and reuse. 
- Add property-based tests to verify timing and toggle behaviour so the title animation remains deterministic under varied inputs. 

### Description

- Extracted the frame-advance logic from `observable` into a new method `HeartTitleScreenStateProvider._advance_state`. 
- Updated `observable` to call `self._advance_state(state=..., frame_ms=clock.get_time())` to preserve existing behaviour. 
- Added property-based tests in `tests/renderers/test_heart_title_screen_provider.py` that use `hypothesis` to validate accumulation below the threshold and toggling above the threshold. 
- Modified file `src/heart/renderers/heart_title_screen/provider.py` and added the new test file. 

### Testing

- Ran formatting with `make format` which completed successfully. 
- Ran the test suite with `make test`, resulting in `144 passed, 1 skipped` and no failures. 
- The new Hypothesis-based tests passed as part of the full test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad22a1458832186346f72cda1166c)