### PR TITLE
Handle CLI output paths with pathlib

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - Avoid declaring module-level `__all__` exports. Prefer explicit imports at call sites instead of curating export lists.
 - Avoid building filesystem paths via string concatenation. Use `os.path.join` or `pathlib.Path` instead.
 - Prefer `pathlib.Path` over `os.path.join` when constructing paths, and ensure functions annotated to return a `Path` return a `Path` object.
+- When CLI arguments accept file paths, parse them as `pathlib.Path` objects and ensure parent directories exist before writing.
 - Avoid using `print` for runtime diagnostics in CLI commands; use the shared logger.
 - Avoid using `print` for runtime diagnostics in peripheral modules; use the shared logger.
 - Prefer `StrEnum` values over raw strings for strategy/configuration mode selections.

--- a/scripts/devex_snapshot.py
+++ b/scripts/devex_snapshot.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Iterable
 
 
@@ -150,6 +151,7 @@ def main() -> int:
     )
     parser.add_argument(
         "--output",
+        type=Path,
         help="Optional file path to write the snapshot output.",
     )
     args = parser.parse_args()
@@ -161,9 +163,9 @@ def main() -> int:
         output = _format_text(payload)
 
     if args.output:
-        with open(args.output, "w", encoding="utf-8") as handle:
-            handle.write(output)
-            handle.write("\n")
+        output_path: Path = args.output
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(f"{output}\n", encoding="utf-8")
     else:
         print(output)
     return 0


### PR DESCRIPTION
### Motivation

- Ensure CLI tools consistently treat file paths as `pathlib.Path` objects to avoid string-manipulation bugs and improve correctness when creating files.  
- Provide a repository-level guidance for CLI path handling so contributors follow a single convention.  
- Make `scripts/devex_snapshot.py` robust when writing output files by creating parent directories automatically.  

### Description

- Add a formatting rule to `AGENTS.md` instructing that CLI file-path arguments should be parsed as `pathlib.Path` and parent directories ensured before writing.  
- Update `scripts/devex_snapshot.py` to import `Path`, set the `--output` argument `type=Path`, create `output_path.parent` with `mkdir(parents=True, exist_ok=True)`, and write via `Path.write_text()`.  
- Run repository formatting via `make format` to keep code style consistent.  

### Testing

- Ran `make format`, which completed successfully.  
- Ran `make test`; the suite executed but had one failing test (`tests/utilities/test_reactivex_streams.py::TestShareStreamFlowControl::test_share_stream_coalesces_latest_when_configured`).  
- Test summary: `186 passed, 1 failed, 1 skipped` when the test suite finished.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c6a7dc1b483219d4f48f688994cab)