### PR TITLE
Thematic control-room copy and UI updates

### DIFF
--- a/docs/research/mission-control-event-console.md
+++ b/docs/research/mission-control-event-console.md
@@ -1,0 +1,23 @@
+# Mission Control Event Console Research Note
+
+## Summary
+
+Add an ambient event console, scenario deck, and phase runbook to the Electron mission control route so the UI suggests a control-room environment without recreating specific mission-control operations.
+
+## Motivation
+
+The existing mission control view provides a timeline, system status, and telemetry snapshot but lacks a thematic event feed and phase runbook to reinforce the control-room atmosphere. Adding those elements supports full-mission rehearsal while keeping the experience intentionally stylized.
+
+## Implementation Notes
+
+- The event console renders the most recent ambient mission events and the next milestone marker from a static schedule.
+- The scenario deck provides pre-configured simulation variants and keeps the selection in local state.
+- The phase runbook maps each mission phase to operator cues, shown in a dedicated card on the right column.
+
+## Source References
+
+- `experimental/beats/src/routes/mission-control/index.tsx`
+
+## Materials
+
+- None.

--- a/experimental/beats/src/routes/mission-control/index.tsx
+++ b/experimental/beats/src/routes/mission-control/index.tsx
@@ -21,48 +21,144 @@ type SubsystemStatus = {
   detail: string;
 };
 
