### PR TITLE
Improve IR multilateration solver performance and expose solver configuration

### DIFF
--- a/docs/research/ir_sensor_array_positioning.md
+++ b/docs/research/ir_sensor_array_positioning.md
@@ -40,6 +40,16 @@ score derived from the residual root mean square error (RMSE). Unit tests in
 exercise the solver with synthetic geometry and confirm convergence to a known
 point within a millimetre.【F:src/heart/peripheral/ir_sensor_array.py†L118-L207】【F:tests/peripheral/test_ir_sensor_array.py†L28-L52】
 
+## Solver performance and configuration
+
+The solver now evaluates residuals using vectorized NumPy operations and
+supplies an analytical Jacobian for the least-squares optimizer. This reduces
+per-iteration Python overhead and provides direct control over the gradient
+estimate. The solver method (`trf` by default) and Jacobian usage are
+configuration parameters on both `MultilaterationSolver` and `IRSensorArray`,
+so deployments can tune convergence behaviour alongside frame processing
+without modifying the algorithm itself.【F:src/heart/peripheral/ir_sensor_array.py†L118-L268】
+
 ## Frame assembly and decoding
 
 `FrameAssembler` groups samples by `frame_id` until every sensor contributes.


### PR DESCRIPTION
### Motivation

- Reduce per-iteration Python overhead in the IR multilateration solver to improve runtime performance.  
- Allow deployments to tune solver behavior (method, Jacobian usage, convergence) without editing algorithm internals.  
- Provide a robust analytical gradient to improve convergence and stability for common scenarios.  
- Document the performance and configuration changes so operators can make informed tuning choices.

### Description

- Vectorized the residual computation in `MultilaterationSolver.solve` to use NumPy array operations instead of per-sensor Python loops.  
- Implemented an analytical `jacobian` function and optionally pass it to `scipy.optimize.least_squares` when `use_jacobian` is enabled.  
- Exposed solver configuration parameters (`solver_method`, `use_jacobian`, `max_iterations`, `convergence_threshold`) on `MultilaterationSolver` and forwarded them through `IRSensorArray`.  
- Updated documentation in `docs/research/ir_sensor_array_positioning.md` and added a parametrized test in `tests/peripheral/test_ir_sensor_array.py` covering solver algorithm configurations.

### Testing

- Ran `make format` and formatting checks completed successfully.  
- Ran the full test suite with `make test` and the run completed with `147 passed, 1 skipped`.  
- Added `pytest` parameterized coverage for solver options verifying convergence across configurations.  
- Fixed an initial `jac` validation issue by conditionally including the Jacobian in `least_squares` kwargs so tests pass with and without an analytical Jacobian.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad4020a6c8321873907882f97c974)