### PR TITLE
Preserve totem CLI command names

### DIFF
--- a/src/heart/loop.py
+++ b/src/heart/loop.py
@@ -9,8 +9,8 @@ from heart.cli.loop_commands import (bench_device_command, run_command,
 
 app = typer.Typer()
 
-app.command()(run_command)
-app.command()(update_driver_command)
+app.command(name="run")(run_command)
+app.command(name="update-driver")(update_driver_command)
 app.command(name="bench-device")(bench_device_command)
 
 


### PR DESCRIPTION
### Motivation

- Typer derives command names from function names when no explicit `name=` is provided which changes `run_command`/`update_driver_command` to `run-command`/`update-driver-command` at runtime.
- Existing operator scripts and docs expect the `totem run` and `totem update-driver` entry points to remain stable.
- Changing the surfaced command names causes `No such command` failures for callers relying on the documented CLI contract.

### Description

- Register explicit Typer command names by changing `app.command()(run_command)` to `app.command(name="run")(run_command)` and `app.command()(update_driver_command)` to `app.command(name="update-driver")(update_driver_command)` in `src/heart/loop.py`.
- No behavioral changes to the underlying handlers were made, only the CLI registration names were fixed.

### Testing

- Ran `make format` to apply repository formatting rules and confirm no style regressions, which passed.
- Ran the test suite with `make test`, producing `187 passed, 1 skipped` and no failures.
- Verified the modified file is `src/heart/loop.py` and the new registrations preserve the documented `totem` subcommands.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c4331927c8321bb46ff2197cd86fd)