### PR TITLE
Extract RendererProcessor from RenderPipeline

### DIFF
--- a/docs/research/render_pipeline_renderer_processor_split.md
+++ b/docs/research/render_pipeline_renderer_processor_split.md
@@ -1,0 +1,18 @@
+# Render pipeline renderer processor split
+
+## Summary
+
+The renderer-specific surface preparation, initialization, and metrics logging now
+live in a dedicated `RendererProcessor` helper. `RenderPipeline` keeps the
+render-variant selection and surface composition responsibilities, while
+`RendererProcessor` encapsulates per-renderer work so the pipeline reads as a
+high-level orchestration step.
+
+## Sources
+
+- `src/heart/runtime/render_pipeline.py`
+- `src/heart/runtime/rendering/renderer_processor.py`
+
+## Materials
+
+- None

--- a/src/heart/runtime/render_pipeline.py
+++ b/src/heart/runtime/render_pipeline.py
@@ -1,30 +1,24 @@
 from __future__ import annotations
 
-import logging
-import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, cast
 
 import pygame
 from PIL import Image
 
-from heart import DeviceDisplayMode
 from heart.device import Device
 from heart.peripheral.core.manager import PeripheralManager
 from heart.runtime.rendering.constants import RGBA_IMAGE_FORMAT
 from heart.runtime.rendering.display import DisplayModeManager
+from heart.runtime.rendering.renderer_processor import RendererProcessor
 from heart.runtime.rendering.surface_cache import RendererSurfaceCache
 from heart.runtime.rendering.surface_merge import SurfaceMerger
 from heart.runtime.rendering.variants import RendererVariant, RenderMethod
 from heart.utilities.env import Configuration, RenderMergeStrategy
-from heart.utilities.logging import get_logger
 from heart.utilities.logging_control import get_logging_controller
 
 if TYPE_CHECKING:
     from heart.renderers import StatefulBaseRenderer
-
-logger = get_logger(__name__)
-log_controller = get_logging_controller()
 
 
 class RenderPipeline:
@@ -41,6 +35,13 @@ class RenderPipeline:
         self._display_manager = DisplayModeManager(device)
         self._surface_cache = RendererSurfaceCache(device)
         self._surface_merger = SurfaceMerger()
+        self._renderer_processor = RendererProcessor(
+            device=device,
+            peripheral_manager=peripheral_manager,
+            display_manager=self._display_manager,
+            surface_cache=self._surface_cache,
+            log_controller=get_logging_controller(),
+        )
 
         binary_method = cast(RenderMethod, self._render_surfaces_binary)
         iterative_method = cast(RenderMethod, self._render_surface_iterative)
@@ -75,77 +76,12 @@ class RenderPipeline:
             raise RuntimeError("GameLoop clock is not initialized")
         return clock
 
-    def _prepare_renderer_surface(
-        self, renderer: "StatefulBaseRenderer[Any]"
-    ) -> pygame.Surface:
-        self._display_manager.ensure_mode(renderer.device_display_mode)
-        return self._surface_cache.get(renderer)
-
     def process_renderer(
         self, renderer: "StatefulBaseRenderer[Any]"
     ) -> pygame.Surface | None:
-        try:
-            start_ns = time.perf_counter_ns()
-            screen = self._render_renderer_frame(renderer)
-            duration_ms = (time.perf_counter_ns() - start_ns) / 1_000_000
-            self._log_renderer_metrics(renderer, duration_ms)
-            return screen
-        except Exception:
-            logger.exception("Error processing renderer")
-            return None
-
-    def _render_renderer_frame(
-        self, renderer: "StatefulBaseRenderer[Any]"
-    ) -> pygame.Surface:
         clock = self._require_clock()
