### PR TITLE
Route devex_snapshot output through shared logger

### DIFF
--- a/scripts/devex_snapshot.py
+++ b/scripts/devex_snapshot.py
@@ -14,6 +14,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
 
+from heart.utilities.logging import get_logger
+
+
+logger = get_logger(__name__)
+
 
 @dataclass(frozen=True)
 class CommandResult:
@@ -167,7 +172,7 @@ def main() -> int:
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(f"{output}\n", encoding="utf-8")
     else:
-        print(output)
+        logger.info(output)
     return 0
 
 


### PR DESCRIPTION
### Motivation

- Bring `scripts/devex_snapshot.py` into compliance with repository logging guidance by avoiding `print` for runtime diagnostics.
- Follow AGENTS.md guidance to use `heart.utilities.logging.get_logger` so handlers and log levels are consistent across scripts.

### Description

- Import `get_logger` from `heart.utilities.logging` and initialize `logger = get_logger(__name__)` in `scripts/devex_snapshot.py`.
- Replace the direct `print(output)` call with `logger.info(output)` so snapshot output uses the shared logging system.
- Ensure file output behavior is unchanged when `--output` is provided and keep existing formatting logic.

### Testing

- Ran `make format` and the formatter reported: "All checks passed!".
- Ran the test suite with `make test` and observed `187 passed, 1 skipped` within the test run.
- No tests failed after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c6d21232c8321ac492dfd7aaddc09)