### PR TITLE
Extract renderer surface cache and surface merger from RenderPipeline

### DIFF
--- a/docs/research/renderer_surface_helpers.md
+++ b/docs/research/renderer_surface_helpers.md
@@ -1,0 +1,25 @@
+# Renderer surface helper extraction
+
+## Summary
+
+The render pipeline now delegates renderer surface caching and surface merge policy
+to dedicated helpers. The goal is to keep `RenderPipeline` focused on orchestration
+while reusing the same caching and merge behavior across render variants.
+
+## Implementation notes
+
+- `RendererSurfaceCache` (`src/heart/runtime/rendering/surface_cache.py`) owns the
+  cache keyed by renderer identity, display mode, and output size. It returns
+  cleared surfaces on reuse and respects `Configuration.render_screen_cache_enabled()`.
+- `SurfaceMerger` (`src/heart/runtime/rendering/surface_merge.py`) centralizes
+  the merge strategies, reusing `SurfaceComposer` for batched paths and handling
+  in-place or parallel merges based on `RenderMergeStrategy`.
+- `RenderPipeline` (`src/heart/runtime/render_pipeline.py`) now composes these
+  helpers instead of managing cache or merge logic inline.
+
+## Materials
+
+- `src/heart/runtime/render_pipeline.py`
+- `src/heart/runtime/rendering/surface_cache.py`
+- `src/heart/runtime/rendering/surface_merge.py`
+- `src/heart/runtime/rendering/composition.py`

--- a/src/heart/runtime/rendering/surface_cache.py
+++ b/src/heart/runtime/rendering/surface_cache.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pygame
+
+from heart import DeviceDisplayMode
+from heart.device import Device
+from heart.utilities.env import Configuration
+
+if TYPE_CHECKING:
+    from heart.renderers import BaseRenderer, StatefulBaseRenderer
+
+
+class RendererSurfaceCache:
+    def __init__(self, device: Device) -> None:
+        self._device = device
+        self._cache: dict[
+            tuple[int, DeviceDisplayMode, tuple[int, int]], pygame.Surface
+        ] = {}
+
+    def get(
+        self, renderer: "BaseRenderer | StatefulBaseRenderer[Any]"
+    ) -> pygame.Surface:
+        size = self._device.full_display_size()
+        if not Configuration.render_screen_cache_enabled():
+            return pygame.Surface(size, pygame.SRCALPHA)
+
+        cache_key = (id(renderer), renderer.device_display_mode, size)
+        cached = self._cache.get(cache_key)
+        if cached is None:
+            cached = pygame.Surface(size, pygame.SRCALPHA)
+            self._cache[cache_key] = cached
+        else:
+            cached.fill((0, 0, 0, 0))
+        return cached

--- a/src/heart/runtime/rendering/surface_merge.py
+++ b/src/heart/runtime/rendering/surface_merge.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
+
+import pygame
+
+from heart.runtime.rendering.composition import SurfaceComposer
+from heart.utilities.env import Configuration, RenderMergeStrategy
+
+
+class SurfaceMerger:
+    def __init__(self, composer: SurfaceComposer | None = None) -> None:
+        self._composer = composer or SurfaceComposer()
+
+    def merge_in_place(
+        self, surface1: pygame.Surface, surface2: pygame.Surface
+    ) -> pygame.Surface:
+        assert surface1.get_size() == surface2.get_size(), (
+            "Surfaces must be the same size to merge."
+        )
+        surface1.blit(surface2, (0, 0))
+        return surface1
+
+    def compose(self, surfaces: list[pygame.Surface]) -> pygame.Surface | None:
+        if not surfaces:
+            return None
+        if Configuration.render_merge_strategy() == RenderMergeStrategy.IN_PLACE:
+            base = surfaces[0]
+            for surface in surfaces[1:]:
+                base = self.merge_in_place(base, surface)
+            return base
+        return self._composer.compose_batched(surfaces)
+
+    def merge_parallel(
+        self,
+        surfaces: list[pygame.Surface],
+        executor: ThreadPoolExecutor,
+        merge_fn: Callable[[pygame.Surface, pygame.Surface], pygame.Surface] | None = None,
+    ) -> pygame.Surface | None:
+        if not surfaces:
+            return None
+        if Configuration.render_merge_strategy() == RenderMergeStrategy.BATCHED:
+            return self._composer.compose_batched(surfaces)
+        return self._merge_surfaces_parallel(
+            surfaces, executor, merge_fn or self.merge_in_place
+        )
+
+    def _merge_surface_pair(
+        self,
+        surfaces: tuple[pygame.Surface, pygame.Surface],
+        merge_fn: Callable[[pygame.Surface, pygame.Surface], pygame.Surface],
+    ) -> pygame.Surface:
+        return merge_fn(*surfaces)
+
+    def _merge_surfaces_parallel(
+        self,
+        surfaces: list[pygame.Surface],
+        executor: ThreadPoolExecutor,
+        merge_fn: Callable[[pygame.Surface, pygame.Surface], pygame.Surface],
+    ) -> pygame.Surface | None:
+        if not surfaces:
+            return None
+        while len(surfaces) > 1:
+            pairs = list(zip(surfaces[0::2], surfaces[1::2]))
+            merge_pair = partial(self._merge_surface_pair, merge_fn=merge_fn)
+            merged_surfaces = list(executor.map(merge_pair, pairs))
+            if len(surfaces) % 2 == 1:
+                merged_surfaces.append(surfaces[-1])
+            surfaces = merged_surfaces
+        return surfaces[0]


### PR DESCRIPTION
### Motivation

- Reduce complexity in `RenderPipeline` by extracting surface caching and merge logic to focused helpers to improve readability and reuse.  
- Centralize render surface merge strategies so different merge policies (in-place, batched, parallel) can be implemented and tested in one place.  
- Make the pipeline easier to extend and maintain by keeping orchestration separate from low-level surface management.  

### Description

- Added `RendererSurfaceCache` in `src/heart/runtime/rendering/surface_cache.py` to own the renderer surface cache keyed by renderer id, display mode, and size and to respect `Configuration.render_screen_cache_enabled()`.  
- Added `SurfaceMerger` in `src/heart/runtime/rendering/surface_merge.py` to centralize `merge_in_place`, batched composition and parallel pairwise merging, and to accept custom `merge_fn` for pipeline hooks.  
- Updated `src/heart/runtime/render_pipeline.py` to delegate surface creation to `RendererSurfaceCache`, delegate merging to `SurfaceMerger`, and preserve the `merge_surfaces` hook used by tests and callers.  
- Added a research note `docs/research/renderer_surface_helpers.md` documenting the refactor and the touched modules.  

### Testing

- Ran `make format` to apply repository formatting rules and it completed successfully.  
- Ran the full test suite with `make test` and the test run completed with `187 passed, 1 skipped`.  
- Verified the pipeline still exposes `merge_surfaces` so existing tests that monkeypatch that hook continue to work.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c6e06e32c83218283dfaa0c89dc26)