### PR TITLE
Replace peripheral print diagnostics with logger and add AGENTS.md rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - Avoid building filesystem paths via string concatenation. Use `os.path.join` or `pathlib.Path` instead.
 - Prefer `pathlib.Path` over `os.path.join` when constructing paths, and ensure functions annotated to return a `Path` return a `Path` object.
 - Avoid using `print` for runtime diagnostics in CLI commands; use the shared logger.
+- Avoid using `print` for runtime diagnostics in peripheral modules; use the shared logger.
 - Prefer `StrEnum` values over raw strings for strategy/configuration mode selections.
 
 ## Testing

--- a/src/heart/peripheral/gamepad/gamepad.py
+++ b/src/heart/peripheral/gamepad/gamepad.py
@@ -120,8 +120,8 @@ class Gamepad(Peripheral[Any]):
     def update(self) -> None:
         try:
             self._update()
-        except Exception as e:
-            print(f"Error updating gamepad state: {e}")
+        except Exception:
+            logger.exception("Error updating gamepad state")
 
     def _update(self) -> None:
         if not self.joystick:
@@ -174,7 +174,7 @@ class Gamepad(Peripheral[Any]):
             pygame.joystick.init()
             yield cls()
         except pygame.error as e:
-            print(f"Error initializing joystick module: {e}")
+            logger.error("Error initializing joystick module: %s", e)
             return
 
     def is_connected(self) -> bool:
@@ -217,12 +217,12 @@ class Gamepad(Peripheral[Any]):
                         text=True,
                     )
                     if result.returncode == 0:
-                        print("Successfully connected to 8bitdo controller")
+                        logger.info("Successfully connected to 8bitdo controller")
                     else:
-                        print("Failed to connect to 8bitdo controller")
+                        logger.warning("Failed to connect to 8bitdo controller")
 
         except KeyboardInterrupt:
-            print("Program terminated")
+            logger.info("Program terminated")
         except Exception:
             pass
 

--- a/src/heart/peripheral/switch.py
+++ b/src/heart/peripheral/switch.py
@@ -291,7 +291,7 @@ class BluetoothSwitch(BaseSwitch):
                             self.update_due_to_data(event)
                         time.sleep(0.1)
                 except KeyboardInterrupt:
-                    print("Program terminated")
+                    logger.info("Program terminated")
                 except Exception:
                     self.connected = False
                     pass


### PR DESCRIPTION
### Motivation

- Ensure peripheral modules use the shared logging infrastructure instead of `print` to provide consistent, structured diagnostics.
- Reduce noisy and inconsistent stdout output from long-running peripheral threads and handlers.
- Align repository guidance with code by adding a higher-level rule that enforces logging in peripheral modules.

### Description

- Added a rule to `AGENTS.md`: `Avoid using \`print\` for runtime diagnostics in peripheral modules; use the shared logger.`
- Replaced `print` calls in `src/heart/peripheral/gamepad/gamepad.py` with appropriate `logger.exception`, `logger.error`, `logger.info`, or `logger.warning` calls.
- Replaced the `print` termination message in `src/heart/peripheral/switch.py` with `logger.info`.
- Ran formatting as part of the change with `make format` to keep code style consistent.

### Testing

- Ran `make format` and it completed with all checks passing.
- Ran the test suite with `make test` and observed `174 passed, 1 skipped`.
- No new unit tests were added for this change because it only replaces diagnostics calls with logging.
- All automated tests succeeded after the modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c0b48322c83219d7c5c534e55dd0e)