### PR TITLE
Use StrEnum for strategy configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - Avoid declaring module-level `__all__` exports. Prefer explicit imports at call sites instead of curating export lists.
 - Avoid building filesystem paths via string concatenation. Use `os.path.join` or `pathlib.Path` instead.
 - Avoid using `print` for runtime diagnostics in CLI commands; use the shared logger.
+- Prefer `StrEnum` values over raw strings for strategy/configuration mode selections.
 
 ## Testing
 

--- a/src/heart/modules/life/state.py
+++ b/src/heart/modules/life/state.py
@@ -5,7 +5,7 @@ from typing import Any
 import numpy as np
 from scipy.ndimage import convolve
 
-from heart.utilities.env import Configuration
+from heart.utilities.env import Configuration, LifeUpdateStrategy
 
 DEFAULT_LIFE_KERNEL = np.array([[1, 1, 1], [1, 0, 1], [1, 1, 1]], dtype=int)
 
@@ -20,12 +20,15 @@ class LifeState:
         kernel = self.kernel
         strategy = Configuration.life_update_strategy()
 
-        if kernel is None and strategy in {"auto", "pad"}:
+        if kernel is None and strategy in {
+            LifeUpdateStrategy.AUTO,
+            LifeUpdateStrategy.PAD,
+        }:
             neighbors = _count_neighbors_with_padding(self.grid)
         else:
             if kernel is None:
                 kernel = DEFAULT_LIFE_KERNEL
-            if kernel is not None and strategy == "pad":
+            if kernel is not None and strategy == LifeUpdateStrategy.PAD:
                 raise ValueError(
                     "HEART_LIFE_UPDATE_STRATEGY='pad' only supports the default kernel."
                 )

--- a/src/heart/renderers/__init__.py
+++ b/src/heart/renderers/__init__.py
@@ -10,7 +10,7 @@ from heart import DeviceDisplayMode
 from heart.device import Layout, Orientation
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import ObservableProvider
-from heart.utilities.env import Configuration
+from heart.utilities.env import Configuration, RenderTileStrategy
 from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
@@ -137,7 +137,7 @@ class BaseRenderer:
         else:
             tiled_surface = pygame.Surface(target_size, pygame.SRCALPHA)
 
-        if Configuration.render_tile_strategy() == "blits":
+        if Configuration.render_tile_strategy() == RenderTileStrategy.BLITS:
             positions_key = (tile_width, tile_height, rows, cols)
             positions = self._tile_positions_cache.get(positions_key)
             if positions is None:
@@ -351,7 +351,7 @@ class AtomicBaseRenderer(Generic[StateT]):
         else:
             tiled_surface = pygame.Surface(target_size, pygame.SRCALPHA)
 
-        if Configuration.render_tile_strategy() == "blits":
+        if Configuration.render_tile_strategy() == RenderTileStrategy.BLITS:
             positions_key = (tile_width, tile_height, rows, cols)
             positions = self._tile_positions_cache.get(positions_key)
             if positions is None:

--- a/src/heart/renderers/internal/frame_accumulator.py
+++ b/src/heart/renderers/internal/frame_accumulator.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 import numpy as np
 import pygame
 
-from heart.utilities.env import Configuration
+from heart.utilities.env import Configuration, FrameArrayStrategy
 
 _ColorInput = pygame.Color | str | tuple[int, int, int] | tuple[int, int, int, int]
 _RectInput = pygame.Rect | tuple[int, int, int, int] | None
@@ -136,7 +136,7 @@ class FrameAccumulator:
         """Return an RGB array view of the accumulated frame."""
 
         if self._array_cache is None:
-            if Configuration.frame_array_strategy() == "view":
+            if Configuration.frame_array_strategy() == FrameArrayStrategy.VIEW:
                 array = pygame.surfarray.pixels3d(self._surface)
             else:
                 array = pygame.surfarray.array3d(self._surface)

--- a/src/heart/utilities/env.py
+++ b/src/heart/utilities/env.py
@@ -2,6 +2,7 @@ import os
 import platform
 import re
 from dataclasses import dataclass
