### PR TITLE
Split heart.utilities.env into config, enums, and ports submodules

### DIFF
--- a/docs/research/env_module_restructure.md
+++ b/docs/research/env_module_restructure.md
@@ -1,0 +1,16 @@
+# Environment configuration module restructure
+
+## Summary
+
+The environment configuration helpers previously lived in a single module. They are now split into focused submodules to keep configuration parsing, enum definitions, and device port discovery separate while preserving the `heart.utilities.env` import path.
+
+## Source references
+
+- `src/heart/utilities/env/config.py`
+- `src/heart/utilities/env/enums.py`
+- `src/heart/utilities/env/ports.py`
+- `src/heart/utilities/env/__init__.py`
+
+## Materials
+
+- None

--- a/src/heart/utilities/README.md
+++ b/src/heart/utilities/README.md
@@ -1,1 +1,1 @@
-Shared helpers used across the project. Modules here handle environment configuration, logging control, filesystem paths, and signal handling.
+Shared helpers used across the project. Modules here handle environment configuration (split across the env package), logging control, filesystem paths, and signal handling.

--- a/src/heart/utilities/env/__init__.py
+++ b/src/heart/utilities/env/__init__.py
@@ -1,0 +1,19 @@
+"""Environment configuration helpers."""
+
+from heart.utilities.env.config import Configuration as Configuration
+from heart.utilities.env.config import Pi as Pi
+from heart.utilities.env.enums import DeviceLayoutMode as DeviceLayoutMode
+from heart.utilities.env.enums import FrameArrayStrategy as FrameArrayStrategy
+from heart.utilities.env.enums import LifeUpdateStrategy as LifeUpdateStrategy
+from heart.utilities.env.enums import \
+    ReactivexEventBusScheduler as ReactivexEventBusScheduler
+from heart.utilities.env.enums import \
+    ReactivexStreamConnectMode as ReactivexStreamConnectMode
+from heart.utilities.env.enums import \
+    ReactivexStreamShareStrategy as ReactivexStreamShareStrategy
+from heart.utilities.env.enums import \
+    RenderMergeStrategy as RenderMergeStrategy
+from heart.utilities.env.enums import RenderTileStrategy as RenderTileStrategy
+from heart.utilities.env.enums import \
+    SpritesheetFrameCacheStrategy as SpritesheetFrameCacheStrategy
+from heart.utilities.env.ports import get_device_ports as get_device_ports

--- a/src/heart/utilities/env/enums.py
+++ b/src/heart/utilities/env/enums.py
@@ -1,0 +1,53 @@
+from enum import StrEnum
+
+
+class RenderTileStrategy(StrEnum):
+    BLITS = "blits"
+    LOOP = "loop"
+
+
+class RenderMergeStrategy(StrEnum):
+    IN_PLACE = "in_place"
+    BATCHED = "batched"
+
+
+class FrameArrayStrategy(StrEnum):
+    COPY = "copy"
+    VIEW = "view"
+
+
+class SpritesheetFrameCacheStrategy(StrEnum):
+    NONE = "none"
+    FRAMES = "frames"
+    SCALED = "scaled"
+
+
+class LifeUpdateStrategy(StrEnum):
+    AUTO = "auto"
+    CONVOLVE = "convolve"
+    PAD = "pad"
+
+
+class DeviceLayoutMode(StrEnum):
+    CUBE = "cube"
+    RECTANGLE = "rectangle"
+
+
+class ReactivexEventBusScheduler(StrEnum):
+    INLINE = "inline"
+    BACKGROUND = "background"
+    INPUT = "input"
+
+
+class ReactivexStreamShareStrategy(StrEnum):
+    SHARE = "share"
+    SHARE_AUTO_CONNECT = "share_auto_connect"
+    REPLAY_LATEST = "replay_latest"
+    REPLAY_LATEST_AUTO_CONNECT = "replay_latest_auto_connect"
+    REPLAY_BUFFER = "replay_buffer"
+    REPLAY_BUFFER_AUTO_CONNECT = "replay_buffer_auto_connect"
+
+
+class ReactivexStreamConnectMode(StrEnum):
+    LAZY = "lazy"
+    EAGER = "eager"