+type MissionEvent = {
+  timeSeconds: number;
+  role: string;
+  label: string;
+  detail: string;
+};
+
 const missionPhases: MissionPhase[] = [
   {
-    name: "Pre-Launch",
+    name: "Systems Warmup",
     durationSeconds: 420,
-    objective: "Vehicle power-up and integrated systems checks.",
-    callout: "All stations confirm readiness for terminal count.",
+    objective: "Bring core systems online and establish baseline telemetry.",
+    callout: "Control room lighting sequence green; systems online.",
   },
   {
-    name: "Terminal Count",
+    name: "Final Sync",
     durationSeconds: 600,
-    objective: "Guidance alignment, range clearance, and propellant load.",
-    callout: "Guidance, flight, and booster are green across the board.",
+    objective: "Lock in synchronization passes and verify data loops.",
+    callout: "All consoles aligned to mission tempo.",
   },
   {
-    name: "Launch + Ascent",
+    name: "Ignition Run",
     durationSeconds: 780,
-    objective: "Lift-off through staging and orbital insertion burn.",
-    callout: "We have liftoff, tracking through max-Q and staging.",
+    objective: "Simulated ignition and ascent sequence with load checks.",
+    callout: "Primary loop stable; ascent profile nominal.",
   },
   {
-    name: "Translunar Injection",
+    name: "Trajectory Burn",
     durationSeconds: 540,
-    objective: "Execute injection burn and configure navigation updates.",
-    callout: "Trajectory looks tight; onboard navigation synced.",
+    objective: "Commit a long-burn segment and align guidance updates.",
+    callout: "Trajectory holding steady, guidance aligned.",
   },
   {
-    name: "Lunar Orbit",
+    name: "Orbit Hold",
     durationSeconds: 720,
-    objective: "Orbit insertion and surface operations staging.",
-    callout: "Orbit stable; prepare for descent timeline review.",
+    objective: "Stabilize simulated orbit and queue subsystem handoffs.",
+    callout: "Orbit hold locked, preparing the next sequence.",
   },
   {
     name: "Surface Ops",
     durationSeconds: 900,
-    objective: "Simulated EVA, sample collection, and comm loops.",
-    callout: "Surface EVA complete; samples secured.",
+    objective: "Run ground operations and staged comm loops.",
+    callout: "Surface operations in progress; comms locked.",
   },
   {
     name: "Return & Recovery",
     durationSeconds: 840,
-    objective: "Trans-Earth injection, entry corridor, and splashdown.",
-    callout: "Recovery forces standing by; capsule tracking nominal.",
+    objective: "Execute return burn, entry corridor checks, and recovery.",
+    callout: "Recovery team staged; capsule tracking nominal.",
+  },
+];
+
+const phaseChecklists: Record<string, string[]> = {
+  "Systems Warmup": [
+    "Verify control room loops are synchronized.",
+    "Confirm simulation telemetry and status buses are live.",
+    "Load guidance targets and validate sensor alignment.",
+  ],
+  "Final Sync": [
+    "Poll critical subsystems for final commit.",
+    "Load the full mission sequence into the timeline.",
+    "Confirm comm routing and handover windows.",
+  ],
+  "Ignition Run": [
+    "Monitor peak-load passage and throttle profile adherence.",
+    "Track staged transitions and telemetry packet loss.",
+    "Confirm orbit insertion solution locked.",
+  ],
+  "Trajectory Burn": [
+    "Verify burn start/stop markers against call-up.",
+    "Update correction windows in the guidance table.",
+    "Confirm antenna deployment command time.",
+  ],
+  "Orbit Hold": [
+    "Poll orbit insertion status and delta-v residuals.",
+    "Review descent alignment checklist with systems.",
+    "Update surface operations timeline for next pass.",
+  ],
+  "Surface Ops": [
+    "Confirm operator telemetry trending nominal.",
+    "Log surface task targets and return priorities.",
+    "Schedule comms blackout expectations for the pass.",
+  ],
+  "Return & Recovery": [
+    "Verify return burn delta-v achieved.",
+    "Review re-entry corridor and blackout timing.",
+    "Confirm recovery asset positions and splashdown window.",
+  ],
+};
+
+const missionEvents: MissionEvent[] = [
+  {
+    timeSeconds: 60,
+    role: "Control",
+    label: "Loop Sync",
+    detail: "Primary loops aligned; console audio levels matched.",
+  },
+  {
+    timeSeconds: 300,
+    role: "Systems",
+    label: "Power Grid",
+    detail: "Battery and capacitor banks balanced; draw nominal.",
+  },
+  {
+    timeSeconds: 720,
+    role: "Dynamics",
+    label: "Peak Load",
+    detail: "Stress envelope cleared; structural loads steady.",
+  },
+  {
+    timeSeconds: 1020,
+    role: "Guidance",
+    label: "Orbit Insert",
+    detail: "Target orbit achieved; guidance switching to coast.",
+  },
+  {
+    timeSeconds: 1500,
+    role: "Comms",
+    label: "Long Burn",
+    detail: "Ignition confirmed; comms loop remains clear.",
+  },
+  {
+    timeSeconds: 1980,
+    role: "Systems",
+    label: "Orbit Hold",
+    detail: "Insertion confirmed; systems configured for descent.",
+  },
+  {
+    timeSeconds: 2520,
+    role: "Life Support",
+    label: "Surface Ops",
+    detail: "Environmental loop steady; surface timeline clear.",
+  },
+  {
+    timeSeconds: 3300,
+    role: "Recovery",
+    label: "Entry Interface",
+    detail: "Entry corridor aligned; comms blackout expected.",
   },
 ];
 
