### PR TITLE
Prefer pathlib.Path in assets loader and document guideline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 
 - Avoid declaring module-level `__all__` exports. Prefer explicit imports at call sites instead of curating export lists.
 - Avoid building filesystem paths via string concatenation. Use `os.path.join` or `pathlib.Path` instead.
+- Prefer `pathlib.Path` over `os.path.join` when constructing paths, and ensure functions annotated to return a `Path` return a `Path` object.
 - Avoid using `print` for runtime diagnostics in CLI commands; use the shared logger.
 - Prefer `StrEnum` values over raw strings for strategy/configuration mode selections.
 

--- a/src/heart/assets/loader.py
+++ b/src/heart/assets/loader.py
@@ -12,10 +12,7 @@ class Loader:
     def resolve_path(cls, path: str | os.PathLike[str]) -> Path:
         """Return the absolute path to a file in ``src/heart/assets``."""
 
-        return os.path.join(
-            os.path.dirname(__file__),
-            path
-        )
+        return Path(__file__).resolve().parent / Path(path)
 
     @classmethod
     def _resolve_path(cls, path):


### PR DESCRIPTION
### Motivation

- Codify a repository preference for `pathlib.Path`-based path construction to reduce string-based path handling and improve type correctness.  
- Ensure functions annotated to return `Path` actually return `Path` objects rather than plain strings.  
- Remove a divergence between the agent guidelines and the `Loader` implementation in `src/heart/assets/loader.py`.  

### Description

- Add a guideline to `AGENTS.md` preferring `pathlib.Path` and requiring `Path`-typed functions to return `Path` objects.  
- Update `Loader.resolve_path` to return a `Path` via `Path(__file__).resolve().parent / Path(path)` instead of using `os.path.join`.  
- Keep `_resolve_path` using `os.fspath` to convert the `Path` to a string for APIs that require it.  
- Changes applied to `AGENTS.md` and `src/heart/assets/loader.py`.

### Testing

- Ran `make format` and the formatting check reported all checks passed.  
- Ran `make test` and the test suite completed with `165 passed, 1 skipped`.  
- No new tests were added for this change.  
- Formatting and tests succeeded without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be43ebee88321884176bd1c154669)