### PR TITLE
Add runtime observability hooks and orientation options

### DIFF
--- a/docs/code_flow.md
+++ b/docs/code_flow.md
@@ -48,6 +48,7 @@ flowchart LR
         Sensors["Accelerometer / Phyphox"]
         HeartRate["HeartRateManager"]
         PhoneText["PhoneText"]
+        LedFrames["LEDMatrixDisplay\n(frame peripheral)"]
     end
 
     subgraph Outputs["Display & Device Services"]
@@ -69,6 +70,7 @@ flowchart LR
     DisplaySvc --> LocalScreen
     DisplaySvc --> Capture --> DeviceBridge --> LedMatrix
     Capture --> AverageMirror --> SingleLED
+    DisplaySvc --> LedFrames --> PeripheralMgr
 
     Loop --> PeripheralMgr --> RxScheduler
     RxScheduler --> Switch --> AppRouter
@@ -79,7 +81,7 @@ flowchart LR
 
     class CLI,Registry,Configurer,ModeServices,FrameComposer service;
     class Loop,AppRouter orchestrator;
-    class PeripheralMgr,RxScheduler,Switch,Gamepad,Sensors,HeartRate,PhoneText input;
+    class PeripheralMgr,RxScheduler,Switch,Gamepad,Sensors,HeartRate,PhoneText,LedFrames input;
     class DisplaySvc,LocalScreen,Capture,DeviceBridge,LedMatrix,AverageMirror,SingleLED output;
 ```
 

--- a/docs/research/runtime_observability.md
+++ b/docs/research/runtime_observability.md
@@ -1,0 +1,36 @@
+# Runtime Observability Research Note
+
+## Problem Statement
+
+Runtime consumers need direct access to rendered output and renderer state updates so that
+analytics, companion effects, and diagnostics can subscribe to live signals without
+instrumenting the core render loop.
+
+## Materials
+
+- Local Heart repository checkout.
+- Python environment capable of running the Heart runtime.
+- Access to the runtime sources under `src/heart/`.
+
+## Sources Consulted
+
+- `src/heart/peripheral/led_matrix.py` for the display-frame peripheral interface.
+- `src/heart/environment.py` for GameLoop frame publishing hooks.
+- `src/heart/renderers/mario/provider.py` for state stream construction.
+- `src/heart/loop.py` for CLI-driven runtime configuration.
+
+## Findings
+
+- Registering `LEDMatrixDisplay` with the `PeripheralManager` makes rendered frames observable
+  through the same event bus used by physical peripherals.
+- The Mario renderer provider can expose a shared `MarioRendererState` observable so other
+  components can subscribe to animation timing and acceleration-triggered transitions.
+- Publishing frame metadata alongside the image payload provides enough context for consumers
+  to identify active renderers without tight coupling to the renderer pipeline.
+
+## Follow-Up Ideas
+
+- Emit renderer state updates for additional interactive renderers that benefit from external
+  diagnostics or synchronization.
+- Add a lightweight sampling hook that downscales frames before emitting them to reduce
+  downstream bandwidth when needed.

--- a/docs/runtime_feedback_loop.md
+++ b/docs/runtime_feedback_loop.md
@@ -16,6 +16,8 @@ Higher-level gestures are implemented as `VirtualPeripheralDefinition` instances
 
 The primary `GameLoop` attaches the `PeripheralManager` to the same event bus, initialises an `LEDMatrixDisplay` peripheral, and registers it so rendered frames are published just like any other input. Every frame, the loop blits renderer output to the pygame surface, forwards it to the active device, and asks the LED matrix peripheral to emit a `peripheral.display.frame` payload. External consumers can then read those frames via the event bus or the peripheral’s `latest_frame` property. 【F:src/heart/environment.py†L263-L734】【F:src/heart/peripheral/led_matrix.py†L19-L111】
 
+Renderer-specific state can also be observed directly. For example, the Mario renderer shares a `MarioRendererState` stream from `heart/renderers/mario/provider.py`, allowing diagnostics or companion effects to subscribe to sprite timing and acceleration thresholds without inspecting the renderer internals. 【F:src/heart/renderers/mario/provider.py†L1-L150】
+
 ## Recursive Flow Diagram
 
 ```mermaid

