### PR TITLE
Extract render surface cache and merge helpers

### DIFF
--- a/docs/code_flow.md
+++ b/docs/code_flow.md
@@ -12,7 +12,7 @@ Describe how a `totem run` execution traverses configuration services, the runti
 
 ## Technical Approach
 
-Represent each execution stage as a node in a Mermaid flowchart. Colour code orchestration components, service layers, inputs, and outputs so reviewers can trace transitions. The diagram captures call sequencing between the CLI, configuration registry, runtime loop, app routing, peripheral managers, and display drivers. The goal is to surface every point where the runtime crosses a service boundary or hardware interface. The frame composition stage includes merge-strategy selection and cached surface reuse.
+Represent each execution stage as a node in a Mermaid flowchart. Colour code orchestration components, service layers, inputs, and outputs so reviewers can trace transitions. The diagram captures call sequencing between the CLI, configuration registry, runtime loop, app routing, peripheral managers, and display drivers. The goal is to surface every point where the runtime crosses a service boundary or hardware interface. The frame composition stage includes merge-strategy selection and cached surface reuse handled by the RendererSurfaceCache and SurfaceMerger helpers.
 
 ## Flow Diagram
 
@@ -36,7 +36,9 @@ flowchart LR
         Loop["GameLoop Service\n(heart.runtime.game_loop.GameLoop)"]
         AppRouter["AppController / Mode Router"]
         ModeServices["Mode Services & Renderers"]
+        SurfaceCache["Surface Cache\n(RendererSurfaceCache)"]
         FrameComposer["Frame Composer\n(surface merge + strategy selection)"]
+        SurfaceMerger["Surface Merger\n(SurfaceMerger)"]
     end
 
     subgraph Inputs["Peripheral & Signal Services"]
@@ -64,8 +66,9 @@ flowchart LR
     CLI --> Registry --> Configurer --> Loop
     Configurer --> AppRouter
     Loop --> AppRouter
-    Loop --> FrameComposer
-    AppRouter --> ModeServices --> FrameComposer --> DisplaySvc
+    Loop --> SurfaceCache --> FrameComposer --> SurfaceMerger
+    AppRouter --> ModeServices --> SurfaceCache
+    SurfaceMerger --> DisplaySvc
     DisplaySvc --> LocalScreen
     DisplaySvc --> Capture --> DeviceBridge --> LedMatrix
     Capture --> AverageMirror --> SingleLED
@@ -77,7 +80,7 @@ flowchart LR
     RxScheduler --> HeartRate --> AppRouter
     RxScheduler --> PhoneText --> AppRouter
 
-    class CLI,Registry,Configurer,ModeServices,FrameComposer service;
+    class CLI,Registry,Configurer,ModeServices,SurfaceCache,FrameComposer,SurfaceMerger service;
     class Loop,AppRouter orchestrator;
     class PeripheralMgr,RxScheduler,Switch,Gamepad,Sensors,HeartRate,PhoneText input;
     class DisplaySvc,LocalScreen,Capture,DeviceBridge,LedMatrix,AverageMirror,SingleLED output;

--- a/docs/research/render_surface_helpers_refactor.md
+++ b/docs/research/render_surface_helpers_refactor.md
@@ -1,0 +1,24 @@
+# Render Surface Helper Refactor
+
+## Problem Statement
+
+The render pipeline in `src/heart/runtime/render_pipeline.py` mixed renderer surface caching, merge strategy selection, and merge execution in the same class. That coupling made it harder to reason about cache behavior versus composition logic and required tests to monkeypatch pipeline methods directly. We need dedicated helpers so the caching and merge behavior are easier to evolve while keeping pipeline-level overrides available for tests.
+
+## Materials
+
+- Local checkout of this repository.
+- Python environment with dependencies from `pyproject.toml`.
+- Source files in `src/heart/runtime/rendering/` and `src/heart/runtime/render_pipeline.py`.
+
+## Notes
+
+- `RendererSurfaceCache` now owns the per-renderer screen cache used by the runtime pipeline. This keeps the cache keying and screen reset behavior in a focused helper that can be reused or swapped without modifying the pipeline.
+- `SurfaceMerger` centralizes merge strategy selection, serial merges, and parallel merge loops. The pipeline still exposes `merge_surfaces` so tests can override the pairwise merge logic, and the helper defers to that callable.
+- The render pipeline now wires these helpers into the existing execution flow, keeping the public behavior intact while isolating cache and merge responsibilities.
+
+## References
+
+- `src/heart/runtime/render_pipeline.py`
+- `src/heart/runtime/rendering/surface_cache.py`
+- `src/heart/runtime/rendering/surface_merger.py`
+- `tests/test_environment_core_logic.py`

--- a/src/heart/runtime/render_pipeline.py
+++ b/src/heart/runtime/render_pipeline.py
@@ -11,11 +11,12 @@ from PIL import Image
 from heart import DeviceDisplayMode
 from heart.device import Device
 from heart.peripheral.core.manager import PeripheralManager
