### PR TITLE
Guard sensor bus diagnostics behind DEBUG

### DIFF
--- a/drivers/sensor_bus/code.py
+++ b/drivers/sensor_bus/code.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import time
 
 import board
@@ -10,9 +9,13 @@ from adafruit_lsm303_accel import LSM303_Accel
 
 from heart.firmware_io import constants, identity
 
-logger = logging.getLogger(__name__)
-
 WAIT_BEFORE_TRYING_TO_CONNECT_TO_SENSOR_SECONDS: float = 1.0
+DEBUG = False
+
+
+def _debug(message: str) -> None:
+    if DEBUG:
+        print(message)
 
 IDENTITY = identity.Identity(
     device_name="sensor-bus",
@@ -104,7 +107,7 @@ def connect_to_sensors(i2c):
         try:
             sensors.append(sensor_fn(i2c))
         except Exception as exc:  # noqa: BLE001
-            logger.debug("Failed to initialize sensor %s: %s", sensor_fn.__name__, exc)
+            _debug(f"Failed to initialize sensor {sensor_fn.__name__}: {exc}")
     return sensors
 
 


### PR DESCRIPTION
### Motivation

- Align the sensor bus driver with the drivers AGENTS.md guidance to keep CircuitPython diagnostics opt-in and CircuitPython-friendly. 
- Remove reliance on the `logging` module in a module intended to run on constrained CircuitPython environments that may not ship standard logging frameworks. 

### Description

- Updated `drivers/sensor_bus/code.py` to remove the `logging` import and `logger` usage and added a module-level `DEBUG` flag. 
- Added a guarded print helper function `_debug` and replaced the `logger.debug` call with `_debug(...)` so diagnostics are emitted only when `DEBUG` is `True`. 
- Kept behavior of sensor initialization and the rest of the module unchanged beyond the diagnostics change. 

### Testing

- Ran `make format` and the formatter/lint checks completed successfully. 
- Ran `make test` and the full test suite completed with all tests passing: `180 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c2f3c74ec83219bef1b5af8378d65)