### PR TITLE
Refactor peripheral configuration loading

### DIFF
--- a/docs/research/peripheral-configuration-loader.md
+++ b/docs/research/peripheral-configuration-loader.md
@@ -1,0 +1,16 @@
+# Peripheral configuration loading refactor
+
+## Problem statement
+
+The peripheral manager handled configuration resolution, registry lookup, and detection orchestration in one class. This mixed concerns made the configuration lifecycle harder to follow when reading `PeripheralManager` and obscured the single responsibility of loading a configuration by name.
+
+## Notes
+
+- Moved configuration resolution and caching into `heart.peripheral.configuration_loader.PeripheralConfigurationLoader` so `PeripheralManager` focuses on peripheral orchestration.
+- Retained the same configuration selection logic while centralizing the registry lookup and logging in one place.
+
+## Materials
+
+- `src/heart/peripheral/configuration_loader.py`
+- `src/heart/peripheral/core/manager.py`
+- `src/heart/peripheral/registry.py`

--- a/src/heart/peripheral/configuration_loader.py
+++ b/src/heart/peripheral/configuration_loader.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from heart.peripheral.configuration import PeripheralConfiguration
+from heart.peripheral.registry import PeripheralConfigurationRegistry
+from heart.utilities.env import Configuration
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class PeripheralConfigurationLoader:
+    """Load and cache peripheral configurations by name."""
+
+    def __init__(
+        self,
+        *,
+        configuration: str | None = None,
+        registry: PeripheralConfigurationRegistry | None = None,
+    ) -> None:
+        self._registry = registry or PeripheralConfigurationRegistry()
+        self._configuration_name = (
+            configuration or Configuration.peripheral_configuration()
+        )
+        self._configuration: PeripheralConfiguration | None = None
+
+    @property
+    def name(self) -> str:
+        return self._configuration_name
+
+    def load(self) -> PeripheralConfiguration:
+        if self._configuration is None:
+            self._configuration = self._load_configuration(self._configuration_name)
+        return self._configuration
+
+    def _load_configuration(self, name: str) -> PeripheralConfiguration:
+        factory = self._registry.get(name)
+        if factory is None:
+            raise ValueError(f"Peripheral configuration '{name}' not found")
+        logger.info("Loading peripheral configuration: %s", name)
+        return factory()


### PR DESCRIPTION
### Motivation

- Reduce complexity in `PeripheralManager` by removing configuration resolution responsibilities. 
- Improve single-responsibility and readability by centralising config lookup and caching. 
- Make the configuration lifecycle easier to test and reason about. 

### Description

- Add `PeripheralConfigurationLoader` in `src/heart/peripheral/configuration_loader.py` to handle registry lookup and caching of `PeripheralConfiguration` instances. 
- Update `PeripheralManager` in `src/heart/peripheral/core/manager.py` to delegate configuration loading to the new `PeripheralConfigurationLoader` and simplify detection logic. 
- Add a research note documenting the change at `docs/research/peripheral-configuration-loader.md`. 
- Run repository formatting with `make format` to ensure style consistency. 

### Testing

- Ran the full test suite with `make test`, which completed successfully with `174 passed, 1 skipped`.
- Formatting checks were run with `make format` and completed without issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c0b60b79483219bd166dbe4d723c4)