### PR TITLE
Add fixed-state provider support for renderers

### DIFF
--- a/docs/research/renderer_state_providers.md
+++ b/docs/research/renderer_state_providers.md
@@ -1,0 +1,29 @@
+# Renderer state providers for fixed snapshots
+
+## Problem statement
+
+Several renderers need a single immutable state snapshot (for example, a fixed
+color) and currently rely on bespoke provider classes to emit that snapshot. The
+boilerplate makes it harder to keep renderer configuration consistent with the
+shared state model and complicates initialization paths.
+
+## Notes
+
+- Added a generic `FixedStateProvider` to emit a single state snapshot via the
+  existing observable interface. This keeps fixed configuration in state while
+  sharing the provider plumbing. See `src/heart/peripheral/core/providers/__init__.py`.
+- Updated `StatefulBaseRenderer` to accept either a streaming builder or a fixed
+  state snapshot so warm-up and subscriptions share the same lifecycle path. See
+  `src/heart/renderers/__init__.py`.
+- Simplified `RenderColorStateProvider` to build on the new fixed-state provider
+  and allowed `RenderColor` to accept a state snapshot directly. See
+  `src/heart/renderers/color/provider.py` and
+  `src/heart/renderers/color/renderer.py`.
+
+## Materials
+
+- Source files:
+  - `src/heart/peripheral/core/providers/__init__.py`
+  - `src/heart/renderers/__init__.py`
+  - `src/heart/renderers/color/provider.py`
+  - `src/heart/renderers/color/renderer.py`

--- a/src/heart/peripheral/core/providers/__init__.py
+++ b/src/heart/peripheral/core/providers/__init__.py
@@ -3,6 +3,7 @@ from typing import Generic, TypeVar
 
 import reactivex
 from lagom import Container
+from reactivex import operators as ops
 
 from heart.peripheral.core.manager import PeripheralManager
 
@@ -12,6 +13,18 @@ class ObservableProvider(Generic[T]):
     @abstractmethod
     def observable(self) -> reactivex.Observable[T]:
         raise NotImplementedError("")
+
+
+class FixedStateProvider(ObservableProvider[T]):
+    def __init__(self, state: T) -> None:
+        self._state = state
+
+    @property
+    def state(self) -> T:
+        return self._state
+
+    def observable(self) -> reactivex.Observable[T]:
+        return reactivex.just(self._state).pipe(ops.share())
 
 container = Container()
 container[PeripheralManager] = PeripheralManager()

--- a/src/heart/renderers/__init__.py
+++ b/src/heart/renderers/__init__.py
@@ -9,7 +9,8 @@ from reactivex.disposable import Disposable
 from heart import DeviceDisplayMode
 from heart.device import Layout, Orientation
 from heart.peripheral.core.manager import PeripheralManager
-from heart.peripheral.core.providers import ObservableProvider
+from heart.peripheral.core.providers import (FixedStateProvider,
+                                             ObservableProvider)
 from heart.utilities.env import Configuration
 from heart.utilities.logging import get_logger
 
@@ -373,8 +374,16 @@ class AtomicBaseRenderer(Generic[StateT]):
 
 class StatefulBaseRenderer(AtomicBaseRenderer[StateT], Generic[StateT]):
     def __init__(
-        self, builder: ObservableProvider[StateT] | None = None, *args, **kwargs
+        self,
+        builder: ObservableProvider[StateT] | None = None,
+        *args,
+        state: StateT | None = None,
+        **kwargs,
     ) -> None:
+        if builder is not None and state is not None:
+            raise ValueError("StatefulBaseRenderer accepts a builder or state, not both")
+        if state is not None:
+            builder = FixedStateProvider(state)
         self.builder = builder
         self._subscription: Disposable | None = None
         super().__init__(*args, **kwargs)

--- a/src/heart/renderers/color/provider.py
+++ b/src/heart/renderers/color/provider.py
@@ -1,14 +1,8 @@
-import reactivex
-from reactivex import operators as ops
-
 from heart.display.color import Color
-from heart.peripheral.core.providers import ObservableProvider
+from heart.peripheral.core.providers import FixedStateProvider
 from heart.renderers.color.state import RenderColorState
 
 
-class RenderColorStateProvider(ObservableProvider[RenderColorState]):
+class RenderColorStateProvider(FixedStateProvider[RenderColorState]):
     def __init__(self, color: Color):
-        self._color = color
-
-    def observable(self) -> reactivex.Observable[RenderColorState]:
-        return reactivex.just(RenderColorState(color=self._color)).pipe(ops.share())
+        super().__init__(RenderColorState(color=color))

--- a/src/heart/renderers/color/renderer.py
+++ b/src/heart/renderers/color/renderer.py
@@ -2,8 +2,8 @@ import pygame
 
 from heart.device import Orientation
 from heart.display.color import Color
+from heart.peripheral.core.providers import ObservableProvider
 from heart.renderers import StatefulBaseRenderer
-from heart.renderers.color.provider import RenderColorStateProvider
 from heart.renderers.color.state import RenderColorState
 
 
@@ -11,14 +11,22 @@ class RenderColor(StatefulBaseRenderer[RenderColorState]):
     def __init__(
         self,
         color: Color | None = None,
-        provider: RenderColorStateProvider | None = None,
+        state: RenderColorState | None = None,
+        provider: ObservableProvider[RenderColorState] | None = None,
     ) -> None:
+        if provider is not None and (color is not None or state is not None):
+            raise ValueError(
+                "RenderColor accepts either a provider or a color/state snapshot"
+            )
         if provider is None:
-            if color is None:
-                raise ValueError("RenderColor requires a color or provider")
-            provider = RenderColorStateProvider(color)
-        self._provider = provider
-        super().__init__(builder=self._provider)
+            if state is None:
+                if color is None:
+                    raise ValueError("RenderColor requires a color or provider")
+                state = RenderColorState(color=color)
+            super().__init__(state=state)
+        else:
+            self._provider = provider
+            super().__init__(builder=self._provider)
 
     def real_process(
         self,


### PR DESCRIPTION
### Motivation
- Treat renderer-configurable fields as controllable state so simple, immutable configurations (e.g. a fixed color) are expressed as state snapshots rather than bespoke provider classes.
- Provide a reusable provider for renderers that only require a single immutable state snapshot to reduce boilerplate and duplicate providers.
- Simplify lifecycle wiring so `StatefulBaseRenderer` can be initialized from either a streaming `ObservableProvider` or a fixed `state` snapshot for consistent warm-up and subscription handling.

### Description
- Added `FixedStateProvider` in `src/heart/peripheral/core/providers/__init__.py` which emits a single state snapshot via the existing observable interface (`reactivex.just(...).pipe(ops.share())`).
- Updated `StatefulBaseRenderer` in `src/heart/renderers/__init__.py` to accept an optional `state` parameter and automatically wrap it with `FixedStateProvider`, while rejecting passing both `builder` and `state` at once.
- Simplified the color renderer by turning `RenderColorStateProvider` into a `FixedStateProvider` and allowing `RenderColor` to be constructed from either a provider or a fixed `RenderColorState`; changes are in `src/heart/renderers/color/provider.py` and `src/heart/renderers/color/renderer.py`.
- Added a research note describing the approach in `docs/research/renderer_state_providers.md`.

### Testing
- Ran `make format` and the codebase formatting completed successfully.
- Ran `make test` and the test suite completed with all automated tests passing (`162 passed, 1 skipped`).
- No new unit tests were added in this change set and existing tests continued to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be3ba741c83219f9669138a62cbbe)