### PR TITLE
Use StrEnum for reactivex configuration options

### DIFF
--- a/src/heart/peripheral/core/manager.py
+++ b/src/heart/peripheral/core/manager.py
@@ -11,7 +11,7 @@ from heart.peripheral.core import Peripheral, PeripheralMessageEnvelope
 from heart.peripheral.gamepad import Gamepad
 from heart.peripheral.registry import PeripheralConfigurationRegistry
 from heart.peripheral.switch import FakeSwitch, SwitchState
-from heart.utilities.env import Configuration
+from heart.utilities.env import Configuration, ReactivexEventBusScheduler
 from heart.utilities.logging import get_logger
 from heart.utilities.reactivex_streams import share_stream
 from heart.utilities.reactivex_threads import (background_scheduler,
@@ -134,8 +134,8 @@ class PeripheralManager:
     @staticmethod
     def _event_bus_scheduler() -> SchedulerBase | None:
         strategy = Configuration.reactivex_event_bus_scheduler()
-        if strategy == "background":
+        if strategy is ReactivexEventBusScheduler.BACKGROUND:
             return background_scheduler()
-        if strategy == "input":
+        if strategy is ReactivexEventBusScheduler.INPUT:
             return input_scheduler()
         return None

--- a/src/heart/utilities/env.py
+++ b/src/heart/utilities/env.py
@@ -117,25 +117,27 @@ class Configuration:
         return _env_int("HEART_RX_INPUT_MAX_WORKERS", default=2, minimum=1)
 
     @classmethod
-    def reactivex_event_bus_scheduler(cls) -> str:
+    def reactivex_event_bus_scheduler(cls) -> "ReactivexEventBusScheduler":
         scheduler = os.environ.get("HEART_RX_EVENT_BUS_SCHEDULER", "inline").strip().lower()
-        if scheduler in {"inline", "background", "input"}:
-            return scheduler
-        raise ValueError(
-            "HEART_RX_EVENT_BUS_SCHEDULER must be 'inline', 'background', or 'input'"
-        )
+        try:
+            return ReactivexEventBusScheduler(scheduler)
+        except ValueError as exc:
+            raise ValueError(
+                "HEART_RX_EVENT_BUS_SCHEDULER must be 'inline', 'background', or 'input'"
+            ) from exc
 
     @classmethod
-    def reactivex_stream_share_strategy(cls) -> str:
+    def reactivex_stream_share_strategy(cls) -> "ReactivexStreamShareStrategy":
         strategy = os.environ.get(
             "HEART_RX_STREAM_SHARE_STRATEGY",
             "replay_latest",
         ).strip().lower()
-        if strategy in {"share", "replay_latest", "replay_buffer"}:
-            return strategy
-        raise ValueError(
-            "HEART_RX_STREAM_SHARE_STRATEGY must be 'share', 'replay_latest', or 'replay_buffer'"
-        )
+        try:
+            return ReactivexStreamShareStrategy(strategy)
+        except ValueError as exc:
+            raise ValueError(
+                "HEART_RX_STREAM_SHARE_STRATEGY must be 'share', 'replay_latest', or 'replay_buffer'"
+            ) from exc
 
     @classmethod
     def reactivex_stream_replay_buffer(cls) -> int:
@@ -262,6 +264,18 @@ class LifeUpdateStrategy(StrEnum):
     AUTO = "auto"
     CONVOLVE = "convolve"
     PAD = "pad"
+
+
+class ReactivexEventBusScheduler(StrEnum):
+    INLINE = "inline"
+    BACKGROUND = "background"
+    INPUT = "input"
+
+
+class ReactivexStreamShareStrategy(StrEnum):
+    SHARE = "share"
+    REPLAY_LATEST = "replay_latest"
+    REPLAY_BUFFER = "replay_buffer"
 
 
 def get_device_ports(prefix: str) -> Iterator[str]:

--- a/src/heart/utilities/reactivex_streams.py
+++ b/src/heart/utilities/reactivex_streams.py
@@ -5,7 +5,7 @@ from typing import TypeVar
 import reactivex
 from reactivex import operators as ops
 
-from heart.utilities.env import Configuration
+from heart.utilities.env import Configuration, ReactivexStreamShareStrategy
 from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
@@ -21,12 +21,12 @@ def share_stream(
     """Share a stream using the configured strategy."""
 
     strategy = Configuration.reactivex_stream_share_strategy()
-    if strategy == "share":
+    if strategy is ReactivexStreamShareStrategy.SHARE:
         return source.pipe(ops.share())
-    if strategy == "replay_latest":
+    if strategy is ReactivexStreamShareStrategy.REPLAY_LATEST:
         logger.debug("Sharing %s with replay_latest", stream_name)
         return source.pipe(ops.replay(buffer_size=1), ops.ref_count())
-    if strategy == "replay_buffer":
+    if strategy is ReactivexStreamShareStrategy.REPLAY_BUFFER:
         buffer_size = Configuration.reactivex_stream_replay_buffer()
         logger.debug("Sharing %s with replay_buffer=%d", stream_name, buffer_size)
         return source.pipe(ops.replay(buffer_size=buffer_size), ops.ref_count())


### PR DESCRIPTION
### Motivation

- Replace ad-hoc string matching for reactive configuration with typed `StrEnum` values to reduce typos and improve clarity.
- Centralize and validate allowed values for the reactivex event-bus scheduler and stream share strategy. 
- Align runtime configuration handling with repository guidance that prefers `StrEnum` over raw strings. 

### Description

- Add `ReactivexEventBusScheduler` and `ReactivexStreamShareStrategy` `StrEnum` types in `src/heart/utilities/env.py`.
- Change `Configuration.reactivex_event_bus_scheduler()` and `Configuration.reactivex_stream_share_strategy()` to return the new enum types and to validate input via enum construction. 
- Update consumers to compare against enums instead of raw strings in `src/heart/peripheral/core/manager.py` and `src/heart/utilities/reactivex_streams.py`.
- Adjusted return type annotations and error messaging to reflect the enum-backed configuration values. 

### Testing

- Ran `make format` and formatting checks reported all checks passed. 
- Ran `make test` and the full test suite completed with `165 passed, 1 skipped`.
- Unit tests that exercise environment parsing and reactivex behavior passed without modification. 
- No additional failing tests were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be5ffa0d08321a02334a90a0025b8)