--- a/src/heart/utilities/env/ports.py
+++ b/src/heart/utilities/env/ports.py
@@ -1,0 +1,42 @@
+import platform
+from pathlib import Path
+from typing import Iterator
+
+import serial.tools.list_ports
+
+
+def get_device_ports(prefix: str) -> Iterator[str]:
+    base_port = Path("/dev/serial/by-id")
+
+    directory_matches = tuple(_iter_directory_ports(base_port, prefix))
+    if directory_matches:
+        yield from directory_matches
+        return
+
+    # Fallback for macOS and other platforms
+    if platform.system() == "Darwin":  # macOS
+        yield from _iter_serial_ports(prefix)
+
+
+def _iter_directory_ports(base_port: Path, prefix: str) -> Iterator[str]:
+    """Yield ports in ``base_port`` whose names begin with ``prefix``."""
+
+    try:
+        if not base_port.exists():
+            return
+        for entry in base_port.iterdir():
+            if entry.name.startswith(prefix):
+                yield str(entry)
+    except (FileNotFoundError, PermissionError):
+        return
+
+
+def _iter_serial_ports(prefix: str) -> Iterator[str]:
+    """Yield serial devices whose metadata contains ``prefix``."""
+
+    lower_prefix = prefix.lower()
+    for port in serial.tools.list_ports.comports():
+        port_name = Path(port.device).name
+        description = getattr(port, "description", "")
+        if lower_prefix in description.lower() or lower_prefix in port_name.lower():
+            yield port.device

--- a/tests/utilities/test_env.py
+++ b/tests/utilities/test_env.py
@@ -262,9 +262,9 @@ class TestUtilitiesEnv:
         monkeypatch.setenv("ISOLATED_RENDER_HOST", "")  # ensure unrelated env noise is absent
         monkeypatch.setenv("ISOLATED_RENDER_PORT", "")
 
-        monkeypatch.setattr("heart.utilities.env.Path.exists", lambda self: True)
+        monkeypatch.setattr("heart.utilities.env.ports.Path.exists", lambda self: True)
         monkeypatch.setattr(
-            "heart.utilities.env.Path.iterdir",
+            "heart.utilities.env.ports.Path.iterdir",
             lambda self: iter(fake_entries),
         )
 
@@ -285,14 +285,14 @@ class TestUtilitiesEnv:
                 ]
             )
 
-        monkeypatch.setattr("heart.utilities.env.Path.exists", lambda self: True)
+        monkeypatch.setattr("heart.utilities.env.ports.Path.exists", lambda self: True)
         monkeypatch.setattr(
-            "heart.utilities.env.Path.iterdir",
+            "heart.utilities.env.ports.Path.iterdir",
             lambda self: iter([Path("/dev/serial/by-id/other-device")]),
         )
-        monkeypatch.setattr("heart.utilities.env.platform.system", lambda: "Darwin")
+        monkeypatch.setattr("heart.utilities.env.ports.platform.system", lambda: "Darwin")
         monkeypatch.setattr(
-            "heart.utilities.env.serial.tools.list_ports.comports",
+            "heart.utilities.env.ports.serial.tools.list_ports.comports",
             fake_comports,
         )
 
@@ -311,11 +311,11 @@ class TestUtilitiesEnv:
                 ]
             )
 
-        monkeypatch.setattr("heart.utilities.env.Path.exists", lambda self: False)
+        monkeypatch.setattr("heart.utilities.env.ports.Path.exists", lambda self: False)
 
-        monkeypatch.setattr("heart.utilities.env.platform.system", lambda: "Darwin")
+        monkeypatch.setattr("heart.utilities.env.ports.platform.system", lambda: "Darwin")
         monkeypatch.setattr(
-            "heart.utilities.env.serial.tools.list_ports.comports",
+            "heart.utilities.env.ports.serial.tools.list_ports.comports",
             fake_comports,
         )
 


### PR DESCRIPTION
### Motivation
- Improve clarity and separation of concerns by splitting a large `heart.utilities.env` module into focused pieces for configuration parsing, enum definitions, and device port discovery.
- Make the environment helpers easier to maintain and reason about by grouping related responsibilities into `config`, `enums`, and `ports` modules.
- Preserve the existing import surface so callers can continue using `from heart.utilities.env import ...` without changes.

### Description
- Move the original `src/heart/utilities/env.py` into `src/heart/utilities/env/config.py` and extract enum types to `src/heart/utilities/env/enums.py` and device-port helpers to `src/heart/utilities/env/ports.py`.
- Add `src/heart/utilities/env/__init__.py` that re-exports `Configuration`, `Pi`, enums, and `get_device_ports` to preserve the original import path.
- Update `tests/utilities/test_env.py` and other references to import from the new `env` package submodules, and update `src/heart/utilities/README.md` to note the package split.
- Add a short research note at `docs/research/env_module_restructure.md` documenting the refactor.

### Testing
- Ran `make format` to apply lint/format tooling and confirmed formatting checks passed.
- Ran `make test` which executed the full Pytest suite.
- Test results: `184 passed, 1 failed, 1 skipped` (see failing test below).
- Failing test: `tests/utilities/test_reactivex_streams.py::TestShareStreamFlowControl::test_share_stream_coalesces_latest_when_configured` failed due to an assertion mismatch expecting `[2, 3]` but receiving `[2]`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c3e6d4ccc8321a346154726da1b45)