### PR TITLE
Refactor frame presentation in game loop

### DIFF
--- a/src/heart/runtime/frame_presenter.py
+++ b/src/heart/runtime/frame_presenter.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import pygame
+from PIL import Image
+
+from heart.device import Device
+from heart.runtime.display_context import DisplayContext
+from heart.runtime.render_pipeline import RenderPipeline
+
+if TYPE_CHECKING:
+    from heart.renderers import StatefulBaseRenderer
+
+
+@dataclass
+class FramePresenter:
+    device: Device
+    display: DisplayContext
+    render_pipeline: RenderPipeline
+
+    def present(
+        self,
+        renderers: list["StatefulBaseRenderer[Any]"],
+        render_surface: pygame.Surface | None,
+    ) -> None:
+        if not renderers:
+            return
+        pygame.display.flip()
+        if render_surface is not None:
+            self._present_render_surface(render_surface)
+            return
+        self._present_from_screen()
+
+    def _present_render_surface(self, render_surface: pygame.Surface) -> None:
+        render_image = self.render_pipeline.finalize_rendering(render_surface)
+        device_image = (
+            render_image.convert("RGB") if render_image.mode != "RGB" else render_image
+        )
+        self.device.set_image(device_image)
+
+    def _present_from_screen(self) -> None:
+        if self.display.screen is None:
+            raise RuntimeError("GameLoop screen is not initialized")
+        screen_array = pygame.surfarray.array3d(self.display.screen)
+        transposed_array = np.transpose(screen_array, (1, 0, 2))
+        pil_image = Image.fromarray(transposed_array)
+        self.device.set_image(pil_image)


### PR DESCRIPTION
### Motivation

- Separate concerns so GameLoop focuses on orchestration while frame presentation is handled by a dedicated helper.
- Improve clarity and testability by extracting device frame publishing and screen-to-image conversion logic.
- Reduce single-file complexity in runtime code by moving presentation responsibilities into a small, focused module.

### Description

- Add `src/heart/runtime/frame_presenter.py` which implements a `FramePresenter` dataclass responsible for flipping the display and publishing frames to the `Device`.
- Update `src/heart/runtime/game_loop.py` to instantiate and use `FramePresenter.present(...)` instead of inlining the presentation logic.
- Remove the former `_present_rendered_frame` method from `GameLoop` and update imports/initialization to wire the new presenter.
- The refactor preserves existing behavior (finalizing `pygame.Surface` to `PIL.Image` or converting render surfaces to RGB) while clarifying responsibilities.

### Testing

- Ran formatting with `make format` and the formatter checks passed.
- Ran the test suite with `make test` and the full suite completed successfully with `187 passed, 1 skipped`.
- No additional automated tests were added or modified for this refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c6c3f4ba483219ad375bbcb9f692a)