### PR TITLE
Add Mission Control simulation console to Electron Beats renderer

### DIFF
--- a/docs/research/mission-control-simulation.md
+++ b/docs/research/mission-control-simulation.md
@@ -1,0 +1,31 @@
+# Mission Control Simulation Console Research Note
+
+## Summary
+
+Add a mission-control-style operations console to the Electron renderer so operators can rehearse an end-to-end Apollo-like mission timeline while monitoring simulated subsystem status and telemetry checkpoints.
+
+## Motivation
+
+The current Electron UI provides peripheral, stream, and device views but lacks a unified control-room experience. Introducing a mission timeline and simulation controls makes the application feel like a historical flight director station while offering an in-app rehearsal loop.
+
+## Proposed Experience
+
+- Present a mission timeline that advances through discrete phases (pre-launch through recovery).
+- Provide a mission elapsed time clock and a phase callout panel to simulate flight director voice loops.
+- Offer start, pause, reset, and rate controls to rehearse the full mission quickly.
+- Display a Go/No-Go poll panel with subsystem statuses and quick telemetry snapshot cards.
+
+## Implementation Notes
+
+- The UI is implemented as a new route under `experimental/beats/src/routes/mission-control/index.tsx`.
+- Navigation is added to the main sidebar in `experimental/beats/src/components/app-sidebar.tsx`.
+- The simulation loop uses a simple interval timer with a selectable rate to update elapsed time and phase state.
+
+## Source References
+
+- `experimental/beats/src/routes/mission-control/index.tsx`
+- `experimental/beats/src/components/app-sidebar.tsx`
+
+## Materials
+
+- None.

