### PR TITLE
Remove module-level __all__ from renderer package initializers

### DIFF
--- a/src/heart/renderers/hilbert_curve/__init__.py
+++ b/src/heart/renderers/hilbert_curve/__init__.py
@@ -1,3 +1,1 @@
-from heart.renderers.hilbert_curve.renderer import HilbertScene
-
-__all__ = ["HilbertScene"]
+from heart.renderers.hilbert_curve.renderer import HilbertScene as HilbertScene

--- a/src/heart/renderers/sliding_image/__init__.py
+++ b/src/heart/renderers/sliding_image/__init__.py
@@ -1,19 +1,15 @@
 from heart.peripheral.core.providers import container
-from heart.renderers.sliding_image.provider import (
-    SlidingImageStateProvider, SlidingRendererStateProvider)
-from heart.renderers.sliding_image.renderer import (SlidingImage,
-                                                    SlidingRenderer)
-from heart.renderers.sliding_image.state import (SlidingImageState,
-                                                 SlidingRendererState)
+from heart.renderers.sliding_image.provider import \
+    SlidingImageStateProvider as SlidingImageStateProvider
+from heart.renderers.sliding_image.provider import \
+    SlidingRendererStateProvider as SlidingRendererStateProvider
+from heart.renderers.sliding_image.renderer import SlidingImage as SlidingImage
+from heart.renderers.sliding_image.renderer import \
+    SlidingRenderer as SlidingRenderer
+from heart.renderers.sliding_image.state import \
+    SlidingImageState as SlidingImageState
+from heart.renderers.sliding_image.state import \
+    SlidingRendererState as SlidingRendererState
 
 container[SlidingImageStateProvider] = SlidingImageStateProvider
 container[SlidingRendererStateProvider] = SlidingRendererStateProvider
-
-__all__ = [
-    "SlidingImage",
-    "SlidingRenderer",
-    "SlidingImageState",
-    "SlidingRendererState",
-    "SlidingImageStateProvider",
-    "SlidingRendererStateProvider",
-]

--- a/src/heart/renderers/spritesheet/__init__.py
+++ b/src/heart/renderers/spritesheet/__init__.py
@@ -1,17 +1,13 @@
-from heart.renderers.spritesheet.provider import SpritesheetProvider
-from heart.renderers.spritesheet.renderer import (SpritesheetLoop,
-                                                  create_spritesheet_loop)
-from heart.renderers.spritesheet.state import (BoundingBox, FrameDescription,
-                                               LoopPhase, Size,
-                                               SpritesheetLoopState)
-
-__all__ = [
-    "BoundingBox",
-    "FrameDescription",
-    "LoopPhase",
-    "Size",
-    "SpritesheetLoopState",
-    "SpritesheetLoop",
-    "create_spritesheet_loop",
-    "SpritesheetProvider",
-]
+from heart.renderers.spritesheet.provider import \
+    SpritesheetProvider as SpritesheetProvider
+from heart.renderers.spritesheet.renderer import \
+    SpritesheetLoop as SpritesheetLoop
+from heart.renderers.spritesheet.renderer import \
+    create_spritesheet_loop as create_spritesheet_loop
+from heart.renderers.spritesheet.state import BoundingBox as BoundingBox
+from heart.renderers.spritesheet.state import \
+    FrameDescription as FrameDescription
+from heart.renderers.spritesheet.state import LoopPhase as LoopPhase
+from heart.renderers.spritesheet.state import Size as Size
+from heart.renderers.spritesheet.state import \
+    SpritesheetLoopState as SpritesheetLoopState


### PR DESCRIPTION
### Motivation

- Conform to the repository guidance in `AGENTS.md` which advises to avoid module-level `__all__` exports.
- Eliminate a maintenance/linting source where explicit re-exports are preferred.

### Description

- Removed module-level `__all__` declarations from `src/heart/renderers/hilbert_curve/__init__.py`, `src/heart/renderers/spritesheet/__init__.py`, and `src/heart/renderers/sliding_image/__init__.py`.
- Converted imports to explicit re-exports using redundant aliases (for example `from ... import X as X`) so exported symbols remain available while satisfying linting rules.
- Left provider registration (`container[...] = ...`) in `sliding_image` unchanged.
- Ran repository formatting to normalise style using `make format`.

### Testing

- Ran `make format` and the formatter completed successfully.
- Ran `make test` and the full test suite completed with `153 passed, 1 skipped`.
- Formatting and tests were run in the repository environment and succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad9061d088321829ca1e0b4399266)