### PR TITLE
Fix renderer type hints

### DIFF
--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -7,7 +7,7 @@ import time
 from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor
 from types import ModuleType
-from typing import TYPE_CHECKING, Callable, Literal, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal, cast
 
 import numpy as np
 import pygame
@@ -26,7 +26,7 @@ from heart.utilities.logging import get_logger
 from heart.utilities.logging_control import get_logging_controller
 
 if TYPE_CHECKING:
-    pass
+    from heart.renderers import StatefulBaseRenderer
 
 
 def _load_cv2_module() -> ModuleType | None:
@@ -52,7 +52,7 @@ HSV_CALIBRATION_ENABLED = HSV_CALIBRATION_MODE != "off"
 HSV_CALIBRATION_STRICT = HSV_CALIBRATION_MODE == "strict"
 HSV_TO_BGR_CACHE: OrderedDict[tuple[int, int, int], np.ndarray] = OrderedDict()
 
-RenderMethod = Callable[[list["StatefulBaseRenderer"]], pygame.Surface | None]
+RenderMethod = Callable[[list["StatefulBaseRenderer[Any]"]], pygame.Surface | None]
 
 
 def _numpy_hsv_from_bgr(image: np.ndarray) -> np.ndarray:
@@ -309,9 +309,6 @@ def _convert_hsv_to_bgr(image: np.ndarray) -> np.ndarray:
     return result
 
 
-if TYPE_CHECKING:
-    from heart.renderers import StatefulBaseRenderer
-
 logger = get_logger(__name__)
 log_controller = get_logging_controller()
 
@@ -364,7 +361,7 @@ class GameLoop:
         self._last_mode_offset = 0
         self._last_offset_on_change = 0
         self._current_offset_on_change = 0
-        self.renderers_cache: list["StatefulBaseRenderer"] | None = None
+        self.renderers_cache: list["StatefulBaseRenderer[Any]"] | None = None
 
         self._active_mode_index = 0
 
@@ -384,7 +381,9 @@ class GameLoop:
 
         self._last_render_mode = pygame.SHOWN
 
-    def _get_renderer_surface(self, renderer: "BaseRenderer") -> pygame.Surface:
+    def _get_renderer_surface(
+        self, renderer: "StatefulBaseRenderer[Any]"
+    ) -> pygame.Surface:
         size = self.device.full_display_size()
         if not Configuration.render_screen_cache_enabled():
             return pygame.Surface(size, pygame.SRCALPHA)
@@ -407,7 +406,10 @@ class GameLoop:
 
     def add_mode(
         self,
-        title: str | list["StatefulBaseRenderer"] | "StatefulBaseRenderer" | None = None,
+        title: str
+        | list["StatefulBaseRenderer[Any]"]
+        | "StatefulBaseRenderer[Any]"
+        | None = None,
     ) -> ComposedRenderer:
         return self.app_controller.add_mode(title=title)
 
@@ -479,13 +481,13 @@ class GameLoop:
         self.clock = clock
         self.peripheral_manager.clock.on_next(self.clock)
 
-    def _select_renderers(self) -> list["StatefulBaseRenderer"]:
+    def _select_renderers(self) -> list["StatefulBaseRenderer[Any]"]:
         base_renderers = self.app_controller.get_renderers()
         renderers = list(base_renderers) if base_renderers else []
         return renderers
 
     def process_renderer(
-        self, renderer: "StatefulBaseRenderer"
+        self, renderer: "StatefulBaseRenderer[Any]"
     ) -> pygame.Surface | None:
         clock = self.clock
         if clock is None:
@@ -640,7 +642,7 @@ class GameLoop:
         return surface1
 
     def _render_surface_iterative(
-        self, renderers: list["StatefulBaseRenderer"]
+        self, renderers: list["StatefulBaseRenderer[Any]"]
     ) -> pygame.Surface | None:
         self._render_queue_depth = len(renderers)
         base = None
@@ -655,7 +657,7 @@ class GameLoop:
         return base
 
     def _render_surfaces_binary(
-        self, renderers: list["StatefulBaseRenderer"]
+        self, renderers: list["StatefulBaseRenderer[Any]"]
     ) -> pygame.Surface | None:
         if not renderers:
             return None
@@ -704,7 +706,7 @@ class GameLoop:
 
     def _render_fn(
         self,
-        renderers: list["StatefulBaseRenderer"],
+        renderers: list["StatefulBaseRenderer[Any]"],
         override_renderer_variant: RendererVariant | None,
     ) -> RenderMethod:
         variant = self._resolve_render_variant(len(renderers), override_renderer_variant)
@@ -714,7 +716,7 @@ class GameLoop:
 
     def _one_loop(
         self,
-        renderers: list["StatefulBaseRenderer"],
+        renderers: list["StatefulBaseRenderer[Any]"],
         override_renderer_variant: RendererVariant | None = None,
     ) -> None:
         if self.screen is None:


### PR DESCRIPTION
### Motivation

- The module had undefined and insufficiently-parameterized renderer types that caused formatting/typecheck failures during `make format`.
- Static typing for renderer APIs needed to be explicit to avoid mypy errors around generic `StatefulBaseRenderer` usage.

### Description

- Import `Any` and reference `StatefulBaseRenderer[Any]` in `RenderMethod` and all `GameLoop` renderer-related annotations to provide explicit generic type parameters.
- Replace a direct `BaseRenderer` annotation usage with the `StatefulBaseRenderer[Any]`-typed parameter for `_get_renderer_surface` and align the `renderers_cache` type accordingly.
- Move the `TYPE_CHECKING` import to include `StatefulBaseRenderer` and update signatures for `_select_renderers`, `process_renderer`, `_render_surface_iterative`, `_render_surfaces_binary`, `_render_fn`, and `_one_loop`.

### Testing

- Ran `make format` and the formatter/linter checks completed successfully.
- Ran `make test` and the test suite completed with `159 passed, 1 skipped`.
- Confirmed no remaining formatting/typecheck failures after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bdc5a97f08321b34a6441a6041df0)