### PR TITLE
Configurable device layouts, multi-panel LED support, and IO observability improvements

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -55,6 +55,24 @@ Important flags:
 
 Ensure SDL dependencies are installed (`libsdl2-dev` and `libsdl2-image-dev` on Debian-based systems) if the window fails to open.
 
+## Display Layout Configuration
+
+Set the display layout through environment variables to match the physical LED panel geometry without editing code:
+
+- `HEART_DEVICE_LAYOUT`: `cube` (default) or `rectangle`.
+- `HEART_LAYOUT_COLUMNS` / `HEART_LAYOUT_ROWS`: panel grid dimensions for `rectangle` layouts.
+- `HEART_PANEL_COLUMNS` / `HEART_PANEL_ROWS`: per-panel pixel dimensions (default `64×64`).
+
+Example for a 2×2 wall of 64×64 panels:
+
+```bash
+export HEART_DEVICE_LAYOUT=rectangle
+export HEART_LAYOUT_COLUMNS=2
+export HEART_LAYOUT_ROWS=2
+export HEART_PANEL_COLUMNS=64
+export HEART_PANEL_ROWS=64
+```
+
 ## Raspberry Pi Deployment Procedure
 
 1. Install system dependencies:

--- a/docs/research/runtime_layout_io_observability.md
+++ b/docs/research/runtime_layout_io_observability.md
@@ -1,0 +1,48 @@
+# Runtime layout and IO observability research note
+
+## Context
+
+The runtime now supports layout configuration without code edits and adds
+visibility into high-volume IO paths. These changes reduce startup risk when
+panel geometry varies and make BLE, sensor, and display frame traffic easier to
+monitor during integration.
+
+## Materials
+
+- Heart runtime configuration via environment variables.
+- Logging control via `HEART_LOG_RULES` and `HEART_LOG_DEFAULT_INTERVAL`.
+- Source references listed below.
+
+## Findings
+
+- Layout configuration is driven by `HEART_DEVICE_LAYOUT`,
+  `HEART_LAYOUT_COLUMNS`, and `HEART_LAYOUT_ROWS`. Panel pixel dimensions come
+  from `HEART_PANEL_COLUMNS` and `HEART_PANEL_ROWS`.
+- BLE UART parsing now drains multiple JSON frames per callback and reports
+  byte/message counters through the logging controller.
+- The LED matrix peripheral publishes frames as an observable stream and logs
+  frame cadence for monitoring pipelines.
+- Serial accelerometer reads use line-based reads with timeouts, salvage JSON
+  payloads that contain preamble bytes, and log decode failures for debugging.
+- Game mode registration initializes renderers immediately once navigation is
+  ready, avoiding initialization races when new scenes are registered late.
+
+## Operational guidance
+
+- Use `HEART_DEVICE_LAYOUT=rectangle` for non-cube deployments and ensure layout
+  and panel dimensions match the physical rig.
+- Tune log sampling with `HEART_LOG_RULES` to surface BLE/sensor/display stats
+  without spamming the console (for example,
+  `HEART_LOG_RULES="ble.uart.poll=5:INFO,peripheral.display.frame=2:INFO"`).
+- Watch `sensor.serial.poll` to confirm incoming sensor payload volume and
+  decode error trends during bring-up.
+
+## References
+
+- `src/heart/utilities/env.py`
+- `src/heart/device/selection.py`
+- `src/heart/device/rgb_display/device.py`
+- `src/heart/peripheral/bluetooth.py`
+- `src/heart/peripheral/led_matrix.py`
+- `src/heart/peripheral/sensor.py`
+- `src/heart/navigation.py`

--- a/src/heart/device/rgb_display/device.py
+++ b/src/heart/device/rgb_display/device.py
@@ -16,11 +16,11 @@ class LEDMatrix(Device, SampleBase):
     def __init__(self, orientation: Orientation, *args: Any, **kwargs: Any) -> None:
         Device.__init__(self, orientation=orientation)
         SampleBase.__init__(self, *args, **kwargs)
-        assert orientation.layout.rows == 1, "Maximum 1 row supported at the moment"
 
         self.chain_length = orientation.layout.columns
-        self.row_size = 64
-        self.col_size = 64
+        self.parallel = orientation.layout.rows
+        self.row_size = Configuration.panel_rows()
+        self.col_size = Configuration.panel_columns()
 
         self._client: Optional[MatrixClient] = None
         self.worker: Optional[MatrixDisplayWorker] = None
@@ -43,11 +43,10 @@ class LEDMatrix(Device, SampleBase):
             from rgbmatrix import RGBMatrix, RGBMatrixOptions
 
             options = RGBMatrixOptions()
-            # TODO: Might need to change these if we want N screens
             options.rows = self.row_size
             options.cols = self.col_size
             options.chain_length = self.chain_length
-            options.parallel = 1
+            options.parallel = self.parallel
             options.pwm_bits = 11
 
             options.show_refresh_rate = 1
