### PR TITLE
Avoid importing sounddevice without PortAudio

### DIFF
--- a/src/heart/peripheral/microphone.py
+++ b/src/heart/peripheral/microphone.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import contextlib
+import ctypes.util
+import importlib
+import importlib.util
 import threading
 import time
 from collections.abc import Iterator
@@ -18,11 +21,11 @@ from heart.utilities.logging import get_logger
 logger = get_logger(__name__)
 
 sd: Any | None = None
-try:  # pragma: no cover - import guarded for optional dependency
-    import sounddevice as _sounddevice
-except Exception:  # pragma: no cover - module may be missing on CI
-    _sounddevice = None
-sd = cast(Any | None, _sounddevice)
+if (
+    importlib.util.find_spec("sounddevice") is not None
+    and ctypes.util.find_library("portaudio") is not None
+):  # pragma: no cover - optional dependency
+    sd = cast(Any | None, importlib.import_module("sounddevice"))
 
 
 class Microphone(Peripheral[MicrophoneLevel]):


### PR DESCRIPTION
### Motivation

- Prevent test collection failures when the `sounddevice` package is present but the native PortAudio library is missing and would raise on import.  
- Keep the microphone peripheral optional and inert on CI or hosts without a working audio backend.  
- Reduce runtime surprises by avoiding importing hardware-backed libraries at module import time.  
- Align with repository guidance to isolate hardware-heavy dependencies so unit tests run reliably.

### Description

- Modified `src/heart/peripheral/microphone.py` to conditionally import `sounddevice` only when the `sounddevice` module is available and `portaudio` is present via `ctypes.util.find_library`.  
- Replaced the previous try/except import pattern with an `importlib.util.find_spec` + `ctypes.util.find_library` guard and `importlib.import_module` to avoid raising `OSError` at import time.  
- Kept the microphone peripheral behavior unchanged when the audio backend is unavailable so detection short-circuits as intended.  
- Reformatted code with the repository formatter.

### Testing

- Ran `make format` and the formatter checks completed successfully.  
- Ran `make test` and the full test suite completed with `187 passed, 1 skipped`.  
- Confirmed the microphone detection test (`tests/peripheral/test_microphone.py::TestPeripheralMicrophone::test_detect_without_sounddevice`) passes when `sd` is `None`.  
- Verified the change removes the previous import-time `OSError: PortAudio library not found` failure during test collection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c6852ada883218f919cb236ed27a6)