### PR TITLE
Refactor configuration registries to share discovery helper

### DIFF
--- a/docs/research/module_registry_helper.md
+++ b/docs/research/module_registry_helper.md
@@ -1,0 +1,15 @@
+# Module registry helper extraction
+
+## Summary
+
+Registry discovery logic is now centralized in a shared helper so configuration registries reuse the same import/scan behavior. This keeps each registry focused on its specific configuration type while improving consistency and clarity.
+
+## Source references
+
+- `src/heart/utilities/module_registry.py`
+- `src/heart/programs/registry.py`
+- `src/heart/peripheral/registry.py`
+
+## Materials
+
+- None

--- a/src/heart/peripheral/registry.py
+++ b/src/heart/peripheral/registry.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import importlib
 from functools import cached_property
 from pathlib import Path
 from typing import Callable
 
 from heart.peripheral.configuration import PeripheralConfiguration
+from heart.utilities.module_registry import discover_registry
 
 ConfigurationFactory = Callable[[], PeripheralConfiguration]
 
@@ -17,18 +17,12 @@ class PeripheralConfigurationRegistry:
 
     @cached_property
     def registry(self) -> dict[str, ConfigurationFactory]:
-        registry: dict[str, ConfigurationFactory] = {}
         configurations_dir = Path(__file__).resolve().parent / "configurations"
-        for entry in configurations_dir.iterdir():
-            if not entry.is_file():
-                continue
-            if entry.suffix != ".py" or entry.name == "__init__.py":
-                continue
-            module_name = f"heart.peripheral.configurations.{entry.stem}"
-            module = importlib.import_module(module_name)
-            if hasattr(module, "configure"):
-                registry[entry.stem] = getattr(module, "configure")
-        return registry
+        return discover_registry(
+            configurations_dir,
+            "heart.peripheral.configurations",
+            attribute="configure",
+        )
 
     def get(self, name: str) -> ConfigurationFactory | None:
         return self.registry.get(name)

--- a/src/heart/programs/registry.py
+++ b/src/heart/programs/registry.py
@@ -1,30 +1,21 @@
-import importlib
 from functools import cached_property
 from pathlib import Path
 from typing import Callable
 
 from heart.runtime.game_loop import GameLoop
-from heart.utilities.logging import get_logger
-
-logger = get_logger(__name__)
+from heart.utilities.module_registry import discover_registry
 
 
 class ConfigurationRegistry:
     @cached_property
     def registry(self) -> dict[str, Callable[[GameLoop], None]]:
-        registry: dict[str, Callable[[GameLoop], None]] = {}
         configurations_dir = Path(__file__).resolve().parent / "configurations"
-        for configuration in configurations_dir.iterdir():
-            if configuration.suffix == ".py" and configuration.name != "__init__.py":
-                module_name = (
-                    f"heart.programs.configurations.{configuration.stem}"
-                )
-                module = importlib.import_module(module_name)
-                logger.info("Importing configuration: %s", module_name)
-                if hasattr(module, "configure"):
-                    registry[configuration.stem] = module.configure
-
-        return registry
+        return discover_registry(
+            configurations_dir,
+            "heart.programs.configurations",
+            attribute="configure",
+            log_imports=True,
+        )
 
     def get(self, name: str) -> Callable[[GameLoop], None] | None:
         return self.registry.get(name)

--- a/src/heart/utilities/module_registry.py
+++ b/src/heart/utilities/module_registry.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+from typing import TypeVar
+
+from heart.utilities.logging import get_logger
+
+T = TypeVar("T")
+
+logger = get_logger(__name__)
+
+
+def discover_registry(
+    configurations_dir: Path,
+    module_root: str,
+    attribute: str = "configure",
+    *,
+    log_imports: bool = False,
+) -> dict[str, T]:
+    registry: dict[str, T] = {}
+    for entry in configurations_dir.iterdir():
+        if not entry.is_file():
+            continue
+        if entry.suffix != ".py" or entry.name == "__init__.py":
+            continue
+        module_name = f"{module_root}.{entry.stem}"
+        module = import_module(module_name)
+        if log_imports:
+            logger.info("Importing configuration: %s", module_name)
+        if hasattr(module, attribute):
+            registry[entry.stem] = getattr(module, attribute)
+    return registry


### PR DESCRIPTION
### Motivation

- Remove duplicated filesystem import/scan logic across configuration registries to improve readability and consistency.
- Centralize discovery and import behaviour so different registries share the same filtering and logging semantics.
- Make it easier to add additional registries in the future by providing a small reusable helper.

### Description

- Add `src/heart/utilities/module_registry.py` which implements a `discover_registry` helper that scans a configurations directory and imports modules exposing a given attribute.
- Update `src/heart/programs/registry.py` to call `discover_registry(..., log_imports=True)` and remove inline discovery code.
- Update `src/heart/peripheral/registry.py` to call `discover_registry(...)` and remove its inline discovery code.
- Add a short research note at `docs/research/module_registry_helper.md` documenting the refactor.

### Testing

- Ran `make format` to apply repository formatting rules and the command completed successfully.
- Ran `make test` and the test suite completed with `187 passed, 1 skipped`.
- The `discover_registry` behaviour was exercised indirectly via the existing registry tests that remained green.
- No new automated tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c659fea0c8321b23455d4be4fc71b)