### PR TITLE
Improve build efficiency with stamped package builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ test:
 	@uv run pytest
 
 build: check-harness
-	@uv build $(BUILD_ARGS)
+	@bash scripts/build_package.sh
 
 check-harness:
 	@bash scripts/check_harness.sh

--- a/docs/research/build_stamp_caching.md
+++ b/docs/research/build_stamp_caching.md
@@ -1,0 +1,32 @@
+# Build stamp caching for package builds
+
+## Problem statement
+
+Repeated local packaging runs are expensive when the build inputs have not
+changed. Developers running `make build` during sync loops or iterative testing
+end up paying for redundant `uv build` work.
+
+## Observations
+
+- `make build` currently invokes `uv build` directly, so it has no awareness of
+  when packaging inputs are unchanged.
+- Build inputs are already well-defined around the source tree and packaging
+  metadata, so they can be hashed to determine whether work is needed.
+
+## Proposed adjustment
+
+Introduce a build stamp helper that hashes build inputs and skips `uv build`
+when the hash matches the last successful build. Expose environment variables so
+teams can force rebuilds or expand the input list for specialized workflows.
+
+## Source locations reviewed
+
+- `Makefile`
+- `scripts/build_package.sh`
+- `docs/sync_harness.md`
+
+## Materials
+
+- `bash`
+- `python` (for hashing files)
+- `uv` (packaging)

--- a/docs/sync_harness.md
+++ b/docs/sync_harness.md
@@ -53,8 +53,17 @@ Example with multiple hooks:
   --post-sync "make test" --post-sync "scripts/check_harness.sh" --once
 ```
 
-`make build` runs `uv build`. Use `BUILD_ARGS` to pass extra arguments to the
-build command.
+`make build` runs `uv build` through `scripts/build_package.sh`. The wrapper
+skips repeated builds when the packaging inputs are unchanged, writing a stamp
+under `build/.package_stamp`.
+
+Build helpers:
+
+- `BUILD_ARGS` passes extra arguments to `uv build`.
+- `BUILD_FORCE=true` forces a build even if the inputs are unchanged.
+- `BUILD_STAMP_PATH` overrides the build stamp location.
+- `BUILD_INPUTS` overrides the default inputs (`src`, `pyproject.toml`,
+  `README.md`, `uv.lock`) as a space-delimited list.
 
 ## Harness check helper
 

--- a/scripts/build_package.sh
+++ b/scripts/build_package.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+BUILD_STAMP_PATH=${BUILD_STAMP_PATH:-"${REPO_ROOT}/build/.package_stamp"}
+BUILD_FORCE=${BUILD_FORCE:-false}
+BUILD_ARGS=${BUILD_ARGS:-}
+
+DEFAULT_BUILD_INPUTS=(src pyproject.toml README.md uv.lock)
+if [[ -n "${BUILD_INPUTS:-}" ]]; then
+  read -r -a build_inputs <<<"${BUILD_INPUTS}"
+else
+  build_inputs=("${DEFAULT_BUILD_INPUTS[@]}")
+fi
+
+collect_build_files() {
+  if command -v git >/dev/null 2>&1; then
+    git -C "${REPO_ROOT}" ls-files -z -- "${build_inputs[@]}"
+    return
+  fi
+
+  for entry in "${build_inputs[@]}"; do
+    if [[ -d "${REPO_ROOT}/${entry}" ]]; then
+      find "${REPO_ROOT}/${entry}" -type f -print0
+    elif [[ -f "${REPO_ROOT}/${entry}" ]]; then
+      printf '%s\0' "${REPO_ROOT}/${entry}"
+    fi
+  done
+}
+
+mapfile -d '' -t build_files < <(collect_build_files)
+if [[ ${#build_files[@]} -eq 0 ]]; then
+  echo "Warning: no build inputs found; proceeding with build." >&2
+fi
+
+current_hash=$(printf '%s\n' "${build_files[@]}" | python - <<'PYTHON'
+import hashlib
+import os
+import sys
+
+paths = [line.strip() for line in sys.stdin if line.strip()]
+paths.sort()
+
+hasher = hashlib.sha256()
+for path in paths:
+  rel_path = os.path.relpath(path)
+  hasher.update(rel_path.encode())
+  with open(path, "rb") as handle:
+    for chunk in iter(lambda: handle.read(8192), b""):
+      hasher.update(chunk)
+
+print(hasher.hexdigest())
+PYTHON
+)
+
+if [[ "${BUILD_FORCE}" != "true" ]] && [[ -f "${BUILD_STAMP_PATH}" ]]; then
+  previous_hash=$(cat "${BUILD_STAMP_PATH}")
+  if [[ "${previous_hash}" == "${current_hash}" ]]; then
+    echo "Build inputs unchanged; skipping uv build."
+    exit 0
+  fi
+fi
+
+mkdir -p "$(dirname "${BUILD_STAMP_PATH}")"
+
+build_args=()
+if [[ -n "${BUILD_ARGS}" ]]; then
+  read -r -a build_args <<<"${BUILD_ARGS}"
+fi
+
+uv build "${build_args[@]}"
+
+echo "${current_hash}" > "${BUILD_STAMP_PATH}"


### PR DESCRIPTION
### Motivation
- Avoid redundant `uv build` runs during iterative development and sync loops to reduce wasted packaging time. 
- Make `make build` aware of when package inputs have actually changed so developers get faster feedback. 
- Provide simple controls for forcing builds or customizing which inputs are considered. 

### Description
- Add `scripts/build_package.sh`, a wrapper that hashes configured build inputs and skips `uv build` when the hash matches the last successful build. 
- Wire the `build` Makefile target to call `scripts/build_package.sh` instead of invoking `uv build` directly. 
- Update `docs/sync_harness.md` to document the new wrapper and environment variables (`BUILD_ARGS`, `BUILD_FORCE`, `BUILD_STAMP_PATH`, `BUILD_INPUTS`). 
- Add a research note `docs/research/build_stamp_caching.md` explaining the rationale and implementation approach. 

### Testing
- Ran `make format` which completed successfully. 
- Ran `make test` (Pytest) which completed with `144 passed, 1 skipped`. 
- Verified formatting and linting steps in the Makefile path during the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad459cd508321b9189fb98615fe61)