### PR TITLE
Replace renderer prints with shared logging

### DIFF
--- a/src/heart/display/shaders/shader.py
+++ b/src/heart/display/shaders/shader.py
@@ -5,6 +5,9 @@ from OpenGL.GL import *
 
 from heart.display.shaders.template import __file__ as template_location
 from heart.display.shaders.util import _UNIFORMS, to_vec3
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class Shader:
@@ -70,11 +73,11 @@ class Shader:
         program = glCreateProgram()
 
         if vertex_source:
-            print("Compiling Vertex Shader...")
+            logger.info("Compiling Vertex Shader...")
             vertex_shader = self.compile_shader(vertex_source, GL_VERTEX_SHADER)
             glAttachShader(program, vertex_shader)
         if fragment_source:
-            print("Compiling Fragment Shader...")
+            logger.info("Compiling Fragment Shader...")
             fragment_shader = self.compile_shader(fragment_source, GL_FRAGMENT_SHADER)
             glAttachShader(program, fragment_shader)
 
@@ -93,4 +96,7 @@ class Shader:
         glGetShaderiv(shader, GL_INFO_LOG_LENGTH, byref(length))
 
         if length.value > 0:
-            print(glGetShaderInfoLog(shader))
+            info_log = glGetShaderInfoLog(shader)
+            if isinstance(info_log, bytes):
+                info_log = info_log.decode("utf-8", errors="replace")
+            logger.error("Shader compile log: %s", info_log)

