### PR TITLE
Use pathlib for asset path construction

### DIFF
--- a/src/heart/assets/loader.py
+++ b/src/heart/assets/loader.py
@@ -22,24 +22,24 @@ class Loader:
 
     @classmethod
     @cache
-    def load(cls, path: str):
+    def load(cls, path: str | os.PathLike[str]):
         return pygame.image.load(cls._resolve_path(path))
 
     @classmethod
-    def load_spirtesheet(cls, path):
+    def load_spirtesheet(cls, path: str | os.PathLike[str]):
         resolved_path = cls._resolve_path(path)
         return spritesheet(resolved_path)
 
     @classmethod
-    def load_animation(cls, path):
+    def load_animation(cls, path: str | os.PathLike[str]):
         return Animation(cls._resolve_path(path), 100)
 
     @classmethod
-    def load_font(cls, path, font_size: int = 10):
+    def load_font(cls, path: str | os.PathLike[str], font_size: int = 10):
         return pygame.font.Font(cls._resolve_path(path), size=font_size)
 
     @classmethod
-    def load_json(cls, path) -> dict[str, Any]:
+    def load_json(cls, path: str | os.PathLike[str]) -> dict[str, Any]:
         resolved_path = cls._resolve_path(path)
         with open(resolved_path, "r") as fp:
             return json.load(fp)

--- a/src/heart/renderers/artist/state.py
+++ b/src/heart/renderers/artist/state.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from pathlib import Path
 
 from heart.renderers import StatefulBaseRenderer
 from heart.renderers.sliding_image import SlidingImage
@@ -22,10 +23,12 @@ class ArtistState:
             "john_summit_neon",
             "troyboi_glitch_cartwheel",
         ]:
+            sheet_path = Path("artist") / f"{artist}.png"
+            metadata_path = Path("artist") / f"{artist}.json"
             scenes.append(
                 SpritesheetLoop(
-                    sheet_file_path=f"artist/{artist}.png",
-                    metadata_file_path=f"artist/{artist}.json",
+                    sheet_file_path=str(sheet_path),
+                    metadata_file_path=str(metadata_path),
                     boomerang=(artist != "troyboi_glitch_cartwheel"),
                 )
             )
@@ -33,9 +36,10 @@ class ArtistState:
         for artist in [
             "jamie_xx_in_color",
         ]:
+            sheet_path = Path("artist") / f"{artist}.png"
             scenes.append(
                 SpritesheetLoop.from_frame_data(
-                    sheet_file_path=f"artist/{artist}.png",
+                    sheet_file_path=str(sheet_path),
                     duration=75,
                     boomerang=False,
                     skip_last_frame=True,
@@ -44,7 +48,7 @@ class ArtistState:
 
         scenes.append(
             SlidingImage(
-                image_file="artist/virji_spritesheet.png",
+                image_file=str(Path("artist") / "virji_spritesheet.png"),
                 speed=1,
             )
         )

--- a/src/heart/renderers/max_bpm_screen/renderer.py
+++ b/src/heart/renderers/max_bpm_screen/renderer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import reactivex
 from pygame import Surface, font, time
 
@@ -36,8 +38,9 @@ class AvatarBpmRenderer(StatefulBaseRenderer[AvatarBpmRendererState]):
 
         self.avatar_images = {}
         for name in AVATAR_MAPPINGS.keys():
+            avatar_path = Path("avatars") / f"{name}_32.png"
             try:
-                self.avatar_images[name] = Loader.load(f"avatars/{name}_32.png")
+                self.avatar_images[name] = Loader.load(avatar_path)
             except Exception:
                 logger.warning("Could not load avatar for %s", name)
 

--- a/src/heart/renderers/metadata_screen/renderer.py
+++ b/src/heart/renderers/metadata_screen/renderer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Dict, Iterable
 
 import reactivex
@@ -30,10 +31,11 @@ class MetadataScreen(StatefulBaseRenderer[MetadataScreenState]):
 
         self.heart_images: Dict[str, dict[str, Surface]] = {}
         for color in self.colors:
+            heart_base = Path("hearts") / color
             self.heart_images[color] = {
-                "small": Loader.load(f"hearts/{color}/small.png"),
-                "med": Loader.load(f"hearts/{color}/med.png"),
-                "big": Loader.load(f"hearts/{color}/big.png"),
+                "small": Loader.load(heart_base / "small.png"),
+                "med": Loader.load(heart_base / "med.png"),
+                "big": Loader.load(heart_base / "big.png"),
             }
 
         self.avatar_images: Dict[str, Surface] = {}
@@ -41,7 +43,9 @@ class MetadataScreen(StatefulBaseRenderer[MetadataScreenState]):
 
         for name, sensor_id in AVATAR_MAPPINGS.items():
             try:
-                self.avatar_images[sensor_id] = Loader.load(f"avatars/{name}_16.png")
+                self.avatar_images[sensor_id] = Loader.load(
+                    Path("avatars") / f"{name}_16.png"
+                )
             except Exception:
                 logger.warning(f"Could not load avatar for {name}")
 


### PR DESCRIPTION
### Motivation

- Align asset path construction with repository guidance to prefer `pathlib.Path` over string concatenation when building filesystem paths.
- Reduce fragile f-string path usage and ensure functions annotated to accept `Path`-like resources handle `os.PathLike` inputs.

### Description

- Replace formatted asset path strings with `pathlib.Path` construction in `src/heart/renderers/artist/state.py`, `src/heart/renderers/max_bpm_screen/renderer.py`, and `src/heart/renderers/metadata_screen/renderer.py` so assets are built via `Path` objects.
- Update `Loader` signatures in `src/heart/assets/loader.py` to accept `str | os.PathLike[str]` for `load`, `load_spirtesheet`, `load_animation`, `load_font`, and `load_json` and keep internal resolution logic in `resolve_path`/`_resolve_path`.
- Use `Loader.load` with `Path` instances where assets are loaded (avatars and hearts) and convert artist asset paths to `str` where required by existing APIs.

### Testing

- Ran `make format` and formatting checks completed successfully.
- Ran the test suite with `make test` and observed `185 passed, 1 skipped` in ~25.5s.
- Confirmed no new lint/format violations were introduced by the changes.
- Verified updated type hints and `Path` usage do not break asset loading in unit tests that exercise spritesheet and avatar loading.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c3e7a029c8321bc7189a952e37a88)