### PR TITLE
Make HSV conversion backend configurable and vectorize calibration step

### DIFF
--- a/docs/color_conversion_tuning.md
+++ b/docs/color_conversion_tuning.md
@@ -17,8 +17,14 @@ needed.
   - Sets the maximum number of HSV-to-BGR entries stored in the in-memory LRU
     cache.
   - Set to `0` to disable cache population and lookup entirely.
+- `HEART_HSV_BACKEND` (default: `auto`)
+  - Chooses the implementation for HSV/BGR conversions.
+  - `auto` uses OpenCV when available and falls back to numpy otherwise.
+  - `numpy` forces the numpy implementation even when OpenCV is available.
+  - `cv2` requires OpenCV and fails fast if the module is unavailable.
 
 ## Materials
 
-- Environment variables: `HEART_HSV_CALIBRATION`, `HEART_HSV_CACHE_MAX_SIZE`.
+- Environment variables: `HEART_HSV_CALIBRATION`, `HEART_HSV_CACHE_MAX_SIZE`,
+  `HEART_HSV_BACKEND`.
 - Source: `src/heart/environment.py`.

--- a/docs/research/hsv_backend_selection.md
+++ b/docs/research/hsv_backend_selection.md
@@ -1,0 +1,34 @@
+# HSV backend selection and calibration batching
+
+## Context
+
+HSV/BGR conversion in `heart.environment` is part of the core render loop. The
+numpy path includes calibration steps to align with OpenCV outputs, and those
+steps can dominate frame time when many pixels need correction. The system also
+implicitly picked OpenCV whenever the module was installed, which made it hard
+to compare backends or enforce a deterministic path during performance testing.
+
+## Findings
+
+- The per-pixel neighbourhood search used during HSV-to-BGR calibration can be
+  batched across all mismatches to reduce Python-level loops.
+- Selecting the HSV conversion backend should be configurable so that
+  deployments can opt into numpy-only behaviour or require OpenCV explicitly.
+
+## Decision
+
+- Batch the HSV-to-BGR calibration search so mismatches are resolved in a single
+  vectorized pass, reducing Python-level looping in the hot path.
+- Introduce a `HEART_HSV_BACKEND` environment variable to allow `auto`, `numpy`,
+  or `cv2` selection of the conversion backend.
+
+## Follow-up
+
+- Track render-loop timing with and without OpenCV to quantify the benefit of
+  each backend on target hardware.
+
+## Materials
+
+- `src/heart/environment.py`
+- `src/heart/utilities/env.py`
+- `docs/color_conversion_tuning.md`

--- a/src/heart/utilities/env.py
+++ b/src/heart/utilities/env.py
@@ -152,6 +152,13 @@ class Configuration:
         return _env_flag("HEART_HSV_CALIBRATION", default=True)
 
     @classmethod
+    def hsv_conversion_backend(cls) -> str:
+        backend = os.environ.get("HEART_HSV_BACKEND", "auto").strip().lower()
+        if backend in {"auto", "numpy", "cv2"}:
+            return backend
+        raise ValueError("HEART_HSV_BACKEND must be 'auto', 'numpy', or 'cv2'")
+
+    @classmethod
     def render_variant(cls) -> str:
         return os.environ.get("HEART_RENDER_VARIANT", "iterative")
 

--- a/tests/utilities/test_env.py
+++ b/tests/utilities/test_env.py
@@ -161,6 +161,28 @@ class TestUtilitiesEnv:
 
         assert Configuration.render_executor_max_workers() == 3
 
+    @pytest.mark.parametrize(
+        "backend,expected",
+        [("auto", "auto"), ("numpy", "numpy"), ("cv2", "cv2")],
+        ids=("auto", "numpy", "cv2"),
+    )
+    def test_hsv_backend_reads_env(
+        self, monkeypatch: pytest.MonkeyPatch, backend: str, expected: str
+    ) -> None:
+        """Verify that hsv backend reads the environment value so conversion strategies stay configurable."""
+        monkeypatch.setenv("HEART_HSV_BACKEND", backend)
+
+        assert Configuration.hsv_conversion_backend() == expected
+
+    def test_hsv_backend_rejects_invalid_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify that hsv backend rejects invalid values so configuration errors surface quickly."""
+        monkeypatch.setenv("HEART_HSV_BACKEND", "invalid")
+
+        with pytest.raises(ValueError):
+            Configuration.hsv_conversion_backend()
+
 
     def test_get_device_ports_prefers_symlink_directory(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Verify that get device ports prefers symlink directory. This keeps connectivity configuration robust."""


### PR DESCRIPTION
### Motivation
- The HSV/BGR conversion path was performing expensive per-pixel neighbourhood searches during calibration, which can dominate frame time in the render loop.
- It should be possible to select or force a conversion backend to make performance testing and deployments deterministic.
- Batching the calibration matching reduces Python-level loops and improves throughput for large frames.

### Description
- Add `Configuration.hsv_conversion_backend()` and support the `HEART_HSV_BACKEND` environment variable with values `auto`, `numpy`, or `cv2` in `src/heart/utilities/env.py`.
- Introduce `HSV_BACKEND` and `_use_cv2_backend()` and update `_convert_bgr_to_hsv` / `_convert_hsv_to_bgr` to consult the configured backend in `src/heart/environment.py`.
- Replace the nested per-pixel search used for HSV calibration with a vectorized, batched candidate generation and matching pass to eliminate Python-level loops during mismatch correction.
- Document the new option in `docs/color_conversion_tuning.md`, add a research note `docs/research/hsv_backend_selection.md`, and add tests in `tests/utilities/test_env.py` to validate the backend configuration.

### Testing
- Ran `make format` to apply formatting tools and checks, which completed successfully.
- Ran `make test`, executing the full Pytest suite, which completed successfully (`157 passed, 1 skipped`).
- The newly added tests for `Configuration.hsv_conversion_backend()` in `tests/utilities/test_env.py` were executed as part of the suite and passed.
- No automated tests failed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694add00c1408321b21a2e8715850d55)