### PR TITLE
Add PyPI publish script and documentation

### DIFF
--- a/docs/publish_pypi.md
+++ b/docs/publish_pypi.md
@@ -1,0 +1,57 @@
+# Publish the package to PyPI
+
+Use the repository publish script when you need to upload a release build to PyPI
+or TestPyPI. The script builds the package with `scripts/build_package.sh` and
+uploads the resulting artifacts with `twine` via `uv tool run`.
+
+## Materials
+
+- A PyPI API token or an existing `~/.pypirc` configuration.
+- `uv` installed locally.
+- Access to the Heart repository checkout.
+
+## Publish to PyPI
+
+1. Export credentials for PyPI (or configure `~/.pypirc`):
+
+   ```bash
+   export PYPI_TOKEN="<token>"
+   ```
+
+1. Run the publish script:
+
+   ```bash
+   scripts/publish_pypi.sh
+   ```
+
+## Publish to TestPyPI
+
+1. Export a TestPyPI token and repository URL:
+
+   ```bash
+   export PYPI_TOKEN="<test-token>"
+   export PYPI_REPOSITORY_URL="https://test.pypi.org/legacy/"
+   ```
+
+1. Run the publish script:
+
+   ```bash
+   scripts/publish_pypi.sh
+   ```
+
+## Environment variables
+
+| Variable | Description |
+| --- | --- |
+| `PYPI_TOKEN` | Token used when authenticating as `__token__`. |
+| `PYPI_REPOSITORY_URL` | Override the repository URL (for example, TestPyPI). |
+| `PYPI_REPOSITORY` | Named repository in `~/.pypirc` to target. |
+| `DIST_DIR` | Override the `dist/` directory path. |
+| `TWINE_USERNAME` | Custom username for `twine` when not using a token. |
+| `TWINE_PASSWORD` | Custom password for `twine` when not using a token. |
+
+## Notes
+
+- The script expects build artifacts at `dist/*.whl` and `dist/*.tar.gz`.
+- Keep tokens out of shell history by using a password manager or a scoped
+  environment file.

--- a/scripts/publish_pypi.sh
+++ b/scripts/publish_pypi.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+DIST_DIR=${DIST_DIR:-"${REPO_ROOT}/dist"}
+PYPI_REPOSITORY_URL=${PYPI_REPOSITORY_URL:-}
+PYPI_REPOSITORY=${PYPI_REPOSITORY:-}
+PYPI_TOKEN=${PYPI_TOKEN:-}
+TWINE_USERNAME=${TWINE_USERNAME:-}
+TWINE_PASSWORD=${TWINE_PASSWORD:-}
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "Error: uv is required to publish. Install it and try again." >&2
+  exit 1
+fi
+
+publish_args=()
+if [[ -n "${PYPI_REPOSITORY_URL}" ]]; then
+  publish_args+=(--repository-url "${PYPI_REPOSITORY_URL}")
+elif [[ -n "${PYPI_REPOSITORY}" ]]; then
+  publish_args+=(--repository "${PYPI_REPOSITORY}")
+fi
+
+if [[ -n "${PYPI_TOKEN}" ]]; then
+  : "${TWINE_USERNAME:=__token__}"
+  : "${TWINE_PASSWORD:=${PYPI_TOKEN}}"
+fi
+
+if [[ -z "${TWINE_PASSWORD}" ]] && [[ ! -f "${HOME}/.pypirc" ]]; then
+  echo "Error: missing credentials. Set PYPI_TOKEN or TWINE_PASSWORD, or configure ~/.pypirc." >&2
+  exit 1
+fi
+
+"${REPO_ROOT}/scripts/build_package.sh"
+
+if [[ ! -d "${DIST_DIR}" ]]; then
+  echo "Error: dist directory not found at ${DIST_DIR}." >&2
+  exit 1
+fi
+
+shopt -s nullglob
+artifacts=("${DIST_DIR}"/*.whl "${DIST_DIR}"/*.tar.gz)
+shopt -u nullglob
+
+if [[ ${#artifacts[@]} -eq 0 ]]; then
+  echo "Error: no distribution artifacts found in ${DIST_DIR}." >&2
+  exit 1
+fi
+
+export TWINE_USERNAME
+export TWINE_PASSWORD
+
+uv tool run twine upload --non-interactive "${publish_args[@]}" "${artifacts[@]}"


### PR DESCRIPTION
### Motivation

- Provide a simple, repeatable helper to build and upload releases to PyPI or TestPyPI from the repository.
- Reuse the repository's existing build tooling (`uv` and `scripts/build_package.sh`) and avoid adding new packaging dependencies.
- Surface a clear credential workflow so CI or local developers can authenticate with `PYPI_TOKEN` or `~/.pypirc`.

### Description

- Add `scripts/publish_pypi.sh` which calls `scripts/build_package.sh`, collects `dist/*.whl` and `dist/*.tar.gz` artifacts, and uploads them with `uv tool run twine upload`.
- The script supports `PYPI_TOKEN`, `TWINE_USERNAME`, `TWINE_PASSWORD`, `PYPI_REPOSITORY_URL`, `PYPI_REPOSITORY`, and `DIST_DIR` environment variables for flexible targeting and credentials.
- Add `docs/publish_pypi.md` documenting publish steps for PyPI and TestPyPI, required materials, and the environment variables used by the script.
- The script performs basic checks and exits with clear messages when `uv` is missing, credentials are not provided, or no distribution artifacts are found.

### Testing

- Ran `make format` and code/doc formatting checks passed.
- Ran `make test` and the test suite completed successfully with `156 passed, 1 skipped`.
- Verified the publish script was made executable and added to the repository (script-level sanity checks exercised during local creation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b69ee145c83219a62f15bd4ae8723)