### PR TITLE
Replace bench-device print with logger, add AGENTS guidance, and tighten renderer typing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 
 - Avoid declaring module-level `__all__` exports. Prefer explicit imports at call sites instead of curating export lists.
 - Avoid building filesystem paths via string concatenation. Use `os.path.join` or `pathlib.Path` instead.
+- Avoid using `print` for runtime diagnostics in CLI commands; use the shared logger.
 
 ## Testing
 

--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -7,7 +7,7 @@ import time
 from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor
 from types import ModuleType
-from typing import TYPE_CHECKING, Callable, Literal, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal, cast
 
 import numpy as np
 import pygame
@@ -52,7 +52,7 @@ HSV_CALIBRATION_ENABLED = HSV_CALIBRATION_MODE != "off"
 HSV_CALIBRATION_STRICT = HSV_CALIBRATION_MODE == "strict"
 HSV_TO_BGR_CACHE: OrderedDict[tuple[int, int, int], np.ndarray] = OrderedDict()
 
-RenderMethod = Callable[[list["StatefulBaseRenderer"]], pygame.Surface | None]
+RenderMethod = Callable[[list["StatefulBaseRenderer[Any]"]], pygame.Surface | None]
 
 
 def _numpy_hsv_from_bgr(image: np.ndarray) -> np.ndarray:
@@ -310,7 +310,7 @@ def _convert_hsv_to_bgr(image: np.ndarray) -> np.ndarray:
 
 
 if TYPE_CHECKING:
-    from heart.renderers import StatefulBaseRenderer
+    from heart.renderers import BaseRenderer, StatefulBaseRenderer
 
 logger = get_logger(__name__)
 log_controller = get_logging_controller()
@@ -364,7 +364,7 @@ class GameLoop:
         self._last_mode_offset = 0
         self._last_offset_on_change = 0
         self._current_offset_on_change = 0
-        self.renderers_cache: list["StatefulBaseRenderer"] | None = None
+        self.renderers_cache: list["StatefulBaseRenderer[Any]"] | None = None
 
         self._active_mode_index = 0
 
@@ -384,7 +384,9 @@ class GameLoop:
 
         self._last_render_mode = pygame.SHOWN
 
-    def _get_renderer_surface(self, renderer: "BaseRenderer") -> pygame.Surface:
+    def _get_renderer_surface(
+        self, renderer: "BaseRenderer | StatefulBaseRenderer[Any]"
+    ) -> pygame.Surface:
         size = self.device.full_display_size()
         if not Configuration.render_screen_cache_enabled():
             return pygame.Surface(size, pygame.SRCALPHA)
@@ -407,7 +409,7 @@ class GameLoop:
 
     def add_mode(
         self,
-        title: str | list["StatefulBaseRenderer"] | "StatefulBaseRenderer" | None = None,
+        title: str | list["StatefulBaseRenderer[Any]"] | "StatefulBaseRenderer[Any]" | None = None,
     ) -> ComposedRenderer:
         return self.app_controller.add_mode(title=title)
 
@@ -479,13 +481,13 @@ class GameLoop:
         self.clock = clock
         self.peripheral_manager.clock.on_next(self.clock)
 
-    def _select_renderers(self) -> list["StatefulBaseRenderer"]:
+    def _select_renderers(self) -> list["StatefulBaseRenderer[Any]"]:
         base_renderers = self.app_controller.get_renderers()
         renderers = list(base_renderers) if base_renderers else []
         return renderers
 
     def process_renderer(
-        self, renderer: "StatefulBaseRenderer"
+        self, renderer: "StatefulBaseRenderer[Any]"
     ) -> pygame.Surface | None:
         clock = self.clock
         if clock is None:
@@ -640,7 +642,7 @@ class GameLoop:
         return surface1
 
     def _render_surface_iterative(
-        self, renderers: list["StatefulBaseRenderer"]
+        self, renderers: list["StatefulBaseRenderer[Any]"]
     ) -> pygame.Surface | None:
         self._render_queue_depth = len(renderers)
         base = None
@@ -655,7 +657,7 @@ class GameLoop:
         return base
 
     def _render_surfaces_binary(
-        self, renderers: list["StatefulBaseRenderer"]
+        self, renderers: list["StatefulBaseRenderer[Any]"]
     ) -> pygame.Surface | None:
         if not renderers:
             return None
@@ -704,7 +706,7 @@ class GameLoop:
 
     def _render_fn(
         self,
-        renderers: list["StatefulBaseRenderer"],
+        renderers: list["StatefulBaseRenderer[Any]"],
         override_renderer_variant: RendererVariant | None,
     ) -> RenderMethod:
         variant = self._resolve_render_variant(len(renderers), override_renderer_variant)
@@ -714,7 +716,7 @@ class GameLoop:
 
     def _one_loop(
         self,
-        renderers: list["StatefulBaseRenderer"],
+        renderers: list["StatefulBaseRenderer[Any]"],
         override_renderer_variant: RendererVariant | None = None,
     ) -> None:
         if self.screen is None:

--- a/src/heart/loop.py
+++ b/src/heart/loop.py
@@ -119,7 +119,7 @@ def bench_device() -> None:
     d = _get_device(x11_forward=False)
 
     size = d.full_display_size()
-    print(size)
+    logger.info("Device full display size: %s", size)
 
     image = Image.new("RGB", size)
     while True:


### PR DESCRIPTION
### Motivation
- Remove ad-hoc `print` usage in CLI/runtime diagnostics and encourage consistent structured logging via the shared logger.
- Fix type-check/format failures caused by under-specified renderer generics in `GameLoop` so `make format`/`mypy` checks pass.
- Ensure runtime behaviour and diagnostics remain stable while adopting the repository guidance.

### Description
- Add a formatting/documentation rule to `AGENTS.md` to avoid `print` for runtime diagnostics and prefer the shared logger.
- Replace the `print(size)` call in the `bench-device` command with `logger.info("Device full display size: %s", size)` in `src/heart/loop.py`.
- Tighten typing in `src/heart/environment.py` by importing `BaseRenderer` in `TYPE_CHECKING`, adding `Any` to typing imports, and using `StatefulBaseRenderer[Any]` and `BaseRenderer | StatefulBaseRenderer[Any]` where appropriate.

### Testing
- Ran `make format` and the formatting/type checks completed successfully.
- Ran the test suite with `make test` and automated tests passed: `159 passed, 1 skipped`.
- No additional failing tests were observed after the changes.
- Formatting and tests were repeated after fixes to confirm stability.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bdd1141948321bf9b7a95e2badc79)