### PR TITLE
Fix renderer frame pixel format typing

### DIFF
--- a/src/heart/peripheral/input_payloads.py
+++ b/src/heart/peripheral/input_payloads.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from types import MappingProxyType
-from typing import (TYPE_CHECKING, Any, ClassVar, Mapping, MutableMapping,
-                    Protocol, Sequence, runtime_checkable)
+from typing import (TYPE_CHECKING, Any, ClassVar, Literal, Mapping,
+                    MutableMapping, Protocol, Sequence, runtime_checkable)
 
 if TYPE_CHECKING:  # pragma: no cover - import for type checking only
     import pygame
@@ -377,7 +377,7 @@ class RendererFrame(InputEventPayload):
     frame_id: int
     width: int
     height: int
-    pixel_format: str
+    pixel_format: Literal["RGBA", "RGB", "ARGB", "BGRA"]
     data: bytes
     metadata: Mapping[str, Any] | None = None
 
@@ -408,7 +408,7 @@ class RendererFrame(InputEventPayload):
         *,
         renderer: str,
         frame_id: int,
-        pixel_format: str = "RGBA",
+        pixel_format: Literal["RGBA", "RGB", "ARGB", "BGRA"] = "RGBA",
         metadata: Mapping[str, Any] | None = None,
     ) -> "RendererFrame":
         """Capture ``surface`` pixels into a :class:`RendererFrame` payload."""


### PR DESCRIPTION
### Motivation

- Resolve typing errors where `RendererFrame.pixel_format` was a plain `str` and caused incompatible-argument complaints with `pygame.image` helpers.
- Constrain acceptable pixel format values to the set actually supported by the code paths to make static checking precise.

### Description

- Import `Literal` from `typing` and replace `RendererFrame.pixel_format: str` with `Literal["RGBA", "RGB", "ARGB", "BGRA"]`.
- Update `RendererFrame.from_surface` parameter to `pixel_format: Literal[...] = "RGBA"` and keep the runtime validation set unchanged.
- Keep runtime behavior intact while tightening the type annotations to satisfy static type checks.

### Testing

- Ran `make format` which completed successfully and applied formatting changes.
- Ran `make test` and the test suite completed with `165 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be49e54e48321830cd23566cb022e)