### PR TITLE
Add REPL debugging guidance for rotary encoder and sensor bus drivers

### DIFF
--- a/drivers/rotary_encoder/code.py
+++ b/drivers/rotary_encoder/code.py
@@ -1,4 +1,11 @@
-"""Expose a testable entry point for the rotary encoder driver."""
+"""Expose a testable entry point for the rotary encoder driver.
+
+REPL reproduction:
+    1. Connect to the board REPL and import this module.
+    2. Call ``create_handler()`` to construct the hardware adapter.
+    3. Iterate ``read_events(handler)`` while turning the encoder or pressing the
+       switch to verify event output without running the full game runtime.
+"""
 
 from __future__ import annotations
 

--- a/drivers/sensor_bus/code.py
+++ b/drivers/sensor_bus/code.py
@@ -1,3 +1,12 @@
+"""Stream sensor bus readings over serial and document REPL debugging steps.
+
+REPL reproduction:
+    1. Connect to the board REPL and import this module.
+    2. Run ``main()`` to stream JSON payloads over serial.
+    3. Toggle ``DEBUG = True`` and call ``connect_to_sensors(board.STEMMA_I2C())``
+       to surface initialization failures without running the full game runtime.
+"""
+
 import json
 import time
 


### PR DESCRIPTION
### Motivation

- Bring driver modules into compliance with the repository `AGENTS.md` guidance to include REPL reproduction steps for hardware debugging.
- Make it easier to reproduce initialization and runtime issues on-device without running the full runtime.
- Preserve the existing lightweight, CircuitPython-friendly driver design while improving on-device diagnostics.

### Description

- Added REPL reproduction docstring to `drivers/sensor_bus/code.py` that documents how to run `main()` and use `DEBUG = True` with `connect_to_sensors(board.STEMMA_I2C())` for initialization diagnosis.
- Expanded the module docstring in `drivers/rotary_encoder/code.py` with steps to call `create_handler()` and iterate `read_events(handler)` from the board REPL to verify encoder and switch behaviour.
- No behavioral changes to runtime logic or diagnostic guards were introduced; only module-level documentation was added.

### Testing

- Ran `make format` and the formatting checks passed successfully.
- Ran `make test` and the full test suite completed with `187 passed, 1 skipped`.
- No new unit tests were required for the docstring changes and existing driver tests continued to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c451e7a148321883a2ee57c026d38)