### PR TITLE
Refactor device selection and renderer variant parsing

### DIFF
--- a/src/heart/device/selection.py
+++ b/src/heart/device/selection.py
@@ -1,0 +1,46 @@
+import os
+
+from heart.device import Cube, Device
+from heart.device.local import LocalScreen
+from heart.utilities.env import Configuration
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def select_device(*, x11_forward: bool) -> Device:
+    # TODO: Add a way of adding orientation either from Config or `run`
+    orientation = Cube.sides()
+
+    if Configuration.forward_to_beats_app():
+        from heart.device.beats import StreamedScreen
+
+        return StreamedScreen(orientation=orientation)
+
+    if Configuration.use_isolated_renderer():
+        if x11_forward:
+            logger.warning("USE_ISOLATED_RENDERER enabled; ignoring x11_forward flag")
+        from heart.device.rgb_display import LEDMatrix
+
+        return LEDMatrix(orientation=orientation)
+
+    if Configuration.is_pi():
+        os.environ["SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS"] = "1"
+
+        pi_info = Configuration.pi()
+        if pi_info is not None and pi_info.version > 4:
+            logger.warning(
+                f"Shit not guaranteed to work Pi5 and higher. Detected: {pi_info}"
+            )
+
+        if Configuration.is_x11_forward():
+            # This makes it work on Pi when no screens are connected.
+            # You need to setup X11 forwarding with XQuartz to do that.
+            logger.warning("X11_FORWARD set, running with `LocalScreen`")
+            return LocalScreen(width=64, height=64, orientation=orientation)
+
+        from heart.device.rgb_display import LEDMatrix
+
+        return LEDMatrix(orientation=orientation)
+
+    return LocalScreen(width=64, height=64, orientation=orientation)

--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -317,11 +317,24 @@ ACTIVE_GAME_LOOP: "GameLoop" | None = None
 RGBA_IMAGE_FORMAT: Literal["RGBA"] = "RGBA"
 
 
-class RendererVariant(enum.Enum):
+class RendererVariant(enum.StrEnum):
     BINARY = "BINARY"
     ITERATIVE = "ITERATIVE"
     AUTO = "AUTO"
     # TODO: Add more
+
+    @classmethod
+    def parse(cls, value: str) -> "RendererVariant":
+        normalized = value.strip().upper()
+        if not normalized:
+            raise ValueError("HEART_RENDER_VARIANT must not be empty")
+        try:
+            return cls[normalized]
+        except KeyError as exc:
+            options = ", ".join(variant.name.lower() for variant in cls)
+            raise ValueError(
+                f"Unknown render variant '{value}'. Expected one of: {options}"
+            ) from exc
 
 
 class GameLoop:

--- a/src/heart/loop.py
+++ b/src/heart/loop.py
@@ -7,8 +7,7 @@ from typing import Annotated
 import typer
 from PIL import Image
 
-from heart.device import Cube, Device
-from heart.device.local import LocalScreen
+from heart.device.selection import select_device
 from heart.environment import GameLoop, RendererVariant
 from heart.manage.update import main as update_driver_main
 from heart.peripheral.core.providers import container
@@ -19,58 +18,6 @@ from heart.utilities.logging import get_logger
 logger = get_logger(__name__)
 
 app = typer.Typer()
-
-
-def _get_device(x11_forward: bool) -> Device:
-    # TODO: Add a way of adding orientation either from Config or `run`
-    orientation = Cube.sides()
-    device: Device
-
-    if Configuration.forward_to_beats_app():
-        from heart.device.beats import StreamedScreen
-
-        return StreamedScreen(orientation=orientation)
-
-    if Configuration.use_isolated_renderer():
-        if x11_forward:
-            logger.warning("USE_ISOLATED_RENDERER enabled; ignoring x11_forward flag")
-        from heart.device.rgb_display import LEDMatrix
-
-        return LEDMatrix(orientation=orientation)
-    if Configuration.is_pi():
-        os.environ["SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS"] = "1"
-
-        pi_info = Configuration.pi()
-        if pi_info is not None and pi_info.version > 4:
-            logger.warning(
-                f"Shit not guaranteed to work Pi5 and higher. Detected: {pi_info}"
-            )
-
-        if Configuration.is_x11_forward():
-            # This makes it work on Pi when no screens are connected.
-            # You need to setup X11 forwarding with XQuartz to do that.
-            logger.warning("X11_FORWARD set, running with `LocalScreen`")
-            device = LocalScreen(width=64, height=64, orientation=orientation)
-        else:
-            from heart.device.rgb_display import LEDMatrix
-
-            device = LEDMatrix(orientation=orientation)
-    else:
-        device = LocalScreen(width=64, height=64, orientation=orientation)
-    return device
-
-
-def _parse_render_variant(value: str) -> RendererVariant:
-    normalized = value.strip().upper()
-    if not normalized:
-        raise ValueError("HEART_RENDER_VARIANT must not be empty")
-    try:
-        return RendererVariant[normalized]
-    except KeyError as exc:
-        options = ", ".join(variant.name.lower() for variant in RendererVariant)
-        raise ValueError(
-            f"Unknown render variant '{value}'. Expected one of: {options}"
-        ) from exc
 
 
 @app.command()
@@ -87,9 +34,9 @@ def run(
     configuration_fn = registry.get(configuration)
     if configuration_fn is None:
         raise Exception(f"Configuration '{configuration}' not found in registry")
-    render_variant = _parse_render_variant(Configuration.render_variant())
+    render_variant = RendererVariant.parse(Configuration.render_variant())
     loop = GameLoop(
-        device=_get_device(x11_forward),
+        device=select_device(x11_forward=x11_forward),
         resolver=container,
         render_variant=render_variant,
     )
@@ -114,7 +61,7 @@ def update_driver(name: Annotated[str, typer.Option("--name")]) -> None:
     name="bench-device",
 )
 def bench_device() -> None:
-    d = _get_device(x11_forward=False)
+    d = select_device(x11_forward=False)
 
     size = d.full_display_size()
     logger.info("Device full display size: %s", size)


### PR DESCRIPTION
### Motivation

- Separate device selection logic from CLI wiring to improve clarity and single-responsibility in the entrypoint.
- Centralize parsing and validation of render-variant strings to avoid duplicated parsing logic and improve error messages.
- Use `StrEnum` for render variants to prefer enum-backed string values over raw strings for configuration modes.

### Description

- Extracted device selection into a new helper `select_device` in `src/heart/device/selection.py` and removed inlined selection logic from `src/heart/loop.py`.
- Converted `RendererVariant` to a `StrEnum` and added a `parse` classmethod in `src/heart/environment.py` to normalize and validate input strings.
- Updated `src/heart/loop.py` to use `select_device(x11_forward=...)` and `RendererVariant.parse(Configuration.render_variant())`.
- Minor logging and behavior preserved while moving selection and parsing logic into dedicated functions.

### Testing

- Ran `make format` to apply formatting rules and the command completed successfully.
- Ran the test suite with `make test` which returned `169 passed, 1 skipped`.
- Verified the CLI bench and run codepaths compile and use the new `select_device` and `RendererVariant.parse` helpers.
- No automated tests failed during the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be9678f048321b6f6059d4b34ca52)