### PR TITLE
Fix typing/import issues in device selection and environment shim

### DIFF
--- a/src/heart/device/selection.py
+++ b/src/heart/device/selection.py
@@ -12,7 +12,7 @@ def select_device(*, x11_forward: bool) -> Device:
     layout_mode = Configuration.device_layout_mode()
     orientation: Orientation
     if layout_mode == DeviceLayoutMode.CUBE:
-        orientation: Orientation = Cube.sides()
+        orientation = Cube.sides()
     else:
         orientation = Rectangle.with_layout(
             columns=Configuration.device_layout_columns(),

--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -2,4 +2,4 @@
 
 from heart import DeviceDisplayMode  # noqa: F401
 from heart.runtime.game_loop import GameLoop  # noqa: F401
-from heart.runtime.render_pipeline import RendererVariant  # noqa: F401
+from heart.runtime.render_pipeline_helpers import RendererVariant  # noqa: F401


### PR DESCRIPTION
### Motivation
- `make format` was failing due to typing and export issues detected by the type checker and linter. 
- The device selection code redefined the `orientation` variable annotation in a way that produced a type-checking error. 
- The environment shim imported `RendererVariant` from a module that did not explicitly export it, triggering a mypy `attr-defined` error. 

### Description
- Declare `orientation` once and assign it according to `DeviceLayoutMode` to avoid a redefinition error in `src/heart/device/selection.py`. 
- Import `Orientation` from `heart.device` to make the annotation valid and explicit. 
- Change the environment shim to import `RendererVariant` from `heart.runtime.render_pipeline_helpers` where it is defined in `src/heart/environment.py`. 

### Testing
- Ran `make format` (which runs ruff/isort/docformatter/mdformat and `mypy` per the Makefile) and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c684317348321aabace95689e088c)