### PR TITLE
Add configurable replay strategy for reactive event streams

### DIFF
--- a/docs/research/reactive_event_stream_share_strategy.md
+++ b/docs/research/reactive_event_stream_share_strategy.md
@@ -1,0 +1,44 @@
+# Reactive event stream share strategy configuration
+
+## Problem statement
+
+Core reactive event streams currently use a single sharing operator with no way to
+configure replay behaviour. Late subscribers may miss the most recent peripheral
+events, which complicates diagnostics and can lead to inconsistent initialization
+in downstream streams. The lack of configurability also limits experimentation with
+buffered replay when tuning for performance and correctness.
+
+## Approach
+
+- Introduce a configurable share strategy for core reactive streams so the event
+  bus and peripheral observables can be replayed when needed.
+- Default to replaying the latest value to improve debuggability while preserving
+  a straightforward `share` option when back-compatibility is desired.
+- Support a bounded replay buffer size for scenarios that need a short history for
+  late subscribers.
+
+## Configuration
+
+- `HEART_RX_STREAM_SHARE_STRATEGY`
+  - `replay_latest` (default): replay the most recent event to late subscribers.
+  - `replay_buffer`: replay the last `HEART_RX_STREAM_REPLAY_BUFFER` events.
+  - `share`: preserve the pre-existing no-replay share behaviour.
+- `HEART_RX_STREAM_REPLAY_BUFFER`
+  - Integer buffer size used when the strategy is `replay_buffer`.
+
+## Implementation notes
+
+- `heart.utilities.reactivex_streams.share_stream` wraps the sharing logic and
+  provides logging hints for the configured strategy.
+- `heart.peripheral.core.Peripheral.observe` and
+  `heart.peripheral.core.manager.PeripheralManager.get_event_bus` now use the
+  shared helper so configuration applies consistently across core event streams.
+- Tests validate that late subscribers receive the configured replay buffer.
+
+## Materials
+
+- `src/heart/utilities/reactivex_streams.py`
+- `src/heart/utilities/env.py`
+- `src/heart/peripheral/core/__init__.py`
+- `src/heart/peripheral/core/manager.py`
+- `tests/utilities/test_reactivex_streams.py`

--- a/src/heart/peripheral/core/__init__.py
+++ b/src/heart/peripheral/core/__init__.py
@@ -10,6 +10,8 @@ from typing import Any, Generic, Iterator, Mapping, Self, Sequence, TypeVar
 import reactivex
 from reactivex import operators as ops
 
+from heart.utilities.reactivex_streams import share_stream
+
 
 @dataclass(slots=True)
 class Input:
@@ -74,7 +76,10 @@ class Peripheral(Generic[A]):
                 peripheral_info=self.peripheral_info()
             )
 
-        return self._event_stream().pipe(ops.map(wrap), ops.share())
+        return share_stream(
+            self._event_stream().pipe(ops.map(wrap)),
+            stream_name=f"{type(self).__name__}.observe",
+        )
 
     @classmethod
     def detect(cls) -> Iterator[Self]:

--- a/src/heart/peripheral/core/manager.py
+++ b/src/heart/peripheral/core/manager.py
@@ -13,6 +13,7 @@ from heart.peripheral.registry import PeripheralConfigurationRegistry
 from heart.peripheral.switch import FakeSwitch, SwitchState
 from heart.utilities.env import Configuration
 from heart.utilities.logging import get_logger
+from heart.utilities.reactivex_streams import share_stream
 from heart.utilities.reactivex_threads import (background_scheduler,
                                                input_scheduler)
 
@@ -102,7 +103,7 @@ class PeripheralManager:
         scheduler = self._event_bus_scheduler()
         if scheduler is not None:
             event_bus = event_bus.pipe(ops.observe_on(scheduler))
-        return event_bus.pipe(ops.share())
+        return share_stream(event_bus, stream_name="PeripheralManager.event_bus")
 
     def get_main_switch_subscription(self) -> reactivex.Observable[SwitchState]:
         main_switches = [

--- a/src/heart/utilities/env.py
+++ b/src/heart/utilities/env.py
@@ -125,6 +125,22 @@ class Configuration:
         )
 
     @classmethod
+    def reactivex_stream_share_strategy(cls) -> str:
+        strategy = os.environ.get(
+            "HEART_RX_STREAM_SHARE_STRATEGY",
+            "replay_latest",
+        ).strip().lower()
+        if strategy in {"share", "replay_latest", "replay_buffer"}:
+            return strategy
+        raise ValueError(
+            "HEART_RX_STREAM_SHARE_STRATEGY must be 'share', 'replay_latest', or 'replay_buffer'"
+        )
+
+    @classmethod
+    def reactivex_stream_replay_buffer(cls) -> int:
+        return _env_int("HEART_RX_STREAM_REPLAY_BUFFER", default=16, minimum=1)
+
+    @classmethod
     def isolated_renderer_socket(cls) -> str | None:
         socket_path = os.environ.get("ISOLATED_RENDER_SOCKET")
         if socket_path == "":