@@ -71,13 +70,13 @@ class LEDMatrix(Device, SampleBase):
             self.worker = MatrixDisplayWorker(self.matrix)
 
     def layout(self) -> Layout:
-        return Layout(columns=self.chain_length, rows=1)
+        return Layout(columns=self.chain_length, rows=self.parallel)
 
     def individual_display_size(self) -> tuple[int, int]:
         return (self.col_size, self.row_size)
 
     def full_display_size(self) -> tuple[int, int]:
-        return (self.col_size * self.chain_length, self.row_size)
+        return (self.col_size * self.chain_length, self.row_size * self.parallel)
 
     def set_display_mode(self, mode: str) -> None:
         self.display_mode = mode

--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -833,7 +833,7 @@ class GameLoop:
             # (clem): gamepad shit is weird and can randomly put caught segfault
             #   events on queue, I see allusions to this online, people say
             #   try pygame-ce instead
-            print("SystemError: Encountered segfaulted event")
+            logger.exception("Encountered segfaulted event")
 
     def _preprocess_setup(self) -> None:
         self.__dim_display()

--- a/src/heart/navigation.py
+++ b/src/heart/navigation.py
@@ -170,6 +170,15 @@ class GameModes(StatefulBaseRenderer[GameModeState]):
     Navigation is built-in to this, assuming the user long-presses
 
     """
+    def __init__(self) -> None:
+        super().__init__()
+        self._init_context: tuple[
+            pygame.Surface,
+            pygame.time.Clock,
+            PeripheralManager,
+            Orientation,
+        ] | None = None
+
     def _create_initial_state(
         self,
         window: pygame.Surface,
@@ -177,6 +186,7 @@ class GameModes(StatefulBaseRenderer[GameModeState]):
         peripheral_manager: PeripheralManager,
         orientation: Orientation
     ) -> GameModeState:
+        self._init_context = (window, clock, peripheral_manager, orientation)
         if self._state is not None:
             for renderer in self.state.renderers:
                 renderer.initialize(window, clock, peripheral_manager, orientation)
@@ -193,11 +203,14 @@ class GameModes(StatefulBaseRenderer[GameModeState]):
     def add_new_pages(
         self, title_renderer: "StatefulBaseRenderer", renderers: "StatefulBaseRenderer"
     ) -> None:
-        # TODO: Hack because we are trying to build and have state at the same time
         if self._state is None:
             self.set_state(GameModeState())
         self.state.renderers.append(renderers)
         self.state.title_renderers.append(title_renderer)
+        if self.is_initialized() and self._init_context is not None:
+            window, clock, peripheral_manager, orientation = self._init_context
+            title_renderer.initialize(window, clock, peripheral_manager, orientation)
+            renderers.initialize(window, clock, peripheral_manager, orientation)
 
     def get_renderers(
         self

--- a/src/heart/peripheral/led_matrix.py
+++ b/src/heart/peripheral/led_matrix.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import logging
 import threading
 from datetime import datetime
 from typing import Any, Mapping
 
+import reactivex
 from PIL import Image
+from reactivex.subject import Subject
 
 from heart.peripheral.core import Peripheral
 from heart.peripheral.input_payloads import DisplayFrame
 from heart.utilities.logging import get_logger
+from heart.utilities.logging_control import get_logging_controller
 
 _LOGGER = get_logger(__name__)
 
@@ -35,6 +39,9 @@ class LEDMatrixDisplay(Peripheral[DisplayFrame]):
         self._latest_frame: DisplayFrame | None = None
         self._sequence = 0
         self._stop = threading.Event()
+        self._frame_subject: Subject[DisplayFrame] = Subject()
+        self._log_controller = get_logging_controller()
+        self._frame_count = 0
 
         super().__init__()
 
@@ -53,6 +60,8 @@ class LEDMatrixDisplay(Peripheral[DisplayFrame]):
         with self._frame_lock:
             return self._latest_frame
 
+    def _event_stream(self) -> reactivex.Observable[DisplayFrame]:
+        return self._frame_subject
 
     def publish_image(
         self,
@@ -68,7 +77,6 @@ class LEDMatrixDisplay(Peripheral[DisplayFrame]):
                 "Image dimensions do not match configured display size"
             )
 
-        # TODO: Make this observable
         with self._frame_lock:
             frame = DisplayFrame.from_image(
                 image,
@@ -78,4 +86,13 @@ class LEDMatrixDisplay(Peripheral[DisplayFrame]):
             self._sequence += 1
             self._latest_frame = frame
 
+        self._frame_count += 1
+        self._frame_subject.on_next(frame)
+        self._log_controller.log(
+            key="peripheral.display.frame",
+            logger=_LOGGER,
+            level=logging.INFO,
+            msg="Published display frame id=%s size=%sx%s total=%s",
+            args=(frame.frame_id, frame.width, frame.height, self._frame_count),
+        )
         return frame

--- a/src/heart/utilities/env.py
+++ b/src/heart/utilities/env.py
@@ -109,6 +109,32 @@ class Configuration:
         return os.environ.get("PERIPHERAL_CONFIGURATION", "default")
 
     @classmethod
+    def device_layout_mode(cls) -> "DeviceLayoutMode":
+        raw = os.environ.get("HEART_DEVICE_LAYOUT", "cube").strip().lower()
+        try:
+            return DeviceLayoutMode(raw)
+        except ValueError as exc:
+            raise ValueError(
+                "HEART_DEVICE_LAYOUT must be 'cube' or 'rectangle'"
+            ) from exc
+
+    @classmethod
+    def device_layout_columns(cls) -> int:
+        return _env_int("HEART_LAYOUT_COLUMNS", default=1, minimum=1)
+
+    @classmethod
+    def device_layout_rows(cls) -> int:
+        return _env_int("HEART_LAYOUT_ROWS", default=1, minimum=1)
+
+    @classmethod
+    def panel_rows(cls) -> int:
+        return _env_int("HEART_PANEL_ROWS", default=64, minimum=1)
+
+    @classmethod
+    def panel_columns(cls) -> int:
+        return _env_int("HEART_PANEL_COLUMNS", default=64, minimum=1)
+
+    @classmethod
     def reactivex_background_max_workers(cls) -> int:
         return _env_int("HEART_RX_BACKGROUND_MAX_WORKERS", default=4, minimum=1)
 
@@ -313,6 +339,11 @@ class LifeUpdateStrategy(StrEnum):
     AUTO = "auto"
     CONVOLVE = "convolve"
     PAD = "pad"
+
+
+class DeviceLayoutMode(StrEnum):
+    CUBE = "cube"
+    RECTANGLE = "rectangle"
 
 
 class ReactivexEventBusScheduler(StrEnum):

--- a/tests/peripheral/test_led_matrix_display.py
+++ b/tests/peripheral/test_led_matrix_display.py
@@ -25,3 +25,17 @@ class TestPeripheralLedMatrixDisplay:
             assert "dimensions" in str(exc)
         else:  # pragma: no cover - defensive
             raise AssertionError("ValueError expected when dimensions do not match")
+
+    def test_publish_image_emits_latest_frame(self) -> None:
+        """Verify that publish image emits frames to observers so downstream monitors can track LED output health."""
+        peripheral = LEDMatrixDisplay(width=2, height=2)
+        image = _solid_image(2, 2, value=7)
+        received: list = []
+
+        subscription = peripheral.observe.subscribe(
+            on_next=lambda envelope: received.append(envelope.data)
+        )
+        frame = peripheral.publish_image(image)
+        subscription.dispose()
+
+        assert received == [frame]


### PR DESCRIPTION
### Motivation

- Reduce outstanding TODOs by adding pragmatic behaviour improvements across device, peripheral, and renderer code to make runtime deployments more robust.
- Support multi-panel LED layouts and runtime-configurable device layouts so physical rigs can vary geometry without code changes.
- Improve IO efficiency and observability for BLE, serial sensors, and LED frames so integration points are easier to monitor and debug.
- Stabilize renderer/scene initialization to avoid race conditions when renderers or pages are registered after startup.

### Description

- Added environment-driven layout configuration and sizes via `Configuration.device_layout_mode`, `HEART_LAYOUT_*`, and `HEART_PANEL_*` and the `DeviceLayoutMode` enum in `src/heart/utilities/env.py`.
- Expanded LED matrix/device support to multi-panel grids by honoring orientation rows/columns and per-panel sizes in `src/heart/device/rgb_display/device.py` and wiring selection defaults in `src/heart/device/selection.py`.
- Made the LED matrix peripheral observable and instrumented frame publishing with a log counter in `src/heart/peripheral/led_matrix.py`, and added a unit test validating the observable behaviour in `tests/peripheral/test_led_matrix_display.py`.
- Improved BLE UART parsing to drain multiple JSON frames per callback and emit periodic stats, hardened serial sensor reads to use timeouts and salvage payloads while logging decode failures, and added logging-controller-driven sampling hooks (changes in `src/heart/peripheral/bluetooth.py` and `src/heart/peripheral/sensor.py`).
- Fixed renderer/scene initialization ordering in `src/heart/navigation.py` to initialize newly added pages when GameModes is already initialized, and replaced a noisy `print` with structured logging in `src/heart/environment.py`.
- Added documentation explaining display layout configuration in `docs/getting_started.md` and a research note about layout and IO observability in `docs/research/runtime_layout_io_observability.md`.

### Testing

- Ran `make format` to apply repo formatting rules and the command completed successfully.
- Ran the test suite with `make test` and the suite completed successfully with `172 passed, 1 skipped`.
- Added a unit test `TestPeripheralLedMatrixDisplay::test_publish_image_emits_latest_frame` which passed as part of the full test run.
- No automated tests failed during validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bed6116fc832195cc42294fd705fb)