--- a/docs/runtime_overview.md
+++ b/docs/runtime_overview.md
@@ -46,6 +46,8 @@ Renderers extend `heart.renderers.BaseRenderer` (or a specialization) and draw i
 
 Workers push events into the `AppController`, which propagates state to renderers. Scene code can subscribe to helper modules such as `heart.peripheral.heart_rates` to retrieve the latest readings.
 
+The game loop also registers a virtual `LEDMatrixDisplay` peripheral so each rendered frame is emitted as a `peripheral.display.frame` payload. Consumers that need access to the live output (for example, analytics or secondary displays) can subscribe to this event stream without coupling to the renderer stack.
+
 ## Display Pipeline
 
 Each frame flows through the same stages:
@@ -53,6 +55,7 @@ Each frame flows through the same stages:
 1. The active mode asks its renderers for frames. Composite modes may layer results through `ComposedRenderer` or rotate them with `MultiScene`.
 1. `heart.display.service.DisplayService` manages timing and double buffering to prevent tearing.
 1. The chosen `Device` implementation emits the output. `LocalScreen` writes to a pygame window, whereas the LED matrix driver streams pixel rows over SPI. Optional capture paths such as `heart.device.bridge.DeviceBridge` share frames with auxiliary processes.
+1. The `LEDMatrixDisplay` peripheral publishes the rendered frame and metadata so downstream subscribers can observe the runtime output.
 
 ## Extending the Runtime
 
@@ -61,6 +64,7 @@ To add a scene or peripheral:
 1. Implement a renderer under `heart/renderers/` (see `water_cube.py` for reference).
 1. Register it in an existing configuration module or introduce a new module in `heart/programs/configurations/` with `configure(loop)`.
 1. Execute `totem run --configuration <module>` to validate behaviour.
+1. For non-cube layouts, pass `--orientation rectangle --orientation-columns <cols> --orientation-rows <rows>` to override the default cube geometry.
 1. Place new peripheral integrations under `heart/peripheral/` and register them with the `PeripheralManager` so the runtime activates them automatically.
 
 ## Related References

--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -21,6 +21,7 @@ from heart.navigation import AppController, ComposedRenderer, MultiScene
 from heart.peripheral.core import events
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import container
+from heart.peripheral.led_matrix import LEDMatrixDisplay
 from heart.renderers.internal import FrameAccumulator
 from heart.utilities.env import Configuration, RenderMergeStrategy
 from heart.utilities.logging import get_logger
@@ -355,6 +356,7 @@ class GameLoop:
         self.clock: pygame.time.Clock | None = None
         self.screen: pygame.Surface | None = None
         self.renderer_variant = render_variant
+        self._display_peripheral: LEDMatrixDisplay | None = None
         binary_method = cast(RenderMethod, self._render_surfaces_binary)
         iterative_method = cast(RenderMethod, self._render_surface_iterative)
         object.__setattr__(self, "_render_surfaces_binary", binary_method)
@@ -813,12 +815,22 @@ class GameLoop:
                     else render_image
                 )
                 self.device.set_image(device_image)
+                self._publish_display_frame(
+                    device_image,
+                    renderers=renderers,
+                    render_variant=override_renderer_variant,
+                )
             else:
                 # Fallback to a screen capture if we did not render an image.
                 screen_array = pygame.surfarray.array3d(self.screen)
                 transposed_array = np.transpose(screen_array, (1, 0, 2))
                 pil_image = Image.fromarray(transposed_array)
                 self.device.set_image(pil_image)
+                self._publish_display_frame(
+                    pil_image,
+                    renderers=renderers,
+                    render_variant=override_renderer_variant,
+                )
 
     def _handle_events(self) -> None:
         try:
@@ -833,7 +845,7 @@ class GameLoop:
             # (clem): gamepad shit is weird and can randomly put caught segfault
             #   events on queue, I see allusions to this online, people say
             #   try pygame-ce instead
-            print("SystemError: Encountered segfaulted event")
+            logger.exception("SystemError: Encountered segfaulted event")
 
     def _preprocess_setup(self) -> None:
         self.__dim_display()
@@ -854,6 +866,7 @@ class GameLoop:
 
     def _initialize_peripherals(self) -> None:
         logger.info("Attempting to detect attached peripherals")
+        self._initialize_display_peripheral()
         self.peripheral_manager.detect()
         peripherals = self.peripheral_manager.peripherals
         logger.info(
@@ -863,6 +876,36 @@ class GameLoop:
         )
         logger.info("Starting all peripherals")
         self.peripheral_manager.start()
