### PR TITLE
Add docstrings to logging control tests

### DIFF
--- a/tests/utilities/test_logging_control.py
+++ b/tests/utilities/test_logging_control.py
@@ -20,6 +20,7 @@ class StubLogger:
 
 
 def test_logging_controller_applies_interval() -> None:
+    """Verify per-key intervals throttle logs to limit noisy repeats for stability."""
     monotonic_values = [0.0]
 
     def monotonic() -> float:
@@ -80,6 +81,7 @@ def reset_logging_controller_cache() -> None:
 
 
 def test_logging_controller_respects_rule_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Confirm rule overrides adjust fallback levels so operators can tune alerting."""
     monkeypatch.setenv("HEART_LOG_RULES", "render.loop=none:WARNING:none")
     controller = logging_control.get_logging_controller()
 


### PR DESCRIPTION
### Motivation
- Bring tests into compliance with the repository test documentation guidance in `AGENTS.md` which requires docstrings on test functions and pytest classes.
- Make the intent and significance of logging-control tests explicit so future maintainers understand the behaviour under test.

### Description
- Added descriptive docstrings to `test_logging_controller_applies_interval` and `test_logging_controller_respects_rule_overrides` in `tests/utilities/test_logging_control.py`.
- Applied repository formatting tools via `make format` to ensure style consistency.

### Testing
- Ran `make format` which completed successfully.
- Ran the test suite with `make test` and observed `156 passed, 1 skipped`, indicating the changes did not regress existing behaviour.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b6b8d1714832182ef54498b2a8f69)