### PR TITLE
Enhance manage update workflow

### DIFF
--- a/docs/manage_update.md
+++ b/docs/manage_update.md
@@ -1,0 +1,36 @@
+## Heart manage update workflow
+
+The `src/heart/manage/update.py` helper updates CircuitPython driver devices with the
+runtime `boot.py`, `code.py`, and `settings.toml` files stored in `drivers/<driver>`.
+It also syncs the required CircuitPython libraries from the Adafruit bundle and the
+`heart.firmware_io` package when requested.
+
+### Materials
+
+- A host machine with the Heart repository checked out.
+- A CircuitPython-compatible device mounted under `/Volumes` (macOS) or
+  `/media/michael` (Raspberry Pi), or another mount directory passed via `--media-dir`.
+- A driver folder under `drivers/` containing `boot.py`, `code.py`, and
+  `settings.toml` with valid firmware metadata.
+
+### Usage
+
+Run the script with the driver folder name:
+
+```bash
+python -m heart.manage.update <driver-folder-name>
+```
+
+Optional flags:
+
+- `--media-dir`: Override the mount directory used to discover devices.
+- `--skip-uf2`: Skip UF2 firmware installation even if a device is in boot mode.
+- `--skip-libs`: Skip syncing the CircuitPython library bundle to the device.
+- `--dry-run`: Log intended operations without copying files or downloading assets.
+
+### Notes
+
+- UF2 installation is only attempted when a device is detected in boot mode under the
+  configured media directory.
+- Driver settings are read from `drivers/<driver>/settings.toml` and must include the
+  `CIRCUIT_PY_*` keys and `VALID_BOARD_IDS` list expected by the updater.

--- a/src/heart/manage/update.py
+++ b/src/heart/manage/update.py
@@ -1,5 +1,5 @@
+import argparse
 import hashlib
-import os
 import shutil
 import subprocess
 import sys
@@ -13,11 +13,13 @@ import heart
 import heart.firmware_io
 from heart import firmware_io
 from heart.utilities.env import Configuration
+from heart.utilities.logging import get_logger
 
