### PR TITLE
Add configurable Life update strategy with padding fast-path

### DIFF
--- a/docs/performance/life_update_strategy.md
+++ b/docs/performance/life_update_strategy.md
@@ -1,0 +1,24 @@
+# Life Module Update Strategy
+
+## Problem Statement
+
+Reduce the per-frame cost of the Game of Life update while keeping the rules identical to the existing convolution-based implementation.
+
+## Materials
+
+- Python environment with `numpy` and `scipy` installed.
+- `heart.modules.life.state.LifeState` for the update loop.
+- `heart.utilities.env.Configuration` for environment-driven settings.
+
+## Update Strategy Options
+
+The Life module supports selecting the update algorithm via environment variable:
+
+- `HEART_LIFE_UPDATE_STRATEGY=auto` (default) uses a padding-based neighbor count when the default kernel is in use.
+- `HEART_LIFE_UPDATE_STRATEGY=convolve` always uses `scipy.ndimage.convolve`.
+- `HEART_LIFE_UPDATE_STRATEGY=pad` forces the padding-based neighbor count, which only supports the default kernel.
+
+## Operational Notes
+
+- Padding-based updates avoid convolution setup overhead while preserving the same rules on the same grid boundaries.
+- When using custom kernels, keep the strategy at `auto` or `convolve` so the kernel is applied correctly.

--- a/docs/research/life_update_strategy.md
+++ b/docs/research/life_update_strategy.md
@@ -1,0 +1,22 @@
+# Life Module Update Strategy Research Note
+
+## Problem Statement
+
+The Game of Life update in `heart.modules.life.state.LifeState` relied on a convolution-based neighbor count. This note captures the alternative padding-based neighbor count used to reduce per-frame overhead while keeping the same update rules.
+
+## Materials
+
+- `src/heart/modules/life/state.py` for the update logic and neighbor counting.
+- `src/heart/utilities/env.py` for configuration via environment variables.
+- `tests/modules/test_life_state.py` for parity checks between strategies.
+
+## Findings
+
+- A padding-based neighbor count using `numpy.pad` and slice summation matches the convolution result when the default kernel is used.
+- The padding strategy is suitable for the default Moore neighborhood but is not compatible with custom kernels, so configuration must guard that case.
+
+## Source Pointers
+
+- Neighbor counting logic: `heart.modules.life.state._count_neighbors_with_padding`.
+- Strategy selection: `heart.modules.life.state.LifeState._update_grid`.
+- Configuration entry point: `heart.utilities.env.Configuration.life_update_strategy`.

--- a/src/heart/modules/life/state.py
+++ b/src/heart/modules/life/state.py
@@ -5,6 +5,10 @@ from typing import Any
 import numpy as np
 from scipy.ndimage import convolve
 
+from heart.utilities.env import Configuration
+
+DEFAULT_LIFE_KERNEL = np.array([[1, 1, 1], [1, 0, 1], [1, 1, 1]], dtype=int)
+
 
 @dataclass
 class LifeState:
@@ -14,14 +18,36 @@ class LifeState:
 
     def _update_grid(self) -> Any:
         kernel = self.kernel
-        if kernel is None:
-            kernel = np.array([[1, 1, 1], [1, 0, 1], [1, 1, 1]])
-        
-        # Count the number of neighbors
-        neighbors = convolve(self.grid, kernel, mode="constant", cval=0)
+        strategy = Configuration.life_update_strategy()
+
+        if kernel is None and strategy in {"auto", "pad"}:
+            neighbors = _count_neighbors_with_padding(self.grid)
+        else:
+            if kernel is None:
+                kernel = DEFAULT_LIFE_KERNEL
+            if kernel is not None and strategy == "pad":
+                raise ValueError(
+                    "HEART_LIFE_UPDATE_STRATEGY='pad' only supports the default kernel."
+                )
+            neighbors = convolve(self.grid, kernel, mode="constant", cval=0)
+
         new_grid = (neighbors == 3) | (self.grid & (neighbors == 2))
 
         assert new_grid.shape == self.grid.shape, "Grid size must match"
 
