### PR TITLE
Replace print diagnostics with shared logger in debugging scripts

### DIFF
--- a/docs/debugging/read_switch.py
+++ b/docs/debugging/read_switch.py
@@ -1,5 +1,9 @@
 import serial
 
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
 ser = serial.Serial("/dev/ttyACM0", 115200)
 
 try:
@@ -8,8 +12,8 @@ try:
             # TODO (lampe): Handle button state too
             # Will likely switch this over to a JSON format + update the driver on the encoder
             data = ser.readline().decode("utf-8").rstrip()
-            print(data)
+            logger.info("%s", data)
 except KeyboardInterrupt:
-    print("Program terminated")
+    logger.info("Program terminated")
 finally:
     ser.close()


### PR DESCRIPTION
### Motivation

- The repository AGENTS.md instructs avoiding `print` for runtime diagnostics in CLI commands and peripheral modules, but some debugging helpers used `print` and diverged from this guideline.
- Standardizing on the shared logger ensures diagnostic output integrates with the project's logging control and is consistent across tools.

### Description

- Replaced `print` calls with a shared logger by adding `from heart.utilities.logging import get_logger` and `logger = get_logger(__name__)`.
- Updated `docs/debugging/check_ant_devices.py` to use `logger.info` and `logger.warning` and adjusted an exception variable name to `exc` with `# noqa: BLE001`.
- Updated `docs/debugging/read_switch.py` to log serial output and shutdown messages via `logger.info` instead of `print`.
- Applied repository formatting conventions by running `make format` before running tests.

### Testing

- Ran `make format` and it completed successfully.
- Ran `make test` and the test suite completed with all tests passing.
- Test summary: `187 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c43c303d48321bdcbd0836ce7b492)