-from heart.runtime.rendering.composition import SurfaceComposer
 from heart.runtime.rendering.constants import RGBA_IMAGE_FORMAT
 from heart.runtime.rendering.display import DisplayModeManager
+from heart.runtime.rendering.surface_cache import RendererSurfaceCache
+from heart.runtime.rendering.surface_merger import SurfaceMerger
 from heart.runtime.rendering.variants import RendererVariant, RenderMethod
-from heart.utilities.env import Configuration, RenderMergeStrategy
+from heart.utilities.env import Configuration
 from heart.utilities.logging import get_logger
 from heart.utilities.logging_control import get_logging_controller
 
@@ -38,7 +39,10 @@ class RenderPipeline:
         self.renderer_variant = render_variant
         self.clock: pygame.time.Clock | None = None
         self._display_manager = DisplayModeManager(device)
-        self._surface_composer = SurfaceComposer()
+        self._surface_cache = RendererSurfaceCache(device)
+        self._surface_merger = SurfaceMerger(
+            lambda surface1, surface2: self.merge_surfaces(surface1, surface2)
+        )
 
         binary_method = cast(RenderMethod, self._render_surfaces_binary)
         iterative_method = cast(RenderMethod, self._render_surface_iterative)
@@ -51,9 +55,6 @@ class RenderPipeline:
         self._render_executor: ThreadPoolExecutor | None = None
 
         self._render_queue_depth = 0
-        self._renderer_surface_cache: dict[
-            tuple[int, DeviceDisplayMode, tuple[int, int]], pygame.Surface
-        ] = {}
 
     def set_clock(self, clock: pygame.time.Clock | None) -> None:
         self.clock = clock
@@ -66,18 +67,7 @@ class RenderPipeline:
     def _get_renderer_surface(
         self, renderer: "BaseRenderer | StatefulBaseRenderer[Any]"
     ) -> pygame.Surface:
-        size = self.device.full_display_size()
-        if not Configuration.render_screen_cache_enabled():
-            return pygame.Surface(size, pygame.SRCALPHA)
-
-        cache_key = (id(renderer), renderer.device_display_mode, size)
-        cached = self._renderer_surface_cache.get(cache_key)
-        if cached is None:
-            cached = pygame.Surface(size, pygame.SRCALPHA)
-            self._renderer_surface_cache[cache_key] = cached
-        else:
-            cached.fill((0, 0, 0, 0))
-        return cached
+        return self._surface_cache.get_surface(renderer)
 
     def _get_render_executor(self) -> ThreadPoolExecutor:
         if self._render_executor is None:
@@ -195,14 +185,7 @@ class RenderPipeline:
     def _compose_surfaces(
         self, surfaces: list[pygame.Surface]
     ) -> pygame.Surface | None:
-        if not surfaces:
-            return None
-        if Configuration.render_merge_strategy() == RenderMergeStrategy.IN_PLACE:
-            base = surfaces[0]
-            for surface in surfaces[1:]:
-                base = self.merge_surfaces(base, surface)
-            return base
-        return self._surface_composer.compose_batched(surfaces)
+        return self._surface_merger.merge_surfaces_serial(surfaces)
 
     def _collect_surfaces_serial(
         self,
@@ -230,29 +213,6 @@ class RenderPipeline:
             if surface is not None
         ]
 
-    def _merge_surface_pair(
-        self, surfaces: tuple[pygame.Surface, pygame.Surface]
-    ) -> pygame.Surface:
-        return self.merge_surfaces(*surfaces)
-
-    def _merge_surfaces_parallel(
-        self,
-        surfaces: list[pygame.Surface],
-        executor: ThreadPoolExecutor,
-    ) -> pygame.Surface | None:
-        if not surfaces:
-            return None
-        while len(surfaces) > 1:
-            pairs = list(zip(surfaces[0::2], surfaces[1::2]))
-
-            merged_surfaces = list(executor.map(self._merge_surface_pair, pairs))
-
-            if len(surfaces) % 2 == 1:
-                merged_surfaces.append(surfaces[-1])
-
-            surfaces = merged_surfaces
-        return surfaces[0]
-
     def _render_surface_iterative(
         self, renderers: list["StatefulBaseRenderer[Any]"]
     ) -> pygame.Surface | None:
@@ -269,10 +229,8 @@ class RenderPipeline:
         surfaces = self._collect_surfaces_parallel(renderers)
         if not surfaces:
             return None
-        if Configuration.render_merge_strategy() == RenderMergeStrategy.BATCHED:
-            return self._surface_composer.compose_batched(surfaces)
         executor = self._get_render_executor()
