### PR TITLE
Refine renderer/provider boundaries for image and sliding renderers

### DIFF
--- a/docs/research/renderer_role_audit.md
+++ b/docs/research/renderer_role_audit.md
@@ -1,0 +1,24 @@
+# Renderer role audit: image and sliding renderers
+
+## Problem
+
+The renderer/state/provider split drifted in two packages. The image renderer provider scaled pixels instead of only updating state, and the sliding image/rendering paths advanced state inside render loops instead of letting providers own event-driven updates. This blurred responsibilities across files and made the state stream harder to reason about.
+
+## Findings
+
+- `RenderImageStateProvider` scaled images in response to window changes, which is rendering work rather than state construction.
+- `SlidingImage` and `SlidingRenderer` advanced state directly during `real_process`, even though providers already define update logic.
+
+## Adjustments
+
+- The image provider now emits a base image plus window size, while `RenderImage` scales during `real_process` and caches the scaled surface.
+- Sliding providers now combine the game tick with the window-size stream to advance offsets, so renderers only read state and draw.
+
+## Materials
+
+- `src/heart/renderers/image/provider.py`
+- `src/heart/renderers/image/state.py`
+- `src/heart/renderers/image/renderer.py`
+- `src/heart/renderers/sliding_image/provider.py`
+- `src/heart/renderers/sliding_image/state.py`
+- `src/heart/renderers/sliding_image/renderer.py`

--- a/src/heart/renderers/image/provider.py
+++ b/src/heart/renderers/image/provider.py
@@ -35,8 +35,7 @@ class RenderImageStateProvider(ObservableProvider[RenderImageState]):
 
         base_image = self._load_base_image()
 
-        def scale_to_window(size: tuple[int, int]) -> RenderImageState:
-            scaled = pygame.transform.scale(base_image, size)
-            return RenderImageState(image=scaled)
+        def build_state(size: tuple[int, int]) -> RenderImageState:
+            return RenderImageState(base_image=base_image, window_size=size)
 
-        return window_stream.pipe(ops.map(scale_to_window), ops.share())
+        return window_stream.pipe(ops.map(build_state), ops.share())

--- a/src/heart/renderers/image/renderer.py
+++ b/src/heart/renderers/image/renderer.py
@@ -13,6 +13,8 @@ class RenderImage(StatefulBaseRenderer[RenderImageState]):
 
     def __init__(self, image_file: str) -> None:
         super().__init__(builder=RenderImageStateProvider(image_file=image_file))
+        self._scaled_image: pygame.Surface | None = None
+        self._scaled_size: tuple[int, int] | None = None
 
     def state_observable(
         self, peripheral_manager: PeripheralManager
@@ -25,4 +27,9 @@ class RenderImage(StatefulBaseRenderer[RenderImageState]):
         clock: pygame.time.Clock,
         orientation: Orientation,
     ) -> None:
-        window.blit(self.state.image, (0, 0))
+        if self._scaled_image is None or self._scaled_size != self.state.window_size:
+            self._scaled_image = pygame.transform.scale(
+                self.state.base_image, self.state.window_size
+            )
+            self._scaled_size = self.state.window_size
+        window.blit(self._scaled_image, (0, 0))

--- a/src/heart/renderers/image/state.py
+++ b/src/heart/renderers/image/state.py
@@ -5,4 +5,5 @@ import pygame
 
 @dataclass(frozen=True)
 class RenderImageState:
-    image: pygame.Surface
+    base_image: pygame.Surface
+    window_size: tuple[int, int]

--- a/src/heart/renderers/sliding_image/state.py
+++ b/src/heart/renderers/sliding_image/state.py
@@ -2,15 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import pygame
-
 
 @dataclass(frozen=True)
 class SlidingImageState:
     offset: int = 0
     speed: int = 1
     width: int = 0
-    image: pygame.Surface | None = None
 
 
 @dataclass(frozen=True)

