### PR TITLE
Refactor CLI command structure

### DIFF
--- a/docs/cli_structure.md
+++ b/docs/cli_structure.md
@@ -1,0 +1,16 @@
+# CLI structure
+
+## Technical problem
+
+The CLI entrypoint previously mixed Typer wiring with command implementations, which made the
+module harder to scan and reason about when adding new commands.
+
+## Restructured layout
+
+- `src/heart/loop.py` now focuses on Typer app setup and command registration.
+- `src/heart/cli/loop_commands.py` contains the implementations for `run`, `update-driver`, and
+  `bench-device`.
+
+## Materials
+
+- None.

--- a/src/heart/cli/__init__.py
+++ b/src/heart/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI entrypoints and command implementations."""

--- a/src/heart/cli/loop_commands.py
+++ b/src/heart/cli/loop_commands.py
@@ -1,0 +1,64 @@
+from typing import Annotated
+
+import typer
+from PIL import Image
+
+from heart.device.selection import select_device
+from heart.manage.update import main as update_driver_main
+from heart.peripheral.core.providers import container
+from heart.programs.registry import ConfigurationRegistry
+from heart.runtime.game_loop import GameLoop
+from heart.runtime.render_pipeline import RendererVariant
+from heart.utilities.env import Configuration
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def run_command(
+    configuration: Annotated[str, typer.Option("--configuration")] = "lib_2025",
+    add_low_power_mode: bool = typer.Option(
+        True, "--add-low-power-mode", help="Add a low power mode"
+    ),
+    x11_forward: bool = typer.Option(
+        False, "--x11-forward", help="Use X11 forwarding for RGB display"
+    ),
+) -> None:
+    registry = ConfigurationRegistry()
+    configuration_fn = registry.get(configuration)
+    if configuration_fn is None:
+        raise Exception(f"Configuration '{configuration}' not found in registry")
+    render_variant = RendererVariant.parse(Configuration.render_variant())
+    loop = GameLoop(
+        device=select_device(x11_forward=x11_forward),
+        resolver=container,
+        render_variant=render_variant,
+    )
+    configuration_fn(loop)
+
+    ## ============================= ##
+    ## ADD ALL MODES ABOVE THIS LINE ##
+    ## ============================= ##
+    # Retain an empty loop for "lower power" mode
+    if add_low_power_mode:
+        loop.app_controller.add_sleep_mode()
+    loop.start()
+
+
+def update_driver_command(name: Annotated[str, typer.Option("--name")]) -> None:
+    update_driver_main(device_driver_name=name)
+
+
+def bench_device_command() -> None:
+    device = select_device(x11_forward=False)
+
+    size = device.full_display_size()
+    logger.info("Device full display size: %s", size)
+
+    image = Image.new("RGB", size)
+    while True:
+        for i in range(256):
+            for j in range(256):
+                for k in range(256):
+                    image.putdata([(i, j, k)] * (size[0] * size[1]))
+                    device.set_image(image)

--- a/src/heart/loop.py
+++ b/src/heart/loop.py
@@ -2,78 +2,16 @@ import os
 
 os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "1"
 
-from typing import Annotated
-
 import typer
-from PIL import Image
 
-from heart.device.selection import select_device
-from heart.manage.update import main as update_driver_main
-from heart.peripheral.core.providers import container
-from heart.programs.registry import ConfigurationRegistry
-from heart.runtime.game_loop import GameLoop
-from heart.runtime.render_pipeline import RendererVariant
-from heart.utilities.env import Configuration
-from heart.utilities.logging import get_logger
-
-logger = get_logger(__name__)
+from heart.cli.loop_commands import (bench_device_command, run_command,
+                                     update_driver_command)
 
 app = typer.Typer()
 
-
-@app.command()
-def run(
-    configuration: Annotated[str, typer.Option("--configuration")] = "lib_2025",
-    add_low_power_mode: bool = typer.Option(
-        True, "--add-low-power-mode", help="Add a low power mode"
-    ),
-    x11_forward: bool = typer.Option(
-        False, "--x11-forward", help="Use X11 forwarding for RGB display"
-    ),
-) -> None:
-    registry = ConfigurationRegistry()
-    configuration_fn = registry.get(configuration)
-    if configuration_fn is None:
-        raise Exception(f"Configuration '{configuration}' not found in registry")
-    render_variant = RendererVariant.parse(Configuration.render_variant())
-    loop = GameLoop(
-        device=select_device(x11_forward=x11_forward),
-        resolver=container,
-        render_variant=render_variant,
-    )
-    configuration_fn(loop)
-
-    ## ============================= ##
-    ## ADD ALL MODES ABOVE THIS LINE ##
-    ## ============================= ##
-    # Retain an empty loop for "lower power" mode
-    if add_low_power_mode:
-        loop.app_controller.add_sleep_mode()
-    loop.start()
-
-
-
-@app.command()
-def update_driver(name: Annotated[str, typer.Option("--name")]) -> None:
-    update_driver_main(device_driver_name=name)
-
-
-@app.command(
-    name="bench-device",
-)
-def bench_device() -> None:
-    d = select_device(x11_forward=False)
-
-    size = d.full_display_size()
-    logger.info("Device full display size: %s", size)
-
-    image = Image.new("RGB", size)
-    while True:
-        for i in range(256):
-            for j in range(256):
-                for k in range(256):
-                    image.putdata([(i, j, k)] * (size[0] * size[1]))
-                    d.set_image(image)
+app.command()(run_command)
+app.command()(update_driver_command)
+app.command(name="bench-device")(bench_device_command)
 
 
 def main() -> None:


### PR DESCRIPTION
### Motivation

- Separate Typer wiring from command implementations to make the CLI easier to read and extend.
- Reduce cognitive load in the top-level entrypoint by moving behavior into a focused module.
- Improve maintainability and align the repository with the guideline to keep files narrowly scoped.

### Description

- Extract command implementations into `src/heart/cli/loop_commands.py` and add `src/heart/cli/__init__.py` as the CLI package.
- Simplify `src/heart/loop.py` so it only sets up the `typer` app and registers commands from `heart.cli.loop_commands`.
- Add `docs/cli_structure.md` documenting the new CLI layout and rationale.
- Apply repository formatting fixes via `make format` as part of the change.

### Testing

- Ran `make format` and automatic formatting checks completed successfully.
- Ran `make test` and the full test suite completed with `185 passed, 1 skipped`.
- No new unit tests were added or modified for this refactor.
- All automated tests passed after the refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c40d4b0408321831b94858b1a12e8)