-        return self._merge_surfaces_parallel(surfaces, executor)
+        return self._surface_merger.merge_surfaces_parallel(surfaces, executor)
 
     def _resolve_render_variant(
         self,

--- a/src/heart/runtime/rendering/surface_cache.py
+++ b/src/heart/runtime/rendering/surface_cache.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pygame
+
+from heart import DeviceDisplayMode
+from heart.device import Device
+from heart.utilities.env import Configuration
+
+if TYPE_CHECKING:
+    from heart.renderers import BaseRenderer, StatefulBaseRenderer
+
+
+class RendererSurfaceCache:
+    def __init__(self, device: Device) -> None:
+        self._device = device
+        self._renderer_surface_cache: dict[
+            tuple[int, DeviceDisplayMode, tuple[int, int]], pygame.Surface
+        ] = {}
+
+    def get_surface(
+        self, renderer: "BaseRenderer | StatefulBaseRenderer[Any]"
+    ) -> pygame.Surface:
+        size = self._device.full_display_size()
+        if not Configuration.render_screen_cache_enabled():
+            return pygame.Surface(size, pygame.SRCALPHA)
+
+        cache_key = (id(renderer), renderer.device_display_mode, size)
+        cached = self._renderer_surface_cache.get(cache_key)
+        if cached is None:
+            cached = pygame.Surface(size, pygame.SRCALPHA)
+            self._renderer_surface_cache[cache_key] = cached
+        else:
+            cached.fill((0, 0, 0, 0))
+        return cached

--- a/src/heart/runtime/rendering/surface_merger.py
+++ b/src/heart/runtime/rendering/surface_merger.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Callable
+
+import pygame
+
+from heart.runtime.rendering.composition import SurfaceComposer
+from heart.utilities.env import Configuration, RenderMergeStrategy
+
+
+class SurfaceMerger:
+    def __init__(
+        self,
+        merge_pair: Callable[[pygame.Surface, pygame.Surface], pygame.Surface],
+        *,
+        composer: SurfaceComposer | None = None,
+    ) -> None:
+        self._merge_pair = merge_pair
+        self._composer = composer or SurfaceComposer()
+
+    def merge_surfaces_serial(
+        self, surfaces: list[pygame.Surface]
+    ) -> pygame.Surface | None:
+        if not surfaces:
+            return None
+        if Configuration.render_merge_strategy() == RenderMergeStrategy.IN_PLACE:
+            base = surfaces[0]
+            for surface in surfaces[1:]:
+                base = self._merge_pair(base, surface)
+            return base
+        return self._composer.compose_batched(surfaces)
+
+    def merge_surfaces_parallel(
+        self,
+        surfaces: list[pygame.Surface],
+        executor: ThreadPoolExecutor,
+    ) -> pygame.Surface | None:
+        if not surfaces:
+            return None
+        if Configuration.render_merge_strategy() == RenderMergeStrategy.BATCHED:
+            return self._composer.compose_batched(surfaces)
+        return self._merge_surfaces_parallel(surfaces, executor)
+
+    def _merge_surface_pair(
+        self, surfaces: tuple[pygame.Surface, pygame.Surface]
+    ) -> pygame.Surface:
+        return self._merge_pair(*surfaces)
+
+    def _merge_surfaces_parallel(
+        self,
+        surfaces: list[pygame.Surface],
+        executor: ThreadPoolExecutor,
+    ) -> pygame.Surface:
+        while len(surfaces) > 1:
+            pairs = list(zip(surfaces[0::2], surfaces[1::2]))
+
+            merged_surfaces = list(executor.map(self._merge_surface_pair, pairs))
+
+            if len(surfaces) % 2 == 1:
+                merged_surfaces.append(surfaces[-1])
+
+            surfaces = merged_surfaces
+        return surfaces[0]


### PR DESCRIPTION
### Motivation
- Separate concerns in the render pipeline by removing surface caching and merge logic from `RenderPipeline` so each responsibility is easier to reason about and test.
- Centralize merge strategy selection and parallel merge loops to make composition behaviour consistent and pluggable.
- Preserve existing pipeline-level pairwise merge overrides used by tests while enabling future changes to caching and composition implementations.
- Document the refactor to make the runtime flow and design intent discoverable for reviewers and future contributors.

### Description
- Added `src/heart/runtime/rendering/surface_cache.py` implementing `RendererSurfaceCache` to own per-renderer screen cache keying and reset behaviour.
- Added `src/heart/runtime/rendering/surface_merger.py` implementing `SurfaceMerger` to centralize merge strategy selection, serial merging, and parallel merging logic.
- Wired the helpers into `src/heart/runtime/render_pipeline.py` by replacing inline cache and merge loops with `RendererSurfaceCache.get_surface` and `SurfaceMerger` calls while keeping `RenderPipeline.merge_surfaces` available for test overrides.
- Updated documentation with `docs/research/render_surface_helpers_refactor.md` and adjusted `docs/code_flow.md` and regenerated the flow diagram to mention `RendererSurfaceCache` and `SurfaceMerger`.

### Testing
- Ran `make format` and formatting checks completed successfully.
- Ran `python scripts/render_code_flow.py` to regenerate the runtime diagram (no errors reported during generation).
- Ran `make test`, which executed the test suite; the run produced `186 passed, 1 failed, 1 skipped` and overall exited non-zero due to one failing test.
- The failing test is `tests/renderers/test_sliding_state_provider.py::TestSlidingStateProviderTransitions::test_advance_state_uses_expected_width[spec0]`, which failed with a Hypothesis `FailedHealthCheck` (input generation slow) rather than an assertion related to the new helpers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c7c4e937c8321a3d7525ed7e6a7dd)