@@ -70,15 +166,15 @@ const subsystemStatuses: SubsystemStatus[] = [
   {
     name: "Guidance",
     status: "GO",
-    detail: "IMU aligned and nav star checks nominal.",
+    detail: "Alignment passes nominal.",
   },
   {
     name: "Propulsion",
     status: "GO",
-    detail: "Chamber pressures within simulated tolerance.",
+    detail: "Pressure bands within simulated tolerance.",
   },
   {
-    name: "EECOM",
+    name: "Life Support",
     status: "GO",
     detail: "Environmental control loops stable.",
   },
@@ -90,17 +186,17 @@ const subsystemStatuses: SubsystemStatus[] = [
   {
     name: "Comms",
     status: "STANDBY",
-    detail: "High-gain antenna pass scheduled for next phase.",
+    detail: "Handover pass scheduled for next phase.",
   },
   {
     name: "Flight Dynamics",
     status: "GO",
-    detail: "Trajectory dispersions well within corridor.",
+    detail: "Trajectory dispersions within corridor.",
   },
   {
     name: "Recovery",
     status: "STANDBY",
-    detail: "Splashdown assets staged in the Pacific box.",
+    detail: "Recovery assets staged in the window.",
   },
 ];
 
@@ -109,6 +205,20 @@ const simulationRates = [
   { label: "5x", value: "5" },
   { label: "20x", value: "20" },
 ];
+
+const simulationScenarios = [
+  { label: "Nominal", value: "nominal" },
+  { label: "Comms Fade", value: "comms" },
+  { label: "Life Support Drift", value: "support" },
+  { label: "Guidance Dispersions", value: "guidance" },
+];
+
+const scenarioBriefs: Record<string, string> = {
+  nominal: "Nominal mission flow with standard callouts and telemetry.",
+  comms: "Simulate brief comms dropouts during handover windows.",
+  support: "Inject environmental control drift requiring operator guidance.",
+  guidance: "Add minor trajectory dispersions to rehearse correction calls.",
+};
 
 function formatElapsed(seconds: number) {
   const clamped = Math.max(0, seconds);
@@ -134,6 +244,7 @@ function MissionControlPage() {
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const [isRunning, setIsRunning] = useState(false);
   const [rate, setRate] = useState("5");
+  const [scenario, setScenario] = useState("nominal");
 
   const totalDuration = useMemo(
     () => missionPhases.reduce((total, phase) => total + phase.durationSeconds, 0),
@@ -168,15 +279,18 @@ function MissionControlPage() {
   const missionTime = formatElapsed(elapsedSeconds);
 
   const goStatusCount = subsystemStatuses.filter((item) => item.status === "GO").length;
+  const checklistItems = phaseChecklists[currentPhase.name] ?? [];
+  const recentEvents = missionEvents.filter((event) => event.timeSeconds <= elapsedSeconds).slice(-6);
+  const nextEvent = missionEvents.find((event) => event.timeSeconds > elapsedSeconds);
 
   return (
     <div className="flex h-full flex-col gap-4 text-foreground">
       <header className="flex flex-wrap items-center justify-between gap-4 rounded-lg border border-border bg-card px-6 py-4">
         <div className="space-y-1">
-          <p className="text-xs font-tomorrow uppercase text-muted-foreground">Apollo Simulation Control</p>
-          <h1 className="text-2xl font-semibold tracking-tight">Mission Control Operations</h1>
+          <p className="text-xs font-tomorrow uppercase text-muted-foreground">Control Room Simulation</p>
+          <h1 className="text-2xl font-semibold tracking-tight">Mission Simulation Console</h1>
           <p className="text-sm text-muted-foreground">
-            Monitor mission health, advance the timeline, and run a full-flight simulation from launch to recovery.
+            Monitor mission health, advance the timeline, and rehearse the complete mission loop.
           </p>
         </div>
         <div className="flex flex-col items-end gap-2 rounded-md border border-border bg-background px-4 py-3">
@@ -208,9 +322,9 @@ function MissionControlPage() {
                   const isActive = index === currentPhaseIndex;
                   const isComplete = index < currentPhaseIndex;
                   return (
-                    <div
-                      key={phase.name}
-                      className={`rounded-md border px-3 py-2 transition ${
+                  <div
+                    key={phase.name}
+                    className={`rounded-md border px-3 py-2 transition ${
                         isActive
                           ? "border-primary/70 bg-primary/10"
                           : "border-border bg-background"
@@ -310,6 +424,58 @@ function MissionControlPage() {
                 </p>
               </div>
             </div>
+            <div className="mt-4 space-y-2 rounded-md border border-border bg-background p-3">
+              <p className="text-xs font-tomorrow uppercase text-muted-foreground">Scenario Deck</p>
+              <ToggleGroup
+                type="single"
+                value={scenario}
+                onValueChange={(value) => value && setScenario(value)}
+                className="justify-start"
+              >
+                {simulationScenarios.map((option) => (
+                  <ToggleGroupItem key={option.value} value={option.value}>
+                    {option.label}
+                  </ToggleGroupItem>
+                ))}
+              </ToggleGroup>
+              <p className="text-xs text-muted-foreground">{scenarioBriefs[scenario]}</p>
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-border bg-card p-4">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <p className="text-xs font-tomorrow uppercase text-muted-foreground">Control Room Loop</p>
+                <h2 className="text-lg font-semibold">Ambient Event Console</h2>
+              </div>
+              {nextEvent ? (
+                <div className="text-xs text-muted-foreground">
+                  Next: {formatElapsed(nextEvent.timeSeconds)} · {nextEvent.label}
+                </div>
+              ) : (
+                <div className="text-xs text-muted-foreground">Mission events complete</div>
+              )}
+            </div>
+            <Separator className="my-4" />
+            <div className="space-y-3">
+              {recentEvents.length === 0 ? (
+                <p className="text-xs text-muted-foreground">
+                  Awaiting timeline start. Event feed will populate once the simulation runs.
+                </p>
+              ) : (
+                recentEvents.map((event) => (
+                  <div key={`${event.timeSeconds}-${event.label}`} className="rounded-md border border-border bg-background px-3 py-2">
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs font-tomorrow uppercase text-muted-foreground">
+                        {event.role} · {formatElapsed(event.timeSeconds)}
+                      </span>
+                      <span className="text-xs text-muted-foreground">{event.label}</span>
+                    </div>
+                    <p className="mt-1 text-sm font-semibold">{event.detail}</p>
+                  </div>
+                ))
+              )}
+            </div>
           </div>
         </div>
 
@@ -317,11 +483,11 @@ function MissionControlPage() {
           <div className="rounded-lg border border-border bg-card p-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-xs font-tomorrow uppercase text-muted-foreground">Flight Director</p>
-                <h2 className="text-lg font-semibold">Go/No-Go Poll</h2>
+                <p className="text-xs font-tomorrow uppercase text-muted-foreground">Status Matrix</p>
+                <h2 className="text-lg font-semibold">Subsystem Confidence</h2>
               </div>
               <div className="text-xs text-muted-foreground">
-                {goStatusCount}/{subsystemStatuses.length} stations GO
+                {goStatusCount}/{subsystemStatuses.length} systems green
               </div>
             </div>
             <div className="mt-4 space-y-3">
@@ -386,6 +552,21 @@ function MissionControlPage() {
                 </div>
                 <p className="text-xs text-muted-foreground">EVA timeline pre-brief complete.</p>
               </div>
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-border bg-card p-4">
+            <p className="text-xs font-tomorrow uppercase text-muted-foreground">Flight Plan</p>
+            <h2 className="text-lg font-semibold">Phase Runbook</h2>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Active phase cues for {currentPhase.name}.
+            </p>
+            <div className="mt-4 space-y-2">
+              {checklistItems.map((item) => (
+                <div key={item} className="rounded-md border border-border bg-background px-3 py-2">
+                  <p className="text-xs text-muted-foreground">{item}</p>
+                </div>
+              ))}
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Reframe the mission-control UI to present a thematic control-room experience and avoid literal mission-control references.
- Provide an ambient event feed, scenario deck, and a phase runbook to support full-mission rehearsal while keeping the experience stylized.
- Make subsystem and checklist language operator-focused rather than using specific mission-control jargon.

### Description
- Update `experimental/beats/src/routes/mission-control/index.tsx` to rename phases and adjust `missionPhases`, `missionEvents`, `phaseChecklists`, `subsystemStatuses`, `simulationScenarios`, and `scenarioBriefs`.
- Replace director-loop wording with thematic labels such as "Control Room Loop", "Ambient Event Console", and "Phase Runbook", and add local `scenario` state and UI controls for the scenario deck.
- Render recent ambient events and the next milestone, surface scenario brief text, and show phase runbook checklist items in the right column.
- Update documentation at `docs/research/mission-control-event-console.md` to document the thematic framing and new UI elements.

### Testing
- Ran `make format` and formatting checks passed.
- Ran `make test` and the automated test suite completed with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ae40808e4832180ba788dc7d2c500)