### PR TITLE
Add `make develop` target and document one-stop developer flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DOCS_SOURCES = docs
 TOOL_LIST_FILE = scripts/harness_tools.txt
 TOOLS := $(shell scripts/list_harness_tools.sh $(TOOL_LIST_FILE))
 BUILD_ARGS ?=
-.PHONY: install pi_install format check test build check-harness build-info doctor focus focus-watch
+.PHONY: install pi_install format check test build check-harness build-info doctor focus focus-watch develop dev
 
 install:
 	@uv sync --all-extras --group dev
@@ -47,6 +47,11 @@ focus:
 
 focus-watch:
 	@uv run python scripts/devex_focus.py --watch
+
+develop: install
+	@$(MAKE) focus-watch
+
+dev: develop
 
 pi_install:
 	@sudo bash src/heart/manage/install_rgb_matrix.sh

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ See the following references for deeper analysis:
 
 ## Development Workflow
 - `make install` sets up the editable package and dev extras using `uv`.
+- `make develop` syncs dependencies and launches the change-aware watch loop.
 - `make format` applies Ruff, isort, Black, docformatter, and mdformat; run before committing.
 - `make test` executes the pytest suite.
 - `make check` verifies formatting and linting without applying fixes.

--- a/docs/developer_experience.md
+++ b/docs/developer_experience.md
@@ -43,6 +43,32 @@ The default output highlights the platform, tool versions, and repository state.
 
 The developer focus loop provides change-aware formatting and test feedback to shorten iteration time when working on a subset of files. It targets modified Python and documentation files, runs focused tests, and can watch for changes.
 
+## Normal Development Flow
+
+Use the flow below to get a repeatable edit-format-test loop while keeping feedback focused on changed files.
+
+1. Sync dependencies and tooling.
+   ```bash
+   make install
+   ```
+2. Work on code or documentation, then run the focus loop when you want a single pass.
+   ```bash
+   make focus
+   ```
+3. Run full formatting and tests before pushing changes.
+   ```bash
+   make format
+   make test
+   ```
+
+## One-Stop Developer Mode
+
+Use the developer mode target to sync dependencies and start the watch loop in one command.
+
+```bash
+make develop
+```
+
 Run the loop once:
 
 ```bash


### PR DESCRIPTION
### Motivation

- Provide a single, repeatable command to enter development mode that syncs deps and starts the change-aware watch loop. 
- Reduce friction from running multiple make targets when iterating (install, focus/watch, format, test). 
- Surface the recommended edit-format-test loop in documentation for consistent developer experience. 

### Description

- Added `develop` and `dev` phony targets to the `Makefile` where `develop` runs `install` then invokes the focus watcher via `make focus-watch`. 
- Updated `docs/developer_experience.md` to document a normal development flow and the one-stop `make develop` mode. 
- Updated `README.md` to reference the new `make develop` target in the Development Workflow section. 

### Testing

- Ran `make format`, which failed due to a linter error: Ruff reported an undefined name `BaseRenderer` in `src/heart/environment.py`. 
- Ran `make test`, which executed the test suite and completed successfully with `159 passed, 1 skipped`. 
- The new `develop` target was exercised locally by invoking `make develop` (it chains to `make install` and `make focus-watch`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bde1a4ce88321a3d555d726c8a4eb)