### PR TITLE
Cancel pending refcount grace disconnect timer

### DIFF
--- a/src/heart/utilities/reactivex_streams.py
+++ b/src/heart/utilities/reactivex_streams.py
@@ -111,6 +111,9 @@ def _share_with_refcount_grace(
                     grace_ms,
                     min_subscribers,
                 )
+                if disconnect_timer is not None:
+                    disconnect_timer.dispose()
+                    disconnect_timer = None
                 disconnect_timer = _GRACE_SCHEDULER.schedule_relative(
                     grace_ms / 1000,
                     lambda *_: _disconnect(),


### PR DESCRIPTION
### Motivation
- When `min_subscribers > 1` and `grace_ms > 0`, multiple calls to `_dispose` could schedule overlapping disconnect timers and leave older timers to fire and disconnect an active `connection`.
- The change prevents stale timers from disposing active connections during subscriber churn and avoids dropping events for active subscribers.

### Description
- In `_share_with_refcount_grace`'s `_dispose`, cancel any existing `disconnect_timer` by calling `disconnect_timer.dispose()` and clearing it before scheduling a new one.
- The change is implemented in `src/heart/utilities/reactivex_streams.py` to ensure only the most recent grace timer remains pending.

### Testing
- Ran `make format` which completed successfully.
- Ran `make test` and the test suite passed with `187 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c42fb106883219a5bc8d74b34c535)