+from enum import StrEnum
 from functools import cache
 from typing import Iterator
 
@@ -192,31 +193,50 @@ class Configuration:
         return _env_flag("HEART_RENDER_SCREEN_CACHE", default=True)
 
     @classmethod
-    def render_tile_strategy(cls) -> str:
+    def render_tile_strategy(cls) -> "RenderTileStrategy":
         strategy = os.environ.get("HEART_RENDER_TILE_STRATEGY", "blits").strip().lower()
-        if strategy in {"blits", "loop"}:
-            return strategy
-        raise ValueError(
-            "HEART_RENDER_TILE_STRATEGY must be 'blits' or 'loop'"
-        )
+        try:
+            return RenderTileStrategy(strategy)
+        except ValueError as exc:
+            raise ValueError(
+                "HEART_RENDER_TILE_STRATEGY must be 'blits' or 'loop'"
+            ) from exc
 
     @classmethod
-    def frame_array_strategy(cls) -> str:
+    def frame_array_strategy(cls) -> "FrameArrayStrategy":
         strategy = os.environ.get("HEART_FRAME_ARRAY_STRATEGY", "copy").strip().lower()
-        if strategy in {"copy", "view"}:
-            return strategy
-        raise ValueError(
-            "HEART_FRAME_ARRAY_STRATEGY must be 'copy' or 'view'"
-        )
+        try:
+            return FrameArrayStrategy(strategy)
+        except ValueError as exc:
+            raise ValueError(
+                "HEART_FRAME_ARRAY_STRATEGY must be 'copy' or 'view'"
+            ) from exc
 
     @classmethod
-    def life_update_strategy(cls) -> str:
+    def life_update_strategy(cls) -> "LifeUpdateStrategy":
         strategy = os.environ.get("HEART_LIFE_UPDATE_STRATEGY", "auto").strip().lower()
-        if strategy in {"auto", "convolve", "pad"}:
-            return strategy
-        raise ValueError(
-            "HEART_LIFE_UPDATE_STRATEGY must be 'auto', 'convolve', or 'pad'"
-        )
+        try:
+            return LifeUpdateStrategy(strategy)
+        except ValueError as exc:
+            raise ValueError(
+                "HEART_LIFE_UPDATE_STRATEGY must be 'auto', 'convolve', or 'pad'"
+            ) from exc
+
+
+class RenderTileStrategy(StrEnum):
+    BLITS = "blits"
+    LOOP = "loop"
+
+
+class FrameArrayStrategy(StrEnum):
+    COPY = "copy"
+    VIEW = "view"
+
+
+class LifeUpdateStrategy(StrEnum):
+    AUTO = "auto"
+    CONVOLVE = "convolve"
+    PAD = "pad"
 
 
 def get_device_ports(prefix: str) -> Iterator[str]:


### PR DESCRIPTION
### Motivation
- Make strategy/configuration values typed and safer by preferring `StrEnum` over raw strings for mode selections.
- Reduce stringly-typed comparisons and centralize allowed strategy values to avoid typo-driven bugs.

### Description
- Add an AGENTS rule recommending `StrEnum` for strategy/configuration mode selections in `AGENTS.md`.
- Introduce `RenderTileStrategy`, `FrameArrayStrategy`, and `LifeUpdateStrategy` as `StrEnum` types in `src/heart/utilities/env.py` and have `Configuration` return these types from `render_tile_strategy`, `frame_array_strategy`, and `life_update_strategy`.
- Update callers to compare against the new enums in `src/heart/renderers/__init__.py`, `src/heart/renderers/internal/frame_accumulator.py`, and `src/heart/modules/life/state.py`.

### Testing
- Ran `make test`, which completed successfully with `159 passed, 1 skipped`.
- Ran `make format`, which surfaced mypy `attr-defined` errors referencing `heart.peripheral.uwb` (related to `ops`) and prevented a clean format run.
- Formatting was otherwise applied to the modified files before committing; type check issue remains scoped to the unrelated `heart.peripheral.uwb` exports.
- No new unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be153a5648321a5c907f91d3cecc3)