### PR TITLE
Stabilize reactive stream coalescing and guard sounddevice import

### DIFF
--- a/src/heart/peripheral/microphone.py
+++ b/src/heart/peripheral/microphone.py
@@ -25,7 +25,10 @@ if (
     importlib.util.find_spec("sounddevice") is not None
     and ctypes.util.find_library("portaudio") is not None
 ):  # pragma: no cover - optional dependency
-    sd = cast(Any | None, importlib.import_module("sounddevice"))
+    try:
+        sd = cast(Any | None, importlib.import_module("sounddevice"))
+    except Exception as exc:  # pragma: no cover - depends on host
+        logger.info("sounddevice import failed; skipping microphone support: %s", exc)
 
 
 class Microphone(Peripheral[MicrophoneLevel]):


### PR DESCRIPTION
### Motivation

- Prevent missed or delayed emissions from coalesced reactive streams when the scheduled timer is late or overdue. 
- Avoid import-time crashes when `sounddevice` is installed but not loadable so microphone support remains optional. 

### Description

- In `src/heart/utilities/reactivex_streams.py` add `time`-based monotonic `deadline` tracking and emit overdue pending values immediately inside `_coalesce_latest` so a delayed timer doesn't skip a coalesce window. 
- Ensure `deadline` is cleared on flush, error, completion, and dispose to keep coalescing state consistent. 
- In `src/heart/peripheral/microphone.py` wrap `importlib.import_module("sounddevice")` in a `try/except Exception` and log failures so `sd` is left as `None` when the import cannot be completed. 

### Testing

- Ran `make format` and formatting checks passed. 
- Ran `make test` and the test suite completed successfully with `187 passed, 1 skipped`. 
- Verified targeted coalescing behavior by exercising `share_stream` paths that use `_coalesce_latest`. 
- No automated tests failed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c7b1abb148321a66646a0ee41eaee)