--- a/experimental/beats/src/components/app-sidebar.tsx
+++ b/experimental/beats/src/components/app-sidebar.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, Home, Monitor, Mouse, Tv } from "lucide-react";
+import { ChevronRight, Home, Monitor, Mouse, Rocket, Tv } from "lucide-react";
 
 import {
   Sidebar,
@@ -22,6 +22,11 @@ const items = {
             title: "Home",
             url: "/",
             icon: Home,
+        },
+        {
+            title: "Mission Control",
+            url: "/mission-control",
+            icon: Rocket,
         },
         {
             title: "Current Stream",

--- a/experimental/beats/src/routeTree.gen.ts
+++ b/experimental/beats/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as StreamIndexRouteImport } from './routes/stream/index'
+import { Route as MissionControlIndexRouteImport } from './routes/mission-control/index'
 import { Route as PeripheralsEventsRouteImport } from './routes/peripherals/events'
 import { Route as PeripheralsConnectedRouteImport } from './routes/peripherals/connected'
 
@@ -22,6 +23,11 @@ const IndexRoute = IndexRouteImport.update({
 const StreamIndexRoute = StreamIndexRouteImport.update({
   id: '/stream/',
   path: '/stream/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MissionControlIndexRoute = MissionControlIndexRouteImport.update({
+  id: '/mission-control/',
+  path: '/mission-control/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PeripheralsEventsRoute = PeripheralsEventsRouteImport.update({
@@ -37,12 +43,14 @@ const PeripheralsConnectedRoute = PeripheralsConnectedRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/mission-control': typeof MissionControlIndexRoute
   '/peripherals/connected': typeof PeripheralsConnectedRoute
   '/peripherals/events': typeof PeripheralsEventsRoute
   '/stream': typeof StreamIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/mission-control': typeof MissionControlIndexRoute
   '/peripherals/connected': typeof PeripheralsConnectedRoute
   '/peripherals/events': typeof PeripheralsEventsRoute
   '/stream': typeof StreamIndexRoute
@@ -50,18 +58,25 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/mission-control/': typeof MissionControlIndexRoute
   '/peripherals/connected': typeof PeripheralsConnectedRoute
   '/peripherals/events': typeof PeripheralsEventsRoute
   '/stream/': typeof StreamIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/peripherals/connected' | '/peripherals/events' | '/stream'
+  fullPaths:
+    | '/'
+    | '/mission-control'
+    | '/peripherals/connected'
+    | '/peripherals/events'
+    | '/stream'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/peripherals/connected' | '/peripherals/events' | '/stream'
+  to: '/' | '/mission-control' | '/peripherals/connected' | '/peripherals/events' | '/stream'
   id:
     | '__root__'
     | '/'
+    | '/mission-control/'
     | '/peripherals/connected'
     | '/peripherals/events'
     | '/stream/'
@@ -69,6 +84,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  MissionControlIndexRoute: typeof MissionControlIndexRoute
   PeripheralsConnectedRoute: typeof PeripheralsConnectedRoute
   PeripheralsEventsRoute: typeof PeripheralsEventsRoute
   StreamIndexRoute: typeof StreamIndexRoute
@@ -81,6 +97,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/mission-control/': {
+      id: '/mission-control/'
+      path: '/mission-control'
+      fullPath: '/mission-control'
+      preLoaderRoute: typeof MissionControlIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/stream/': {
@@ -109,6 +132,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  MissionControlIndexRoute: MissionControlIndexRoute,
   PeripheralsConnectedRoute: PeripheralsConnectedRoute,
   PeripheralsEventsRoute: PeripheralsEventsRoute,
   StreamIndexRoute: StreamIndexRoute,

--- a/experimental/beats/src/routes/mission-control/index.tsx
+++ b/experimental/beats/src/routes/mission-control/index.tsx
@@ -1,0 +1,399 @@
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import {
+  ToggleGroup,
+  ToggleGroupItem,
+} from "@/components/ui/toggle-group";
+import { createFileRoute } from "@tanstack/react-router";
+import { CheckCircle2, Pause, Play, RotateCcw, TriangleAlert } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+type MissionPhase = {
+  name: string;
+  durationSeconds: number;
+  objective: string;
+  callout: string;
+};
+
+type SubsystemStatus = {
+  name: string;
+  status: "GO" | "NO GO" | "STANDBY";
+  detail: string;
+};
+
+const missionPhases: MissionPhase[] = [
+  {
+    name: "Pre-Launch",
+    durationSeconds: 420,
+    objective: "Vehicle power-up and integrated systems checks.",
+    callout: "All stations confirm readiness for terminal count.",
+  },
+  {
+    name: "Terminal Count",
+    durationSeconds: 600,
+    objective: "Guidance alignment, range clearance, and propellant load.",
+    callout: "Guidance, flight, and booster are green across the board.",
+  },
+  {
+    name: "Launch + Ascent",
+    durationSeconds: 780,
+    objective: "Lift-off through staging and orbital insertion burn.",
+    callout: "We have liftoff, tracking through max-Q and staging.",
+  },
+  {
+    name: "Translunar Injection",
+    durationSeconds: 540,
+    objective: "Execute injection burn and configure navigation updates.",
+    callout: "Trajectory looks tight; onboard navigation synced.",
+  },
+  {
+    name: "Lunar Orbit",
+    durationSeconds: 720,
+    objective: "Orbit insertion and surface operations staging.",
+    callout: "Orbit stable; prepare for descent timeline review.",
+  },
+  {
+    name: "Surface Ops",
+    durationSeconds: 900,
+    objective: "Simulated EVA, sample collection, and comm loops.",
+    callout: "Surface EVA complete; samples secured.",
+  },
+  {
+    name: "Return & Recovery",
+    durationSeconds: 840,
+    objective: "Trans-Earth injection, entry corridor, and splashdown.",
+    callout: "Recovery forces standing by; capsule tracking nominal.",
+  },
+];
+
+const subsystemStatuses: SubsystemStatus[] = [
+  {
+    name: "Guidance",
+    status: "GO",
+    detail: "IMU aligned and nav star checks nominal.",
+  },
+  {
+    name: "Propulsion",
+    status: "GO",
+    detail: "Chamber pressures within simulated tolerance.",
+  },
+  {
+    name: "EECOM",
+    status: "GO",
+    detail: "Environmental control loops stable.",
+  },
+  {
+    name: "Telemetry",
+    status: "GO",
+    detail: "Downlink lock solid; redundancy verified.",
+  },
+  {
+    name: "Comms",
+    status: "STANDBY",
+    detail: "High-gain antenna pass scheduled for next phase.",
+  },
+  {
+    name: "Flight Dynamics",
+    status: "GO",
+    detail: "Trajectory dispersions well within corridor.",
+  },
+  {
+    name: "Recovery",
+    status: "STANDBY",
+    detail: "Splashdown assets staged in the Pacific box.",
+  },
+];
+
+const simulationRates = [
+  { label: "1x", value: "1" },
+  { label: "5x", value: "5" },
+  { label: "20x", value: "20" },
+];
+
+function formatElapsed(seconds: number) {
+  const clamped = Math.max(0, seconds);
+  const hrs = Math.floor(clamped / 3600);
+  const mins = Math.floor((clamped % 3600) / 60);
+  const secs = Math.floor(clamped % 60);
+  const padded = [hrs, mins, secs].map((value) => String(value).padStart(2, "0"));
+  return padded.join(":");
+}
+
+function getPhaseIndex(elapsedSeconds: number) {
+  let tally = 0;
+  for (let index = 0; index < missionPhases.length; index += 1) {
+    tally += missionPhases[index].durationSeconds;
+    if (elapsedSeconds < tally) {
+      return index;
+    }
+  }
+  return missionPhases.length - 1;
+}
+
+function MissionControlPage() {
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [isRunning, setIsRunning] = useState(false);
+  const [rate, setRate] = useState("5");
+
+  const totalDuration = useMemo(
+    () => missionPhases.reduce((total, phase) => total + phase.durationSeconds, 0),
+    [],
+  );
+
+  const currentPhaseIndex = getPhaseIndex(elapsedSeconds);
+  const currentPhase = missionPhases[currentPhaseIndex];
+
+  useEffect(() => {
+    if (!isRunning) {
+      return undefined;
+    }
+
+    const tickMs = 1000 / Number(rate);
+    const interval = window.setInterval(() => {
+      setElapsedSeconds((prev) => {
+        const next = prev + 1;
+        if (next >= totalDuration) {
+          window.clearInterval(interval);
+          setIsRunning(false);
+          return totalDuration;
+        }
+        return next;
+      });
+    }, tickMs);
+
+    return () => window.clearInterval(interval);
+  }, [isRunning, rate, totalDuration]);
+
+  const progress = Math.min(1, elapsedSeconds / totalDuration);
+  const missionTime = formatElapsed(elapsedSeconds);
+
+  const goStatusCount = subsystemStatuses.filter((item) => item.status === "GO").length;
+
+  return (
+    <div className="flex h-full flex-col gap-4 text-foreground">
+      <header className="flex flex-wrap items-center justify-between gap-4 rounded-lg border border-border bg-card px-6 py-4">
+        <div className="space-y-1">
+          <p className="text-xs font-tomorrow uppercase text-muted-foreground">Apollo Simulation Control</p>
+          <h1 className="text-2xl font-semibold tracking-tight">Mission Control Operations</h1>
+          <p className="text-sm text-muted-foreground">
+            Monitor mission health, advance the timeline, and run a full-flight simulation from launch to recovery.
+          </p>
+        </div>
+        <div className="flex flex-col items-end gap-2 rounded-md border border-border bg-background px-4 py-3">
+          <span className="text-xs font-tomorrow uppercase text-muted-foreground">Mission Elapsed Time</span>
+          <span className="text-2xl font-semibold tabular-nums">{missionTime}</span>
+          <span className="text-xs text-muted-foreground">Phase: {currentPhase.name}</span>
+        </div>
+      </header>
+
+      <section className="grid gap-4 lg:grid-cols-[1.4fr_1fr]">
+        <div className="space-y-4">
+          <div className="rounded-lg border border-border bg-card p-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="text-xs font-tomorrow uppercase text-muted-foreground">Mission Timeline</p>
+                <h2 className="text-lg font-semibold">Phase Sequencer</h2>
+              </div>
+              <div className="text-xs text-muted-foreground">Total Duration: {formatElapsed(totalDuration)}</div>
+            </div>
+            <div className="mt-4">
+              <div className="h-2 w-full rounded-full bg-muted">
+                <div
+                  className="h-2 rounded-full bg-primary transition-all"
+                  style={{ width: `${progress * 100}%` }}
+                />
+              </div>
+              <div className="mt-4 space-y-3">
+                {missionPhases.map((phase, index) => {
+                  const isActive = index === currentPhaseIndex;
+                  const isComplete = index < currentPhaseIndex;
+                  return (
+                    <div
+                      key={phase.name}
+                      className={`rounded-md border px-3 py-2 transition ${
+                        isActive
+                          ? "border-primary/70 bg-primary/10"
+                          : "border-border bg-background"
+                      }`}
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="flex items-center gap-2">
+                          <span
+                            className={`text-xs font-tomorrow uppercase ${
+                              isComplete
+                                ? "text-emerald-400"
+                                : isActive
+                                  ? "text-primary"
+                                  : "text-muted-foreground"
+                            }`}
+                          >
+                            {isComplete ? "Complete" : isActive ? "Active" : "Queued"}
+                          </span>
+                          <span className="text-sm font-semibold">{phase.name}</span>
+                        </div>
+                        <span className="text-xs text-muted-foreground">{formatElapsed(phase.durationSeconds)}</span>
+                      </div>
+                      <p className="mt-1 text-xs text-muted-foreground">{phase.objective}</p>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-border bg-card p-4">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <p className="text-xs font-tomorrow uppercase text-muted-foreground">Simulation Console</p>
+                <h2 className="text-lg font-semibold">Mission Playback</h2>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={() => setIsRunning(true)}
+                  disabled={isRunning}
+                >
+                  <Play className="mr-2 h-4 w-4" />
+                  Run Simulation
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setIsRunning(false)}
+                  disabled={!isRunning}
+                >
+                  <Pause className="mr-2 h-4 w-4" />
+                  Pause
+                </Button>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    setElapsedSeconds(0);
+                    setIsRunning(false);
+                  }}
+                >
+                  <RotateCcw className="mr-2 h-4 w-4" />
+                  Reset
+                </Button>
+              </div>
+            </div>
+            <Separator className="my-4" />
+            <div className="grid gap-4 md:grid-cols-[1.2fr_1fr]">
+              <div className="space-y-3 rounded-md border border-border bg-background p-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-tomorrow uppercase text-muted-foreground">Active Callout</span>
+                  <span className="text-xs text-muted-foreground">MET {missionTime}</span>
+                </div>
+                <p className="text-sm font-semibold">{currentPhase.callout}</p>
+                <p className="text-xs text-muted-foreground">{currentPhase.objective}</p>
+              </div>
+              <div className="space-y-2">
+                <p className="text-xs font-tomorrow uppercase text-muted-foreground">Simulation Rate</p>
+                <ToggleGroup
+                  type="single"
+                  value={rate}
+                  onValueChange={(value) => value && setRate(value)}
+                  className="justify-start"
+                >
+                  {simulationRates.map((speed) => (
+                    <ToggleGroupItem key={speed.value} value={speed.value}>
+                      {speed.label}
+                    </ToggleGroupItem>
+                  ))}
+                </ToggleGroup>
+                <p className="text-xs text-muted-foreground">
+                  Adjust the playback speed to rehearse the full mission timeline.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div className="rounded-lg border border-border bg-card p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs font-tomorrow uppercase text-muted-foreground">Flight Director</p>
+                <h2 className="text-lg font-semibold">Go/No-Go Poll</h2>
+              </div>
+              <div className="text-xs text-muted-foreground">
+                {goStatusCount}/{subsystemStatuses.length} stations GO
+              </div>
+            </div>
+            <div className="mt-4 space-y-3">
+              {subsystemStatuses.map((system) => (
+                <div key={system.name} className="rounded-md border border-border bg-background px-3 py-2">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      {system.status === "GO" ? (
+                        <CheckCircle2 className="h-4 w-4 text-emerald-400" />
+                      ) : (
+                        <TriangleAlert className="h-4 w-4 text-amber-400" />
+                      )}
+                      <span className="text-sm font-semibold">{system.name}</span>
+                    </div>
+                    <span
+                      className={`text-xs font-tomorrow uppercase ${
+                        system.status === "GO"
+                          ? "text-emerald-400"
+                          : system.status === "NO GO"
+                            ? "text-red-400"
+                            : "text-amber-400"
+                      }`}
+                    >
+                      {system.status}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">{system.detail}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-border bg-card p-4">
+            <p className="text-xs font-tomorrow uppercase text-muted-foreground">Telemetry Loop</p>
+            <h2 className="text-lg font-semibold">Systems Snapshot</h2>
+            <div className="mt-4 grid gap-3">
+              <div className="rounded-md border border-border bg-background px-3 py-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-tomorrow uppercase text-muted-foreground">Cabin Pressure</span>
+                  <span className="text-sm font-semibold">5.2 psi</span>
+                </div>
+                <p className="text-xs text-muted-foreground">Suit loop maintaining nominal range.</p>
+              </div>
+              <div className="rounded-md border border-border bg-background px-3 py-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-tomorrow uppercase text-muted-foreground">Battery Load</span>
+                  <span className="text-sm font-semibold">74%</span>
+                </div>
+                <p className="text-xs text-muted-foreground">Power budget balanced for current phase.</p>
+              </div>
+              <div className="rounded-md border border-border bg-background px-3 py-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-tomorrow uppercase text-muted-foreground">High Gain Lock</span>
+                  <span className="text-sm font-semibold">Stable</span>
+                </div>
+                <p className="text-xs text-muted-foreground">Deep-space tracking aligned with relay.</p>
+              </div>
+              <div className="rounded-md border border-border bg-background px-3 py-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-tomorrow uppercase text-muted-foreground">Surface Ops</span>
+                  <span className="text-sm font-semibold">Ready</span>
+                </div>
+                <p className="text-xs text-muted-foreground">EVA timeline pre-brief complete.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export const Route = createFileRoute("/mission-control/")({
+  component: MissionControlPage,
+});


### PR DESCRIPTION
### Motivation
- Provide a control-room / mission-control experience in the Electron renderer to rehearse an Apollo-like mission timeline and improve the overall “control room” feel.
- Allow operators to run a full simulated mission from pre-launch through recovery with adjustable playback rate and timeline visibility.
- Surface subsystem Go/No-Go status and brief telemetry snapshots so the view reads like a flight director console.
- Keep the implementation self-contained in the experimental Beats Electron app so it can be iterated without affecting core Python code.

### Description
- Add a new route component `experimental/beats/src/routes/mission-control/index.tsx` that implements mission phases, a mission-elapsed clock, playback controls, selectable simulation rates, a phase sequencer, and telemetry/status panels.
- Add a navigation entry to the Electron sidebar in `experimental/beats/src/components/app-sidebar.tsx` with a Rocket icon linking to `/mission-control`.
- Register the new route in the generated router tree by updating `experimental/beats/src/routeTree.gen.ts` so the route is available to the app router.
- Add a research note `docs/research/mission-control-simulation.md` documenting the UX intent and implementation notes.

### Testing
- Ran `make format` and code formatting checks which completed successfully.
- Ran the Python test suite with `make test` (Pytest) and received: 144 passed, 1 skipped.
- No automated frontend build/test was run for the Electron renderer in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad4e0082483218aceea50b820d53f)