### PR TITLE
Remove redundant no-op code

### DIFF
--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -25,9 +25,6 @@ from heart.utilities.env import Configuration
 from heart.utilities.logging import get_logger
 from heart.utilities.logging_control import get_logging_controller
 
-if TYPE_CHECKING:
-    pass
-
 
 def _load_cv2_module() -> ModuleType | None:
     module: ModuleType | None = None

--- a/src/heart/loop.py
+++ b/src/heart/loop.py
@@ -38,8 +38,6 @@ def _get_device(x11_forward: bool) -> Device:
 
         return LEDMatrix(orientation=orientation)
     if Configuration.is_pi():
-        import os
-
         os.environ["SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS"] = "1"
 
         pi_info = Configuration.pi()


### PR DESCRIPTION
### Motivation
- Remove vestigial no-op constructs to keep modules focused and avoid confusing dead code.
- Simplify import usage and reduce clutter in the main loop device selection logic.
- Keep the codebase consistent with formatting and linting expectations defined in repository tooling.

### Description
- Remove an empty `if TYPE_CHECKING: pass` block from `src/heart/environment.py` so type-checking scaffolding is not left as a no-op.
- Drop a redundant nested `import os` from `src/heart/loop.py` since the module-level environment variable is set directly.
- Run repository formatting to ensure imports and style are consistent with project standards using `make format`.

### Testing
- Ran `make format` and the formatter/linter checks completed successfully.
- Ran the test suite with `make test` and observed `159 passed, 1 skipped`.
- All automated tests passed after the changes.
- No additional test failures were introduced by these edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bdf7cbb548321913a4ec86e7d5e31)