### PR TITLE
Extract render pipeline helpers into dedicated module

### DIFF
--- a/src/heart/runtime/render_pipeline.py
+++ b/src/heart/runtime/render_pipeline.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import enum
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import TYPE_CHECKING, Any, Callable, Literal, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pygame
 from PIL import Image
@@ -12,7 +11,11 @@ from PIL import Image
 from heart import DeviceDisplayMode
 from heart.device import Device
 from heart.peripheral.core.manager import PeripheralManager
-from heart.renderers.internal import FrameAccumulator
+from heart.runtime.render_pipeline_helpers import (RGBA_IMAGE_FORMAT,
+                                                   DisplayModeManager,
+                                                   RendererVariant,
+                                                   RenderMethod,
+                                                   SurfaceComposer)
 from heart.utilities.env import Configuration, RenderMergeStrategy
 from heart.utilities.logging import get_logger
 from heart.utilities.logging_control import get_logging_controller
@@ -22,93 +25,6 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 log_controller = get_logging_controller()
-
-RGBA_IMAGE_FORMAT: Literal["RGBA"] = "RGBA"
-
-RenderMethod = Callable[[list["StatefulBaseRenderer[Any]"]], pygame.Surface | None]
-
-
-class RendererVariant(enum.StrEnum):
-    BINARY = "BINARY"
-    ITERATIVE = "ITERATIVE"
-    AUTO = "AUTO"
-    # TODO: Add more
-
-    @classmethod
-    def parse(cls, value: str) -> "RendererVariant":
-        normalized = value.strip().upper()
-        if not normalized:
-            raise ValueError("HEART_RENDER_VARIANT must not be empty")
-        try:
-            return cls[normalized]
-        except KeyError as exc:
-            options = ", ".join(variant.name.lower() for variant in cls)
-            raise ValueError(
-                f"Unknown render variant '{value}'. Expected one of: {options}"
-            ) from exc
-
-
-class DisplayModeManager:
-    def __init__(self, device: Device) -> None:
-        self._device = device
-        self._last_render_mode = pygame.SHOWN
-
-    def ensure_mode(self, display_mode: DeviceDisplayMode) -> None:
-        target_mode = self._to_pygame_mode(display_mode)
-        if self._last_render_mode == target_mode:
-            return
-        logger.info("Switching to %s mode", display_mode.name)
-        pygame.display.set_mode(self._display_size(), target_mode)
-        self._last_render_mode = target_mode
-
-    def _display_size(self) -> tuple[int, int]:
-        width, height = self._device.full_display_size()
-        return (width * self._device.scale_factor, height * self._device.scale_factor)
-
-    @staticmethod
-    def _to_pygame_mode(display_mode: DeviceDisplayMode) -> int:
-        if display_mode == DeviceDisplayMode.OPENGL:
-            return pygame.OPENGL | pygame.DOUBLEBUF
-        return pygame.SHOWN
-
-
-class SurfaceComposer:
-    def __init__(self) -> None:
-        self._composite_surface_cache: dict[tuple[int, int], pygame.Surface] = {}
-        self._composite_accumulator: FrameAccumulator | None = None
-
-    def compose_batched(self, surfaces: list[pygame.Surface]) -> pygame.Surface:
-        size = surfaces[0].get_size()
-        composite = self._get_composite_surface(size)
-        accumulator = self._get_composite_accumulator(composite)
-        for surface in surfaces:
-            accumulator.queue_blit(surface)
-        return accumulator.flush(clear=False)
-
-    def _get_composite_surface(self, size: tuple[int, int]) -> pygame.Surface:
-        if not Configuration.render_screen_cache_enabled():
-            surface = pygame.Surface(size, pygame.SRCALPHA)
-            surface.fill((0, 0, 0, 0))
-            return surface
-
-        cached = self._composite_surface_cache.get(size)
-        if cached is None:
-            cached = pygame.Surface(size, pygame.SRCALPHA)
-            self._composite_surface_cache[size] = cached
-        cached.fill((0, 0, 0, 0))
-        return cached
-
-    def _get_composite_accumulator(
-        self, surface: pygame.Surface
-    ) -> FrameAccumulator:
-        if (
-            self._composite_accumulator is None
-            or self._composite_accumulator.surface is not surface
-        ):
-            self._composite_accumulator = FrameAccumulator(surface)
-        else:
-            self._composite_accumulator.reset()
-        return self._composite_accumulator
 
 
 class RenderPipeline:

