### PR TITLE
Add file-focus guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,3 +32,7 @@ Running `make check` is recommended to verify formatting and linting without app
 ## Documentation Guidelines
 
 Update `docs/code_flow.md` and re-render the diagram with `scripts/render_code_flow.py` whenever runtime architecture changes. Pair thoughtful implementations with a research note under `docs/research/` that cites the relevant source files. Plans under `docs/planning/` must follow the structure defined in their `AGENTS.md` file, and contributors should review the master project list in `docs/planning/README.md` before scoping new work. Before implementing a proposal, check `docs/planning/` for related higher-level plans and review any relevant documents.
+
+## File Focus
+
+Keep files narrowly scoped. If a module starts handling multiple concerns (e.g., orchestration plus parsing plus rendering), split the responsibilities into smaller, purpose-built modules so each file does slightly fewer things and has a clear single focus.


### PR DESCRIPTION
### Motivation

- Reduce module complexity by encouraging single-responsibility files so individual modules handle fewer concerns. 
- Prevent files from accumulating orchestration, parsing, and rendering responsibilities that make maintenance harder. 
- Provide a lightweight, repo-level rule to guide contributors toward splitting multi-concern modules.

### Description

- Add a new `File Focus` section to `AGENTS.md` that advises keeping files narrowly scoped. 
- Recommend splitting modules that mix concerns (for example, orchestration + parsing + rendering) into smaller purpose-built modules. 
- Keep guidance short and actionable so it complements existing formatting, testing, and documentation rules.

### Testing

- Ran `make format` and formatting checks passed. 
- Ran `make test` and the test suite completed with `159 passed, 1 skipped`. 
- Verified no lint/format violations remained after formatting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b6c6b9a608321b744753e317ee2a2)