### PR TITLE
Fix mypy import and redundant orientation redeclaration

### DIFF
--- a/src/heart/device/selection.py
+++ b/src/heart/device/selection.py
@@ -12,7 +12,7 @@ def select_device(*, x11_forward: bool) -> Device:
     layout_mode = Configuration.device_layout_mode()
     orientation: Orientation
     if layout_mode == DeviceLayoutMode.CUBE:
-        orientation: Orientation = Cube.sides()
+        orientation = Cube.sides()
     else:
         orientation = Rectangle.with_layout(
             columns=Configuration.device_layout_columns(),

--- a/src/heart/environment.py
+++ b/src/heart/environment.py
@@ -2,4 +2,4 @@
 
 from heart import DeviceDisplayMode  # noqa: F401
 from heart.runtime.game_loop import GameLoop  # noqa: F401
-from heart.runtime.render_pipeline import RendererVariant  # noqa: F401
+from heart.runtime.render_pipeline_helpers import RendererVariant  # noqa: F401


### PR DESCRIPTION
### Motivation
- Resolve a type-checking error where `RendererVariant` was not exported from the legacy import path.  
- Remove a redundant redeclaration that triggered `no-redef` for the `orientation` name.  
- Keep the compatibility shim and device selection logic correct and idiomatic for static analysis and linters.

### Description
- Update `src/heart/environment.py` to import `RendererVariant` from `heart.runtime.render_pipeline_helpers` instead of `heart.runtime.render_pipeline`.  
- Simplify the orientation assignment in `src/heart/device/selection.py` by changing `orientation: Orientation = Cube.sides()` to `orientation = Cube.sides()`.  
- Apply repository formatting with `make format` to ensure lint/format rules are satisfied.

### Testing
- Ran `make format` and the formatter/lint checks completed successfully.  
- Ran the full test suite with `make test` and all automated tests passed.  
- Test summary: `187 passed, 1 skipped` (Pytest run completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c696ef1b08321be498bb88e1c115e)