### PR TITLE
Make BLE discovery async to avoid nested event loops

### DIFF
--- a/src/heart/peripheral/bluetooth.py
+++ b/src/heart/peripheral/bluetooth.py
@@ -45,12 +45,14 @@ class UartListener:
         self._messages_received = 0
 
     @classmethod
-    def _discover_devices(cls) -> Iterator[BLEDevice]:
-        devices: list[BLEDevice] = asyncio.run(BleakScanner.discover())
-        for device in devices:
+    async def _discover_devices(cls) -> list[BLEDevice]:
+        devices: list[BLEDevice] = await BleakScanner.discover()
+        return [
+            device
+            for device in devices
             # TODO: This should come from somewhere more principled
-            if device.name == "totem-controller":
-                yield device
+            if device.name == "totem-controller"
+        ]
 
     def start(self) -> None:
         self._logger.debug("Starting UART listener thread for %s", self.device.address)

--- a/src/heart/peripheral/switch.py
+++ b/src/heart/peripheral/switch.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import time
 from dataclasses import dataclass
@@ -275,7 +276,8 @@ class BluetoothSwitch(BaseSwitch):
 
     @classmethod
     def detect(cls) -> Iterator[Self]:
-        for device in UartListener._discover_devices():
+        devices = asyncio.run(UartListener._discover_devices())
+        for device in devices:
             yield cls(device=device)
 
     def _connect_to_ser(self) -> None:


### PR DESCRIPTION
### Motivation
- Calling `BleakScanner.discover()` via `asyncio.run()` could raise `RuntimeError` when invoked from an existing event loop, preventing reconnects.
- Make the discovery helper awaitable so callers running inside an event loop can `await` discovery instead of nesting `asyncio.run`.

### Description
- Convert `UartListener._discover_devices` to an `async` function that `await`s `BleakScanner.discover()` and returns a filtered `list[BLEDevice]`.
- Adjust `BluetoothSwitch.detect` to call the new async discovery helper with `asyncio.run` to preserve current synchronous call sites.
- Minor typing and import cleanup in `src/heart/peripheral/bluetooth.py` and add `asyncio` import to `src/heart/peripheral/switch.py`.

### Testing
- Ran `make format` to apply lint and formatting fixes and it completed successfully. 
- Ran the test suite with `make test` and all tests passed (187 passed, 1 skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c6ad69f9c8321832a567bf8387651)