### PR TITLE
Log recoverable exceptions and update agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 ## Error Handling
 
 - Avoid catching `BaseException`; catch `Exception` or more specific error types so system-exiting signals propagate.
+- Avoid swallowing recoverable exceptions; log them with the shared logger (use debug-level logging for high-frequency loops).
 
 ## Testing
 

--- a/src/heart/peripheral/phyphox.py
+++ b/src/heart/peripheral/phyphox.py
@@ -5,6 +5,9 @@ import requests
 
 from heart.peripheral.core import Peripheral
 from heart.peripheral.sensor import Acceleration
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class Phyphox(Peripheral[Acceleration]):
@@ -27,8 +30,8 @@ class Phyphox(Peripheral[Acceleration]):
                 self.acc_x = float(data["buffer"]["accX"]["buffer"][-1])
                 self.acc_y = float(data["buffer"]["accY"]["buffer"][-1])
                 self.acc_z = float(data["buffer"]["accZ"]["buffer"][-1])
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("Phyphox request failed: %s", exc)
             time.sleep(0.05)
 
     def get_acceleration(self) -> Acceleration | None:


### PR DESCRIPTION
### Motivation

- Prevent silent swallowing of recoverable exceptions in long-running or high-frequency loops to aid debugging and observability.
- Bring repository guidance into alignment with runtime practices by requiring recoverable errors be logged with the shared logger.
- Encourage consistent use of `heart.utilities.logging.get_logger` in peripheral modules for uniform log handling.

### Description

- Add a new error-handling rule to `AGENTS.md`: "Avoid swallowing recoverable exceptions; log them with the shared logger (use debug-level logging for high-frequency loops)".
- Update `src/heart/peripheral/phyphox.py` to use `get_logger(__name__)` and replace a silent `except Exception: pass` with `logger.debug("Phyphox request failed: %s", exc)` to surface failures non-intrusively.
- No behavioral changes to public APIs; changes are limited to logging and documentation.

### Testing

- Ran `make format`, which completed successfully.
- Ran `make test`, which executed the full test suite and reported `187 passed, 1 skipped`.
- Lint/format checks passed as part of the `make format` step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ca7c4a00c8321b0394b60184e0133)