### PR TITLE
Make Life neighbor buffer dtype kernel-aware to avoid truncation

### DIFF
--- a/src/heart/renderers/life/state.py
+++ b/src/heart/renderers/life/state.py
@@ -70,16 +70,22 @@ class LifeState:
         return _count_neighbors_shifted(self.grid, self._ensure_neighbor_buffer())
 
     def _convolve_neighbors(self, kernel: np.ndarray) -> np.ndarray:
-        neighbors = self._ensure_neighbor_buffer()
+        neighbors = self._ensure_neighbor_buffer(
+            dtype=np.result_type(self.grid, kernel)
+        )
         convolve(self.grid, kernel, mode="constant", cval=0, output=neighbors)
         return neighbors
 
-    def _ensure_neighbor_buffer(self) -> np.ndarray:
+    def _ensure_neighbor_buffer(self, dtype: np.dtype | None = None) -> np.ndarray:
+        if dtype is None:
+            dtype = np.result_type(self.grid, np.int16)
+        dtype = np.dtype(dtype)
         if (
             self.neighbor_buffer is None
             or self.neighbor_buffer.shape != self.grid.shape
+            or self.neighbor_buffer.dtype != dtype
         ):
-            self.neighbor_buffer = np.zeros(self.grid.shape, dtype=np.int16)
+            self.neighbor_buffer = np.zeros(self.grid.shape, dtype=dtype)
         else:
             self.neighbor_buffer.fill(0)
         return self.neighbor_buffer


### PR DESCRIPTION
### Motivation
- The neighbor buffer was always allocated as `int16`, which caused `scipy.ndimage.convolve(..., output=neighbors)` to cast and truncate or overflow weighted or large-kernel convolution results. 
- Custom kernels with fractional or large integer weights could therefore corrupt neighbor counts used for Life updates.
- The intent is to let the buffer use an appropriate numeric type derived from the grid and kernel to preserve convolution results.
- Keep existing strategies (`AUTO`, `PAD`, `SHIFTED`) behaviour unchanged except for convolution buffering.

### Description
- `LifeState._convolve_neighbors` now calls `_ensure_neighbor_buffer(dtype=np.result_type(self.grid, kernel))` so the buffer dtype matches `np.result_type(self.grid, kernel)`.
- `LifeState._ensure_neighbor_buffer` signature was extended to accept an optional `dtype` and it now derives a sensible default using `np.result_type(self.grid, np.int16)` when `dtype` is not provided.
- The neighbor buffer is reallocated when shape or `dtype` differs, and allocated with the requested `dtype` to avoid silent truncation.
- All other neighbour-count paths (`_count_neighbors_with_padding`, `_count_neighbors_shifted`) remain functionally unchanged.

### Testing
- Ran `make format` and the formatter/lint checks passed. 
- Ran the full test suite with `make test`, which reported one failing test under xdist parallel execution (`tests/utilities/test_reactivex_streams.py::TestShareStreamFlowControl::test_share_stream_coalesces_latest_when_configured`).
- Re-ran the failing test single-threaded with `.venv/bin/pytest -n 0 tests/utilities/test_reactivex_streams.py::TestShareStreamFlowControl::test_share_stream_coalesces_latest_when_configured` and it passed. 
- No new tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c6b42bb688321a6ac62faeb445e7a)