-        new_grid =  new_grid.astype(int)
-        return LifeState(grid=new_grid, cache_id=self.cache_id)
+        new_grid = new_grid.astype(int)
+        return LifeState(grid=new_grid, cache_id=self.cache_id, kernel=self.kernel)
+
+
+def _count_neighbors_with_padding(grid: np.ndarray) -> np.ndarray:
+    padded = np.pad(grid, 1, mode="constant")
+    return (
+        padded[:-2, :-2]
+        + padded[:-2, 1:-1]
+        + padded[:-2, 2:]
+        + padded[1:-1, :-2]
+        + padded[1:-1, 2:]
+        + padded[2:, :-2]
+        + padded[2:, 1:-1]
+        + padded[2:, 2:]
+    )

--- a/src/heart/utilities/env.py
+++ b/src/heart/utilities/env.py
@@ -185,6 +185,15 @@ class Configuration:
             "HEART_FRAME_ARRAY_STRATEGY must be 'copy' or 'view'"
         )
 
+    @classmethod
+    def life_update_strategy(cls) -> str:
+        strategy = os.environ.get("HEART_LIFE_UPDATE_STRATEGY", "auto").strip().lower()
+        if strategy in {"auto", "convolve", "pad"}:
+            return strategy
+        raise ValueError(
+            "HEART_LIFE_UPDATE_STRATEGY must be 'auto', 'convolve', or 'pad'"
+        )
+
 
 def get_device_ports(prefix: str) -> Iterator[str]:
     base_port = "/dev/serial/by-id"

--- a/tests/modules/test_life_state.py
+++ b/tests/modules/test_life_state.py
@@ -1,0 +1,56 @@
+import numpy as np
+import pytest
+
+from heart.modules.life.state import LifeState
+
+
+class TestLifeUpdateStrategies:
+    """Cover Life update strategies to preserve performance and correctness guarantees."""
+
+    @pytest.mark.parametrize(
+        "strategy",
+        ["auto", "pad"],
+        ids=["auto-uses-padding", "pad-uses-padding"],
+    )
+    def test_padding_strategy_matches_convolution(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        strategy: str,
+    ) -> None:
+        """Confirm padding-based updates match convolution so performance gains do not alter rules."""
+
+        grid = np.array(
+            [
+                [0, 1, 0, 0, 1],
+                [1, 1, 0, 1, 0],
+                [0, 0, 1, 0, 0],
+                [1, 0, 0, 1, 1],
+                [0, 1, 0, 0, 0],
+            ],
+            dtype=int,
+        )
+
+        monkeypatch.setenv("HEART_LIFE_UPDATE_STRATEGY", "convolve")
+        expected = LifeState(grid=grid)._update_grid().grid
+
+        monkeypatch.setenv("HEART_LIFE_UPDATE_STRATEGY", strategy)
+        result = LifeState(grid=grid)._update_grid().grid
+
+        assert np.array_equal(
+            expected,
+            result,
+        ), "Padding strategy should preserve the Life update rules."
+
+    def test_padding_strategy_rejects_custom_kernel(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Ensure unsupported custom kernels are blocked to avoid incorrect fast paths."""
+
+        grid = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=int)
+        kernel = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], dtype=int)
+
+        monkeypatch.setenv("HEART_LIFE_UPDATE_STRATEGY", "pad")
+
+        with pytest.raises(ValueError, match="default kernel"):
+            LifeState(grid=grid, kernel=kernel)._update_grid()


### PR DESCRIPTION
### Motivation

- Reduce per-frame cost of the Game of Life update while keeping the update rules identical to the existing convolution-based implementation.
- Allow runtime selection of the update algorithm so deployments can tune performance for target hardware.

### Description

- Add `Configuration.life_update_strategy()` and the `HEART_LIFE_UPDATE_STRATEGY` environment option supporting `auto`, `convolve`, and `pad` modes.
- Implement a padding-based neighbor count `_count_neighbors_with_padding` and use it as a fast-path in `LifeState._update_grid` when appropriate.
- Preserve support for custom kernels and introduce `DEFAULT_LIFE_KERNEL` for the default Moore neighborhood, with `pad` mode rejecting non-default kernels to avoid incorrect fast paths.
- Add documentation under `docs/performance/life_update_strategy.md` and `docs/research/life_update_strategy.md` and a test file `tests/modules/test_life_state.py` that validates parity and guards unsupported usage.

### Testing

- Ran `make format` to apply repository formatting rules and fixed sources automatically.
- Ran `make test` and observed the full test suite complete with `156 passed, 1 skipped`.
- New tests `tests/modules/test_life_state.py` passed under the CI test run.
- No regressions were reported by the test suite after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ae37a15408321aef01e785e249ffd)