### PR TITLE
Refactor keyboard events & tighten peripheral input streams

### DIFF
--- a/docs/research/keyboard-inputs-debugging.md
+++ b/docs/research/keyboard-inputs-debugging.md
@@ -1,0 +1,36 @@
+# Keyboard input state and debug mappings
+
+## Summary
+
+- Reworked keyboard event payloads to carry a single `KeyState` snapshot plus the
+  key name so debug tooling can inspect a complete state transition in one
+  object.
+- Tightened input declarations for peripherals and observable providers so each
+  descriptor exposes a filtered stream of exactly the input payload it consumes.
+
+## Motivation
+
+Debug tooling for fake peripherals benefits when keyboard events describe their
+state transitions in a single payload, and when input descriptors already match
+what downstream consumers handle. The new keyboard event structure now bundles
+state alongside the action and key metadata, and the input descriptors for
+`DrawingPad`, `FakeSwitch`, and observable providers only emit the payloads
+those components consume.
+
+## Implementation notes
+
+- `heart.peripheral.keyboard.KeyboardEvent` now includes `key_name` and a single
+  `KeyState` snapshot (`pressed`, `held`, `last_change_ms`).
+- `heart.peripheral.switch.FakeSwitch` uses a dedicated key-press stream helper
+  so input declarations and runtime subscriptions both consume pressed edges.
+- `heart.peripheral.drawing_pad.DrawingPad` input descriptors now filter the
+  event bus to the two supported event types and expose only the payloads.
+- Observable providers return input descriptors that already unwrap or filter
+  the peripheral envelopes into the payload type they advertise.
+
+## Materials
+
+- Pygame keyboard state polling (`pygame.key.get_pressed`) in
+  `src/heart/peripheral/keyboard.py`.
+- Input descriptor definitions in `src/heart/peripheral/core/__init__.py`.
+- Fake switch keyboard mappings in `src/heart/peripheral/switch.py`.

--- a/src/heart/peripheral/providers/switch/provider.py
+++ b/src/heart/peripheral/providers/switch/provider.py
@@ -11,32 +11,27 @@ class MainSwitchProvider(ObservableProvider[SwitchState]):
     def __init__(self, peripheral_manager: PeripheralManager):
         self._pm = peripheral_manager
 
-    def inputs(self) -> tuple[InputDescriptor, ...]:
+    def _switch_stream(self) -> reactivex.Observable[SwitchState]:
         main_switches = [
             peripheral.observe
             for peripheral in self._pm.peripherals
             if isinstance(peripheral, FakeSwitch)
         ]
-        switch_stream = (
-            reactivex.merge(*main_switches)
-            if main_switches
-            else reactivex.empty()
+        if not main_switches:
+            return reactivex.empty()
+        return reactivex.merge(*main_switches).pipe(
+            ops.map(PeripheralMessageEnvelope[SwitchState].unwrap_peripheral)
         )
+
+    def inputs(self) -> tuple[InputDescriptor, ...]:
         return (
             InputDescriptor(
-                name="fake_switch.observe",
-                stream=switch_stream,
+                name="fake_switch.observe.state",
+                stream=self._switch_stream(),
                 payload_type=SwitchState,
-                description="Observable stream emitted by FakeSwitch peripherals.",
+                description="Observable stream of SwitchState updates from FakeSwitch.",
             ),
         )
 
     def observable(self) -> reactivex.Observable[SwitchState]:
-        main_switches = [
-            peripheral.observe
-            for peripheral in self._pm.peripherals
-            if isinstance(peripheral, FakeSwitch)
-        ]
-        return reactivex.merge(*main_switches).pipe(
-            ops.map(PeripheralMessageEnvelope[SwitchState].unwrap_peripheral)
-        )
+        return self._switch_stream()


### PR DESCRIPTION
### Motivation

- Make keyboard events carry a single, inspectable snapshot so debug tooling (e.g. FakeSwitch) can consume complete state transitions easily.
- Ensure peripherals explicitly declare the exact input streams they expect so wiring and debugging are clearer.
- Align observable providers to unwrap or filter peripheral envelopes so their advertised payload types match what they actually emit.

### Description

- `KeyboardEvent` was changed to include `key_name` and a single `KeyState` snapshot, and `KeyState.last_change_ts` was renamed to `last_change_ms` for clarity in `src/heart/peripheral/keyboard.py`.
- `FakeSwitch` now exposes a `_key_press_stream` helper and its `inputs`/runtime subscriptions use filtered `KeyboardAction.PRESSED` streams and a renamed descriptor `keyboard.arrow_keys.pressed` in `src/heart/peripheral/switch.py`.
- `DrawingPad` input descriptors now filter `event_bus` into `drawing_pad.stroke` and `drawing_pad.erase` payload streams, and observable providers (`MainSwitchProvider`, `AllAccelerometersProvider`) were refactored to return already-unwrapped/filtered streams with clearer descriptor names in `src/heart/peripheral/providers`.
- Added a short research note at `docs/research/keyboard-inputs-debugging.md` describing the motivation and implementation details.

### Testing

- Ran `make format` and formatting checks passed successfully.
- Ran `make test` and the full test suite completed with `173 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694beee545208321a4520e610927086d)