### PR TITLE
Refactor runtime loop and renderer processing for clarity

### DIFF
--- a/docs/research/runtime_loop_refactor.md
+++ b/docs/research/runtime_loop_refactor.md
@@ -1,0 +1,19 @@
+# Runtime loop refactor for clarity
+
+## Problem statement
+
+The runtime loop and render pipeline logic are correct but the control flow is dense, which makes it harder to scan for initialization order, per-frame steps, and renderer logging responsibilities.
+
+## Notes
+
+- Broke the game loop into explicit helper steps for initialization, peripheral streaming, and per-frame processing to make the lifecycle easier to follow.
+- Extracted renderer frame execution and logging into focused helpers so the render pipeline reads as a sequence of steps instead of a monolithic method.
+
+## Source references
+
+- `src/heart/runtime/game_loop.py`
+- `src/heart/runtime/render_pipeline.py`
+
+## Materials
+
+- Repository source files listed above.


### PR DESCRIPTION
### Motivation

- Improve readability and maintainability of the runtime by breaking the dense start/loop control flow into named helper steps.  
- Make renderer processing responsibilities (rendering vs logging) explicit so the pipeline is easier to reason about.  
- Reduce implicit private naming and clarify initialization state handling.  
- Document the refactor rationale under `docs/research` for future reference.  

### Description

- Split `GameLoop.start` into focused helpers including ` _ensure_initialized`, `_initialize_app_controller`, `_ensure_display_initialized`, `_configure_peripheral_streaming`, `_tick_peripherals`, and `_run_main_loop`, and replaced ad-hoc logic with these helpers.  
- Clarified initialization flag by renaming `initalized` to `initialized` and converted double-underscore private helpers to single-underscore methods like `_set_singleton` and `_dim_display`.  
- Simplified frame presentation by centralizing presentation logic in `_present_rendered_frame` and updated `_one_loop` to call `RenderPipeline.render` then present.  
- Extracted renderer execution and logging in `RenderPipeline` into `_render_renderer_frame` and `_log_renderer_metrics`, and improved exception logging with `logger.exception`.  
- Added a research note at `docs/research/runtime_loop_refactor.md` describing the motivation and touched sources.  

### Testing

- Ran formatting with `make format` and the formatting check completed successfully.  
- Ran the test suite with `make test`.  
- Result: automated tests passed: `187 passed, 1 skipped`.  
- Verified the refactor did not change public behavior by relying on existing tests that exercise the loop and pipeline logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c5878ce688321a49c14f884f3b93b)