--- a/src/heart/utilities/reactivex_streams.py
+++ b/src/heart/utilities/reactivex_streams.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import TypeVar
+
+import reactivex
+from reactivex import operators as ops
+
+from heart.utilities.env import Configuration
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+T = TypeVar("T")
+
+
+def share_stream(
+    source: reactivex.Observable[T],
+    *,
+    stream_name: str,
+) -> reactivex.Observable[T]:
+    """Share a stream using the configured strategy."""
+
+    strategy = Configuration.reactivex_stream_share_strategy()
+    if strategy == "share":
+        return source.pipe(ops.share())
+    if strategy == "replay_latest":
+        logger.debug("Sharing %s with replay_latest", stream_name)
+        return source.pipe(ops.replay(buffer_size=1), ops.ref_count())
+    if strategy == "replay_buffer":
+        buffer_size = Configuration.reactivex_stream_replay_buffer()
+        logger.debug("Sharing %s with replay_buffer=%d", stream_name, buffer_size)
+        return source.pipe(ops.replay(buffer_size=buffer_size), ops.ref_count())
+    raise ValueError(f"Unknown reactive stream share strategy: {strategy}")

--- a/tests/utilities/test_reactivex_streams.py
+++ b/tests/utilities/test_reactivex_streams.py
@@ -1,0 +1,69 @@
+import pytest
+from reactivex.subject import Subject
+
+from heart.utilities.reactivex_streams import share_stream
+
+
+class TestShareStreamStrategy:
+    """Validate reactive stream sharing strategies for core event pipelines."""
+
+    @pytest.mark.parametrize(
+        ("strategy", "expected_initial"),
+        [
+            ("share", []),
+            ("replay_latest", [2]),
+        ],
+        ids=["share_no_replay", "replay_latest_replays_last"],
+    )
+    def test_share_stream_replays_latest_when_configured(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        strategy: str,
+        expected_initial: list[int],
+    ) -> None:
+        """Ensure configured replay behaviour matches expectations to preserve late-subscriber correctness."""
+
+        monkeypatch.setenv("HEART_RX_STREAM_SHARE_STRATEGY", strategy)
+        source: Subject[int] = Subject()
+        shared = share_stream(source, stream_name="test")
+
+        received_a: list[int] = []
+        shared.subscribe(received_a.append)
+
+        source.on_next(1)
+        source.on_next(2)
+
+        received_b: list[int] = []
+        shared.subscribe(received_b.append)
+
+        assert received_b == expected_initial
+
+        source.on_next(3)
+
+        assert received_a == [1, 2, 3]
+        assert received_b == [*expected_initial, 3]
+
+    def test_share_stream_replays_buffer_when_configured(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Confirm replay buffer sizing keeps recent context available for observability and recovery."""
+
+        monkeypatch.setenv("HEART_RX_STREAM_SHARE_STRATEGY", "replay_buffer")
+        monkeypatch.setenv("HEART_RX_STREAM_REPLAY_BUFFER", "2")
+        source: Subject[int] = Subject()
+        shared = share_stream(source, stream_name="buffered")
+
+        received_a: list[int] = []
+        shared.subscribe(received_a.append)
+
+        source.on_next(1)
+        source.on_next(2)
+        source.on_next(3)
+
+        received_b: list[int] = []
+        shared.subscribe(received_b.append)
+
+        assert received_b == [2, 3]
+        source.on_next(4)
+        assert received_b == [2, 3, 4]


### PR DESCRIPTION
### Motivation
- Late subscribers to core reactive streams currently miss recent events which complicates debugging and can lead to inconsistent initialization. 
- Provide a configurable, testable way to control sharing/replay behaviour across core event pipelines to improve debuggability and correctness. 
- Allow experimentation with bounded replay buffers to balance memory, latency and correctness trade-offs. 

### Description
- Add `heart.utilities.reactivex_streams.share_stream` which selects a share strategy (`share`, `replay_latest`, `replay_buffer`) based on environment configuration. 
- Add configuration accessors `Configuration.reactivex_stream_share_strategy` and `Configuration.reactivex_stream_replay_buffer` in `src/heart/utilities/env.py`. 
- Replace direct `ops.share()` usage with `share_stream` for `Peripheral.observe` and `PeripheralManager.get_event_bus` so the configured strategy is applied consistently. 
- Add unit tests `tests/utilities/test_reactivex_streams.py` and a research note `docs/research/reactive_event_stream_share_strategy.md` describing the approach. 

### Testing
- Ran formatting with `make format` which completed successfully. 
- Ran the full test suite with `make test` and all automated tests passed. 
- Included new unit tests exercise replay strategies (`tests/utilities/test_reactivex_streams.py`) which passed. 
- Test summary: `165 passed, 1 skipped` (full CI-local test run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be16d46108321aab3cb4bb48aa9cd)