### PR TITLE
Expand test docstring rationale

### DIFF
--- a/tests/navigation/test_composed_renderer_initialization.py
+++ b/tests/navigation/test_composed_renderer_initialization.py
@@ -23,7 +23,7 @@ class _ColdAtomicRenderer(StatefulBaseRenderer[int]):
 
 
 class TestComposedRendererInitialization:
-    """Validate composed renderer warms up child state even when warmup is disabled."""
+    """Validate composed renderer warms up child state so cold renderers do not crash."""
 
     def test_initializes_child_renderer_with_warmup_disabled(self) -> None:
         """The composed renderer should initialize children regardless of warmup flags to avoid atomic errors."""

--- a/tests/peripheral/test_microphone.py
+++ b/tests/peripheral/test_microphone.py
@@ -7,7 +7,7 @@ class TestPeripheralMicrophone:
     """Group Peripheral Microphone tests so peripheral microphone behaviour stays reliable. This preserves confidence in peripheral microphone for end-to-end scenarios."""
 
     def test_detect_without_sounddevice(self, monkeypatch):
-        """Detection should short-circuit when sounddevice is unavailable."""
+        """Verify detect short-circuits without sounddevice so deployments degrade gracefully."""
 
         monkeypatch.setattr(microphone, "sd", None)
         assert list(Microphone.detect()) == []

--- a/tests/renderers/test_combined_bpm_screen_provider.py
+++ b/tests/renderers/test_combined_bpm_screen_provider.py
@@ -21,7 +21,7 @@ def _timing_inputs(draw: st.DrawFn) -> tuple[int, int, int, int, bool]:
 
 
 class TestCombinedBpmScreenProviderTransitions:
-    """Property tests for combined BPM transitions to keep screen toggles reliable."""
+    """Property tests for combined BPM transitions so screen toggles stay predictable."""
 
     @given(data=_timing_inputs())
     def test_advance_state_holds_until_threshold(

--- a/tests/renderers/test_slide_transition_provider.py
+++ b/tests/renderers/test_slide_transition_provider.py
@@ -41,7 +41,7 @@ def _screen_refresh_inputs(draw: st.DrawFn) -> tuple[int, int, int]:
 
 
 class TestSlideTransitionProviderStateTransitions:
-    """Property checks for slide transitions to keep renderer sequencing stable."""
+    """Property checks for slide transitions so renderer sequencing stays stable under motion."""
 
     class _StubRenderer(StatefulBaseRenderer[int]):
         def _create_initial_state(self, window, clock, peripheral_manager, orientation) -> int:

--- a/tests/utilities/test_reactivex_streams.py
+++ b/tests/utilities/test_reactivex_streams.py
@@ -9,7 +9,7 @@ from heart.utilities.reactivex_streams import share_stream
 
 
 class TestShareStreamStrategy:
-    """Validate reactive stream sharing strategies for core event pipelines."""
+    """Validate reactive stream sharing strategies so core event pipelines stay consistent."""
 
     @pytest.mark.parametrize(
         ("strategy", "expected_initial"),
@@ -97,7 +97,7 @@ class TestShareStreamStrategy:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Confirm replay buffer sizing keeps recent context available for observability and recovery."""
+        """Confirm replay buffer sizing keeps recent context available so observability stays accurate."""
 
         monkeypatch.setenv("HEART_RX_STREAM_SHARE_STRATEGY", "replay_buffer")
         monkeypatch.setenv("HEART_RX_STREAM_REPLAY_BUFFER", "2")
@@ -274,7 +274,7 @@ class TestShareStreamStrategy:
 
 
 class TestShareStreamFlowControl:
-    """Cover flow-control safeguards that protect reactive streams under high-frequency loads."""
+    """Cover flow-control safeguards so reactive streams stay stable under high-frequency loads."""
 
     def test_share_stream_coalesces_latest_when_configured(
         self,


### PR DESCRIPTION
### Motivation

- Improve test docstrings to state both the specific behaviour under test and the higher-level rationale so test documentation meets repository conventions.
- Make intent clearer for renderer, peripheral, navigation, and reactive-stream tests so future readers and maintainers understand why each assertion matters.

### Description

- Updated docstrings in test files to emphasize behaviour and system-level rationale, including `tests/navigation/test_composed_renderer_initialization.py`, `tests/peripheral/test_microphone.py`, `tests/renderers/test_combined_bpm_screen_provider.py`, `tests/renderers/test_slide_transition_provider.py`, and `tests/utilities/test_reactivex_streams.py`.
- Rephrased several class- and function-level test docstrings to follow the guidance in the repository `AGENTS.md` about describing behaviour and why it matters.
- Applied project formatting via `make format` to ensure linting and style consistency.

### Testing

- Ran `make format` and the formatter reported success.
- Ran `make test` and the full Pytest suite completed successfully with `187 passed, 1 skipped`.
- All modified tests executed as part of the suite and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c7bd31d548321830b464912f3f9e5)