### PR TITLE
Replace netlist print with logger.info

### DIFF
--- a/experimental/circuit/main.py
+++ b/experimental/circuit/main.py
@@ -305,7 +305,7 @@ class Hub75DriverBoard:
         self.assemble()
         ERC()
         generate_netlist(tool=KICAD8)
-        print("Netlist written as hub75_fpga_driver.net")
+        logger.info("Netlist written as hub75_fpga_driver.net")
 
 
 class FPGAPinAllocator:


### PR DESCRIPTION
### Motivation

- The AGENTS.md guidance forbids using `print` for runtime diagnostics and directs code to use the shared logger. 
- The circuit board builder emitted a completion message with `print`, which diverged from repository logging policy. 
- Keep diagnostics consistent with the repository's logging approach and make runtime output easier to control. 

### Description

- Replace the `print("Netlist written as hub75_fpga_driver.net")` call with `logger.info("Netlist written as hub75_fpga_driver.net")` in `experimental/circuit/main.py` within `Hub75DriverBoard.build`.
- Run repository formatting to apply style tools via `make format` after the change. 
- Commit the change so the build script now uses the shared logger for diagnostics. 

### Testing

- Ran `make format` and it completed successfully. 
- Executed a repository test-docstring check which reported `violations 0` for test functions and classes. 
- No unit test suite (`make test`) was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c4231c3588321af4dcde09bb8eb26)