### PR TITLE
Add serial-bus writer for rotary encoder events

### DIFF
--- a/drivers/rotary_encoder/code.py
+++ b/drivers/rotary_encoder/code.py
@@ -28,6 +28,16 @@ def _debug(message: str) -> None:
         print(message)
 
 
+def _write_serial_bus(message: str) -> None:
+    """Emit the event payload over the serial bus.
+
+    Do not route event payloads through ``_debug``; the host depends on these
+    lines arriving over the serial connection.
+    """
+
+    print(message)
+
+
 def respond_to_identify_query(*, stdin=None, print_fn=print) -> bool:
     """Process any pending Identify query."""
 
@@ -67,7 +77,7 @@ def main() -> None:  # pragma: no cover - exercised on hardware
     while True:
         respond_to_identify_query()
         for event in read_events(handler):
-            print(event)
+            _write_serial_bus(event)
 
 
 if __name__ == "__main__":  # pragma: no cover - exercised on hardware


### PR DESCRIPTION
### Motivation

- Ensure rotary encoder event lines are emitted directly to the serial bus rather than being gated by the module `DEBUG` flag.  
- Clarify in-code why these event payloads must not be routed through the debug helper so the host can rely on the serial output.  
- Avoid altering runtime behaviour while removing ambiguity about which prints are diagnostic vs. protocol output.  

### Description

- Added a new helper `def _write_serial_bus(message: str) -> None` with a docstring explaining that event payloads must be printed to the serial bus.  
- Replaced the unguarded `print(event)` call in `main()` with a call to `_write_serial_bus(event)` to make the intent explicit.  
- Preserved existing behaviour (events still use `print`) while keeping debug prints controlled by `DEBUG` via the existing `_debug` helper.  
- Ran repository formatting to keep style consistent.  

### Testing

- Ran `make format` and formatting checks passed.  
- No unit tests were added or modified for this change.  
- No runtime or hardware tests were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c640df9108321852a804ebd4d0c69)