-        screen = self._prepare_renderer_surface(renderer)
-        if not renderer.initialized:
-            renderer.initialize(
-                window=screen,
-                clock=clock,
-                peripheral_manager=self.peripheral_manager,
-                orientation=self.device.orientation,
-            )
-        renderer._internal_process(
-            window=screen,
-            clock=clock,
-            peripheral_manager=self.peripheral_manager,
-            orientation=self.device.orientation,
-        )
-        return screen
-
-    def _log_renderer_metrics(
-        self, renderer: "StatefulBaseRenderer[Any]", duration_ms: float
-    ) -> None:
-        log_message = (
-            "render.loop renderer=%s duration_ms=%.2f queue_depth=%s "
-            "display_mode=%s uses_opengl=%s initialized=%s"
-        )
-        log_args = (
-            renderer.name,
-            duration_ms,
-            self._render_queue_depth,
-            renderer.device_display_mode.name,
-            renderer.device_display_mode == DeviceDisplayMode.OPENGL,
-            renderer.is_initialized(),
-        )
-        log_extra = {
-            "renderer": renderer.name,
-            "duration_ms": duration_ms,
-            "queue_depth": self._render_queue_depth,
-            "display_mode": renderer.device_display_mode.name,
-            "uses_opengl": renderer.device_display_mode == DeviceDisplayMode.OPENGL,
-            "initialized": renderer.is_initialized(),
-        }
-
-        log_controller.log(
-            key="render.loop",
-            logger=logger,
-            level=logging.INFO,
-            msg=log_message,
-            args=log_args,
-            extra=log_extra,
-            fallback_level=logging.DEBUG,
+        return self._renderer_processor.process(
+            renderer, clock, self._render_queue_depth
         )
 
     def finalize_rendering(self, screen: pygame.Surface) -> Image.Image:

--- a/src/heart/runtime/rendering/renderer_processor.py
+++ b/src/heart/runtime/rendering/renderer_processor.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+import pygame
+
+from heart import DeviceDisplayMode
+from heart.device import Device
+from heart.peripheral.core.manager import PeripheralManager
+from heart.runtime.rendering.display import DisplayModeManager
+from heart.runtime.rendering.surface_cache import RendererSurfaceCache
+from heart.utilities.logging import get_logger
+from heart.utilities.logging_control import LoggingController
+
+if TYPE_CHECKING:
+    from heart.renderers import StatefulBaseRenderer
+
+logger = get_logger(__name__)
+
+
+class RendererProcessor:
+    def __init__(
+        self,
+        *,
+        device: Device,
+        peripheral_manager: PeripheralManager,
+        display_manager: DisplayModeManager,
+        surface_cache: RendererSurfaceCache,
+        log_controller: LoggingController,
+    ) -> None:
+        self._device = device
+        self._peripheral_manager = peripheral_manager
+        self._display_manager = display_manager
+        self._surface_cache = surface_cache
+        self._log_controller = log_controller
+
+    def process(
+        self,
+        renderer: "StatefulBaseRenderer[Any]",
+        clock: pygame.time.Clock,
+        queue_depth: int,
+    ) -> pygame.Surface | None:
+        try:
+            start_ns = time.perf_counter_ns()
+            screen = self._render_renderer_frame(renderer, clock)
+            duration_ms = (time.perf_counter_ns() - start_ns) / 1_000_000
+            self._log_renderer_metrics(renderer, duration_ms, queue_depth)
+            return screen
+        except Exception:
+            logger.exception("Error processing renderer")
+            return None
+
+    def _prepare_renderer_surface(
+        self, renderer: "StatefulBaseRenderer[Any]"
+    ) -> pygame.Surface:
+        self._display_manager.ensure_mode(renderer.device_display_mode)
+        return self._surface_cache.get(renderer)
+
+    def _render_renderer_frame(
+        self, renderer: "StatefulBaseRenderer[Any]", clock: pygame.time.Clock
+    ) -> pygame.Surface:
+        screen = self._prepare_renderer_surface(renderer)
+        if not renderer.initialized:
+            renderer.initialize(
+                window=screen,
+                clock=clock,
+                peripheral_manager=self._peripheral_manager,
+                orientation=self._device.orientation,
+            )
+        renderer._internal_process(
+            window=screen,
+            clock=clock,
+            peripheral_manager=self._peripheral_manager,
+            orientation=self._device.orientation,
+        )
+        return screen
+
+    def _log_renderer_metrics(
+        self,
+        renderer: "StatefulBaseRenderer[Any]",
+        duration_ms: float,
+        queue_depth: int,
+    ) -> None:
+        log_message = (
+            "render.loop renderer=%s duration_ms=%.2f queue_depth=%s "
+            "display_mode=%s uses_opengl=%s initialized=%s"
+        )
+        log_args = (
+            renderer.name,
+            duration_ms,
+            queue_depth,
+            renderer.device_display_mode.name,
+            renderer.device_display_mode == DeviceDisplayMode.OPENGL,
+            renderer.is_initialized(),
+        )
+        log_extra = {
+            "renderer": renderer.name,
+            "duration_ms": duration_ms,
+            "queue_depth": queue_depth,
+            "display_mode": renderer.device_display_mode.name,
+            "uses_opengl": renderer.device_display_mode == DeviceDisplayMode.OPENGL,
+            "initialized": renderer.is_initialized(),
+        }
+
+        self._log_controller.log(
+            key="render.loop",
+            logger=logger,
+            level=logging.INFO,
+            msg=log_message,
+            args=log_args,
+            extra=log_extra,
+            fallback_level=logging.DEBUG,
+        )


### PR DESCRIPTION
### Motivation

- Reduce complexity in `RenderPipeline` by moving per-renderer responsibilities into a focused helper, improving readability and single-responsibility boundaries. 
- Isolate renderer surface preparation, initialization, and metric logging so these concerns can be tested and evolved independently. 
- Make the render orchestration easier to reason about and maintain by delegating detailed renderer work to a separate component. 

### Description

- Add a new helper `RendererProcessor` in `src/heart/runtime/rendering/renderer_processor.py` that encapsulates surface preparation, renderer initialization, frame processing, and metrics logging. 
- Simplify `src/heart/runtime/render_pipeline.py` to delegate per-renderer processing to `RendererProcessor` while preserving render-variant selection, surface composition, and merge behavior. 
- Add a research note `docs/research/render_pipeline_renderer_processor_split.md` documenting the split and rationale. 
- Update the code to obtain a shared `LoggingController` and pass it into `RendererProcessor` for consistent logging/sampling behavior. 

### Testing

- Ran `make format` and formatting checks completed successfully. 
- Ran the test suite with `make test` and all automated tests passed. 
- Test run summary: `187 passed, 1 skipped`. 
- Verified the new helper is exercised indirectly by existing render pipeline tests that cover rendering and merge behaviors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ca7acb1a8832188144d51c0e75865)