### PR TITLE
Refactor render pipeline: separate surface provider and composition manager

### DIFF
--- a/docs/code_flow.svg
+++ b/docs/code_flow.svg
@@ -14,7 +14,7 @@
     <text x="194.00" y="74.00" text-anchor="middle" class="column-title">Launch &amp; Configuration Services</text>
   </g>
   <g>
-    <rect x="404.00" y="48.00" width="260.00" height="400.00" rx="18" fill="#e2e8f0" stroke="#cbd5f5" />
+    <rect x="404.00" y="48.00" width="260.00" height="564.00" rx="18" fill="#e2e8f0" stroke="#cbd5f5" />
     <text x="534.00" y="74.00" text-anchor="middle" class="column-title">GameLoop Orchestration</text>
   </g>
   <g>
@@ -34,7 +34,9 @@
     <path d="M 534.00 174.00 C 534.00 265.00 534.00 265.00 534.00 356.00" marker-end="url(#arrowhead)" />
     <path d="M 534.00 256.00 C 534.00 265.00 534.00 265.00 534.00 274.00" marker-end="url(#arrowhead)" />
     <path d="M 534.00 338.00 C 534.00 347.00 534.00 347.00 534.00 356.00" marker-end="url(#arrowhead)" />
-    <path d="M 646.00 388.00 C 686.00 388.00 1062.00 142.00 1102.00 142.00" marker-end="url(#arrowhead)" />
+    <path d="M 534.00 420.00 C 534.00 470.00 534.00 470.00 534.00 520.00" marker-end="url(#arrowhead)" />
+    <path d="M 534.00 420.00 C 534.00 429.00 534.00 429.00 534.00 438.00" marker-end="url(#arrowhead)" />
+    <path d="M 646.00 552.00 C 686.00 552.00 1062.00 142.00 1102.00 142.00" marker-end="url(#arrowhead)" />
     <path d="M 1214.00 174.00 C 1214.00 183.00 1214.00 183.00 1214.00 192.00" marker-end="url(#arrowhead)" />
     <path d="M 1214.00 174.00 C 1214.00 224.00 1214.00 224.00 1214.00 274.00" marker-end="url(#arrowhead)" />
     <path d="M 1214.00 338.00 C 1214.00 347.00 1214.00 347.00 1214.00 356.00" marker-end="url(#arrowhead)" />
@@ -70,7 +72,7 @@
     <rect x="422.00" y="110.00" width="224.00" height="64.00" rx="12" fill="#1d4ed8" stroke="#1d4ed8" />
     <text x="534.00" y="133.00" fill="#f8fafc" text-anchor="middle">
       <tspan x="534.00">GameLoop Service</tspan>
-      <tspan x="534.00" dy="18">(start + main loop)</tspan>
+      <tspan x="534.00" dy="18">(heart.runtime.game_loop.GameLoop)</tspan>
     </text>
     <rect x="422.00" y="192.00" width="224.00" height="64.00" rx="12" fill="#1d4ed8" stroke="#1d4ed8" />
     <text x="534.00" y="224.00" fill="#f8fafc" text-anchor="middle">
@@ -81,9 +83,18 @@
       <tspan x="534.00">Mode Services &amp; Renderers</tspan>
     </text>
     <rect x="422.00" y="356.00" width="224.00" height="64.00" rx="12" fill="#0f172a" stroke="#0f172a" />
-    <text x="534.00" y="379.00" fill="#f8fafc" text-anchor="middle">
-      <tspan x="534.00">Frame Composer</tspan>
-      <tspan x="534.00" dy="18">(surface merge + timing)</tspan>
+    <text x="534.00" y="388.00" fill="#f8fafc" text-anchor="middle">
+      <tspan x="534.00">Render Pipeline</tspan>
+    </text>
+    <rect x="422.00" y="438.00" width="224.00" height="64.00" rx="12" fill="#0f172a" stroke="#0f172a" />
+    <text x="534.00" y="461.00" fill="#f8fafc" text-anchor="middle">
+      <tspan x="534.00">Surface Provider</tspan>
+      <tspan x="534.00" dy="18">(display mode + surface cache)</tspan>
+    </text>
+    <rect x="422.00" y="520.00" width="224.00" height="64.00" rx="12" fill="#0f172a" stroke="#0f172a" />
+    <text x="534.00" y="543.00" fill="#f8fafc" text-anchor="middle">
+      <tspan x="534.00">Composition Manager</tspan>
+      <tspan x="534.00" dy="18">(merge strategy + parallel loops)</tspan>
     </text>
     <rect x="762.00" y="110.00" width="224.00" height="64.00" rx="12" fill="#0369a1" stroke="#0369a1" />
     <text x="874.00" y="133.00" fill="#f8fafc" text-anchor="middle">