--- a/src/heart/renderers/mandelbrot/scene.py
+++ b/src/heart/renderers/mandelbrot/scene.py
@@ -22,8 +22,10 @@ from heart.renderers.mandelbrot.control_mappings import (BitDoLite2Controls,
 from heart.renderers.mandelbrot.controls import SceneControls
 from heart.renderers.mandelbrot.state import AppState, ViewMode
 from heart.runtime.game_loop import DeviceDisplayMode
+from heart.utilities.logging import get_logger
 
 ColorPalette = list[tuple[int, int, int]]
+logger = get_logger(__name__)
 
 
 class MandelbrotMode(StatefulBaseRenderer[AppState]):
@@ -154,7 +156,7 @@ class MandelbrotMode(StatefulBaseRenderer[AppState]):
                     self.state.set_mode_auto()
             self.input_error = not gamepad_connected
         except Exception as e:
-            print(f"Error processing input: {e}. Resetting.")
+            logger.exception("Error processing input; resetting. %s", e)
             if not self.input_error:
                 self.reset()
                 self.state.set_mode_auto()
@@ -655,28 +657,29 @@ def main():
         if profiling:
             # === Profiling Teardown and Analysis ===
             profiler.disable()  # Stop profiling
-            print(f"Profiling finished after {frame_count} frames.")
+            logger.info("Profiling finished after %s frames.", frame_count)
 
             # --- Option 1: Print stats to console ---
             s = io.StringIO()
             # Sort by cumulative time spent in function and its callees
             ps = pstats.Stats(profiler, stream=s).sort_stats("cumulative")
             ps.print_stats(30)  # Print top 30 lines
-            print("\n--- Profiling Stats (Sorted by Cumulative Time) ---")
-            print(s.getvalue())
+            logger.info("--- Profiling Stats (Sorted by Cumulative Time) ---")
+            logger.info("%s", s.getvalue())
 
             # You might also want to sort by 'tottime' (total time spent ONLY in the function itself)
             s = io.StringIO()
             ps = pstats.Stats(profiler, stream=s).sort_stats("tottime")
             ps.print_stats(30)  # Print top 30 lines
-            print("\n--- Profiling Stats (Sorted by Total Time) ---")
-            print(s.getvalue())
+            logger.info("--- Profiling Stats (Sorted by Total Time) ---")
+            logger.info("%s", s.getvalue())
 
             # --- Option 2: Save stats to a file for later analysis ---
             profiler.dump_stats(profile_filename)
-            print(f"\nProfiling data saved to {profile_filename}")
-            print(
-                "You can analyze this file later, e.g., using 'snakeviz {profile_filename}'"
+            logger.info("Profiling data saved to %s", profile_filename)
+            logger.info(
+                "You can analyze this file later, e.g., using 'snakeviz %s'",
+                profile_filename,
             )
 
     # Clean up

--- a/src/heart/renderers/max_bpm_screen/renderer.py
+++ b/src/heart/renderers/max_bpm_screen/renderer.py
@@ -13,6 +13,9 @@ from heart.renderers.flame import FlameRenderer
 from heart.renderers.max_bpm_screen.provider import (AVATAR_MAPPINGS,
                                                      AvatarBpmStateProvider)
 from heart.renderers.max_bpm_screen.state import AvatarBpmRendererState
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class MaxBpmScreen(ComposedRenderer):
@@ -36,7 +39,7 @@ class AvatarBpmRenderer(StatefulBaseRenderer[AvatarBpmRendererState]):
             try:
                 self.avatar_images[name] = Loader.load(f"avatars/{name}_32.png")
             except Exception:
-                print(f"Could not load avatar for {name}")
+                logger.warning("Could not load avatar for %s", name)
 
         self.image = self.avatar_images.get("seb")
 

--- a/src/heart/renderers/three_fractal/renderer.py
+++ b/src/heart/renderers/three_fractal/renderer.py
@@ -20,9 +20,12 @@ from heart.peripheral.gamepad.peripheral_mappings import (BitDoLite2,
 from heart.renderers import StatefulBaseRenderer
 from heart.renderers.three_fractal.state import FractalSceneState
 from heart.utilities.env import Configuration
+from heart.utilities.logging import get_logger
 
 if TYPE_CHECKING:
     from heart.renderers.three_fractal.provider import FractalSceneProvider
+
+logger = get_logger(__name__)
 
 
 @dataclass
@@ -108,7 +111,7 @@ class FractalRuntime(StatefulBaseRenderer[FractalRuntimeState]):
 
         self.shader = Shader()
         self.program = self.shader.create()
-        print("Compiled shader!")
+        logger.info("Compiled shader.")
 
         # Get uniform locations
         self.matID = glGetUniformLocation(self.program, "iMat")
@@ -155,11 +158,23 @@ class FractalRuntime(StatefulBaseRenderer[FractalRuntimeState]):
         orientation: Orientation,
     ) -> FractalRuntimeState:
         """Initialize the fractal renderer with the given window size."""
-        print(f"OpenGL Version: {glGetString(GL_VERSION).decode('utf-8')}")
-        print(f"OpenGL Vendor: {glGetString(GL_VENDOR).decode('utf-8')}")
-        print(f"OpenGL Renderer: {glGetString(GL_RENDERER).decode('utf-8')}")
-        print(
-            f"OpenGL Shading Language Version: {glGetString(GL_SHADING_LANGUAGE_VERSION).decode('utf-8')}"
+        logger.info(
+            "OpenGL Version: %s",
+            glGetString(GL_VERSION).decode("utf-8", errors="replace"),
+        )
+        logger.info(
+            "OpenGL Vendor: %s",
+            glGetString(GL_VENDOR).decode("utf-8", errors="replace"),
+        )
+        logger.info(
+            "OpenGL Renderer: %s",
+            glGetString(GL_RENDERER).decode("utf-8", errors="replace"),
+        )
+        logger.info(
+            "OpenGL Shading Language Version: %s",
+            glGetString(GL_SHADING_LANGUAGE_VERSION).decode(
+                "utf-8", errors="replace"
+            ),
         )
 
         self.time_initialized = time.time()
@@ -246,7 +261,7 @@ class FractalRuntime(StatefulBaseRenderer[FractalRuntimeState]):
                     else:
                         glUniform3fv(key_id, 1, val)
                 except Exception as e:
-                    print(f"Error setting uniform {key}: {e}")
+                    logger.exception("Error setting uniform %s: %s", key, e)
 
             # Clear pending uniforms after applying
             self.shader.pending_uniforms = {}
@@ -663,7 +678,7 @@ class FractalRuntime(StatefulBaseRenderer[FractalRuntimeState]):
         except Exception as e:
             # TODO: Very occasionally this raises an exception for some reason, no idea why
             self.active_radius = self.BASE_RADIUS
-            print(f"error but why: {e}")
+            logger.exception("Failed to update active radius: %s", e)
 
         if not self.tiled_mode:
             # eagerly apply the uniforms

--- a/src/heart/renderers/yolisten/renderer.py
+++ b/src/heart/renderers/yolisten/renderer.py
@@ -1,4 +1,3 @@
-import logging
 import threading
 import time
 
@@ -13,9 +12,10 @@ from heart.peripheral.core.manager import PeripheralManager
 from heart.renderers import StatefulBaseRenderer
 from heart.renderers.yolisten.provider import YoListenStateProvider
 from heart.renderers.yolisten.state import YoListenState
+from heart.utilities.logging import get_logger
 
 PHYPOX_URL = "http://192.168.1.50/get?accY&accX&accZ&dB"
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class YoListenRenderer(StatefulBaseRenderer[YoListenState]):
@@ -258,7 +258,7 @@ def poll_phyphox():
             x = data["buffer"]["acceleration"]["x"][-1]
             y = data["buffer"]["acceleration"]["y"][-1]
             z = data["buffer"]["acceleration"]["z"][-1]
-            print(f"x={x}, y={y}, z={z}")
+            logger.info("Phyphox acceleration x=%s, y=%s, z=%s", x, y, z)
         except Exception as exc:
             logger.error("Error: %s", exc)
         time.sleep(0.1)


### PR DESCRIPTION
### Motivation
- Remove ad-hoc `print()` diagnostics in renderers and shaders to comply with repository logging guidance and improve runtime observability.
- Standardize diagnostic output so logs can be routed to the configured stream and rotating file handlers.

### Description
- Replaced `print()` calls with the shared logger created via `get_logger` in `src/heart/display/shaders/shader.py` and multiple renderers (`three_fractal`, `mandelbrot`, `yolisten`, `max_bpm_screen`) and provider (`mario`).
- Enhanced shader compile logging by decoding byte logs and emitting them with `logger.error` in `print_log`.
- Converted ad-hoc error prints to structured `logger.exception` / `logger.error` / `logger.info` calls and added `logger = get_logger(__name__)` where needed.
- Minor formatting and signature tidy-up in `src/heart/renderers/mario/provider.py` to match repository style rules.

### Testing
- Ran formatting via `make format` and formatting checks passed.
- Ran the test suite with `make test` and the automated tests completed with `177 passed, 1 skipped`.
- No new unit tests were added for logging changes and existing tests were not modified.
- The codebase lint/format and test suite were used as the authoritative validation steps and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c0d4e1f6883218e5717dc8c866906)