### PR TITLE
Use pathlib and logger in configuration registry

### DIFF
--- a/src/heart/programs/registry.py
+++ b/src/heart/programs/registry.py
@@ -1,23 +1,28 @@
 import importlib
-import os
 from functools import cached_property
+from pathlib import Path
 from typing import Callable
 
 from heart.environment import GameLoop
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class ConfigurationRegistry:
     @cached_property
     def registry(self) -> dict[str, Callable[[GameLoop], None]]:
         registry: dict[str, Callable[[GameLoop], None]] = {}
-        configurations_dir = os.path.join(os.path.dirname(__file__), "configurations")
-        for filename in os.listdir(configurations_dir):
-            if filename.endswith(".py") and filename != "__init__.py":
-                module_name = f"heart.programs.configurations.{filename[:-3]}"
+        configurations_dir = Path(__file__).resolve().parent / "configurations"
+        for configuration in configurations_dir.iterdir():
+            if configuration.suffix == ".py" and configuration.name != "__init__.py":
+                module_name = (
+                    f"heart.programs.configurations.{configuration.stem}"
+                )
                 module = importlib.import_module(module_name)
-                print(f"Importing configuration: {module_name}")
+                logger.info("Importing configuration: %s", module_name)
                 if hasattr(module, "configure"):
-                    registry[filename[:-3]] = module.configure
+                    registry[configuration.stem] = module.configure
 
         return registry
 


### PR DESCRIPTION
### Motivation
- Align the configuration registry with repository guidance by using `pathlib.Path` for filesystem operations instead of `os.path` and manual string handling.
- Replace ad-hoc `print` diagnostics with the shared logger to follow the logging guidance in `AGENTS.md`.
- Improve clarity and robustness of module discovery by iterating `configurations` with `Path.iterdir()` and using `Path.stem` for names.

### Description
- Replace `os.path`/`os.listdir` usage with `Path(__file__).resolve().parent / "configurations"` and `iterdir()` to find configuration modules.
- Import `get_logger` and create `logger = get_logger(__name__)`, and change the import message from `print` to `logger.info("Importing configuration: %s", module_name)`.
- Use `configuration.stem` as the registry key when a module exposes a `configure` callable so names are derived from the file stem.

### Testing
- Ran `make format`; an initial run reported all checks passed but a subsequent run surfaced `mypy` type errors in `src/heart/utilities/reactivex_streams.py` which caused `make format` to fail.
- Ran `make test` and the test suite completed successfully with `171 passed, 1 skipped` in approximately 16s.
- Formatting was applied to the changed file prior to committing the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bed11c4508321a6df9de3276fb136)