### PR TITLE
Avoid catching BaseException in shared memory and sensor driver

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,10 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - Avoid using `print` for runtime diagnostics in peripheral modules; use the shared logger.
 - Prefer `StrEnum` values over raw strings for strategy/configuration mode selections.
 
+## Error Handling
+
+- Avoid catching `BaseException`; catch `Exception` or more specific error types so system-exiting signals propagate.
+
 ## Testing
 
 Run `make test` to execute the Pytest suite located in the `tests/` directory. Ensure all tests pass before submitting changes.

--- a/drivers/sensor_bus/code.py
+++ b/drivers/sensor_bus/code.py
@@ -199,8 +199,6 @@ def main() -> None:
         except OSError:
             sensors = None
             time.sleep(WAIT_BEFORE_TRYING_TO_CONNECT_TO_SENSOR_SECONDS)
-        except BaseException as e:
-            raise e
 
 
 if __name__ == "__main__":

--- a/experimental/isolated_rendering/src/isolated_rendering/shared_memory.py
+++ b/experimental/isolated_rendering/src/isolated_rendering/shared_memory.py
@@ -87,7 +87,7 @@ class SharedMemoryFile:
             self._mapping = _SharedMemoryMapping(fd=fd, mm=mm, size=total_size)
             self._maybe_initialize_header(mm)
             return self._mapping
-        except BaseException:
+        except Exception:
             os.close(fd)
             raise
 


### PR DESCRIPTION
### Motivation

- Add an explicit error-handling rule to `AGENTS.md` to encourage safer exception handling and ensure system-exiting signals propagate.  
- Remove or narrow uses of `except BaseException` found in the tree to follow the new rule and reduce accidental swallowing of `KeyboardInterrupt`/`SystemExit`.  
- Prevent resource-cleanup code from catching all exceptions in a way that can hide fatal signals or obscure real failures.  

### Description

- Added an `Error Handling` section to `AGENTS.md` that states: "Avoid catching `BaseException`; catch `Exception` or more specific error types."  
- Removed a redundant `except BaseException` clause from the sensor bus driver loop in `drivers/sensor_bus/code.py`.  
- Replaced `except BaseException` with `except Exception` around shared memory file setup in `experimental/isolated_rendering/src/isolated_rendering/shared_memory.py` to limit catch scope during cleanup.  

### Testing

- Ran `make format` and the formatter checks completed successfully.  
- Ran the test suite with `make test`; the run produced mostly green results but one test failed.  
- The failing test is `tests/utilities/test_reactivex_streams.py::TestShareStreamStrategy::test_share_stream_refcount_grace_delays_disconnect`.  
- Test summary: 186 passed, 1 failed, 1 skipped (overall `pytest` run exited non-zero due to the single failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c586c59bc832187883cbf9a3dedc0)