### PR TITLE
Add configurable frame array strategy to FrameAccumulator

### DIFF
--- a/docs/research/frame_accumulator_array_strategy.md
+++ b/docs/research/frame_accumulator_array_strategy.md
@@ -1,0 +1,30 @@
+# Frame accumulator array strategy tuning
+
+## Problem
+
+`FrameAccumulator.as_array` converts the accumulated surface into an RGB array by
+calling `pygame.surfarray.array3d`. That helper copies pixel data every time the
+array cache is rebuilt, which becomes noticeable when renderers request arrays
+frequently. The current implementation does not provide a way to trade memory
+safety for lower per-frame allocation cost.
+
+## Approach
+
+Expose an environment-controlled strategy for array conversion. The default
+`copy` strategy keeps the existing behavior by using `array3d`. When `view` is
+selected, the accumulator uses `pygame.surfarray.pixels3d` to return a view
+into the surface, reducing allocations at the cost of holding a surface lock
+for as long as the array view is alive. This allows performance-sensitive
+renderers to opt into the faster path while preserving the safer default.
+
+## Configuration
+
+- `HEART_FRAME_ARRAY_STRATEGY=copy` (default) keeps array copies and avoids
+  holding surface locks.
+- `HEART_FRAME_ARRAY_STRATEGY=view` returns a view into the surface for lower
+  allocation overhead.
+
+## Materials
+
+- `src/heart/renderers/internal/frame_accumulator.py` (`FrameAccumulator.as_array`)
+- `src/heart/utilities/env.py` (`Configuration.frame_array_strategy`)

--- a/src/heart/renderers/internal/frame_accumulator.py
+++ b/src/heart/renderers/internal/frame_accumulator.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 import numpy as np
 import pygame
 
+from heart.utilities.env import Configuration
+
 _ColorInput = pygame.Color | str | tuple[int, int, int] | tuple[int, int, int, int]
 _RectInput = pygame.Rect | tuple[int, int, int, int] | None
 
@@ -134,7 +136,10 @@ class FrameAccumulator:
         """Return an RGB array view of the accumulated frame."""
 
         if self._array_cache is None:
-            array = pygame.surfarray.array3d(self._surface)
+            if Configuration.frame_array_strategy() == "view":
+                array = pygame.surfarray.pixels3d(self._surface)
+            else:
+                array = pygame.surfarray.array3d(self._surface)
             self._array_cache = array.swapaxes(0, 1)
         return self._array_cache
 

--- a/src/heart/utilities/env.py
+++ b/src/heart/utilities/env.py
@@ -176,6 +176,15 @@ class Configuration:
             "HEART_RENDER_TILE_STRATEGY must be 'blits' or 'loop'"
         )
 
+    @classmethod
+    def frame_array_strategy(cls) -> str:
+        strategy = os.environ.get("HEART_FRAME_ARRAY_STRATEGY", "copy").strip().lower()
+        if strategy in {"copy", "view"}:
+            return strategy
+        raise ValueError(
+            "HEART_FRAME_ARRAY_STRATEGY must be 'copy' or 'view'"
+        )
+
 
 def get_device_ports(prefix: str) -> Iterator[str]:
     base_port = "/dev/serial/by-id"


### PR DESCRIPTION
### Motivation
- Reduce allocation overhead when renderers frequently request pixel arrays from the accumulated surface. 
- Allow tuning between safety (copying) and performance (view into surface) without changing renderer code. 
- Surface-to-array conversion was previously always a copy which can be costly for high-frequency access. 
- Provide an opt-in configuration so performance-sensitive deployments can trade surface locks for fewer allocations. 

### Description
- Add `Configuration.frame_array_strategy()` in `src/heart/utilities/env.py` and expose the `HEART_FRAME_ARRAY_STRATEGY` environment variable with values `copy` (default) or `view`.
- Update `FrameAccumulator.as_array` in `src/heart/renderers/internal/frame_accumulator.py` to use `pygame.surfarray.pixels3d` when `view` is selected and fall back to `pygame.surfarray.array3d` for `copy`.
- Add a research note `docs/research/frame_accumulator_array_strategy.md` documenting the rationale, trade-offs, and configuration options.
- Preserve existing behavior by default to avoid surprising changes in callers. 

### Testing
- Ran `make format` to apply repository formatting rules and the step completed successfully. 
- Ran the full test suite with `make test` resulting in `153 passed, 1 skipped` in ~27.4s. 
- No additional automated benchmarks were added; tests focused on compatibility and existing behavior. 
- Updated documentation file was added to `docs/research` to capture the tuning guidance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694adce801e0832199488292a9ef1b56)