### PR TITLE
Refactor display management in GameLoop

### DIFF
--- a/docs/research/display-context-refactor.md
+++ b/docs/research/display-context-refactor.md
@@ -1,0 +1,24 @@
+# Display context refactor notes
+
+## Summary
+
+The game loop previously managed pygame display state (screen and clock) directly while also
+handling peripheral setup, renderer orchestration, and frame presentation. To make the display
+responsibilities clearer, I introduced a dedicated `DisplayContext` that owns initialization and
+validation of the screen and clock.
+
+## Rationale
+
+The loop lifecycle mixes several responsibilities. Extracting a display-focused helper makes it
+easier to locate where display configuration happens and keeps screen/clock checks in one place.
+This keeps the game loop focused on orchestration while the new helper isolates display setup.
+
+## Source references
+
+- `src/heart/runtime/display_context.py`
+- `src/heart/runtime/game_loop.py`
+
+## Materials
+
+- `src/heart/runtime/display_context.py`
+- `src/heart/runtime/game_loop.py`

--- a/src/heart/runtime/display_context.py
+++ b/src/heart/runtime/display_context.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pygame
+
+from heart.device import Device
+from heart.utilities.env import Configuration
+
+
+@dataclass
+class DisplayContext:
+    """Track and initialize pygame display resources."""
+
+    device: Device
+    screen: pygame.Surface | None = None
+    clock: pygame.time.Clock | None = None
+
+    def configure_window(self) -> None:
+        pygame.display.set_mode(
+            (
+                self.device.full_display_size()[0] * self.device.scale_factor,
+                self.device.full_display_size()[1] * self.device.scale_factor,
+            ),
+            pygame.SHOWN,
+        )
+        if Configuration.is_pi() and not Configuration.is_x11_forward():
+            pygame.event.set_grab(True)
+
+    def initialize(self) -> None:
+        pygame.init()
+        self.screen = pygame.Surface(self.device.full_display_size(), pygame.SHOWN)
+        self.clock = pygame.time.Clock()
+
+    def ensure_initialized(self) -> None:
+        if self.clock is None or self.screen is None:
+            raise RuntimeError("GameLoop failed to initialize display surfaces")
+
+    def set_screen(self, screen: pygame.Surface) -> None:
+        self.screen = screen
+
+    def set_clock(self, clock: pygame.time.Clock) -> None:
+        self.clock = clock


### PR DESCRIPTION
### Motivation

- The `GameLoop` mixed display initialization and lifecycle checks with orchestration logic, making it harder to reason about screen/clock responsibilities.
- Centralizing display operations reduces duplication and isolates pygame surface and clock handling.

### Description

- Add a new `DisplayContext` helper in `src/heart/runtime/display_context.py` to own window configuration, initialization, and validation of `screen` and `clock` resources.
- Update `GameLoop` to use `DisplayContext` for window configuration and initialization while preserving `screen` and `clock` accessors for compatibility with existing callers by exposing `GameLoop.screen` and `GameLoop.clock` properties.
- Replace direct calls to `pygame` display setup in `GameLoop.__init__` and `_initialize_screen` with `DisplayContext.configure_window()` and `DisplayContext.initialize()`, and update rendering/presentation paths to use the display context.
- Add a short research note documenting the refactor at `docs/research/display-context-refactor.md`.

### Testing

- Ran code formatting via `make format` and applied formatting checks successfully.
- Executed the full test suite with `make test` which completed with all automated tests passing: `187 passed, 1 skipped`.
- Unit tests that exercise rendering and screen recording were included in the run to validate compatibility of the new `screen`/`clock` accessors.
- No automated test failures remain after the changes were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c6a6dcf0c8321a520badbeb4587cb)