--- a/docs/research/render_pipeline_composition_refactor.md
+++ b/docs/research/render_pipeline_composition_refactor.md
@@ -1,0 +1,26 @@
+# Render pipeline composition refactor note
+
+## Problem statement
+
+Document the render pipeline refactor that separates surface preparation, caching, and merge coordination so future contributors can reason about composition responsibilities and extend merge behavior safely.
+
+## Materials
+
+- Local checkout of the Heart repository.
+- `src/heart/runtime/render_pipeline.py` for pipeline orchestration changes.
+- `src/heart/runtime/rendering/surface_provider.py` for surface preparation and caching.
+- `src/heart/runtime/rendering/surface_merge.py` for merge strategy selection and parallel merge coordination.
+- `docs/code_flow.md` for the updated runtime flow diagram and narrative.
+
+## Notes
+
+- Surface preparation now lives in a dedicated provider that owns display-mode enforcement and cached surface reuse, keeping `RenderPipeline` focused on orchestration.
+- Merge strategy selection and the parallel reduction loop are centralized in the composition manager so serial and parallel rendering share the same strategy controls.
+- `RenderPipeline.merge_surfaces` remains as the pairwise merge hook, allowing tests to override the merge function while using the shared composition manager.
+
+## Source references
+
+- `src/heart/runtime/render_pipeline.py`
+- `src/heart/runtime/rendering/surface_provider.py`
+- `src/heart/runtime/rendering/surface_merge.py`
+- `docs/code_flow.md`

--- a/scripts/render_code_flow.py
+++ b/scripts/render_code_flow.py
@@ -58,11 +58,27 @@ COLUMNS: tuple[ColumnDef, ...] = (
     ColumnDef(
         "GameLoop Orchestration",
         (
-            NodeDef("loop", "GameLoop Service\n(start + main loop)", "orchestrator"),
+            NodeDef(
+                "loop",
+                "GameLoop Service\n(heart.runtime.game_loop.GameLoop)",
+                "orchestrator",
+            ),
             NodeDef("app_router", "AppController / Mode Router", "orchestrator"),
             NodeDef("mode_services", "Mode Services & Renderers", "service"),
             NodeDef(
-                "frame_composer", "Frame Composer\n(surface merge + timing)", "service"
+                "render_pipeline",
+                "Render Pipeline",
+                "service",
+            ),
+            NodeDef(
+                "surface_provider",
+                "Surface Provider\n(display mode + surface cache)",
+                "service",
+            ),
+            NodeDef(
+                "composition_manager",
+                "Composition Manager\n(merge strategy + parallel loops)",
+                "service",
             ),
         ),
     ),
@@ -99,10 +115,12 @@ EDGES: tuple[EdgeDef, ...] = (
     EdgeDef("configurer", "loop"),
     EdgeDef("configurer", "app_router", "adds modes & scenes"),
     EdgeDef("loop", "app_router"),
-    EdgeDef("loop", "frame_composer"),
+    EdgeDef("loop", "render_pipeline"),
     EdgeDef("app_router", "mode_services"),
-    EdgeDef("mode_services", "frame_composer"),
-    EdgeDef("frame_composer", "display_service"),
+    EdgeDef("mode_services", "render_pipeline"),
+    EdgeDef("render_pipeline", "composition_manager"),
+    EdgeDef("render_pipeline", "surface_provider"),
+    EdgeDef("composition_manager", "display_service"),
     EdgeDef("display_service", "local_screen"),
     EdgeDef("display_service", "capture"),
     EdgeDef("capture", "device_bridge"),

--- a/src/heart/runtime/rendering/surface_provider.py
+++ b/src/heart/runtime/rendering/surface_provider.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pygame
+
+from heart.device import Device
+from heart.runtime.rendering.display import DisplayModeManager
+from heart.runtime.rendering.surface_cache import RendererSurfaceCache
+
+if TYPE_CHECKING:
+    from heart.renderers import StatefulBaseRenderer
+
+
+class RendererSurfaceProvider:
+    def __init__(
+        self,
+        device: Device,
+        display_manager: DisplayModeManager | None = None,
+        surface_cache: RendererSurfaceCache | None = None,
+    ) -> None:
+        self._display_manager = display_manager or DisplayModeManager(device)
+        self._surface_cache = surface_cache or RendererSurfaceCache(device)
+
+    def prepare(self, renderer: "StatefulBaseRenderer[Any]") -> pygame.Surface:
+        self._display_manager.ensure_mode(renderer.device_display_mode)
+        return self._surface_cache.get(renderer)


### PR DESCRIPTION
### Motivation
- Separate surface preparation and caching from composition so the render pipeline has a single clear orchestration responsibility.
- Centralize merge strategy selection and the parallel reduction loop to make composition behaviour consistent and pluggable.
- Preserve the existing pipeline-level pairwise merge override so tests and callers can still inject custom merge behaviour.
- Document the runtime flow change so reviewers and future contributors can discover the design intent.

### Description
- Extract `RendererSurfaceProvider` (`src/heart/runtime/rendering/surface_provider.py`) to own display-mode enforcement and cached surface reuse.
- Replace the old `SurfaceMerger` with `SurfaceCompositionManager` (`src/heart/runtime/rendering/surface_merge.py`) that exposes `compose_serial` and `compose_parallel` and accepts a merge strategy provider.
- Update `RenderPipeline` to delegate surface preparation to the provider and composition to the composition manager while keeping `RenderPipeline.merge_surfaces` as the pairwise hook for test overrides (`src/heart/runtime/render_pipeline.py`).
- Refresh runtime documentation and the diagram (`docs/code_flow.md`, `scripts/render_code_flow.py`, `docs/code_flow.svg`) and add a research note describing the refactor (`docs/research/render_pipeline_composition_refactor.md`).

### Testing
- Ran `make format` and formatting checks completed successfully.
- Regenerated the runtime diagram with `python scripts/render_code_flow.py --output docs/code_flow.svg`.
- Executed the test suite with `make test` and the run completed with all automated tests passing (187 passed, 1 skipped).
- Verified the previous render-pipeline unit tests still exercise the pipeline-level merge override behaviour via existing test coverage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c9a4eb6688321a104359cd5bdd673)