### PR TITLE
Expose LED frames & Mario state as observables; add CLI orientation and logging improvements

### DIFF
--- a/docs/code_flow.md
+++ b/docs/code_flow.md
@@ -48,6 +48,7 @@ flowchart LR
         Sensors["Accelerometer / Phyphox"]
         HeartRate["HeartRateManager"]
         PhoneText["PhoneText"]
+        DisplayFrame["LED Matrix Frame Peripheral"]
     end
 
     subgraph Outputs["Display & Device Services"]
@@ -76,10 +77,12 @@ flowchart LR
     RxScheduler --> Sensors --> AppRouter
     RxScheduler --> HeartRate --> AppRouter
     RxScheduler --> PhoneText --> AppRouter
+    PeripheralMgr --> DisplayFrame
+    DisplaySvc --> DisplayFrame
 
     class CLI,Registry,Configurer,ModeServices,FrameComposer service;
     class Loop,AppRouter orchestrator;
-    class PeripheralMgr,RxScheduler,Switch,Gamepad,Sensors,HeartRate,PhoneText input;
+    class PeripheralMgr,RxScheduler,Switch,Gamepad,Sensors,HeartRate,PhoneText,DisplayFrame input;
     class DisplaySvc,LocalScreen,Capture,DeviceBridge,LedMatrix,AverageMirror,SingleLED output;
 ```
 

--- a/docs/code_flow.svg
+++ b/docs/code_flow.svg
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1408" height="660" viewBox="0 0 1408 660">
+<svg xmlns="http://www.w3.org/2000/svg" width="1408" height="742" viewBox="0 0 1408 742">
   <defs>
     <style>text { font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif; fill: #0f172a; }
 .column-title { font-size: 16px; font-weight: 600; }
@@ -18,7 +18,7 @@
     <text x="534.00" y="74.00" text-anchor="middle" class="column-title">GameLoop Orchestration</text>
   </g>
   <g>
-    <rect x="744.00" y="48.00" width="260.00" height="564.00" rx="18" fill="#e2e8f0" stroke="#cbd5f5" />
+    <rect x="744.00" y="48.00" width="260.00" height="646.00" rx="18" fill="#e2e8f0" stroke="#cbd5f5" />
     <text x="874.00" y="74.00" text-anchor="middle" class="column-title">Peripheral &amp; Signal Services</text>
   </g>
   <g>
@@ -45,11 +45,13 @@
     <path d="M 874.00 174.00 C 874.00 265.00 874.00 265.00 874.00 356.00" marker-end="url(#arrowhead)" />
     <path d="M 874.00 174.00 C 874.00 306.00 874.00 306.00 874.00 438.00" marker-end="url(#arrowhead)" />
     <path d="M 874.00 174.00 C 874.00 347.00 874.00 347.00 874.00 520.00" marker-end="url(#arrowhead)" />
+    <path d="M 874.00 174.00 C 874.00 388.00 874.00 388.00 874.00 602.00" marker-end="url(#arrowhead)" />
     <path d="M 762.00 224.00 C 722.00 224.00 686.00 224.00 646.00 224.00" marker-end="url(#arrowhead)" />
     <path d="M 762.00 306.00 C 722.00 306.00 686.00 224.00 646.00 224.00" marker-end="url(#arrowhead)" />
     <path d="M 762.00 388.00 C 722.00 388.00 686.00 224.00 646.00 224.00" marker-end="url(#arrowhead)" />
     <path d="M 762.00 470.00 C 722.00 470.00 686.00 224.00 646.00 224.00" marker-end="url(#arrowhead)" />
     <path d="M 762.00 552.00 C 722.00 552.00 686.00 224.00 646.00 224.00" marker-end="url(#arrowhead)" />
+    <path d="M 1102.00 142.00 C 1062.00 142.00 1026.00 634.00 986.00 634.00" marker-end="url(#arrowhead)" />
   </g>
   <rect x="289.50" y="241.00" width="149.00" height="20.00" rx="4" fill="#ffffff" stroke="#d1d5db" opacity="0.95" />
   <text x="364.00" y="251.00" text-anchor="middle" dominant-baseline="middle" class="edge-label">adds modes &amp; scenes</text>
@@ -109,6 +111,10 @@
     <rect x="762.00" y="520.00" width="224.00" height="64.00" rx="12" fill="#0369a1" stroke="#0369a1" />
     <text x="874.00" y="552.00" fill="#f8fafc" text-anchor="middle">
       <tspan x="874.00">PhoneText</tspan>
+    </text>
+    <rect x="762.00" y="602.00" width="224.00" height="64.00" rx="12" fill="#0369a1" stroke="#0369a1" />
+    <text x="874.00" y="634.00" fill="#f8fafc" text-anchor="middle">
+      <tspan x="874.00">LED Matrix Frame Peripheral</tspan>
     </text>
     <rect x="1102.00" y="110.00" width="224.00" height="64.00" rx="12" fill="#7c3aed" stroke="#7c3aed" />
     <text x="1214.00" y="133.00" fill="#f8fafc" text-anchor="middle">

--- a/docs/research/runtime_observability.md
+++ b/docs/research/runtime_observability.md
@@ -1,0 +1,16 @@
+# Runtime observability additions
+
+## Problem statement
+
+Record how recent runtime updates expose LED frame output and Mario state changes as observables so downstream components can subscribe without scraping internal state.
+
+## Materials
+
+- Local checkout of this repository.
+- Python environment with dependencies from `pyproject.toml`.
+
+## Notes
+
+- LED frame emission now uses the `LEDMatrixDisplay` peripheral to publish `DisplayFrame` payloads whenever the run loop outputs an image. The capture happens inside `GameLoop._one_loop` and is registered with the `PeripheralManager` so observers can subscribe through the event bus (`src/heart/environment.py`, `src/heart/peripheral/led_matrix.py`).
+- Mario animation updates are now driven by the game tick clock, and state transitions are shared through a cached observable so other components can attach without duplicating subscriptions (`src/heart/renderers/mario/provider.py`, `src/heart/renderers/mario/state.py`).
+- CLI orientation selection now allows non-cube layouts by mapping `--orientation` and layout dimensions into a concrete `Orientation` before the device is created (`src/heart/loop.py`).

--- a/scripts/render_code_flow.py
+++ b/scripts/render_code_flow.py
@@ -77,6 +77,7 @@ COLUMNS: tuple[ColumnDef, ...] = (
             NodeDef("sensors", "Accelerometer / Phyphox", "input"),
             NodeDef("heart_rate", "HeartRateManager", "input"),
             NodeDef("phone_text", "PhoneText", "input"),
+            NodeDef("display_frame", "LED Matrix Frame Peripheral", "input"),
         ),
     ),
     ColumnDef(
@@ -113,11 +114,13 @@ EDGES: tuple[EdgeDef, ...] = (
     EdgeDef("peripheral_manager", "sensors"),
     EdgeDef("peripheral_manager", "heart_rate"),
     EdgeDef("peripheral_manager", "phone_text"),
+    EdgeDef("peripheral_manager", "display_frame"),
     EdgeDef("switch", "app_router"),
     EdgeDef("gamepad", "app_router"),
     EdgeDef("sensors", "app_router"),
     EdgeDef("heart_rate", "app_router"),
     EdgeDef("phone_text", "app_router"),
+    EdgeDef("display_service", "display_frame"),
 )
 
 

--- a/src/heart/programs/configurations/lib_2025.py
+++ b/src/heart/programs/configurations/lib_2025.py
@@ -6,6 +6,7 @@ from lagom import Singleton
 from heart.display.color import Color
 from heart.environment import GameLoop
 from heart.navigation import ComposedRenderer, MultiScene
+from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.providers.acceleration import AllAccelerometersProvider
 from heart.renderers.artist import ArtistScene
 from heart.renderers.combined_bpm_screen import CombinedBpmScreen
@@ -77,7 +78,12 @@ def configure(loop: GameLoop) -> None:
         )
     )
     loop.context_container[MarioRendererProvider] = Singleton(
-        lambda builder: MarioRendererProvider(accel_stream=builder[AllAccelerometersProvider], sheet_file_path="mario_64.png", metadata_file_path="mario_64.json")
+        lambda builder: MarioRendererProvider(
+            accel_stream=builder[AllAccelerometersProvider],
+            peripheral_manager=builder[PeripheralManager],
+            sheet_file_path="mario_64.png",
+            metadata_file_path="mario_64.json",
+        )
     )
     mario_mode.resolve_renderer(
         container=loop.context_container,

--- a/src/heart/renderers/mario/provider.py
+++ b/src/heart/renderers/mario/provider.py
@@ -1,25 +1,42 @@
 
+from __future__ import annotations
+
+from dataclasses import replace
 
 import reactivex
+from reactivex import operators as ops
 
 from heart.assets.loader import Loader
 from heart.display.models import KeyFrame
+from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.providers.acceleration import AllAccelerometersProvider
 from heart.peripheral.sensor import Acceleration
-from heart.peripheral.uwb import ops
 from heart.renderers.mario.state import MarioRendererState
+from heart.utilities.logging import get_logger
+from heart.utilities.reactivex_streams import share_stream
+
+logger = get_logger(__name__)
 
 
 class MarioRendererProvider:
-        #     self._spritesheet: pygame.Surface | None = None
-
-    def __init__(self, metadata_file_path: str, sheet_file_path: str, accel_stream: AllAccelerometersProvider):
+    def __init__(
+        self,
+        metadata_file_path: str,
+        sheet_file_path: str,
+        accel_stream: AllAccelerometersProvider,
+        peripheral_manager: PeripheralManager,
+        *,
+        trigger_threshold: float = 11.0,
+    ) -> None:
         self.metadata_file_path = metadata_file_path
         self.file = sheet_file_path
         self._accel_stream = accel_stream
+        self._peripheral_manager = peripheral_manager
+        self._trigger_threshold = trigger_threshold
+        self._state_stream: reactivex.Observable[MarioRendererState] | None = None
 
         frame_data = Loader.load_json(self.metadata_file_path)
-        self.frames = []
+        self.frames: list[KeyFrame] = []
         for key in frame_data["frames"]:
             frame_obj = frame_data["frames"][key]
             frame = frame_obj["frame"]
@@ -29,65 +46,104 @@ class MarioRendererProvider:
                     frame_obj["duration"],
                 )
             )
+        if not self.frames:
+            raise ValueError("Mario renderer frames could not be loaded")
 
-    def _create_initial_state(
-        self,
-    ) -> MarioRendererState:
+    def _create_initial_state(self) -> MarioRendererState:
         image = Loader.load_spirtesheet(self.file)
-        return MarioRendererState(spritesheet=image)
+        initial_frame = self.frames[0]
+        return MarioRendererState(
+            spritesheet=image,
+            current_frame_index=0,
+            current_frame=initial_frame,
+        )
 
+    def _handle_acceleration(
+        self, state: MarioRendererState, acceleration: Acceleration
+    ) -> MarioRendererState:
+        highest_z = max(state.highest_z, acceleration.z)
+        updates = {
+            "latest_acceleration": acceleration,
+            "highest_z": highest_z,
+        }
+        if not state.in_loop and acceleration.z > self._trigger_threshold:
+            logger.debug(
+                "Mario jump triggered (highest_z=%.2f, accel_z=%.2f)",
+                highest_z,
+                acceleration.z,
+            )
+            updates.update(
+                {
+                    "in_loop": True,
+                    "time_since_last_update": 0.0,
+                    "current_frame_index": 0,
+                    "current_frame": self.frames[0],
+                }
+            )
+        return replace(state, **updates)
 
-    def observable(
-        self,
-    ) -> reactivex.Observable[MarioRendererState]:
-        observable = self._accel_stream.observable()
-        
+    def _advance_animation(
+        self, state: MarioRendererState, *, elapsed_ms: float
+    ) -> MarioRendererState:
+        if not state.in_loop:
+            if state.time_since_last_update is None:
+                return state
+            return replace(state, time_since_last_update=None)
+
+        previous_elapsed = state.time_since_last_update or 0.0
+        time_since_last_update = previous_elapsed + elapsed_ms
+        current_frame = state.current_frame or self.frames[state.current_frame_index]
+        duration = current_frame.duration or 0
+
+        if duration <= 0 or time_since_last_update >= duration:
+            next_index = state.current_frame_index + 1
+            if next_index >= len(self.frames):
+                return replace(
+                    state,
+                    current_frame_index=0,
+                    current_frame=self.frames[0],
+                    in_loop=False,
+                    time_since_last_update=None,
+                )
+            return replace(
+                state,
+                current_frame_index=next_index,
+                current_frame=self.frames[next_index],
+                time_since_last_update=0.0,
+            )
+
+        return replace(state, time_since_last_update=time_since_last_update)
+
+    def _build_state_stream(self) -> reactivex.Observable[MarioRendererState]:
         initial = self._create_initial_state()
-
-        def update_state(prev: MarioRendererState, acceleration: Acceleration):
-            state = prev
-            current_kf = self.frames[state.current_frame]
-            current_frame = state.current_frame
-            time_since_last_update = state.time_since_last_update
-            in_loop = state.in_loop
-            highest_z = state.highest_z
-
-            kf_duration = current_kf.duration
-
-            if in_loop:
-                if time_since_last_update is None:
-                    time_since_last_update = 0
-
-                # TODO: Stream in the clock / break this up
-                # time_since_last_update += clock.get_time()
-
-                if time_since_last_update > kf_duration:
-                    current_frame += 1
-                    time_since_last_update = 0
-
-                    if current_frame >= len(self.frames):
-                        current_frame = 0
-                        in_loop = False
-            else:
-                vector = self.state.latest_acceleration
-                if vector is not None and vector.z > 11.0:  # vibes based constants
-                    highest_z = max(highest_z, vector.z)
-                    print(f"highest z: {highest_z}, accel z: {vector.z}")
-                    in_loop = True
-                    time_since_last_update = 0
-
-            if not in_loop:
-                time_since_last_update = None
-
-            self.update_state(
-                current_frame=current_frame,
-                time_since_last_update=time_since_last_update,
-                in_loop=in_loop,
-                highest_z=highest_z,
-            )    
-
-        return observable.pipe(
-            ops.start_with(initial),
-            ops.scan(update_state),
+        accelerations = self._accel_stream.observable()
+        tick_stream = self._peripheral_manager.game_tick
+        clocks = self._peripheral_manager.clock.pipe(
+            ops.filter(lambda clock: clock is not None),
             ops.share(),
         )
+
+        accel_updates = accelerations.pipe(
+            ops.map(lambda accel: lambda state: self._handle_acceleration(state, accel))
+        )
+
+        tick_updates = tick_stream.pipe(
+            ops.with_latest_from(clocks),
+            ops.map(
+                lambda latest: lambda state: self._advance_animation(
+                    state,
+                    elapsed_ms=latest[1].get_time(),
+                )
+            ),
+        )
+
+        state_stream = reactivex.merge(accel_updates, tick_updates).pipe(
+            ops.scan(lambda state, update: update(state), seed=initial),
+            ops.start_with(initial),
+        )
+        return share_stream(state_stream, stream_name="MarioRendererProvider.state")
+
+    def observable(self) -> reactivex.Observable[MarioRendererState]:
+        if self._state_stream is None:
+            self._state_stream = self._build_state_stream()
+        return self._state_stream

--- a/src/heart/renderers/mario/renderer.py
+++ b/src/heart/renderers/mario/renderer.py
@@ -27,6 +27,8 @@ class MarioRenderer(StatefulBaseRenderer[MarioRendererState]):
         orientation: Orientation,
     ) -> None:
         screen_width, screen_height = window.get_size()
+        if self.state.current_frame is None:
+            return
         image = self.state.spritesheet.image_at(self.state.current_frame.frame)
         scaled = pygame.transform.scale(image, (screen_width, screen_height))
         center_x = (screen_width - scaled.get_width()) // 2

--- a/src/heart/renderers/mario/state.py
+++ b/src/heart/renderers/mario/state.py
@@ -1,13 +1,15 @@
 from dataclasses import dataclass
 from typing import Any
 
+from heart.display.models import KeyFrame
 from heart.peripheral.sensor import Acceleration
 
 
 @dataclass
 class MarioRendererState:
     spritesheet: Any
-    current_frame: int = 0
+    current_frame_index: int = 0
+    current_frame: KeyFrame | None = None
     time_since_last_update: float | None = None
     in_loop: bool = False
     highest_z: float = 0.0


### PR DESCRIPTION
### Motivation

- Replace lingering TODO scaffolding by implementing missing behaviour for peripheral observability and renderer state updates. 
- Make runtime data (LED frames and Mario animation state) observable so other components can subscribe without scraping internal state. 
- Improve runtime robustness by replacing prints and suppressed exceptions with structured logging and sensible error-handling. 
- Provide an explicit CLI orientation option so non-cube LED layouts can be selected at runtime.

### Description

- Publish LED output as `DisplayFrame` events through a new `LEDMatrixDisplay` peripheral and emit frames from `GameLoop._one_loop`, registering the peripheral with `PeripheralManager` so it appears on the event bus (`src/heart/peripheral/led_matrix.py`, `src/heart/environment.py`).
- Rework the Mario renderer provider to build a shared, cached observable stream driven by the peripheral `game_tick` and `clock`, with explicit animation advance and acceleration-trigger handling (`src/heart/renderers/mario/provider.py`, `src/heart/renderers/mario/state.py`, `src/heart/renderers/mario/renderer.py`).
- Add an `--orientation` CLI option with `--layout-columns` / `--layout-rows` to map to concrete `Orientation` instances before device creation, and thread the selected orientation into device construction (`src/heart/loop.py`).
- Improve logging/error handling and remove placeholder raises/prints in sensors and other places to avoid noisy failures (`src/heart/peripheral/sensor.py`), and update runtime documentation and the diagram renderer to reflect the new observability hooks (`docs/code_flow.md`, `scripts/render_code_flow.py`, `docs/research/runtime_observability.md`).

### Testing

- Ran formatting with `make format`, which completed successfully. 
- Regenerated the runtime diagram with `python scripts/render_code_flow.py --output docs/code_flow.svg`. 
- Ran the test suite with `make test`: overall most tests passed (166 passed, 1 skipped) but one test failed due to a Hypothesis health check (`tests/renderers/test_sliding_state_provider.py::TestSlidingStateProviderTransitions::test_advance_state_uses_expected_width[spec0]`). 
- All code changes were committed with the message `Improve runtime observability and orientation options`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be761c7e48321b96ab71019cdd5b1)