### PR TITLE
Add environment cleanup guideline to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,7 @@ Update `docs/code_flow.md` and re-render the diagram with `scripts/render_code_f
 ## File Focus
 
 Keep files narrowly scoped. If a module starts handling multiple concerns (e.g., orchestration plus parsing plus rendering), split the responsibilities into smaller, purpose-built modules so each file does slightly fewer things and has a clear single focus.
+
+## Environment Cleanup
+
+If a single file or module starts accumulating setup, orchestration, configuration, and cleanup logic, move those responsibilities into smaller, focused modules or helpers so each file handles fewer concerns and is easier to reason about.


### PR DESCRIPTION
### Motivation

- Prevent single files or modules from accumulating setup, orchestration, configuration, and cleanup responsibilities to improve readability and maintainability. 
- Provide a clear, repository-level guideline so contributors decompose large files into smaller, focused modules.

### Description

- Add an `Environment Cleanup` section to `AGENTS.md` that instructs moving setup/orchestration/configuration/cleanup logic into focused modules or helpers. 
- Keep the change narrowly scoped to documentation to influence code organization without modifying runtime code.
- Run formatting to ensure the documentation follows repository style via `make format`.

### Testing

- Ran `make format`, which completed successfully. 
- Ran the full test suite with `make test`, which reported `159 passed, 1 skipped` and exited successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bdbe9ef1883219a72f0600cca3d67)