### PR TITLE
Improve compass smoothing performance and configurability

### DIFF
--- a/docs/compass_smoothing.md
+++ b/docs/compass_smoothing.md
@@ -1,0 +1,36 @@
+______________________________________________________________________
+
+## title: Compass smoothing configuration
+
+# Compass smoothing configuration
+
+## Problem
+
+Compass headings can jitter when raw magnetometer samples vary quickly. The
+compass peripheral now supports multiple smoothing algorithms so deployments
+can balance responsiveness against stability based on their noise profile.
+
+## Configuration
+
+Set these environment variables to tune the compass smoothing behaviour:
+
+- `HEART_COMPASS_SMOOTHING` controls the smoothing algorithm.
+  - `window` (default) computes a rolling mean across the window.
+  - `ema` applies an exponential moving average.
+- `HEART_COMPASS_WINDOW_SIZE` sets the number of samples in the rolling mean
+  window (default: `5`, minimum: `1`). This is only used when
+  `HEART_COMPASS_SMOOTHING=window`.
+- `HEART_COMPASS_EMA_ALPHA` sets the EMA blend factor (default: `0.2`,
+  range: `(0.0, 1.0]`). Higher values respond faster but reduce smoothing.
+
+## Implementation notes
+
+- Window smoothing maintains a running sum to avoid recomputing the total
+  on every sample update.
+- EMA smoothing stores the current smoothed vector and blends in new samples.
+
+## Materials
+
+- Magnetometer sample stream (`peripheral.magnetometer.vector` payloads).
+- Environment variables: `HEART_COMPASS_SMOOTHING`,
+  `HEART_COMPASS_WINDOW_SIZE`, `HEART_COMPASS_EMA_ALPHA`.

--- a/docs/research/compass_smoothing_update.md
+++ b/docs/research/compass_smoothing_update.md
@@ -1,0 +1,22 @@
+______________________________________________________________________
+
+## title: Compass smoothing performance update
+
+# Compass smoothing performance update
+
+## Summary
+
+The compass peripheral now supports a configurable smoothing strategy and
+avoids recomputing rolling averages by tracking a running sum of recent
+magnetometer samples. This reduces per-sample work while still exposing an
+EMA option for faster response when noise levels are lower.
+
+## Sources
+
+- `src/heart/peripheral/compass.py` (smoothing logic, running-sum tracking, EMA updates)
+- `src/heart/utilities/env.py` (environment variable configuration)
+
+## Materials
+
+- Environment variables: `HEART_COMPASS_SMOOTHING`,
+  `HEART_COMPASS_WINDOW_SIZE`, `HEART_COMPASS_EMA_ALPHA`.

--- a/tests/peripheral/test_compass.py
+++ b/tests/peripheral/test_compass.py
@@ -1,0 +1,39 @@
+"""Tests for compass smoothing behaviour."""
+
+from __future__ import annotations
+
+from heart.peripheral.compass import Compass
+from heart.peripheral.core import Input
+
+
+class TestCompassSmoothing:
+    """Validate compass smoothing outputs to keep navigation data stable."""
+
+    def test_window_smoothing_tracks_recent_samples(self) -> None:
+        """Confirm the windowed mean uses recent samples to prevent stale headings."""
+
+        compass = Compass(window_size=2, smoothing_mode="window")
+        compass._handle_magnetometer(
+            Input(event_type="peripheral.magnetometer.vector", data={"x": 1, "y": 2, "z": 3})
+        )
+        compass._handle_magnetometer(
+            Input(event_type="peripheral.magnetometer.vector", data={"x": 3, "y": 4, "z": 5})
+        )
+        compass._handle_magnetometer(
+            Input(event_type="peripheral.magnetometer.vector", data={"x": 5, "y": 6, "z": 7})
+        )
+
+        assert compass.get_average_vector() == (4.0, 5.0, 6.0)
+
+    def test_ema_smoothing_blends_samples(self) -> None:
+        """Ensure EMA smoothing blends inputs for responsive yet stable heading updates."""
+
+        compass = Compass(smoothing_mode="ema", ema_alpha=0.5)
+        compass._handle_magnetometer(
+            Input(event_type="peripheral.magnetometer.vector", data={"x": 2, "y": 4, "z": 6})
+        )
+        compass._handle_magnetometer(
+            Input(event_type="peripheral.magnetometer.vector", data={"x": 6, "y": 8, "z": 10})
+        )
+
+        assert compass.get_average_vector() == (4.0, 6.0, 8.0)


### PR DESCRIPTION
### Motivation
- Reduce per-sample CPU work for the compass peripheral by avoiding full recomputation of windowed averages. 
- Provide configurable smoothing strategy to allow deployments to trade responsiveness for stability. 
- Expose environment-driven knobs so runtime tuning is possible without code changes. 
- Keep changes focused on compass smoothing and avoid touching HSV conversion or FFT code.

### Description
- Implemented windowed smoothing with a running sum to avoid repeated `sum(...)` calls and added an `ema` smoothing mode with configurable alpha in `src/heart/peripheral/compass.py`.
- Added constructor parameters and validation for `window_size`, `smoothing_mode`, and `ema_alpha`, and wired defaults to environment getters in `src/heart/utilities/env.py`.
- Introduced `_env_float` and `Configuration` methods `compass_window_size`, `compass_smoothing_mode`, and `compass_ema_alpha` to control behaviour via environment variables.
- Added documentation (`docs/compass_smoothing.md`, `docs/research/compass_smoothing_update.md`) and unit tests (`tests/peripheral/test_compass.py`) that exercise both windowed and EMA smoothing.

### Testing
- Ran `make format` successfully to apply repository formatting rules. 
- Ran the full test suite with `make test`, which completed with `155 passed, 1 skipped` including the new compass tests. 
- New unit tests `tests/peripheral/test_compass.py` exercise window and EMA behaviours and passed. 
- Formatting and linting checks passed as part of the test tooling run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad8f2e2708321843b2060b2247c3d)