--- a/tests/renderers/test_sliding_state_provider.py
+++ b/tests/renderers/test_sliding_state_provider.py
@@ -8,7 +8,6 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
-from heart.peripheral.core.manager import PeripheralManager
 from heart.renderers.sliding_image.provider import (
     SlidingImageStateProvider, SlidingRendererStateProvider)
 from heart.renderers.sliding_image.state import (SlidingImageState,
@@ -22,7 +21,7 @@ class _ProviderSpec:
 
     def build_state(self, *, offset: int, speed: int, width: int):
         if self.state_cls is SlidingImageState:
-            return self.state_cls(offset=offset, speed=speed, width=width, image=None)
+            return self.state_cls(offset=offset, speed=speed, width=width)
         return self.state_cls(offset=offset, speed=speed, width=width)
 
 
@@ -45,8 +44,8 @@ def _width_inputs(draw: st.DrawFn) -> tuple[int, int, int, int]:
     offset = draw(st.integers(min_value=-512, max_value=512))
     speed = draw(st.integers(min_value=1, max_value=32))
     state_width = draw(st.integers(min_value=-10, max_value=256))
-    provider_width = draw(st.integers(min_value=-10, max_value=256))
-    return offset, speed, state_width, provider_width
+    window_width = draw(st.integers(min_value=-10, max_value=256))
+    return offset, speed, state_width, window_width
 
 
 class TestSlidingStateProviderTransitions:
@@ -55,17 +54,13 @@ class TestSlidingStateProviderTransitions:
     @pytest.mark.parametrize("spec", PROVIDER_SPECS)
     @given(data=_width_inputs())
     def test_advance_state_uses_expected_width(self, spec: _ProviderSpec, data) -> None:
-        """Verify width selection follows state or provider so scrolling remains predictable."""
-        offset, speed, state_width, provider_width = data
-        provider = spec.provider_cls(
-            peripheral_manager=PeripheralManager(),
-            speed=speed,
-            width=provider_width,
-        )
+        """Verify window width drives offsets so scrolling remains predictable."""
+        offset, speed, state_width, window_width = data
+        provider = spec.provider_cls(speed=speed)
         state = spec.build_state(offset=offset, speed=speed, width=state_width)
-        expected_width = state_width if state_width != 0 else provider_width
+        expected_width = window_width
 
-        result = provider.advance_state(state)
+        result = provider.advance_state(state, window_width)
 
         assert result.width == expected_width
         assert result.speed == speed
@@ -79,11 +74,7 @@ class TestSlidingStateProviderTransitions:
     def test_reset_state_clears_offset(self, spec: _ProviderSpec, data) -> None:
         """Verify resets zero the offset so replays start at the leading edge reliably."""
         offset, speed, width = data
-        provider = spec.provider_cls(
-            peripheral_manager=PeripheralManager(),
-            speed=speed,
-            width=width,
-        )
+        provider = spec.provider_cls(speed=speed)
         state = spec.build_state(offset=offset, speed=speed, width=width)
 
         result = provider.reset_state(state)
@@ -91,5 +82,3 @@ class TestSlidingStateProviderTransitions:
         assert result.offset == 0
         assert result.speed == speed
         assert result.width == width
-        if isinstance(result, SlidingImageState):
-            assert result.image is None


### PR DESCRIPTION
### Motivation
- Enforce clear roles so the renderer only converts state to pixels, the state modules declare immutable frame data, and providers own event-driven state updates. 
- Remove rendering work from providers to make state streams lightweight and easier to reason about. 
- Prevent state advancement from being coupled to render loops so multiple subscribers and lifecycle events behave predictably. 

### Description
- Change `RenderImageState` to carry a `base_image` and `window_size`, move scaling into `RenderImage.real_process`, and cache the scaled surface. 
- Update `RenderImageStateProvider` to emit the base asset plus window sizing instead of producing a scaled `Surface`. 
- Rework `sliding_image` providers to advance offsets by combining `game_tick` with a window-size stream and to expose `observable(peripheral_manager)`, while removing image payloads from `SlidingImageState`. 
- Adjust `SlidingImage` and `SlidingRenderer` to use providers as `builder`s (subscribe to state) and to only draw based on state without advancing it, and add a research note `docs/research/renderer_role_audit.md` describing the audit and rationale. 

### Testing
- Ran formatting with `make format` and auto-fixes completed successfully. 
- Ran the full test suite with `make test` and all automated tests passed (`142 passed, 1 skipped`). 
- Updated unit/property tests `tests/renderers/test_sliding_state_provider.py` and `tests/display/test_sliding_image_renderer.py` to match the new provider-driven semantics and they pass. 
- Verified no regressions in renderer-related tests by running the CI-style test run locally and confirming green status.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad23b144883218f068072a035cb18)