### PR TITLE
Add developer focus loop for change-aware formatting and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DOCS_SOURCES = docs
 TOOL_LIST_FILE = scripts/harness_tools.txt
 TOOLS := $(shell scripts/list_harness_tools.sh $(TOOL_LIST_FILE))
 BUILD_ARGS ?=
-.PHONY: install pi_install format check test build check-harness build-info doctor
+.PHONY: install pi_install format check test build check-harness build-info doctor focus focus-watch
 
 install:
 	@uv sync --all-extras --group dev
@@ -41,6 +41,12 @@ check-harness:
 
 doctor:
 	@uv run python scripts/devex_snapshot.py
+
+focus:
+	@uv run python scripts/devex_focus.py
+
+focus-watch:
+	@uv run python scripts/devex_focus.py --watch
 
 pi_install:
 	@sudo bash src/heart/manage/install_rgb_matrix.sh

--- a/docs/dev_focus_loop.md
+++ b/docs/dev_focus_loop.md
@@ -1,0 +1,58 @@
+# Developer Focus Loop
+
+## Problem Statement
+
+Running formatting, linting, and tests across the entire repository slows iteration, especially when only a handful of files have changed. The developer focus loop narrows feedback to the files touched in the working tree while still keeping formatting and test feedback close to the change.
+
+## Materials
+
+- Python 3.11+ environment with Heart installed.
+- `uv` for running repository tooling.
+- `git` for detecting change sets (recommended).
+
+## Concept
+
+The developer focus loop is a change-aware workflow that:
+
+- Detects modified or newly-added files with `git`.
+- Runs formatting or lint checks only on changed Python and documentation files.
+- Runs focused tests based on changed tests or last-failed results.
+- Optionally watches for file changes and reruns automatically.
+
+## Usage
+
+Run the focus loop once (formatting changed files and running relevant tests):
+
+```bash
+make focus
+```
+
+Run checks without applying formatting fixes:
+
+```bash
+uv run python scripts/devex_focus.py --mode check
+```
+
+Watch for changes and rerun the loop automatically:
+
+```bash
+make focus-watch
+```
+
+Adjust the polling interval when watching:
+
+```bash
+uv run python scripts/devex_focus.py --watch --poll-interval 1.0
+```
+
+Force all tests (for a heavier validation pass):
+
+```bash
+uv run python scripts/devex_focus.py --test-scope all
+```
+
+## Notes
+
+- When no changed tests are detected, the focus loop will run last-failed tests if available. Run `make test` for full coverage when needed.
+- The loop polls for file changes in `src/`, `tests/`, `docs/`, and `scripts/` when watch mode is enabled.
+- The loop falls back to scanning those folders if `git` is unavailable.

--- a/docs/developer_experience.md
+++ b/docs/developer_experience.md
@@ -38,3 +38,21 @@ uv run python scripts/devex_snapshot.py --format json --output devex_snapshot.js
 ## Outputs
 
 The default output highlights the platform, tool versions, and repository state. Use JSON output when you need to diff snapshots over time or feed them into other tooling.
+
+## Developer Focus Loop
+
+The developer focus loop provides change-aware formatting and test feedback to shorten iteration time when working on a subset of files. It targets modified Python and documentation files, runs focused tests, and can watch for changes.
+
+Run the loop once:
+
+```bash
+make focus
+```
+
+Watch for updates:
+
+```bash
+make focus-watch
+```
+
+See `docs/dev_focus_loop.md` for detailed usage notes and test selection controls.

