### PR TITLE
Import importlib.util in color conversion utilities

### DIFF
--- a/src/heart/utilities/color_conversion.py
+++ b/src/heart/utilities/color_conversion.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import importlib.util
 from collections import OrderedDict
 from types import ModuleType
 from typing import cast


### PR DESCRIPTION
### Motivation
- `importlib.util` is a submodule and is not available via `importlib` alone in a fresh interpreter, which can raise `AttributeError` when calling `find_spec` or `module_from_spec`.
- That `AttributeError` can cause the renderer import path to fail early (preventing fallback to `LocalScreen`) when `cv2` is probed dynamically.
- The change makes dynamic `cv2` loading in the color conversion utilities more robust across environments.

### Description
- Add an explicit `import importlib.util` to `src/heart/utilities/color_conversion.py` so calls to `importlib.util.find_spec` and `importlib.util.module_from_spec` are safe.
- No other behavioral changes were made; the fix is a single-line import to ensure the submodule is loaded before use.

### Testing
- Ran `make format`, which failed due to unrelated mypy type errors in other modules (files: `src/heart/peripheral/drawing_pad.py`, `src/heart/device/selection.py`, and `src/heart/peripheral/switch.py`).
- Ran `make test`, which succeeded with `187 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c42dce378832186588039d84a7bcc)