--- a/src/heart/runtime/render_pipeline_helpers.py
+++ b/src/heart/runtime/render_pipeline_helpers.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import enum
+from typing import TYPE_CHECKING, Any, Callable, Literal
+
+import pygame
+
+from heart import DeviceDisplayMode
+from heart.device import Device
+from heart.renderers.internal import FrameAccumulator
+from heart.utilities.env import Configuration
+from heart.utilities.logging import get_logger
+
+if TYPE_CHECKING:
+    from heart.renderers import StatefulBaseRenderer
+
+logger = get_logger(__name__)
+
+RGBA_IMAGE_FORMAT: Literal["RGBA"] = "RGBA"
+
+RenderMethod = Callable[[list["StatefulBaseRenderer[Any]"]], pygame.Surface | None]
+
+
+class RendererVariant(enum.StrEnum):
+    BINARY = "BINARY"
+    ITERATIVE = "ITERATIVE"
+    AUTO = "AUTO"
+    # TODO: Add more
+
+    @classmethod
+    def parse(cls, value: str) -> "RendererVariant":
+        normalized = value.strip().upper()
+        if not normalized:
+            raise ValueError("HEART_RENDER_VARIANT must not be empty")
+        try:
+            return cls[normalized]
+        except KeyError as exc:
+            options = ", ".join(variant.name.lower() for variant in cls)
+            raise ValueError(
+                f"Unknown render variant '{value}'. Expected one of: {options}"
+            ) from exc
+
+
+class DisplayModeManager:
+    def __init__(self, device: Device) -> None:
+        self._device = device
+        self._last_render_mode = pygame.SHOWN
+
+    def ensure_mode(self, display_mode: DeviceDisplayMode) -> None:
+        target_mode = self._to_pygame_mode(display_mode)
+        if self._last_render_mode == target_mode:
+            return
+        logger.info("Switching to %s mode", display_mode.name)
+        pygame.display.set_mode(self._display_size(), target_mode)
+        self._last_render_mode = target_mode
+
+    def _display_size(self) -> tuple[int, int]:
+        width, height = self._device.full_display_size()
+        return (width * self._device.scale_factor, height * self._device.scale_factor)
+
+    @staticmethod
+    def _to_pygame_mode(display_mode: DeviceDisplayMode) -> int:
+        if display_mode == DeviceDisplayMode.OPENGL:
+            return pygame.OPENGL | pygame.DOUBLEBUF
+        return pygame.SHOWN
+
+
+class SurfaceComposer:
+    def __init__(self) -> None:
+        self._composite_surface_cache: dict[tuple[int, int], pygame.Surface] = {}
+        self._composite_accumulator: FrameAccumulator | None = None
+
+    def compose_batched(self, surfaces: list[pygame.Surface]) -> pygame.Surface:
+        size = surfaces[0].get_size()
+        composite = self._get_composite_surface(size)
+        accumulator = self._get_composite_accumulator(composite)
+        for surface in surfaces:
+            accumulator.queue_blit(surface)
+        return accumulator.flush(clear=False)
+
+    def _get_composite_surface(self, size: tuple[int, int]) -> pygame.Surface:
+        if not Configuration.render_screen_cache_enabled():
+            surface = pygame.Surface(size, pygame.SRCALPHA)
+            surface.fill((0, 0, 0, 0))
+            return surface
+
+        cached = self._composite_surface_cache.get(size)
+        if cached is None:
+            cached = pygame.Surface(size, pygame.SRCALPHA)
+            self._composite_surface_cache[size] = cached
+        cached.fill((0, 0, 0, 0))
+        return cached
+
+    def _get_composite_accumulator(
+        self, surface: pygame.Surface
+    ) -> FrameAccumulator:
+        if (
+            self._composite_accumulator is None
+            or self._composite_accumulator.surface is not surface
+        ):
+            self._composite_accumulator = FrameAccumulator(surface)
+        else:
+            self._composite_accumulator.reset()
+        return self._composite_accumulator


### PR DESCRIPTION
### Motivation
- Reduce complexity in `render_pipeline.py` by moving helper types and classes into a focused module.
- Make display/render composition utilities reusable and easier to test in isolation.
- Improve code clarity and file focus to align with repository guidelines on single-responsibility modules.

### Description
- Add `src/heart/runtime/render_pipeline_helpers.py` implementing `RendererVariant`, `DisplayModeManager`, `SurfaceComposer`, `RGBA_IMAGE_FORMAT`, and `RenderMethod`.
- Update `src/heart/runtime/render_pipeline.py` to import the shared helpers and remove the previous in-file definitions.
- Preserve existing runtime behaviour and dispatch logic in `RenderPipeline` while simplifying imports and reducing file size.

### Testing
- Ran `make format` to apply repository formatting rules, which completed successfully.
- Ran `make test` (Pytest) and the suite completed with all automated tests passing: `187 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c6488b3748321b2ea27115ef5463a)