### PR TITLE
Fix drawing pad input typing

### DIFF
--- a/src/heart/peripheral/drawing_pad.py
+++ b/src/heart/peripheral/drawing_pad.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import threading
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Any, Iterator, Mapping, Self
+from typing import Any, Iterator, Mapping, Self, cast
 
 import reactivex
 from reactivex import operators as ops
@@ -102,12 +102,16 @@ class DrawingPad(Peripheral[Any]):
         if event_bus is None:
             raise ValueError("event_bus is required to describe DrawingPad inputs")
         stroke_stream = event_bus.pipe(
-            ops.filter(lambda event: event.event_type == "drawing_pad.stroke"),
-            ops.map(lambda event: event.data),
+            ops.filter(
+                lambda event: cast(Input, event).event_type == "drawing_pad.stroke"
+            ),
+            ops.map(lambda event: cast(Input, event).data),
         )
         erase_stream = event_bus.pipe(
-            ops.filter(lambda event: event.event_type == "drawing_pad.erase"),
-            ops.map(lambda event: event.data),
+            ops.filter(
+                lambda event: cast(Input, event).event_type == "drawing_pad.erase"
+            ),
+            ops.map(lambda event: cast(Input, event).data),
         )
         return (
             InputDescriptor(


### PR DESCRIPTION
### Motivation
- Resolve a mypy typing error when building the DrawingPad input streams that caused `_T` to be reported as not having `event_type`.
- Ensure the `reactivex` pipeline lambdas are understood as receiving `Input` objects by the static type checker.
- Preserve the existing runtime behavior of the `DrawingPad.inputs` streams while satisfying typing.

### Description
- Import `cast` from `typing` and use `cast(Input, event)` in the `ops.filter` lambdas for stroke and erase streams to expose `event_type` to the type checker.
- Use `cast(Input, event).data` in the `ops.map` lambdas to make the `data` attribute statically visible.
- No changes were made to the public API or runtime semantics of `DrawingPad`; only typing hints were added.

### Testing
- Ran `make format` and all formatting checks passed successfully.
- No unit tests (`make test`) or type-checking suite were executed as part of this change.
- No automated failures were observed from the formatting step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c441d3ac083219cb45cc7ae69aaff)