### PR TITLE
Vectorize HSV calibration and add HEART_HSV_CALIBRATION_MODE

### DIFF
--- a/docs/color_conversion_tuning.md
+++ b/docs/color_conversion_tuning.md
@@ -13,6 +13,11 @@ needed.
   - When set to `false`, disables the hue-roundtrip correction and the per-pixel
     neighbourhood search that aligns numpy conversion output with OpenCV.
   - This reduces per-frame CPU work at the cost of exact round-trip accuracy.
+- `HEART_HSV_CALIBRATION_MODE` (default: `strict`)
+  - Selects the calibration algorithm used by the numpy fallback converter.
+  - Use `strict` for full round-trip correction, `fast` to skip the neighbourhood
+    search while keeping pure-colour adjustments, or `off` to disable calibration.
+  - Overrides `HEART_HSV_CALIBRATION` when set.
 - `HEART_HSV_CACHE_MAX_SIZE` (default: `4096`)
   - Sets the maximum number of HSV-to-BGR entries stored in the in-memory LRU
     cache.
@@ -20,5 +25,6 @@ needed.
 
 ## Materials
 
-- Environment variables: `HEART_HSV_CALIBRATION`, `HEART_HSV_CACHE_MAX_SIZE`.
+- Environment variables: `HEART_HSV_CALIBRATION`,
+  `HEART_HSV_CALIBRATION_MODE`, `HEART_HSV_CACHE_MAX_SIZE`.
 - Source: `src/heart/environment.py`.

--- a/docs/research/hsv_roundtrip_vectorization.md
+++ b/docs/research/hsv_roundtrip_vectorization.md
@@ -12,7 +12,14 @@ which scaled poorly when many pixels required adjustment.
 Vectorize the hue search by batching the candidate hue checks across all mismatched
 pixels for each offset. The updated loop keeps the same offsets and matching logic
 but uses array operations to compare candidate BGR values in bulk, reducing Python
-iteration overhead while preserving the calibrated round-trip behaviour.
+iteration overhead while preserving the calibrated round-trip behaviour. The same
+approach is applied to HSV→BGR correction so mismatched pixels are handled in
+groups rather than one-at-a-time.
+
+Add a configuration switch to opt into a lighter-weight calibration mode (`fast`)
+that skips the neighbourhood search while still applying targeted pure-colour
+adjustments. This allows deployments to pick the precision/performance trade-off
+without patching the conversion helper.
 
 ## Impact
 
@@ -22,5 +29,6 @@ rely on the numpy conversion path.
 
 ## Materials
 
-- `src/heart/environment.py` (`_convert_bgr_to_hsv` hue calibration loop)
+- `src/heart/environment.py` (HSV calibration loops, mode selection)
+- `src/heart/utilities/env.py` (calibration mode configuration)
 - `tests/test_environment_core_logic.py` (HSV conversion round-trip coverage)

--- a/src/heart/utilities/env.py
+++ b/src/heart/utilities/env.py
@@ -149,7 +149,27 @@ class Configuration:
 
     @classmethod
     def hsv_calibration_enabled(cls) -> bool:
+        mode = os.environ.get("HEART_HSV_CALIBRATION_MODE")
+        if mode is not None:
+            normalized = mode.strip().lower()
+            if normalized in {"off", "fast", "strict"}:
+                return normalized != "off"
+            raise ValueError(
+                "HEART_HSV_CALIBRATION_MODE must be 'off', 'fast', or 'strict'"
+            )
         return _env_flag("HEART_HSV_CALIBRATION", default=True)
+
+    @classmethod
+    def hsv_calibration_mode(cls) -> str:
+        mode = os.environ.get("HEART_HSV_CALIBRATION_MODE")
+        if mode is None:
+            return "strict" if cls.hsv_calibration_enabled() else "off"
+        normalized = mode.strip().lower()
+        if normalized in {"off", "fast", "strict"}:
+            return normalized
+        raise ValueError(
+            "HEART_HSV_CALIBRATION_MODE must be 'off', 'fast', or 'strict'"
+        )
 
     @classmethod
     def render_variant(cls) -> str:

--- a/tests/test_environment_core_logic.py
+++ b/tests/test_environment_core_logic.py
@@ -7,6 +7,7 @@ import pytest
 
 from heart.environment import (HSV_TO_BGR_CACHE, RendererVariant,
                                _convert_bgr_to_hsv, _convert_hsv_to_bgr)
+from heart.utilities.env import Configuration
 
 
 @pytest.fixture(autouse=True)
@@ -213,6 +214,23 @@ class TestEnvironmentCoreLogic:
         assert loop._render_fn(renderers, None) is loop._render_surfaces_binary
         loop.renderer_variant = RendererVariant.ITERATIVE
         assert loop._render_fn(renderers, None) is loop._render_surface_iterative
+
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("strict", "strict"),
+            ("fast", "fast"),
+            ("off", "off"),
+        ],
+        ids=["strict-mode", "fast-mode", "off-mode"],
+    )
+    def test_hsv_calibration_mode_env_override(
+        self, monkeypatch, value: str, expected: str
+    ) -> None:
+        """Verify that hsv_calibration_mode reads explicit overrides. This keeps performance tuning consistent across deployments."""
+        monkeypatch.setenv("HEART_HSV_CALIBRATION_MODE", value)
+        assert Configuration.hsv_calibration_mode() == expected
 
 
 


### PR DESCRIPTION
### Motivation
- Reduce per-frame CPU overhead in the numpy HSV↔BGR fallback path by removing per-pixel Python loops while preserving calibration accuracy.
- Provide a runtime knob to trade calibration strictness for throughput on constrained devices. 

### Description
- Add `HEART_HSV_CALIBRATION_MODE` and expose it via `Configuration.hsv_calibration_mode()` with modes `off`, `fast`, and `strict`, and make `hsv_calibration_enabled()` honour the new setting. 
- Introduce `HSV_CALIBRATION_MODE`, `HSV_CALIBRATION_ENABLED`, and `HSV_CALIBRATION_STRICT` in `src/heart/environment.py` and gate calibration behaviour on these flags. 
- Vectorize the strict round-trip hue/candidate search in both `_convert_bgr_to_hsv` and `_convert_hsv_to_bgr` to operate on groups of mismatched pixels instead of iterating one-at-a-time. 
- Update documentation (`docs/color_conversion_tuning.md`, `docs/research/hsv_roundtrip_vectorization.md`) and add a test in `tests/test_environment_core_logic.py` to validate the new mode handling. 

### Testing
- Ran formatting with `make format` to apply repository style checks and fixes. 
- Executed the full test suite with `make test`. 
- All automated tests passed: `159 passed, 1 skipped` (test run time ~26s). 
- The updated tests include a new parametrized case verifying `Configuration.hsv_calibration_mode()` respects environment overrides.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b69f7b23883218c2c5e0fb50adf4a)