### PR TITLE
Vectorize HSV->BGR neighbourhood correction to improve conversion performance

### DIFF
--- a/docs/research/hsv_neighborhood_matching.md
+++ b/docs/research/hsv_neighborhood_matching.md
@@ -1,0 +1,21 @@
+# Vectorized HSV neighbourhood matching
+
+## Problem
+
+The HSV-to-BGR conversion in `src/heart/environment.py` includes a neighbourhood
+search that corrects float rounding errors. The previous implementation walked
+mismatched pixels one at a time and iterated candidate offsets in Python. That
+approach added per-pixel overhead in the main render loop, even though the
+search itself is purely numeric and well-suited to NumPy broadcasting.
+
+## Approach
+
+The neighbourhood search now builds all candidate BGR offsets for the mismatched
+pixels at once, checks bounds, converts candidates back to HSV in a single
+NumPy call, and selects the first matching candidate per pixel. This keeps the
+calibration logic but moves the heavy work into vectorized operations.
+
+## Materials
+
+- Source: `src/heart/environment.py` (`_convert_hsv_to_bgr`)
+- Tests: `tests/test_environment_core_logic.py`


### PR DESCRIPTION
### Motivation
- Reduce per-pixel Python overhead in the HSV-to-BGR calibration step inside the main render conversion pipeline. 
- Preserve existing calibration behaviour while moving numeric work into NumPy to improve throughput during rendering. 

### Description
- Add `HSV_BGR_NEIGHBOR_OFFSETS` and replace the triple-nested per-pixel loop in `_convert_hsv_to_bgr` with a vectorized candidate generation and matching approach in `src/heart/environment.py`. 
- Generate all neighbour BGR candidates at once, filter out-of-bounds values, convert candidates to HSV in a single `NumPy` call, and select the first matching candidate per mismatched pixel. 
- Keep existing cache and calibration semantics (`HSV_TO_BGR_CACHE`) unchanged so behaviour and known special-case corrections remain intact. 
- Add a research note at `docs/research/hsv_neighborhood_matching.md` describing the rationale and vectorization approach. 

### Testing
- Ran `make format` to apply repository formatting rules and it completed successfully. 
- Ran `make test` and the full test suite passed: `142 passed, 1 skipped`. 
- Existing HSV/BGR unit tests under `tests/test_environment_core_logic.py` were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad21046e08321b9cfb95e62d442bd)