### PR TITLE
Configurable FFT padding and thresholding for signal cross-correlation

### DIFF
--- a/docs/research/signal_cross_correlation_fft_tuning.md
+++ b/docs/research/signal_cross_correlation_fft_tuning.md
@@ -1,0 +1,35 @@
+# Signal cross-correlation FFT tuning
+
+## Summary
+
+The cross-correlation helper in `heart.utilities.signal` uses FFT-based
+convolution when the input sizes are large enough. The previous
+implementation always used an FFT length equal to the exact correlation
+length, which can be slower than padding to a power of two for large
+inputs. This note records the change to allow configurable FFT padding
+and thresholding so deployments can choose between compatibility and
+throughput.
+
+## Implementation notes
+
+- `heart.utilities.signal._fft_cross_correlation` now pads to the next
+  power of two by default before calling `numpy.fft.rfft`.
+- The padding behaviour is configurable with
+  `HEART_SIGNAL_FFT_PAD_MODE` (`next_pow2` or `exact`).
+- The FFT switch-over threshold is configurable with
+  `HEART_SIGNAL_FFT_THRESHOLD` so devices can force or defer the FFT path
+  depending on CPU budget.
+
+## Operational guidance
+
+- Use `HEART_SIGNAL_FFT_PAD_MODE=exact` if the FFT padding change needs
+  to be disabled for troubleshooting or performance comparisons.
+- Adjust `HEART_SIGNAL_FFT_THRESHOLD` upward if the FFT path adds
+  overhead for short sequences, or downward if workloads routinely
+  exceed the default size.
+
+## Materials
+
+- `src/heart/utilities/signal.py`
+- `src/heart/utilities/env.py`
+- `tests/utilities/test_signal.py`

--- a/src/heart/utilities/env.py
+++ b/src/heart/utilities/env.py
@@ -128,6 +128,19 @@ class Configuration:
             )
         return None
 
+    @classmethod
+    def signal_fft_correlation_threshold(cls) -> int:
+        return _env_int("HEART_SIGNAL_FFT_THRESHOLD", default=50_000, minimum=1)
+
+    @classmethod
+    def signal_fft_pad_mode(cls) -> str:
+        mode = os.environ.get("HEART_SIGNAL_FFT_PAD_MODE", "next_pow2").strip().lower()
+        if mode not in {"exact", "next_pow2"}:
+            raise ValueError(
+                "HEART_SIGNAL_FFT_PAD_MODE must be 'exact' or 'next_pow2'"
+            )
+        return mode
+
 
 def get_device_ports(prefix: str) -> Iterator[str]:
     base_port = "/dev/serial/by-id"


### PR DESCRIPTION
### Motivation

- Improve runtime performance of large cross-correlation computations by allowing FFT padding to be tuned for throughput.
- Expose the FFT switch-over threshold so environments can force or avoid the FFT path based on CPU budget.
- Provide deterministic behaviour for troubleshooting by allowing exact-length FFTs when required.

### Description

- Add `Configuration.signal_fft_correlation_threshold()` and `Configuration.signal_fft_pad_mode()` to `src/heart/utilities/env.py` to expose `HEART_SIGNAL_FFT_THRESHOLD` and `HEART_SIGNAL_FFT_PAD_MODE` environment settings.
- Update `_fft_cross_correlation` in `src/heart/utilities/signal.py` to pad the FFT to either the exact correlation length or the next power of two (default `next_pow2`) and trim the output back to the correlation length.
- Introduce helpers `_fft_length` and `_next_power_of_two`, and switch the decision to use FFT to read the threshold from `Configuration`.
- Add tests in `tests/utilities/test_signal.py` that validate exact padding, power-of-two padding, and thresholded FFT usage, and add an operational research note at `docs/research/signal_cross_correlation_fft_tuning.md`.

### Testing

- Ran `make format` to apply project formatting rules and ensure style consistency.
- Ran the full test suite with `make test`, which completed successfully with `145 passed, 1 skipped`.
- New unit tests specifically for FFT padding and thresholding were executed and passed.
- No changes were made to HSV conversion code as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad366d5ac8321b92453d32fb36efb)