### PR TITLE
Attach input descriptors to concrete Observable streams

### DIFF
--- a/docs/research/keyboard_input_declarations.md
+++ b/docs/research/keyboard_input_declarations.md
@@ -1,0 +1,29 @@
+# Keyboard input declarations for debugging
+
+## Problem
+
+Keyboard input snapshots exposed pressed/held flags without explicit event edges,
+which made the FakeSwitch mapping harder to follow during debugging. Input
+dependencies were also implicit for peripherals and observable providers, so it
+was not obvious which upstream data each component expects.
+
+## Notes
+
+- Keyboard keys now emit explicit press/hold/release events, allowing the fake
+  switch mapping to filter for clear press edges.
+- Peripherals and observable providers declare their upstream inputs and carry
+  references to the concrete event streams they listen to, improving traceability
+  when inspecting runtime wiring.
+
+## Materials
+
+- None (software-only refactor).
+
+## Sources
+
+- `src/heart/peripheral/keyboard.py`
+- `src/heart/peripheral/switch.py`
+- `src/heart/peripheral/core/__init__.py`
+- `src/heart/peripheral/core/providers/__init__.py`
+- `src/heart/peripheral/providers/switch/provider.py`
+- `src/heart/peripheral/providers/acceleration/provider.py`

--- a/src/heart/peripheral/core/__init__.py
+++ b/src/heart/peripheral/core/__init__.py
@@ -21,6 +21,16 @@ class Input:
     data: Any
     timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
+
+@dataclass(frozen=True, slots=True)
+class InputDescriptor:
+    """Describe an input a peripheral or provider expects to consume."""
+
+    name: str
+    stream: reactivex.Observable[Any]
+    payload_type: type[Any] | None = None
+    description: str | None = None
+
 A = TypeVar("A")
 
 class PeripheralGroup(StrEnum):
@@ -65,6 +75,15 @@ class Peripheral(Generic[A]):
         # with no identifier or tags. Subclasses should override this method
         # to supply meaningful identification and metadata relevant to their hardware.
         return PeripheralInfo()
+
+    def inputs(
+        self,
+        *,
+        event_bus: reactivex.Observable[Input] | None = None,
+    ) -> tuple[InputDescriptor, ...]:
+        """Declare the input events this peripheral consumes."""
+
+        return ()
 
     @cached_property
     def observe(

--- a/src/heart/peripheral/core/providers/__init__.py
+++ b/src/heart/peripheral/core/providers/__init__.py
@@ -5,6 +5,7 @@ import reactivex
 from lagom import Container
 from reactivex import operators as ops
 
+from heart.peripheral.core import InputDescriptor
 from heart.peripheral.core.manager import PeripheralManager
 
 T = TypeVar("T")
@@ -13,6 +14,11 @@ class ObservableProvider(Generic[T]):
     @abstractmethod
     def observable(self) -> reactivex.Observable[T]:
         raise NotImplementedError("")
+
+    def inputs(self) -> tuple[InputDescriptor, ...]:
+        """Declare the input streams this provider consumes."""
+
+        return ()
 
 class StaticStateProvider(ObservableProvider[T]):
     def __init__(self, state: T) -> None:

--- a/src/heart/peripheral/providers/switch/provider.py
+++ b/src/heart/peripheral/providers/switch/provider.py
@@ -1,7 +1,7 @@
 import reactivex
 from reactivex import operators as ops
 
-from heart.peripheral.core import PeripheralMessageEnvelope
+from heart.peripheral.core import InputDescriptor, PeripheralMessageEnvelope
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import ObservableProvider
 from heart.peripheral.switch import FakeSwitch, SwitchState
@@ -10,6 +10,26 @@ from heart.peripheral.switch import FakeSwitch, SwitchState
 class MainSwitchProvider(ObservableProvider[SwitchState]):
     def __init__(self, peripheral_manager: PeripheralManager):
         self._pm = peripheral_manager
+
+    def inputs(self) -> tuple[InputDescriptor, ...]:
+        main_switches = [
+            peripheral.observe
+            for peripheral in self._pm.peripherals
+            if isinstance(peripheral, FakeSwitch)
+        ]
+        switch_stream = (
+            reactivex.merge(*main_switches)
+            if main_switches
+            else reactivex.empty()
+        )
+        return (
+            InputDescriptor(
+                name="fake_switch.observe",
+                stream=switch_stream,
+                payload_type=SwitchState,
+                description="Observable stream emitted by FakeSwitch peripherals.",
+            ),
+        )
 
     def observable(self) -> reactivex.Observable[SwitchState]:
         main_switches = [


### PR DESCRIPTION
### Motivation

- Replace opaque `stream_name` strings with concrete Observable references so input wiring is inspectable at runtime.
- Make keyboard input semantics explicit by emitting edge events instead of timeline snapshots to simplify consumers filtering for press edges.
- Surface the actual upstream streams consumed by providers and peripherals to reduce implicit wiring and improve traceability.

### Description

- Change `InputDescriptor` to carry a `stream` (`reactivex.Observable`) instead of a `stream_name` string and update `Peripheral.inputs` to accept an optional `event_bus` parameter for declarations.
- Update `KeyboardKey` to emit `KeyboardEvent` edges with `KeyboardAction` and `KeyState` to represent `PRESSED`/`HELD`/`RELEASED` semantics and adapt consumers to use `KeyboardAction.PRESSED` filtering.
- Wire peripherals and providers to return concrete merged streams (e.g. `FakeSwitch.inputs` uses merged `KeyboardKey.get(...).observe`, `MainSwitchProvider`/`AllAccelerometersProvider` merge peripheral `observe` streams, and `DrawingPad.inputs` requires an injected `event_bus` reference).
- Update documentation note at `docs/research/keyboard_input_declarations.md` to describe that input descriptors hold stream references.

### Testing

- Ran `make format` which completed successfully and fixed style where applicable.
- Ran `make test` which completed successfully with `169 passed, 1 skipped`.
- All modified modules were exercised by the test suite and no regressions were observed.
- Formatter and test runs were used as the automated validation for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be9a2d32c8321a23f5ec35a7a2489)