--- a/docs/research/dev_focus_loop.md
+++ b/docs/research/dev_focus_loop.md
@@ -1,0 +1,24 @@
+# Research Note: Developer Focus Loop
+
+## Technical Problem
+
+Iteration speed slows when developers must run repository-wide formatting and tests for small changes. The focus loop aims to keep feedback localized to the files that changed while still enforcing formatting rules and providing targeted test coverage.
+
+## Materials
+
+- `scripts/devex_focus.py` for change detection and command orchestration.
+- `Makefile` targets that expose the workflow.
+- `docs/dev_focus_loop.md` for user-facing usage guidance.
+
+## Findings
+
+- Change detection leverages `git diff` and `git ls-files` so formatting and test selection stay close to modified files.
+- The workflow separates formatting and testing into explicit steps so developers can choose between `check` and `format` modes.
+- Watch mode uses polling to rerun the loop when files change, providing continuous feedback during active development.
+
+## Source References
+
+- `scripts/devex_focus.py` (focus loop implementation)
+- `Makefile` (focus and focus-watch targets)
+- `docs/dev_focus_loop.md` (concept and usage)
+- `docs/developer_experience.md` (developer experience summary update)

--- a/scripts/devex_focus.py
+++ b/scripts/devex_focus.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Run a change-aware developer feedback loop."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class FocusTargets:
+    """Group the files relevant to developer feedback loops."""
+
+    python_files: tuple[Path, ...]
+    doc_files: tuple[Path, ...]
+    test_files: tuple[Path, ...]
+
+    @property
+    def has_targets(self) -> bool:
+        return bool(self.python_files or self.doc_files or self.test_files)
+
+
+def resolve_repo_root() -> Path:
+    """Return the git repository root or the current working directory."""
+
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        return Path(result.stdout.strip())
+    return Path.cwd()
+
+
+def collect_paths_from_git(repo_root: Path, base: str) -> set[Path]:
+    """Return changed and untracked paths when available."""
+
+    paths: set[Path] = set()
+    git_commands = [
+        ["git", "diff", "--name-only", "--diff-filter=ACMRTUXB", base],
+        ["git", "diff", "--name-only", "--diff-filter=ACMRTUXB", "--cached"],
+        ["git", "ls-files", "--others", "--exclude-standard"],
+    ]
+    for command in git_commands:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=repo_root,
+        )
+        if result.returncode != 0:
+            continue
+        for line in result.stdout.splitlines():
+            candidate = (repo_root / line.strip()).resolve()
+            if candidate.exists():
+                paths.add(candidate)
+    return paths
+
+
+def collect_paths_from_directories(repo_root: Path) -> set[Path]:
+    """Fallback to scanning common project directories."""
+
+    paths: set[Path] = set()
+    for folder in ("src", "tests", "docs", "scripts"):
+        root = repo_root / folder
+        if not root.exists():
+            continue
+        for candidate in root.rglob("*"):
+            if candidate.is_file():
+                paths.add(candidate.resolve())
+    return paths
+
+
+def collect_focus_targets(repo_root: Path, base: str) -> FocusTargets:
+    """Collect the files that should be formatted, linted, or tested."""
+
+    paths = collect_paths_from_git(repo_root, base)
+    if not paths:
+        paths = collect_paths_from_directories(repo_root)
+
+    python_files: list[Path] = []
+    doc_files: list[Path] = []
+    test_files: list[Path] = []
+
+    for path in paths:
+        if path.suffix != ".py" and path.suffix != ".md":
+            continue
+        try:
+            relative = path.relative_to(repo_root)
+        except ValueError:
+            continue
+        if ".venv" in relative.parts:
+            continue
+        if path.suffix == ".py":
+            python_files.append(path)
+            if relative.parts and relative.parts[0] == "tests":
+                test_files.append(path)
+        if path.suffix == ".md" and relative.parts and relative.parts[0] == "docs":
+            doc_files.append(path)
+
+    return FocusTargets(
+        python_files=tuple(sorted(python_files)),
+        doc_files=tuple(sorted(doc_files)),
+        test_files=tuple(sorted(test_files)),
+    )
+
+
+def run_command(command: list[str], repo_root: Path) -> int:
+    """Run a subprocess command and return the exit code."""
+
+    display = " ".join(command)
+    print(f"\n> {display}")
+    result = subprocess.run(command, check=False, cwd=repo_root)
+    return result.returncode
+
+
+def run_formatting(targets: FocusTargets, repo_root: Path, mode: str) -> list[int]:
+    """Run format or check commands for the collected targets."""
+
+    exit_codes: list[int] = []
+    if targets.python_files:
+        python_args = [str(path.relative_to(repo_root)) for path in targets.python_files]
+        if mode == "format":
+            exit_codes.append(run_command(["uvx", "isort", *python_args], repo_root))
+            exit_codes.append(
+                run_command(["uvx", "ruff", "check", "--fix", *python_args], repo_root)
+            )
+        else:
+            exit_codes.append(
+                run_command(["uvx", "isort", "--check-only", *python_args], repo_root)
+            )
+            exit_codes.append(
+                run_command(["uvx", "ruff", "check", *python_args], repo_root)
+            )
+    if targets.doc_files:
+        doc_args = [str(path.relative_to(repo_root)) for path in targets.doc_files]
+        if mode == "format":
+            exit_codes.append(
+                run_command(
+                    [
+                        "uvx",
+                        "docformatter",
+                        "-i",
+                        "--config",
+                        "./pyproject.toml",
+                        *doc_args,
+                    ],
+                    repo_root,
+                )
+            )
+            exit_codes.append(run_command(["uvx", "mdformat", *doc_args], repo_root))
+        else:
+            exit_codes.append(
+                run_command(
+                    [
+                        "uvx",
+                        "docformatter",
+                        "--check",
+                        "--config",
+                        "./pyproject.toml",
+                        *doc_args,
+                    ],
+                    repo_root,
+                )
+            )
+            exit_codes.append(
+                run_command(["uvx", "mdformat", "--check", *doc_args], repo_root)
+            )
+    return exit_codes
+
+
+def run_tests(
+    targets: FocusTargets,
+    repo_root: Path,
+    test_scope: str,
+) -> list[int]:
+    """Run test commands based on the requested scope."""
+
+    exit_codes: list[int] = []
+    if test_scope == "none":
+        print("\n> Skipping tests (--test-scope none)")
+        return exit_codes
+
+    if test_scope == "changed":
+        if not targets.test_files:
+            print("\n> No changed tests detected")
+            return exit_codes
+        test_args = [str(path.relative_to(repo_root)) for path in targets.test_files]
+        exit_codes.append(run_command(["uv", "run", "pytest", *test_args], repo_root))
+        return exit_codes
+
+    if test_scope == "changed-or-last-failed":
+        if targets.test_files:
+            test_args = [str(path.relative_to(repo_root)) for path in targets.test_files]
+            exit_codes.append(run_command(["uv", "run", "pytest", *test_args], repo_root))
+            return exit_codes
+        last_failed = repo_root / ".pytest_cache" / "v" / "cache" / "lastfailed"
+        if last_failed.exists():
+            exit_codes.append(run_command(["uv", "run", "pytest", "--lf"], repo_root))
+        else:
+            print("\n> No changed tests or last-failed cache found")
+        return exit_codes
+
+    if test_scope == "all":
+        exit_codes.append(run_command(["uv", "run", "pytest"], repo_root))
+        return exit_codes
+
+    raise ValueError(f"Unknown test scope: {test_scope}")
+
+
+def run_focus(
+    repo_root: Path,
+    base: str,
+    mode: str,
+    test_scope: str,
+) -> int:
+    """Run the focus loop once and return an exit status."""
+
+    targets = collect_focus_targets(repo_root, base)
+    if not targets.has_targets:
+        print("No matching files found for focus checks.")
+        return 0
+
+    print("Focus targets:")
+    print(f"  Python files: {len(targets.python_files)}")
+    print(f"  Docs files: {len(targets.doc_files)}")
+    print(f"  Test files: {len(targets.test_files)}")
+
+    exit_codes: list[int] = []
+    exit_codes.extend(run_formatting(targets, repo_root, mode))
+    exit_codes.extend(run_tests(targets, repo_root, test_scope))
+
+    return 0 if all(code == 0 for code in exit_codes) else 1
+
+
+def snapshot_paths(watch_paths: Iterable[Path]) -> dict[Path, float]:
+    """Capture file modification times for the watch loop."""
+
+    snapshot: dict[Path, float] = {}
+    for root in watch_paths:
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            if not path.is_file():
+                continue
+            if path.suffix not in {".py", ".md"}:
+                continue
+            snapshot[path] = path.stat().st_mtime
+    return snapshot
+
+
+def watch_focus(
+    repo_root: Path,
+    base: str,
+    mode: str,
+    test_scope: str,
+    watch_paths: Iterable[Path],
+    poll_interval: float,
+) -> int:
+    """Watch for changes and rerun the focus loop."""
+
+    status = run_focus(repo_root, base, mode, test_scope)
+    previous_snapshot = snapshot_paths(watch_paths)
+    while True:
+        time.sleep(poll_interval)
+        current_snapshot = snapshot_paths(watch_paths)
+        if current_snapshot != previous_snapshot:
+            status = run_focus(repo_root, base, mode, test_scope)
+            previous_snapshot = current_snapshot
+    return status
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run change-aware formatting and tests for fast developer feedback.",
+    )
+    parser.add_argument(
+        "--base",
+        default="HEAD",
+        help="Git base reference used to detect changes (default: HEAD).",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("check", "format"),
+        default="format",
+        help="Whether to format changes or just check them.",
+    )
+    parser.add_argument(
+        "--test-scope",
+        choices=("changed", "changed-or-last-failed", "all", "none"),
+        default="changed-or-last-failed",
+        help="Control how tests are selected for the focus loop.",
+    )
+    parser.add_argument(
+        "--watch",
+        action="store_true",
+        help="Watch for file changes and rerun the focus loop.",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=0.5,
+        help="Polling interval in seconds when watch mode is enabled.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = resolve_repo_root()
+    watch_paths = [repo_root / "src", repo_root / "tests", repo_root / "docs"]
+    watch_paths.append(repo_root / "scripts")
+
+    if args.watch:
+        return watch_focus(
+            repo_root,
+            args.base,
+            args.mode,
+            args.test_scope,
+            watch_paths,
+            args.poll_interval,
+        )
+    return run_focus(repo_root, args.base, args.mode, args.test_scope)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Iteration is slow when formatting and running tests across the entire repo for small changes, so feedback needs to be localized.  
- Provide a lightweight, reproducible workflow that runs formatting and linting only on changed Python and docs files.  
- Enable focused test execution that prefers changed tests and falls back to last-failed runs to reduce turnaround.  
- Offer an optional watch mode so developers get continuous feedback while editing files.

### Description

- Add `scripts/devex_focus.py`, a change-aware focus loop that detects modified files via `git` (or falls back to scanning), runs formatting/linting for changed files, and selects tests using `changed`, `changed-or-last-failed`, or `all` scopes.  
- Implement a watch mode backed by a simple polling-based snapshot (`snapshot_paths`) to rerun the loop on file modifications and allow configuration via `--poll-interval`.  
- Expose `make focus` and `make focus-watch` targets in the `Makefile` and document usage in `docs/dev_focus_loop.md`, `docs/research/dev_focus_loop.md`, and updated `docs/developer_experience.md`.  
- Formatting and checks call existing tools via `uvx`/`uv` (e.g., `isort`, `ruff`, `docformatter`, `mdformat`, `pytest`) so the focus loop integrates with current tooling.

### Testing

- Ran `make format` to exercise formatting flows and confirm tooling integration, and it completed successfully.  
- Ran `make test` and the full test suite passed with `159 passed, 1 skipped` (tests run via `pytest` with xdist).  
- Verified the new `make focus`/`scripts/devex_focus.py` path selection logic locally by exercising changed-file detection and walking the watch loop (manual local checks during development).  
- No automated regressions were introduced by the changes based on the executed formatting and test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b6d244fa88321a26187f2c476d790)