+
+    def _initialize_display_peripheral(self) -> None:
+        if self._display_peripheral is not None:
+            return
+        width, height = self.device.full_display_size()
+        self._display_peripheral = LEDMatrixDisplay(width=width, height=height)
+        self.peripheral_manager.register(self._display_peripheral)
+        logger.info(
+            "Registered LEDMatrixDisplay peripheral for %dx%d output",
+            width,
+            height,
+        )
+
+    def _publish_display_frame(
+        self,
+        image: Image.Image,
+        *,
+        renderers: list["StatefulBaseRenderer[Any]"],
+        render_variant: RendererVariant | None,
+    ) -> None:
+        if self._display_peripheral is None:
+            return
+        metadata = {
+            "renderers": [renderer.name for renderer in renderers],
+            "variant": (render_variant or self.renderer_variant).value,
+        }
+        try:
+            self._display_peripheral.publish_image(image, metadata=metadata)
+        except Exception:
+            logger.exception("Failed to publish display frame metadata")
 
     def _initialize(self) -> None:
         self.__set_singleton()

--- a/src/heart/loop.py
+++ b/src/heart/loop.py
@@ -7,7 +7,8 @@ from typing import Annotated
 import typer
 from PIL import Image
 
-from heart.device.selection import select_device
+from heart.device.selection import (OrientationLayout, resolve_orientation,
+                                    select_device)
 from heart.environment import GameLoop, RendererVariant
 from heart.manage.update import main as update_driver_main
 from heart.peripheral.core.providers import container
@@ -29,14 +30,34 @@ def run(
     x11_forward: bool = typer.Option(
         False, "--x11-forward", help="Use X11 forwarding for RGB display"
     ),
+    orientation_layout: OrientationLayout = typer.Option(
+        OrientationLayout.CUBE,
+        "--orientation",
+        help="Choose the display orientation layout.",
+    ),
+    orientation_columns: int = typer.Option(
+        4,
+        "--orientation-columns",
+        help="Number of display columns for rectangle layouts.",
+    ),
+    orientation_rows: int = typer.Option(
+        1,
+        "--orientation-rows",
+        help="Number of display rows for rectangle layouts.",
+    ),
 ) -> None:
     registry = ConfigurationRegistry()
     configuration_fn = registry.get(configuration)
     if configuration_fn is None:
         raise Exception(f"Configuration '{configuration}' not found in registry")
     render_variant = RendererVariant.parse(Configuration.render_variant())
+    orientation = resolve_orientation(
+        layout=orientation_layout,
+        columns=orientation_columns,
+        rows=orientation_rows,
+    )
     loop = GameLoop(
-        device=select_device(x11_forward=x11_forward),
+        device=select_device(x11_forward=x11_forward, orientation=orientation),
         resolver=container,
         render_variant=render_variant,
     )
@@ -61,7 +82,12 @@ def update_driver(name: Annotated[str, typer.Option("--name")]) -> None:
     name="bench-device",
 )
 def bench_device() -> None:
-    d = select_device(x11_forward=False)
+    orientation = resolve_orientation(
+        layout=OrientationLayout.CUBE,
+        columns=4,
+        rows=1,
+    )
+    d = select_device(x11_forward=False, orientation=orientation)
 
     size = d.full_display_size()
     logger.info("Device full display size: %s", size)

--- a/src/heart/peripheral/led_matrix.py
+++ b/src/heart/peripheral/led_matrix.py
@@ -6,7 +6,9 @@ import threading
 from datetime import datetime
 from typing import Any, Mapping
 
+import reactivex
 from PIL import Image
+from reactivex.subject import Subject
 
 from heart.peripheral.core import Peripheral
 from heart.peripheral.input_payloads import DisplayFrame
@@ -34,7 +36,7 @@ class LEDMatrixDisplay(Peripheral[DisplayFrame]):
         self._frame_lock = threading.Lock()
         self._latest_frame: DisplayFrame | None = None
         self._sequence = 0
-        self._stop = threading.Event()
+        self._frame_subject: Subject[DisplayFrame] = Subject()
 
         super().__init__()
 
@@ -53,6 +55,9 @@ class LEDMatrixDisplay(Peripheral[DisplayFrame]):
         with self._frame_lock:
             return self._latest_frame
 
