### PR TITLE
Fix device orientation typing in selection

### DIFF
--- a/src/heart/device/selection.py
+++ b/src/heart/device/selection.py
@@ -1,6 +1,6 @@
 import os
 
-from heart.device import Cube, Device, Rectangle
+from heart.device import Cube, Device, Orientation, Rectangle
 from heart.device.local import LocalScreen
 from heart.utilities.env import Configuration, DeviceLayoutMode
 from heart.utilities.logging import get_logger
@@ -10,6 +10,7 @@ logger = get_logger(__name__)
 
 def select_device(*, x11_forward: bool) -> Device:
     layout_mode = Configuration.device_layout_mode()
+    orientation: Orientation
     if layout_mode == DeviceLayoutMode.CUBE:
         orientation = Cube.sides()
     else:


### PR DESCRIPTION
### Motivation
- Resolve a mypy type error in `src/heart/device/selection.py` where `orientation` could be assigned a `Cube` or `Rectangle` value.  
- Ensure the local `orientation` variable is typed to the shared base `Orientation` so static type checking accepts both factory results.  
- Keep runtime behavior unchanged while satisfying the type checker.

### Description
- Import `Orientation` from `heart.device` and add the annotation `orientation: Orientation` in `select_device`.  
- Leave calls to `Cube.sides()` and `Rectangle.with_layout(...)` unchanged so behavior remains the same.  
- Adjust the import line to include `Orientation`.

### Testing
- Ran `make format`, which reported `All checks passed!` before the formatting process was interrupted.  
- No unit tests (`make test`) were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c659b37588321af7b267cf4b3b545)