### PR TITLE
Fix provider observable typing for accelerometer and switch

### DIFF
--- a/src/heart/peripheral/providers/acceleration/provider.py
+++ b/src/heart/peripheral/providers/acceleration/provider.py
@@ -1,21 +1,53 @@
+from collections.abc import Callable
+from typing import TypeGuard, cast
 
 import reactivex
+from reactivex import operators as ops
 
 from heart.peripheral.core import PeripheralMessageEnvelope
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import ObservableProvider
 from heart.peripheral.sensor import Acceleration, Accelerometer
-from heart.peripheral.uwb import ops
 
 
 class AllAccelerometersProvider(ObservableProvider[Acceleration]):
     """Provides an observable of Acceleration readings."""
+
     def __init__(self, peripheral_manager: PeripheralManager):
         self._pm = peripheral_manager
 
     def observable(self) -> reactivex.Observable[Acceleration]:
-        accels = [peripheral.observe for peripheral in self._pm.peripherals if isinstance(peripheral, Accelerometer)]
+        accels = [
+            peripheral.observe
+            for peripheral in self._pm.peripherals
+            if isinstance(peripheral, Accelerometer)
+        ]
 
-        return reactivex.merge(*accels).pipe(
-            ops.map(PeripheralMessageEnvelope[Acceleration | None].unwrap_peripheral)
+        def unwrap_acceleration(
+            envelope: PeripheralMessageEnvelope[Acceleration | None],
+        ) -> Acceleration | None:
+            return envelope.data
+
+        def is_acceleration(accel: Acceleration | None) -> TypeGuard[Acceleration]:
+            return accel is not None
+
+        def filter_acceleration(
+            source: reactivex.Observable[Acceleration | None],
+        ) -> reactivex.Observable[Acceleration]:
+            return source.pipe(
+                ops.filter(is_acceleration),
+                ops.map(lambda accel: cast(Acceleration, accel)),
+            )
+
+        merged = cast(
+            reactivex.Observable[PeripheralMessageEnvelope[Acceleration | None]],
+            reactivex.merge(*accels),
+        )
+        map_op: Callable[
+            [reactivex.Observable[PeripheralMessageEnvelope[Acceleration | None]]],
+            reactivex.Observable[Acceleration | None],
+        ] = ops.map(unwrap_acceleration)
+        return merged.pipe(
+            map_op,
+            filter_acceleration,
         )

--- a/src/heart/peripheral/providers/switch/provider.py
+++ b/src/heart/peripheral/providers/switch/provider.py
@@ -1,11 +1,10 @@
-
 import reactivex
+from reactivex import operators as ops
 
 from heart.peripheral.core import PeripheralMessageEnvelope
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import ObservableProvider
 from heart.peripheral.switch import FakeSwitch, SwitchState
-from heart.peripheral.uwb import ops
 
 
 class MainSwitchProvider(ObservableProvider[SwitchState]):
@@ -13,7 +12,11 @@ class MainSwitchProvider(ObservableProvider[SwitchState]):
         self._pm = peripheral_manager
 
     def observable(self) -> reactivex.Observable[SwitchState]:
-        main_switches = [peripheral.observe for peripheral in self._pm.peripherals if isinstance(peripheral, FakeSwitch)]
+        main_switches = [
+            peripheral.observe
+            for peripheral in self._pm.peripherals
+            if isinstance(peripheral, FakeSwitch)
+        ]
         return reactivex.merge(*main_switches).pipe(
             ops.map(PeripheralMessageEnvelope[SwitchState].unwrap_peripheral)
         )


### PR DESCRIPTION
### Motivation
- Mypy was failing on provider modules due to an implicit re-export of `ops` from `heart.peripheral.uwb` and poor type inference through `reactivex` pipelines.
- The change aims to make operator imports explicit and ensure observable pipelines have precise types so static checking and formatting succeed.

### Description
- Import `operators as ops` directly from `reactivex` in `src/heart/peripheral/providers/acceleration/provider.py` and `src/heart/peripheral/providers/switch/provider.py` instead of relying on a re-export.
- In `AllAccelerometersProvider` cast the merged observable, add `unwrap_acceleration`, a `TypeGuard` `is_acceleration`, and a typed `filter_acceleration` operator to remove `None` and produce a correctly typed `Observable[Acceleration]` stream.
- Reformat the list comprehensions used to collect peripheral observables and tidy the `MainSwitchProvider` observable construction for readability.
- Modified files: `src/heart/peripheral/providers/acceleration/provider.py` and `src/heart/peripheral/providers/switch/provider.py`.

### Testing
- Ran `make format` to apply linting and type checks, which completed successfully.  
- Ran `make test`, and the test suite passed with `162 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be162a344832182e8c8f660164331)