### PR TITLE
Avoid string path concatenation; use os.path.join in ConfigurationRegistry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Use the tooling in this repository to manage environments. Prefer `uv` for Pytho
 Run `make format` before committing changes. This applies Ruff fixes, isort, Black, docformatter, and mdformat to Python sources and documentation. Documentation updates should avoid marketing language, state the technical problem in plain terms, and include a materials list when relevant.
 
 - Avoid declaring module-level `__all__` exports. Prefer explicit imports at call sites instead of curating export lists.
+- Avoid building filesystem paths via string concatenation. Use `os.path.join` or `pathlib.Path` instead.
 
 ## Testing
 

--- a/src/heart/programs/registry.py
+++ b/src/heart/programs/registry.py
@@ -10,7 +10,7 @@ class ConfigurationRegistry:
     @cached_property
     def registry(self) -> dict[str, Callable[[GameLoop], None]]:
         registry: dict[str, Callable[[GameLoop], None]] = {}
-        configurations_dir = os.path.dirname(__file__) + "/configurations"
+        configurations_dir = os.path.join(os.path.dirname(__file__), "configurations")
         for filename in os.listdir(configurations_dir):
             if filename.endswith(".py") and filename != "__init__.py":
                 module_name = f"heart.programs.configurations.{filename[:-3]}"


### PR DESCRIPTION
### Motivation

- Prevent fragile and non-portable filesystem path construction that can break across platforms and contexts. 
- Align repository code with documentation guidance to prefer `os.path.join`/`pathlib.Path` over string concatenation. 
- Reduce subtle bugs when discovering configuration modules at runtime via filesystem operations. 

### Description

- Add guidance to `AGENTS.md` advising to avoid building filesystem paths via string concatenation and to use `os.path.join` or `pathlib.Path`. 
- Replace string-concatenated configuration directory path in `src/heart/programs/registry.py` with `os.path.join(os.path.dirname(__file__), "configurations")`. 
- Run repository formatting steps to ensure style consistency via `make format`. 

### Testing

- Ran `make format` and the formatting checks completed successfully. 
- Ran `make test` and the full test suite completed successfully. 
- Test summary: `156 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b6a2fb758832183697e7840cd06e8)