### PR TITLE
Standardize on shared logger utility (`get_logger`) across modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - Avoid using `print` for runtime diagnostics in CLI commands; use the shared logger.
 - Avoid using `print` for runtime diagnostics in peripheral modules; use the shared logger.
 - Prefer `StrEnum` values over raw strings for strategy/configuration mode selections.
+- Use `heart.utilities.logging.get_logger` for internal logging so handlers and log levels stay consistent across modules.
 
 ## Error Handling
 

--- a/src/heart/device/beats/websocket.py
+++ b/src/heart/device/beats/websocket.py
@@ -1,7 +1,6 @@
 import asyncio
 import dataclasses
 import json
-import logging
 import threading
 from dataclasses import dataclass, field
 from datetime import date, datetime
@@ -12,7 +11,9 @@ from uuid import UUID
 import websockets
 from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 
-logger = logging.getLogger(__name__)
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class UniversalJSONEncoder(json.JSONEncoder):

--- a/src/heart/device/local/resolution.py
+++ b/src/heart/device/local/resolution.py
@@ -1,10 +1,11 @@
-import logging
 import platform
 import subprocess
 from abc import ABC, abstractmethod
 from functools import lru_cache
 
-logger = logging.getLogger(__name__)
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class ResolutionDetectionError(RuntimeError):

--- a/src/heart/peripheral/bluetooth.py
+++ b/src/heart/peripheral/bluetooth.py
@@ -11,6 +11,7 @@ from bleak import BleakClient, BleakScanner
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.device import BLEDevice
 
+from heart.utilities.logging import get_logger
 from heart.utilities.logging_control import get_logging_controller
 
 # https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/bluetooth/services/nus.html#service_uuid
@@ -39,7 +40,7 @@ class UartListener:
         self.buffer: str = ""
         self.events: deque[dict[str, Any]] = deque([], maxlen=50)
         self.disconnected = False
-        self._logger = logging.getLogger(f"{__name__}.{type(self).__name__}")
+        self._logger = get_logger(f"{__name__}.{type(self).__name__}")
         self._log_controller = get_logging_controller()
         self._bytes_received = 0
         self._messages_received = 0

--- a/src/heart/peripheral/core/__init__.py
+++ b/src/heart/peripheral/core/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import StrEnum
@@ -10,6 +9,7 @@ from typing import Any, Generic, Iterator, Mapping, Self, Sequence, TypeVar
 import reactivex
 from reactivex import operators as ops
 
+from heart.utilities.logging import get_logger
 from heart.utilities.reactivex_streams import share_stream
 
 
@@ -65,7 +65,7 @@ class PeripheralMessageEnvelope(Generic[A]):
 class Peripheral(Generic[A]):
     """Abstract base class for all peripherals."""
 
-    _logger = logging.getLogger(__name__)
+    _logger = get_logger(__name__)
 
     def _event_stream(self) -> reactivex.Observable[A]:
         return reactivex.empty()

--- a/src/heart/renderers/yolisten/provider.py
+++ b/src/heart/renderers/yolisten/provider.py
@@ -1,4 +1,3 @@
-import logging
 import random
 import time
 from dataclasses import replace
@@ -11,8 +10,9 @@ from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import ObservableProvider
 from heart.peripheral.switch import SwitchState
 from heart.renderers.yolisten.state import YoListenState
+from heart.utilities.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class YoListenStateProvider(ObservableProvider[YoListenState]):


### PR DESCRIPTION
### Motivation
- Ensure logging across the codebase uses the centralized logger configuration so handlers, filenames, and levels are consistent.
- Replace ad-hoc uses of `logging.getLogger(...)` with the shared utility to avoid divergent handler setup and propagation behavior.
- Surface a clear guideline in the repository instructions so future contributors follow the same logging pattern.

### Description
- Add a rule to `AGENTS.md` recommending use of `heart.utilities.logging.get_logger` for internal logging.
- Replace `logging.getLogger(__name__)` with `get_logger(__name__)` in `src/heart/renderers/yolisten/provider.py`, `src/heart/device/local/resolution.py`, `src/heart/device/beats/websocket.py`, `src/heart/peripheral/bluetooth.py`, and `src/heart/peripheral/core/__init__.py`.
- Use the same shared logger for the `Peripheral` base class `_logger` to propagate consistent configuration to peripheral implementations.
- Run repository formatting to apply code style fixes before tests.

### Testing
- Ran `make format` to apply repository formatting, which completed successfully.
- Ran the test suite with `make test`, and all automated tests passed: `187 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c6aa5a5788321bacb554df48cbf80)