### PR TITLE
Restore rotary encoder event output

### DIFF
--- a/drivers/rotary_encoder/code.py
+++ b/drivers/rotary_encoder/code.py
@@ -60,7 +60,7 @@ def main() -> None:  # pragma: no cover - exercised on hardware
     while True:
         respond_to_identify_query()
         for event in read_events(handler):
-            _debug(event)
+            print(event)
 
 
 if __name__ == "__main__":  # pragma: no cover - exercised on hardware


### PR DESCRIPTION
### Motivation
- The driver previously gated event emission behind a module-level `DEBUG` flag which prevented encoder events from reaching the serial REPL on CircuitPython devices.
- Hosts and serial monitors rely on `print(event)` from the script to observe encoder activity, so events must be emitted unconditionally.

### Description
- Changed the rotary encoder main loop to call `print(event)` for each event instead of `_debug(event)` in `drivers/rotary_encoder/code.py` so events are always emitted to stdout.
- Kept the `_debug()` helper and `DEBUG` flag in place so ancillary diagnostics can still be toggled without affecting event emission.

### Testing
- Ran `make test` which completed successfully with `187 passed, 1 skipped`.
- Ran `make format` which reported mypy/type-check errors (not caused by this change) in `src/heart/peripheral/drawing_pad.py`, `src/heart/device/selection.py`, and `src/heart/peripheral/switch.py` and therefore did not finish cleanly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c431c4dec83219125b2f7f5b25b8f)