### PR TITLE
Replace CLI prints with logger in RGB display sample

### DIFF
--- a/src/heart/device/rgb_display/sample_base.py
+++ b/src/heart/device/rgb_display/sample_base.py
@@ -2,6 +2,10 @@ import argparse
 import sys
 from typing import Any
 
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
 
 class SampleBase:
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -154,7 +158,7 @@ class SampleBase:
         self.parser.set_defaults(drop_privileges=True)
 
     def run(self) -> None:
-        print("Running")
+        logger.info("Running")
 
     def process(self) -> bool:
         self.args = self.parser.parse_args()
@@ -191,10 +195,10 @@ class SampleBase:
         self.matrix = RGBMatrix(options=options)
 
         try:
-            print("Press CTRL-C to stop sample")
+            logger.info("Press CTRL-C to stop sample")
             self.run()
         except KeyboardInterrupt:
-            print("Exiting\n")
+            logger.info("Exiting")
             sys.exit(0)
 
         return True


### PR DESCRIPTION
### Motivation

- The repository's `AGENTS.md` instructs to avoid using `print` for runtime diagnostics and to use the shared logger instead.  
- The RGB display sample base class produced CLI prints during runtime which diverged from this guideline.  

### Description

- Imported `get_logger` and created a module logger in `src/heart/device/rgb_display/sample_base.py`.  
- Replaced runtime `print` calls in `run()` and the `process()` KeyboardInterrupt handling with `logger.info()` messages.  
- Kept existing `argparse` behaviour and exit semantics unchanged.  

### Testing

- Ran `make format` and formatting checks passed.  
- Ran `make test` and the full test suite completed with `167 passed, 1 skipped`.  
- No additional unit tests were required for this change; existing tests continued to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be77406e88321b1e55f773d445bd5)