+    def _event_stream(self) -> reactivex.Observable[DisplayFrame]:
+        return self._frame_subject
+
 
     def publish_image(
         self,
@@ -68,7 +73,6 @@ class LEDMatrixDisplay(Peripheral[DisplayFrame]):
                 "Image dimensions do not match configured display size"
             )
 
-        # TODO: Make this observable
         with self._frame_lock:
             frame = DisplayFrame.from_image(
                 image,
@@ -78,4 +82,5 @@ class LEDMatrixDisplay(Peripheral[DisplayFrame]):
             self._sequence += 1
             self._latest_frame = frame
 
+        self._frame_subject.on_next(frame)
         return frame

--- a/src/heart/peripheral/sensor.py
+++ b/src/heart/peripheral/sensor.py
@@ -61,24 +61,24 @@ class Accelerometer(Peripheral[Acceleration | None]):
                         for datum in data:
                             self._process_data(datum)
                 except KeyboardInterrupt:
-                    print("Program terminated")
+                    logger.info("Sensor peripheral terminated by keyboard interrupt")
                 except Exception:
-                    pass
+                    logger.exception("Sensor peripheral failed while reading serial data")
                 finally:
                     ser.close()
             except Exception:
-                pass
+                logger.exception("Sensor peripheral failed to connect to serial port")
 
     def _process_data(self, data: bytes) -> None:
         bus_data = data.decode("utf-8").rstrip()
         if not bus_data or not bus_data.startswith("{"):
-            # TODO: This happens on first connect due to some weird `b'\x1b]0;\xf0\x9f\x90\x8dcode.py | 9.2.7\x1b\\` bytes
+            logger.debug("Ignoring non-JSON sensor payload: %s", bus_data)
             return
 
         try:
             parsed: dict[str, Any] = json.loads(bus_data)
         except json.JSONDecodeError:
-            print(f"Failed to decode JSON: {bus_data}")
+            logger.warning("Failed to decode sensor JSON payload: %s", bus_data)
             return
         self._update_due_to_data(parsed)
 

--- a/src/heart/renderers/mario/provider.py
+++ b/src/heart/renderers/mario/provider.py
@@ -1,93 +1,138 @@
 
+import time
 
 import reactivex
+from reactivex import operators as ops
 
 from heart.assets.loader import Loader
 from heart.display.models import KeyFrame
 from heart.peripheral.providers.acceleration import AllAccelerometersProvider
 from heart.peripheral.sensor import Acceleration
-from heart.peripheral.uwb import ops
 from heart.renderers.mario.state import MarioRendererState
+from heart.utilities.logging import get_logger
+from heart.utilities.reactivex_streams import share_stream
+
+_LOGGER = get_logger(__name__)
 
 
 class MarioRendererProvider:
-        #     self._spritesheet: pygame.Surface | None = None
-
-    def __init__(self, metadata_file_path: str, sheet_file_path: str, accel_stream: AllAccelerometersProvider):
+    def __init__(
+        self,
+        metadata_file_path: str,
+        sheet_file_path: str,
+        accel_stream: AllAccelerometersProvider,
+    ) -> None:
         self.metadata_file_path = metadata_file_path
         self.file = sheet_file_path
         self._accel_stream = accel_stream
+        self._frames = self._load_frames(metadata_file_path)
+        self._state_stream: reactivex.Observable[MarioRendererState] | None = None
 
-        frame_data = Loader.load_json(self.metadata_file_path)
-        self.frames = []
+    def _load_frames(self, metadata_file_path: str) -> list[KeyFrame]:
+        frame_data = Loader.load_json(metadata_file_path)
+        frames: list[KeyFrame] = []
         for key in frame_data["frames"]:
             frame_obj = frame_data["frames"][key]
             frame = frame_obj["frame"]
-            self.frames.append(
+            frames.append(
                 KeyFrame(
                     (frame["x"], frame["y"], frame["w"], frame["h"]),
-                    frame_obj["duration"],
+                    frame_obj.get("duration"),
                 )
             )
+        if not frames:
+            raise ValueError("Mario spritesheet metadata produced no frames")
+        return frames
 
-    def _create_initial_state(
-        self,
-    ) -> MarioRendererState:
+    def _create_initial_state(self) -> MarioRendererState:
         image = Loader.load_spirtesheet(self.file)
-        return MarioRendererState(spritesheet=image)
-
-
-    def observable(
-        self,
-    ) -> reactivex.Observable[MarioRendererState]:
-        observable = self._accel_stream.observable()
-        
-        initial = self._create_initial_state()
-
-        def update_state(prev: MarioRendererState, acceleration: Acceleration):
-            state = prev
-            current_kf = self.frames[state.current_frame]
-            current_frame = state.current_frame
-            time_since_last_update = state.time_since_last_update
-            in_loop = state.in_loop
-            highest_z = state.highest_z
-
-            kf_duration = current_kf.duration
-
-            if in_loop:
-                if time_since_last_update is None:
-                    time_since_last_update = 0
-
-                # TODO: Stream in the clock / break this up
-                # time_since_last_update += clock.get_time()
-
-                if time_since_last_update > kf_duration:
-                    current_frame += 1
-                    time_since_last_update = 0
-
-                    if current_frame >= len(self.frames):
-                        current_frame = 0
-                        in_loop = False
-            else:
-                vector = self.state.latest_acceleration
-                if vector is not None and vector.z > 11.0:  # vibes based constants
-                    highest_z = max(highest_z, vector.z)
-                    print(f"highest z: {highest_z}, accel z: {vector.z}")
-                    in_loop = True
-                    time_since_last_update = 0
-
-            if not in_loop:
-                time_since_last_update = None
-
-            self.update_state(
-                current_frame=current_frame,
-                time_since_last_update=time_since_last_update,
-                in_loop=in_loop,
-                highest_z=highest_z,
-            )    
-
-        return observable.pipe(
-            ops.start_with(initial),
-            ops.scan(update_state),
-            ops.share(),
+        return MarioRendererState(
+            spritesheet=image,
+            current_frame=self._frames[0],
+            current_frame_index=0,
+            time_since_last_update=None,
+            in_loop=False,
+            highest_z=0.0,
+            latest_acceleration=None,
+            last_update_time=None,
         )
+
+    def _frame_duration(self, frame: KeyFrame) -> float:
+        if frame.duration is None:
+            return 100.0
+        return max(float(frame.duration), 1.0)
+
+    def _advance_frames(
+        self,
+        frame_index: int,
+        time_since: float,
+    ) -> tuple[int, float, bool]:
+        duration = self._frame_duration(self._frames[frame_index])
+        if time_since < duration:
+            return frame_index, time_since, True
+        next_index = frame_index + 1
+        if next_index >= len(self._frames):
+            return 0, 0.0, False
+        return next_index, 0.0, True
+
+    def _update_state(
+        self,
+        prev: MarioRendererState,
+        acceleration: Acceleration,
+    ) -> MarioRendererState:
+        now = time.monotonic()
+        last_time = prev.last_update_time or now
+        delta_ms = max((now - last_time) * 1000.0, 0.0)
+
+        frame_index = prev.current_frame_index
+        time_since = prev.time_since_last_update
+        in_loop = prev.in_loop
+        highest_z = prev.highest_z
+
+        if in_loop:
+            time_since = (time_since or 0.0) + delta_ms
+            frame_index, time_since, in_loop = self._advance_frames(
+                frame_index, time_since
+            )
+        else:
+            if acceleration.z > 11.0:
+                highest_z = max(highest_z, acceleration.z)
+                _LOGGER.info(
+                    "Mario loop triggered by acceleration z=%.2f (max=%.2f)",
+                    acceleration.z,
+                    highest_z,
+                )
+                in_loop = True
+                frame_index = 0
+                time_since = 0.0
+
+        if not in_loop:
+            time_since = None
+            frame_index = 0
+
+        return MarioRendererState(
+            spritesheet=prev.spritesheet,
+            current_frame=self._frames[frame_index],
+            current_frame_index=frame_index,
+            time_since_last_update=time_since,
+            in_loop=in_loop,
+            highest_z=highest_z,
+            latest_acceleration=acceleration,
+            last_update_time=now,
+        )
+
+    def observable(self) -> reactivex.Observable[MarioRendererState]:
+        if self._state_stream is None:
+            initial = self._create_initial_state()
+            source = self._accel_stream.observable()
+            stream = source.pipe(
+                ops.scan(self._update_state, seed=initial),
+                ops.start_with(initial),
+            )
+            self._state_stream = share_stream(
+                stream, stream_name="MarioRendererProvider.state"
+            )
+        return self._state_stream
+
+    def state_updates(self) -> reactivex.Observable[MarioRendererState]:
+        return self.observable()

--- a/src/heart/renderers/mario/state.py
+++ b/src/heart/renderers/mario/state.py
@@ -1,14 +1,17 @@
 from dataclasses import dataclass
 from typing import Any
 
+from heart.display.models import KeyFrame
 from heart.peripheral.sensor import Acceleration
 
 
 @dataclass
 class MarioRendererState:
     spritesheet: Any
-    current_frame: int = 0
+    current_frame: KeyFrame
+    current_frame_index: int = 0
     time_since_last_update: float | None = None
     in_loop: bool = False
     highest_z: float = 0.0
     latest_acceleration: Acceleration | None = None
+    last_update_time: float | None = None

--- a/src/heart/renderers/three_fractal/renderer.py
+++ b/src/heart/renderers/three_fractal/renderer.py
@@ -20,10 +20,12 @@ from heart.peripheral.gamepad.peripheral_mappings import (BitDoLite2,
 from heart.renderers import StatefulBaseRenderer
 from heart.renderers.three_fractal.state import FractalSceneState
 from heart.utilities.env import Configuration
+from heart.utilities.logging import get_logger
 
 if TYPE_CHECKING:
     from heart.renderers.three_fractal.provider import FractalSceneProvider
 
+_LOGGER = get_logger(__name__)
 
 @dataclass
 class FractalRuntimeState:
@@ -661,9 +663,8 @@ class FractalRuntime(StatefulBaseRenderer[FractalRuntimeState]):
                     self.delta_real_time * self.INFLATE_SPEED,
                 )
         except Exception as e:
-            # TODO: Very occasionally this raises an exception for some reason, no idea why
             self.active_radius = self.BASE_RADIUS
-            print(f"error but why: {e}")
+            _LOGGER.warning("Failed to update fractal radius", exc_info=e)
 
         if not self.tiled_mode:
             # eagerly apply the uniforms
@@ -686,9 +687,8 @@ class FractalRuntime(StatefulBaseRenderer[FractalRuntimeState]):
         try:
             self._process_mouse()
         except Exception:
-            # todo: tbh i'm just not sure if this will error if there's no mouse
-            #  device detected (e.g. on pi) so just catching in case
-            pass
+            # Some environments (e.g. headless Pi) may not expose a mouse device.
+            _LOGGER.debug("Mouse input unavailable; continuing without it")
 
     def _reset_camera_pos(self):
         # self.mat[3, :3] = np.array([0., 0., 0.])


### PR DESCRIPTION
### Motivation

- Make rendered output and renderer state observable so other components can subscribe to runtime events instead of relying on ad-hoc APIs or prints.
- Replace lingering TODO scaffolding with implemented behaviour for frame publishing and Mario renderer state updates.
- Improve robustness by recording runtime failures via the logger rather than printing or suppressing errors.
- Allow non-cube device layouts from the CLI so the runtime can target different display geometries.

### Description

- Expose LED frames as an observable by adding a `Subject` to `LEDMatrixDisplay` and implementing `_event_stream` so frames are published as `DisplayFrame` payloads. 
- Wire frame publishing into the main loop by registering `LEDMatrixDisplay` in `GameLoop`, and call a new `_publish_display_frame` helper with per-frame `metadata` after `device.set_image`.
- Add explicit orientation support via `OrientationLayout` and `resolve_orientation`, update `select_device` to accept an `orientation`, and introduce CLI flags `--orientation`, `--orientation-columns`, and `--orientation-rows` in `totem run` to override defaults.
- Make the Mario renderer provider a shared observable stream with deterministic frame advancing and a richer `MarioRendererState`, and add logging and state-sharing helpers for consumers to subscribe to renderer updates.
- Improve logging/error handling in peripherals and renderers by replacing `print`/silent excepts with `logger` calls and more descriptive messages (notably in `sensor.py`, `three_fractal/renderer.py`, and `environment.py`).
- Update documentation and diagrams to record the new observability hooks and usage (`docs/` updates and `scripts/render_code_flow.py` was used to re-render `docs/code_flow.svg`).

### Testing

- Ran `make format` to apply linting/formatting fixes and ensure style consistency, which completed successfully.
- Executed `python scripts/render_code_flow.py --output docs/code_flow.svg` to regenerate the flow diagram without errors.
- Ran the full test suite with `make test`, which completed successfully with `171 passed, 1 skipped`.
- Confirmed changes are isolated and the runtime unit/integration tests covering peripherals, environment conversion routines, and render pipeline remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694becfea3d883219a39e7c0f7ddba67)