### PR TITLE
Raise UpdateError for driver updates and avoid sys.exit in reusable modules

### DIFF
--- a/docs/debugging/circuitpython_peripherals.md
+++ b/docs/debugging/circuitpython_peripherals.md
@@ -30,6 +30,7 @@ When you use `heart`'s driver update helper (`src/heart/manage/update.py`), it w
 - Download the configured UF2 or CircuitPython bundle and verify its SHA-256 checksum.
 - Skip optional `.mpy` bundle files that are not present in the bundle.
 - Copy driver `code.py`, `boot.py`, and `settings.toml` into matching `CIRCUITPY` volumes.
+- Raise `UpdateError` when preconditions fail so CLIs can exit with a non-zero status.
 
 ## Iteration Practices
 

--- a/src/heart/cli/loop_commands.py
+++ b/src/heart/cli/loop_commands.py
@@ -4,6 +4,7 @@ import typer
 from PIL import Image
 
 from heart.device.selection import select_device
+from heart.manage.update import UpdateError
 from heart.manage.update import main as update_driver_main
 from heart.peripheral.core.providers import container
 from heart.programs.registry import ConfigurationRegistry
@@ -46,7 +47,11 @@ def run_command(
 
 
 def update_driver_command(name: Annotated[str, typer.Option("--name")]) -> None:
-    update_driver_main(device_driver_name=name)
+    try:
+        update_driver_main(device_driver_name=name)
+    except UpdateError as error:
+        logger.error("Driver update failed: %s", error)
+        raise typer.Exit(code=1) from error
 
 
 def bench_device_command() -> None:

--- a/src/heart/device/rgb_display/sample_base.py
+++ b/src/heart/device/rgb_display/sample_base.py
@@ -1,5 +1,4 @@
 import argparse
-import sys
 from typing import Any
 
 from heart.utilities.logging import get_logger
@@ -199,6 +198,6 @@ class SampleBase:
             self.run()
         except KeyboardInterrupt:
             logger.info("Exiting")
-            sys.exit(0)
+            return False
 
         return True

--- a/src/heart/renderers/mandelbrot/scene.py
+++ b/src/heart/renderers/mandelbrot/scene.py
@@ -4,7 +4,6 @@ import io
 import itertools
 import os
 import pstats
-import sys
 import time
 
 import numpy as np
@@ -681,11 +680,7 @@ def main():
                 "You can analyze this file later, e.g., using 'snakeviz %s'",
                 profile_filename,
             )
-
-    # Clean up
-    raise Exception("stopping")
-    pygame.quit()
-    sys.exit()
+        pygame.quit()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Avoid calling `sys.exit` from reusable library modules so callers (CLIs/tests) can handle failures programmatically.
- Make driver update failures explicit by raising a typed exception instead of terminating the process.
- Ensure demo/sample shutdown paths return cleanly instead of forcing process exit.
- Update documentation to reflect the new driver update failure behaviour.

### Description
- Add `UpdateError` in `src/heart/manage/update.py` and replace internal `sys.exit` calls with logged `UpdateError` raises (while preserving `sys.exit(1)` in the module `__main__` wrapper).
- Have the CLI entry `update_driver_command` in `src/heart/cli/loop_commands.py` catch `UpdateError` and exit via `typer.Exit` after logging the error.
- Change the RGB matrix sample base in `src/heart/device/rgb_display/sample_base.py` to return `False` on `KeyboardInterrupt` instead of calling `sys.exit(0)`.
- Remove an artificial exception and `sys.exit()` from the Mandelbrot demo shutdown path (`src/heart/renderers/mandelbrot/scene.py`) and ensure `pygame.quit()` runs during teardown.
- Update `docs/debugging/circuitpython_peripherals.md` to note that `UpdateError` is raised for driver update precondition failures.

### Testing
- Ran `make format`, which completed successfully and applied formatting fixes.
- Ran `make test`, which executed the Pytest suite; the run produced mostly green results but failed one test due to a Hypothesis health check: `tests/renderers/test_pixels_state_provider.py::TestPixelStateProviderTransitions::test_next_state_advances_without_reset[RainStateProvider-RainState]` with an input-generation slowness error.
- Test summary was approximately `186 passed, 1 skipped, 1 failed` (the failure is the Hypothesis health-check slowdown noted above).
- No additional runtime/manual verification beyond the automated formatting and test runs was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c7bf8a5c08321a193a5c8aaa2d857)