### PR TITLE
Guard optional firmware imports with `importlib.util.find_spec`

### DIFF
--- a/src/heart/firmware_io/bluetooth.py
+++ b/src/heart/firmware_io/bluetooth.py
@@ -1,19 +1,21 @@
 from __future__ import annotations
 
 import importlib
+import importlib.util
 from typing import Any
 
 BLERadio: type[Any] | None = None
 ProvideServicesAdvertisement: type[Any] | None = None
 UARTService: type[Any] | None = None
 
-try:
+if (
+    importlib.util.find_spec("adafruit_ble") is not None
+    and importlib.util.find_spec("adafruit_ble.advertising.standard") is not None
+    and importlib.util.find_spec("adafruit_ble.services.nordic") is not None
+):
     ble_module = importlib.import_module("adafruit_ble")
     advertising_module = importlib.import_module("adafruit_ble.advertising.standard")
     services_module = importlib.import_module("adafruit_ble.services.nordic")
-except ImportError:
-    pass
-else:
     BLERadio = getattr(ble_module, "BLERadio", None)
     ProvideServicesAdvertisement = getattr(advertising_module, "ProvideServicesAdvertisement", None)
     UARTService = getattr(services_module, "UARTService", None)

--- a/src/heart/firmware_io/identity.py
+++ b/src/heart/firmware_io/identity.py
@@ -211,10 +211,9 @@ def _extract_command(raw: str) -> str | None:
 
 
 def _commit_from_generated_module() -> str | None:
-    try:
-        module = importlib.import_module("heart_firmware_build")
-    except ImportError:
+    if importlib.util.find_spec("heart_firmware_build") is None:
         return None
+    module = importlib.import_module("heart_firmware_build")
 
     commit = getattr(module, "FIRMWARE_COMMIT", None)
     if isinstance(commit, str) and commit:
@@ -244,10 +243,9 @@ def _commit_from_git(default: str) -> str | None:
 def _hardware_device_uid(microcontroller_module: ModuleType | None = None) -> str | None:
     module = microcontroller_module
     if module is None:
-        try:  # pragma: no cover - available on CircuitPython only
-            module = importlib.import_module("microcontroller")
-        except ImportError:
+        if importlib.util.find_spec("microcontroller") is None:  # pragma: no cover - hardware only
             return None
+        module = importlib.import_module("microcontroller")
 
     cpu = getattr(module, "cpu", None)
     uid = getattr(cpu, "uid", None) if cpu is not None else None


### PR DESCRIPTION
### Motivation

- Ensure firmware-adjacent modules fail gracefully when CircuitPython-specific packages are not available by checking availability before importing.  
- Replace noisy try/except import patterns with explicit presence checks to avoid masking unrelated `ImportError` cases.  
- Align import handling with the repository's expectations for optional firmware and hardware dependencies.  

### Description

- Added `importlib.util` usage and presence checks to `src/heart/firmware_io/bluetooth.py` and `src/heart/firmware_io/identity.py`.  
- Replaced `try/except ImportError` import guards with `importlib.util.find_spec(...)` followed by conditional `importlib.import_module(...)` to guard optional imports.  
- Preserved previous fallback behaviour by leaving the `ble`, `uart`, and `advertisement` variables set to `None` when dependencies are absent.  

### Testing

- Ran `make format` and formatting checks completed successfully.  
- Ran `make test` and the full test suite completed with `187 passed, 1 skipped`.  
- Verified unit tests covering `firmware_io` behaviours (including `tests/firmware_io/test_bluetooth.py` and identity tests) passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c682edd0c83218a0402bd2bc95c13)