### PR TITLE
Add auto-connect replay strategies for reactive streams

### DIFF
--- a/docs/research/reactive_event_stream_share_strategy.md
+++ b/docs/research/reactive_event_stream_share_strategy.md
@@ -21,7 +21,12 @@ buffered replay when tuning for performance and correctness.
 
 - `HEART_RX_STREAM_SHARE_STRATEGY`
   - `replay_latest` (default): replay the most recent event to late subscribers.
+  - `replay_latest_auto_connect`: replay the most recent event while keeping the
+    source connected after the first subscriber arrives, avoiding repeated
+    subscriptions when observers churn.
   - `replay_buffer`: replay the last `HEART_RX_STREAM_REPLAY_BUFFER` events.
+  - `replay_buffer_auto_connect`: replay the buffer while keeping the source
+    connected after the first subscriber arrives.
   - `share`: preserve the pre-existing no-replay share behaviour.
 - `HEART_RX_STREAM_REPLAY_BUFFER`
   - Integer buffer size used when the strategy is `replay_buffer`.

--- a/src/heart/utilities/env.py
+++ b/src/heart/utilities/env.py
@@ -136,7 +136,9 @@ class Configuration:
             return ReactivexStreamShareStrategy(strategy)
         except ValueError as exc:
             raise ValueError(
-                "HEART_RX_STREAM_SHARE_STRATEGY must be 'share', 'replay_latest', or 'replay_buffer'"
+                "HEART_RX_STREAM_SHARE_STRATEGY must be 'share', 'replay_latest', "
+                "'replay_latest_auto_connect', 'replay_buffer', or "
+                "'replay_buffer_auto_connect'"
             ) from exc
 
     @classmethod
@@ -292,7 +294,9 @@ class ReactivexEventBusScheduler(StrEnum):
 class ReactivexStreamShareStrategy(StrEnum):
     SHARE = "share"
     REPLAY_LATEST = "replay_latest"
+    REPLAY_LATEST_AUTO_CONNECT = "replay_latest_auto_connect"
     REPLAY_BUFFER = "replay_buffer"
+    REPLAY_BUFFER_AUTO_CONNECT = "replay_buffer_auto_connect"
 
 
 def get_device_ports(prefix: str) -> Iterator[str]:

--- a/src/heart/utilities/reactivex_streams.py
+++ b/src/heart/utilities/reactivex_streams.py
@@ -22,12 +22,24 @@ def share_stream(
 
     strategy = Configuration.reactivex_stream_share_strategy()
     if strategy is ReactivexStreamShareStrategy.SHARE:
+        logger.debug("Sharing %s with share", stream_name)
         return source.pipe(ops.share())
     if strategy is ReactivexStreamShareStrategy.REPLAY_LATEST:
         logger.debug("Sharing %s with replay_latest", stream_name)
         return source.pipe(ops.replay(buffer_size=1), ops.ref_count())
+    if strategy is ReactivexStreamShareStrategy.REPLAY_LATEST_AUTO_CONNECT:
+        logger.debug("Sharing %s with replay_latest_auto_connect", stream_name)
+        return source.pipe(ops.replay(buffer_size=1)).auto_connect(1)
     if strategy is ReactivexStreamShareStrategy.REPLAY_BUFFER:
         buffer_size = Configuration.reactivex_stream_replay_buffer()
         logger.debug("Sharing %s with replay_buffer=%d", stream_name, buffer_size)
         return source.pipe(ops.replay(buffer_size=buffer_size), ops.ref_count())
+    if strategy is ReactivexStreamShareStrategy.REPLAY_BUFFER_AUTO_CONNECT:
+        buffer_size = Configuration.reactivex_stream_replay_buffer()
+        logger.debug(
+            "Sharing %s with replay_buffer_auto_connect=%d",
+            stream_name,
+            buffer_size,
+        )
+        return source.pipe(ops.replay(buffer_size=buffer_size)).auto_connect(1)
     raise ValueError(f"Unknown reactive stream share strategy: {strategy}")

--- a/tests/utilities/test_reactivex_streams.py
+++ b/tests/utilities/test_reactivex_streams.py
@@ -1,4 +1,6 @@
 import pytest
+import reactivex
+from reactivex.disposable import Disposable
 from reactivex.subject import Subject
 
 from heart.utilities.reactivex_streams import share_stream
@@ -12,8 +14,13 @@ class TestShareStreamStrategy:
         [
             ("share", []),
             ("replay_latest", [2]),
+            ("replay_latest_auto_connect", [2]),
         ],
-        ids=["share_no_replay", "replay_latest_replays_last"],
+        ids=[
+            "share_no_replay",
+            "replay_latest_replays_last",
+            "replay_latest_auto_connect_replays_last",
+        ],
     )
     def test_share_stream_replays_latest_when_configured(
         self,
@@ -42,6 +49,37 @@ class TestShareStreamStrategy:
 
         assert received_a == [1, 2, 3]
         assert received_b == [*expected_initial, 3]
+
+    def test_share_stream_auto_connect_avoids_resubscribe(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify auto-connect keeps a single subscription to reduce churn and preserve hot stream state."""
+
+        monkeypatch.setenv(
+            "HEART_RX_STREAM_SHARE_STRATEGY", "replay_latest_auto_connect"
+        )
+        subscribe_count = 0
+
+        def _subscribe(observer, scheduler=None):
+            nonlocal subscribe_count
+            subscribe_count += 1
+            observer.on_next(subscribe_count)
+            return Disposable()
+
+        source = reactivex.create(_subscribe)
+        shared = share_stream(source, stream_name="auto_connect")
+
+        received_a: list[int] = []
+        subscription = shared.subscribe(received_a.append)
+        subscription.dispose()
+
+        received_b: list[int] = []
+        shared.subscribe(received_b.append)
+
+        assert subscribe_count == 1
+        assert received_a == [1]
+        assert received_b == [1]
 
     def test_share_stream_replays_buffer_when_configured(
         self,


### PR DESCRIPTION
### Motivation
- Improve reliability for late subscribers to core reactive streams by making replay behaviour configurable.
- Reduce subscription churn for hot sources so transient subscribers do not repeatedly resubscribe to underlying sources.
- Make sharing behaviour tunable via environment variables to aid debugging and production tuning.

### Description
- Add new share strategies `replay_latest_auto_connect` and `replay_buffer_auto_connect` to `ReactivexStreamShareStrategy` and update the error message in `Configuration.reactivex_stream_share_strategy` to list them.
- Extend `heart.utilities.reactivex_streams.share_stream` to support the new strategies using `.auto_connect(1)` and add debug logging for each sharing mode.
- Add unit tests in `tests/utilities/test_reactivex_streams.py` to cover the auto-connect behaviour and update existing parameterized test cases.
- Document the additional strategies and their intended semantics in `docs/research/reactive_event_stream_share_strategy.md`.

### Testing
- Ran `make format` and formatting checks completed successfully.
- Ran `make test` and the full Pytest suite completed with all tests passing: `169 passed, 1 skipped`.
- New and updated unit tests for `share_stream` were executed as part of the test run and passed.
- No runtime or linting errors were reported during the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be78b0de88321997c69267254d4de)