-if Configuration.is_pi():
-    MEDIA_DIRECTORY = "/media/michael"
-else:
-    MEDIA_DIRECTORY = "/Volumes"
+logger = get_logger(__name__)
+
+DEFAULT_MEDIA_DIRECTORY = Path(
+    "/media/michael" if Configuration.is_pi() else "/Volumes"
+)
 
 CIRCUIT_PY_COMMON_LIBS_UNZIPPED_NAME = "adafruit-circuitpython-bundle-9.x-mpy-20250412"
 CIRCUIT_PY_COMMON_LIBS = (
@@ -40,96 +42,121 @@ class DriverConfig:
     valid_board_ids: list[str]
 
 
-def load_driver_libs(libs: list[str], destination: str) -> None:
+@dataclass(frozen=True)
+class UpdateOptions:
+    media_directory: Path
+    skip_uf2: bool
+    skip_libs: bool
+    dry_run: bool
+
+
+def load_driver_libs(
+    libs: list[str], destination: Path, *, dry_run: bool = False
+) -> None:
+    if dry_run:
+        logger.info("Dry run: would reset %s and sync driver libs.", destination)
+        return
+
     shutil.rmtree(destination, ignore_errors=True)
-    os.makedirs(destination, exist_ok=True)
-    # Our local lib
+    destination.mkdir(parents=True, exist_ok=True)
     copy_file(
-        os.path.dirname(firmware_io.__file__),
-        os.path.join(destination, *firmware_io.__package__.split(".")),
+        Path(firmware_io.__file__).parent,
+        destination / Path(*firmware_io.__package__.split(".")),
+        dry_run=dry_run,
     )
 
     if not libs:
-        print("Skipping loading driver libs as no libs were requested.")
+        logger.info("Skipping driver libs because no libs were requested.")
         return
 
-    print(f"Loading the following libs: {libs}")
+    logger.info("Loading driver libs: %s", libs)
     zip_location = download_file(
         CIRCUIT_PY_COMMON_LIBS, CIRCUIT_PY_COMMON_LIBS_CHECKSUM
     )
-    unzipped_location = zip_location.replace(".zip", "")
+    unzipped_location = zip_location.with_suffix("")
     # Lib in this case just comes from the downloaded file, which is separate from the `destination` which is also lib
-    lib_path = os.path.join(unzipped_location, "lib")
+    lib_path = unzipped_location / "lib"
 
-    if not os.path.exists(lib_path):
+    if not lib_path.exists():
         subprocess.run(
-            ["unzip", zip_location], check=True, cwd=os.path.dirname(unzipped_location)
+            ["unzip", str(zip_location)],
+            check=True,
+            cwd=str(unzipped_location.parent),
         )
     else:
-        print(f"Skipping unzipping {zip_location} because {lib_path} exists")
+        logger.info("Skipping unzip for %s because %s exists.", zip_location, lib_path)
 
     for lib in libs:
-        copy_file(os.path.join(lib_path, lib), os.path.join(destination, lib))
+        copy_file(lib_path / lib, destination / lib)
         # There are also .mpy files..
-        mpy_source = os.path.join(lib_path, f"{lib}.mpy")
-        if os.path.exists(mpy_source):
-            copy_file(mpy_source, os.path.join(destination, f"{lib}.mpy"))
+        mpy_source = lib_path / f"{lib}.mpy"
+        if mpy_source.exists():
+            copy_file(mpy_source, destination / f"{lib}.mpy")
         else:
-            print(f"Skipping missing {mpy_source}")
+            logger.info("Skipping missing %s", mpy_source)
 
 
-def _sha256sum(path: str) -> str:
+def _sha256sum(path: Path) -> str:
     digest = hashlib.sha256()
-    with open(path, "rb") as file_handle:
+    with path.open("rb") as file_handle:
         for chunk in iter(lambda: file_handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
 
 
-def download_file(url: str, checksum: str) -> str:
+def download_file(url: str, checksum: str) -> Path:
     try:
-        destination = os.path.join("/tmp", url.split("/")[-1])
-        if os.path.exists(destination):
+        destination = Path("/tmp") / url.split("/")[-1]
+        if destination.exists():
             existing_checksum = _sha256sum(destination)
             if existing_checksum != checksum:
-                print(
-                    f"Removing {destination}; checksum {existing_checksum} did not match {checksum}."
+                logger.warning(
+                    "Removing %s; checksum %s did not match %s.",
+                    destination,
+                    existing_checksum,
+                    checksum,
                 )
-                os.remove(destination)
+                destination.unlink()
 
-        if not os.path.exists(destination):
-            print(f"Starting download: {url}")
+        if not destination.exists():
+            logger.info("Starting download: %s", url)
             if Configuration.is_pi():
-                subprocess.run(["wget", url, "-O", destination], check=True)
+                subprocess.run(["wget", url, "-O", str(destination)], check=True)
             else:
-                subprocess.run(["curl", "-fL", url, "-o", destination], check=True)
-            print(f"Finished download: {destination}")
+                subprocess.run(["curl", "-fL", url, "-o", str(destination)], check=True)
+            logger.info("Finished download: %s", destination)
 
         downloaded_checksum = _sha256sum(destination)
-        print(f"Checksum for {destination}: {downloaded_checksum}")
+        logger.info("Checksum for %s: %s", destination, downloaded_checksum)
         if downloaded_checksum != checksum:
-            print(
-                f"Error: Checksum mismatch for {destination}. Expected {checksum}, but got {downloaded_checksum}."
+            logger.error(
+                "Checksum mismatch for %s. Expected %s, but got %s.",
+                destination,
+                checksum,
+                downloaded_checksum,
             )
-            sys.exit(1)
-        print("Checksum matches expectations.")
+            raise SystemExit(1)
+        logger.info("Checksum matches expectations.")
         return destination
     except subprocess.CalledProcessError:
-        print(f"Error: Failed to download {url}")
-        sys.exit(1)
+        logger.error("Failed to download %s", url)
+        raise SystemExit(1)
 
 
-def copy_file(source: str, destination: str) -> None:
+def copy_file(source: Path, destination: Path, *, dry_run: bool = False) -> None:
+    if dry_run:
+        logger.info("Dry run: would copy %s to %s", source, destination)
+        return
+
     try:
-        print(f"Before copying: {source} to {destination}")
-        if os.path.isdir(source):
+        logger.info("Copying %s to %s", source, destination)
+        if source.is_dir():
             shutil.copytree(source, destination, dirs_exist_ok=True)
         else:
-            os.makedirs(os.path.dirname(destination), exist_ok=True)
+            destination.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source, destination)
-        print(f"After copying: {source} to {destination}")
     except (OSError, shutil.Error) as error:
-        print(f"Error: Failed to copy {source} to {destination}: {error}")
+        logger.error("Failed to copy %s to %s: %s", source, destination, error)
 
 
 def _parse_csv(value: str | list[str], *, field_name: str) -> list[str]:
@@ -157,8 +184,8 @@ def _load_driver_config(settings_path: str) -> DriverConfig:
     try:
         config = toml.load(settings_path)
     except (FileNotFoundError, toml.TomlDecodeError) as error:
-        print(f"Error: Unable to read driver settings at {settings_path}: {error}")
-        sys.exit(1)
+        logger.error("Unable to read driver settings at %s: %s", settings_path, error)
+        raise SystemExit(1)
 
     missing = [
         key
@@ -172,8 +199,8 @@ def _load_driver_config(settings_path: str) -> DriverConfig:
         if key not in config
     ]
     if missing:
-        print(f"Error: Missing keys in {settings_path}: {', '.join(missing)}")
-        sys.exit(1)
+        logger.error("Missing keys in %s: %s", settings_path, ", ".join(missing))
+        raise SystemExit(1)
 
     try:
         driver_libs = _parse_csv(
@@ -194,8 +221,8 @@ def _load_driver_config(settings_path: str) -> DriverConfig:
             config["CIRCUIT_PY_BOOT_NAME"], field_name="CIRCUIT_PY_BOOT_NAME"
         )
     except ValueError as error:
-        print(f"Error: Invalid driver settings in {settings_path}: {error}")
-        sys.exit(1)
+        logger.error("Invalid driver settings in %s: %s", settings_path, error)
+        raise SystemExit(1)
 
     return DriverConfig(
         uf2_url=uf2_url,
@@ -206,67 +233,76 @@ def _load_driver_config(settings_path: str) -> DriverConfig:
     )
 
 
-def _parse_board_id(boot_out_path: str) -> str:
-    with open(boot_out_path, "r") as file_handle:
+def _parse_board_id(boot_out_path: Path) -> str:
+    with boot_out_path.open("r") as file_handle:
         for line in file_handle:
             if "Board ID:" in line:
                 return line.split("Board ID:")[1].strip()
     raise ValueError(f"Unable to find Board ID identifier in {boot_out_path}")
 
 
-def _ensure_driver_files(driver_path: str) -> None:
+def _ensure_driver_files(driver_path: Path) -> None:
     missing = [
-        name
-        for name in DRIVER_FILES
-        if not os.path.exists(os.path.join(driver_path, name))
+        name for name in DRIVER_FILES if not (driver_path / name).exists()
     ]
     if missing:
-        print(f"Error: Missing driver files in {driver_path}: {', '.join(missing)}")
-        sys.exit(1)
+        logger.error("Missing driver files in %s: %s", driver_path, ", ".join(missing))
+        raise SystemExit(1)
 
 
-def _mount_points(media_directory: str) -> list[str]:
-    if not os.path.isdir(media_directory):
-        print(
-            f"Error: Expected media directory {media_directory} to exist before updates."
+def _mount_points(media_directory: Path) -> list[Path]:
+    if not media_directory.is_dir():
+        logger.error(
+            "Expected media directory %s to exist before updates.", media_directory
         )
-        sys.exit(1)
+        raise SystemExit(1)
 
     return [
-        os.path.join(media_directory, entry)
-        for entry in os.listdir(media_directory)
-        if os.path.isdir(os.path.join(media_directory, entry))
+        entry for entry in media_directory.iterdir() if entry.is_dir()
     ]
 
 
-def main(device_driver_name: str) -> None:
-    base_path = str(Path(heart.__file__).resolve().parents[2] / "drivers")
-    code_path = os.path.join(base_path, device_driver_name)
-    if not os.path.isdir(code_path):
-        print(
-            f"Error: The path {code_path} does not exist. This is where we expect the driver code to exist."
+def main(device_driver_name: str, options: UpdateOptions) -> None:
+    base_path = Path(heart.__file__).resolve().parents[2] / "drivers"
+    code_path = base_path / device_driver_name
+    if not code_path.is_dir():
+        logger.error(
+            "The path %s does not exist. This is where we expect the driver code to exist.",
+            code_path,
         )
-        sys.exit(1)
+        raise SystemExit(1)
 
     ###
     # Load a bunch of env vars the driver declares
     ###
-    config = _load_driver_config(os.path.join(code_path, DRIVER_SETTINGS_FILENAME))
+    config = _load_driver_config(str(code_path / DRIVER_SETTINGS_FILENAME))
     _ensure_driver_files(code_path)
-    mount_points = _mount_points(MEDIA_DIRECTORY)
+    mount_points = _mount_points(options.media_directory)
 
     ###
     # If the device is not a CIRCUIT_PY device yet, load the UF2 so that it is converted
     ###
-    UF2_DESTINATION = os.path.join(MEDIA_DIRECTORY, config.device_boot_name)
-    if os.path.isdir(UF2_DESTINATION):
-        downloaded_file_path = download_file(config.uf2_url, config.uf2_checksum)
-        copy_file(downloaded_file_path, UF2_DESTINATION)
-        time.sleep(10)
+    if options.skip_uf2:
+        logger.info("Skipping CircuitPython UF2 installation due to --skip-uf2.")
     else:
-        print(
-            "Skipping CircuitPython UF2 installation as no device is in boot mode currently"
-        )
+        uf2_destination = options.media_directory / config.device_boot_name
+        if uf2_destination.is_dir():
+            if options.dry_run:
+                logger.info(
+                    "Dry run: would install UF2 %s to %s.",
+                    config.uf2_url,
+                    uf2_destination,
+                )
+            else:
+                downloaded_file_path = download_file(
+                    config.uf2_url, config.uf2_checksum
+                )
+                copy_file(downloaded_file_path, uf2_destination)
+                time.sleep(10)
+        else:
+            logger.info(
+                "Skipping CircuitPython UF2 installation as no device is in boot mode currently."
+            )
 
     ###
     # For all the CIRCUITPY devices, try to find whether this specific driver should be loaded onto them
@@ -274,53 +310,87 @@ def main(device_driver_name: str) -> None:
     circuitpy_mounts = [
         mount_point
         for mount_point in mount_points
-        if "CIRCUITPY" in os.path.basename(mount_point)
+        if "CIRCUITPY" in mount_point.name
     ]
     if not circuitpy_mounts:
-        print(f"No CIRCUITPY volumes found under {MEDIA_DIRECTORY}.")
+        logger.info("No CIRCUITPY volumes found under %s.", options.media_directory)
 
     for media_location in circuitpy_mounts:
-        boot_out_path = os.path.join(media_location, "boot_out.txt")
+        boot_out_path = media_location / "boot_out.txt"
 
-        if os.path.exists(boot_out_path):
+        if boot_out_path.exists():
             try:
                 board_id = _parse_board_id(boot_out_path)
             except ValueError as error:
-                print(f"Error: {error}")
+                logger.warning("%s", error)
                 continue
 
             if board_id not in config.valid_board_ids:
-                print(
-                    "Skipping: The board ID "
-                    f"{board_id} is not in the list of valid board IDs: "
-                    f"{config.valid_board_ids}"
+                logger.info(
+                    "Skipping: The board ID %s is not in the list of valid board IDs: %s",
+                    board_id,
+                    config.valid_board_ids,
                 )
                 continue
 
             for file_name in DRIVER_FILES:
                 copy_file(
-                    os.path.join(code_path, file_name),
-                    os.path.join(media_location, file_name),
+                    code_path / file_name,
+                    media_location / file_name,
+                    dry_run=options.dry_run,
                 )
 
-            load_driver_libs(
-                libs=config.driver_libs,
-                destination=os.path.join(os.path.join(media_location, "lib")),
-            )
+            if options.skip_libs:
+                logger.info(
+                    "Skipping driver libs for %s due to --skip-libs.", media_location
+                )
+            else:
+                load_driver_libs(
+                    libs=config.driver_libs,
+                    destination=media_location / "lib",
+                    dry_run=options.dry_run,
+                )
         else:
-            print(f"{boot_out_path} is missing, skipping...")
+            logger.info("%s is missing, skipping...", boot_out_path)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Install or update CircuitPython driver files on mounted devices."
+    )
+    parser.add_argument(
+        "device_driver_name",
+        help="Folder name under drivers/ that contains the CircuitPython assets.",
+    )
+    parser.add_argument(
+        "--media-dir",
+        default=str(DEFAULT_MEDIA_DIRECTORY),
+        help="Override the media directory used for mounted volumes.",
+    )
+    parser.add_argument(
+        "--skip-uf2",
+        action="store_true",
+        help="Skip UF2 installation even if a device is in boot mode.",
+    )
+    parser.add_argument(
+        "--skip-libs",
+        action="store_true",
+        help="Skip syncing the bundled driver libraries.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log intended operations without modifying devices or downloads.",
+    )
+    return parser.parse_args(argv)
 
 
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        print(
-            "Error: DEVICE_DRIVER_NAME is not set. Please supply it as the first argument."
-        )
-        sys.exit(1)
-
-    if not sys.argv[1]:
-        print(
-            "Error: DEVICE_DRIVER_NAME is not set. Please supply it as the first argument."
-        )
-        sys.exit(1)
-    main(sys.argv[1])
+    args = _parse_args(sys.argv[1:])
+    options = UpdateOptions(
+        media_directory=Path(args.media_dir),
+        skip_uf2=args.skip_uf2,
+        skip_libs=args.skip_libs,
+        dry_run=args.dry_run,
+    )
+    main(args.device_driver_name, options)


### PR DESCRIPTION
### Motivation

- Replace ad-hoc prints and string-path handling in the updater with structured logging and safer `Path` usage to make operations auditable and less error-prone.
- Add CLI flags and a dry-run mode so operators can preview actions before touching devices or downloading large artifacts.
- Improve error handling and validation of driver metadata to fail fast and clearly when inputs are malformed or missing.
- Provide documentation describing the updater workflow, inputs, and common usage patterns.

### Description

- Reworked `src/heart/manage/update.py` to use `argparse` with an `UpdateOptions` dataclass and a `_parse_args` helper to expose `--media-dir`, `--skip-uf2`, `--skip-libs` and `--dry-run` options.
- Replaced `print` diagnostics with the shared logger via `get_logger`, tightened error reporting, and raised `SystemExit` instead of calling `sys.exit` in library helpers.
- Migrated path handling to `pathlib.Path` across `download_file`, `copy_file`, `_mount_points`, and other helpers, and updated signatures to accept `Path` and `dry_run` where applicable.
- Added `docs/manage_update.md` explaining materials, usage, optional flags, and notes about `settings.toml` expectations.

### Testing

- Ran `make format` and the repository formatter reported success.
- Ran `make test` and the test suite completed with `162 passed, 1 skipped`.
- Exercised the new CLI parsing locally by running the module entrypoint (via `python -m heart.manage.update`) during development.
- Lint and formatting checks were performed as part of the workflow and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be225bce08321a9003cb4e32cef05)