### PR TITLE
Move spritesheet state progression into provider observables

### DIFF
--- a/docs/research/spritesheet_renderer_state_streams.md
+++ b/docs/research/spritesheet_renderer_state_streams.md
@@ -1,0 +1,24 @@
+# Spritesheet renderer state streams
+
+## Problem
+
+The spritesheet loop renderers were advancing their animation state inside
+`real_process`, which mixed state updates with pixel output. This made it harder
+to reason about event-driven timing and to keep the provider/state/renderer split
+consistent across the renderers.
+
+## Update
+
+- Moved spritesheet loop state advancement into providers driven by the
+  `PeripheralManager` event streams so renderers only read state and blit frames.
+- `SpritesheetProvider` now emits state updates from game ticks and switch input.
+- `SpritesheetLoopRandomProvider` owns frame metadata and timing progression to
+  keep renderer logic focused on scaling and blitting.
+
+## Materials
+
+- `src/heart/renderers/spritesheet/provider.py`
+- `src/heart/renderers/spritesheet/renderer.py`
+- `src/heart/renderers/spritesheet_random/provider.py`
+- `src/heart/renderers/spritesheet_random/renderer.py`
+- `tests/display/test_spritesheet_loop_renderer.py`


### PR DESCRIPTION
### Motivation
- Reduce renderer responsibilities so renderers only convert immutable state snapshots into pixels and providers own state updates.
- Make spritesheet animations driven by the shared `PeripheralManager` event streams so timing and input are observable and testable.
- Bring `spritesheet` and `spritesheet_random` into the provider/state/renderer pattern used elsewhere in the codebase.

### Description
- Converted `SpritesheetProvider` and `SpritesheetLoopRandomProvider` to implement `ObservableProvider` and emit `Spritesheet*State` streams driven by `PeripheralManager.game_tick`, `clock`, and switch inputs.
- Simplified `SpritesheetLoop` and `SpritesheetLoopRandom` renderers to subscribe to provider observables (`builder`) and only read `self.state` when rendering, removing state mutation from `real_process`.
- Updated `SpritesheetLoopRandomProvider` to own frame metadata, timing, and screen-count logic, and changed constructor signatures to accept metadata and screen count.
- Revised tests in `tests/display/test_spritesheet_loop_renderer.py` to drive state via `BehaviorSubject` streams and updated test assertions; added a research note at `docs/research/spritesheet_renderer_state_streams.md` documenting the refactor.

### Testing
- Ran `make test` and the test suite completed successfully with all tests passing (147 passed, 1 skipped). 
- Ran `make format`; formatting checks failed due to a typing error reported in `src/heart/peripheral/ir_sensor_array.py` (line 236) unrelated to these changes. 
- Ensured `make format` and `make test` were invoked during the change process to validate style and behaviour.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad6a493e48321a7c85d1795d31c58)