### PR TITLE
Add configurable frame export strategy for presentation

### DIFF
--- a/docs/research/frame_export_strategy.md
+++ b/docs/research/frame_export_strategy.md
@@ -1,0 +1,46 @@
+# Research Note: Frame export strategy for device presentation
+
+## Problem
+
+`FramePresenter` converts `pygame.Surface` instances into `PIL.Image` payloads
+every frame. The fallback path for presenting directly from the display relied
+on `pygame.surfarray.array3d` plus NumPy transposition, which allocates arrays
+every frame and competes with render time on large displays. We need a single
+place to choose the export algorithm so performance-sensitive deployments can
+opt into the fastest path without changing code.
+
+## Change Summary
+
+Added a `FrameExporter` helper that centralizes surface-to-image conversion and
+selects between a buffer-backed strategy and the existing array strategy. The
+default now favors the buffer-backed path, while the array strategy remains
+available for environments that prefer explicit array conversion.
+
+## Configuration
+
+- `HEART_FRAME_EXPORT_STRATEGY=buffer` (default) uses `pygame.image.tostring`
+  with `Image.frombuffer` for lower per-frame overhead.
+- `HEART_FRAME_EXPORT_STRATEGY=array` uses `pygame.surfarray.array3d` with
+  axis swapping to match the previous screen export behavior.
+
+## Sources
+
+The prior research on surface export notes that: "Switched to `pygame.image.tostring`
+plus `Image.frombuffer` to build the RGBA image directly from SDL's pixel
+buffer." (See `docs/research/perf_finalize_rendering.md`.) This informs the new
+default because it relies on the same C-backed conversion path.
+
+The array strategy mirrors the frame accumulator work that says:
+"`FrameAccumulator.as_array` converts the accumulated surface into an RGB array
+by calling `pygame.surfarray.array3d`." (See
+`docs/research/frame_accumulator_array_strategy.md`.) This remains available as
+an explicit option when that trade-off is desired.
+
+## Materials
+
+- `src/heart/runtime/frame_exporter.py`
+- `src/heart/runtime/frame_presenter.py`
+- `src/heart/utilities/env/enums.py`
+- `src/heart/utilities/env/rendering.py`
+- `docs/research/perf_finalize_rendering.md`
+- `docs/research/frame_accumulator_array_strategy.md`

--- a/src/heart/runtime/frame_exporter.py
+++ b/src/heart/runtime/frame_exporter.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pygame
+from PIL import Image
+
+from heart.runtime.rendering.constants import RGBA_IMAGE_FORMAT
+from heart.utilities.env import Configuration, FrameExportStrategy
+
+
+class FrameExporter:
+    """Convert pygame surfaces into PIL images using configurable strategies."""
+
+    def __init__(
+        self,
+        strategy_provider: Callable[[], FrameExportStrategy] | None = None,
+    ) -> None:
+        self._strategy_provider = (
+            strategy_provider or Configuration.frame_export_strategy
+        )
+
+    def export(self, surface: pygame.Surface) -> Image.Image:
+        strategy = self._strategy_provider()
+        if strategy == FrameExportStrategy.ARRAY:
+            return self._export_array(surface)
+        return self._export_buffer(surface)
+
+    def _export_buffer(self, surface: pygame.Surface) -> Image.Image:
+        image_bytes = pygame.image.tostring(surface, RGBA_IMAGE_FORMAT)
+        return Image.frombuffer(
+            RGBA_IMAGE_FORMAT,
+            surface.get_size(),
+            image_bytes,
+            "raw",
+            RGBA_IMAGE_FORMAT,
+            0,
+            1,
+        )
+
+    def _export_array(self, surface: pygame.Surface) -> Image.Image:
+        array = pygame.surfarray.array3d(surface)
+        return Image.fromarray(array.swapaxes(0, 1))

--- a/src/heart/runtime/frame_presenter.py
+++ b/src/heart/runtime/frame_presenter.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-import numpy as np
 import pygame
 from PIL import Image
 
 from heart.device import Device
 from heart.runtime.display_context import DisplayContext
+from heart.runtime.frame_exporter import FrameExporter
 from heart.runtime.render_pipeline import RenderPipeline
 
 if TYPE_CHECKING:
@@ -20,6 +20,7 @@ class FramePresenter:
     device: Device
     display: DisplayContext
     render_pipeline: RenderPipeline
+    frame_exporter: FrameExporter = field(default_factory=FrameExporter)
 
     def present(
         self,
@@ -35,16 +36,19 @@ class FramePresenter:
         self._present_from_screen()
 
     def _present_render_surface(self, render_surface: pygame.Surface) -> None:
-        render_image = self.render_pipeline.finalize_rendering(render_surface)
-        device_image = (
-            render_image.convert("RGB") if render_image.mode != "RGB" else render_image
-        )
+        render_image = self.frame_exporter.export(render_surface)
+        device_image = self._prepare_device_image(render_image)
         self.device.set_image(device_image)
 
     def _present_from_screen(self) -> None:
         if self.display.screen is None:
             raise RuntimeError("GameLoop screen is not initialized")
-        screen_array = pygame.surfarray.array3d(self.display.screen)
-        transposed_array = np.transpose(screen_array, (1, 0, 2))
-        pil_image = Image.fromarray(transposed_array)
-        self.device.set_image(pil_image)
+        screen_image = self.frame_exporter.export(self.display.screen)
+        device_image = self._prepare_device_image(screen_image)
+        self.device.set_image(device_image)
+
+    @staticmethod
+    def _prepare_device_image(image: Image.Image) -> Image.Image:
+        if image.mode != "RGB":
+            return image.convert("RGB")
+        return image

--- a/src/heart/utilities/env/__init__.py
+++ b/src/heart/utilities/env/__init__.py
@@ -3,6 +3,8 @@
 from heart.utilities.env.config import Configuration as Configuration
 from heart.utilities.env.enums import DeviceLayoutMode as DeviceLayoutMode
 from heart.utilities.env.enums import FrameArrayStrategy as FrameArrayStrategy
+from heart.utilities.env.enums import \
+    FrameExportStrategy as FrameExportStrategy
 from heart.utilities.env.enums import LifeUpdateStrategy as LifeUpdateStrategy
 from heart.utilities.env.enums import \
     ReactivexEventBusScheduler as ReactivexEventBusScheduler

--- a/src/heart/utilities/env/enums.py
+++ b/src/heart/utilities/env/enums.py
@@ -16,6 +16,11 @@ class FrameArrayStrategy(StrEnum):
     VIEW = "view"
 
 
+class FrameExportStrategy(StrEnum):
+    BUFFER = "buffer"
+    ARRAY = "array"
+
+
 class SpritesheetFrameCacheStrategy(StrEnum):
     NONE = "none"
     FRAMES = "frames"

--- a/src/heart/utilities/env/rendering.py
+++ b/src/heart/utilities/env/rendering.py
@@ -1,8 +1,9 @@
 import os
 
 from heart.device.rgb_display.isolated_render import DEFAULT_SOCKET_PATH
-from heart.utilities.env.enums import (FrameArrayStrategy, LifeUpdateStrategy,
-                                       RenderMergeStrategy, RenderTileStrategy)
+from heart.utilities.env.enums import (FrameArrayStrategy, FrameExportStrategy,
+                                       LifeUpdateStrategy, RenderMergeStrategy,
+                                       RenderTileStrategy)
 from heart.utilities.env.parsing import _env_flag, _env_int, _env_optional_int
 
 
@@ -85,6 +86,18 @@ class RenderingConfiguration:
         except ValueError as exc:
             raise ValueError(
                 "HEART_FRAME_ARRAY_STRATEGY must be 'copy' or 'view'"
+            ) from exc
+
+    @classmethod
+    def frame_export_strategy(cls) -> FrameExportStrategy:
+        strategy = os.environ.get(
+            "HEART_FRAME_EXPORT_STRATEGY", "buffer"
+        ).strip().lower()
+        try:
+            return FrameExportStrategy(strategy)
+        except ValueError as exc:
+            raise ValueError(
+                "HEART_FRAME_EXPORT_STRATEGY must be 'buffer' or 'array'"
             ) from exc
 
     @classmethod

--- a/tests/display/test_frame_exporter.py
+++ b/tests/display/test_frame_exporter.py
@@ -1,0 +1,42 @@
+import pygame
+import pytest
+
+from heart.runtime.frame_exporter import FrameExporter
+from heart.utilities.env import FrameExportStrategy
+
+
+class TestFrameExporter:
+    """Validate frame export strategies so device images stay correct and fast."""
+
+    @pytest.mark.parametrize(
+        ("strategy", "expected_mode"),
+        [
+            (FrameExportStrategy.BUFFER, "RGBA"),
+            (FrameExportStrategy.ARRAY, "RGB"),
+        ],
+        ids=["buffer-path", "array-path"],
+    )
+    def test_export_preserves_pixel_orientation(
+        self, strategy: FrameExportStrategy, expected_mode: str
+    ) -> None:
+        """Confirm exports keep pixel coordinates aligned so displays stay accurate."""
+
+        surface = pygame.Surface((2, 2), pygame.SRCALPHA)
+        surface.fill((0, 0, 0, 255))
+        surface.set_at((1, 0), (10, 20, 30, 255))
+        surface.set_at((0, 1), (200, 180, 160, 255))
+
+        exporter = FrameExporter(strategy_provider=lambda: strategy)
+        image = exporter.export(surface)
+
+        assert image.mode == expected_mode
+
+        top_right = image.getpixel((1, 0))
+        bottom_left = image.getpixel((0, 1))
+
+        if strategy == FrameExportStrategy.BUFFER:
+            assert top_right == (10, 20, 30, 255)
+            assert bottom_left == (200, 180, 160, 255)
+        else:
+            assert top_right == (10, 20, 30)
+            assert bottom_left == (200, 180, 160)

--- a/tests/utilities/test_env.py
+++ b/tests/utilities/test_env.py
@@ -9,7 +9,8 @@ from types import SimpleNamespace
 import pytest
 
 from heart.device.isolated_render import DEFAULT_SOCKET_PATH
-from heart.utilities.env import (Configuration, ReactivexStreamConnectMode,
+from heart.utilities.env import (Configuration, FrameExportStrategy,
+                                 ReactivexStreamConnectMode,
                                  RenderMergeStrategy, get_device_ports)
 
 
@@ -162,6 +163,25 @@ class TestUtilitiesEnv:
         monkeypatch.setenv("HEART_RENDER_MAX_WORKERS", "3")
 
         assert Configuration.render_executor_max_workers() == 3
+
+
+    def test_frame_export_strategy_defaults_buffer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify frame export strategy defaults to buffer. This keeps frame conversion fast without extra config."""
+        _clear_env(monkeypatch, "HEART_FRAME_EXPORT_STRATEGY")
+
+        assert Configuration.frame_export_strategy() == FrameExportStrategy.BUFFER
+
+
+    def test_frame_export_strategy_rejects_invalid_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify frame export strategy rejects invalid values. This prevents silent misconfiguration."""
+        monkeypatch.setenv("HEART_FRAME_EXPORT_STRATEGY", "nope")
+
+        with pytest.raises(ValueError):
+            Configuration.frame_export_strategy()
 
 
     def test_render_merge_strategy_defaults_batched(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation

- Convert per-frame `pygame.Surface` -> `PIL.Image` work into a single, configurable place to reduce Python-level allocations on the hot path.
- Prefer a C-backed conversion path where possible to lower per-frame overhead and improve frame-time stability.
- Make the export algorithm tunable for deployments that prefer explicit array conversion or need the safest default.

### Description

- Add `FrameExporter` in `src/heart/runtime/frame_exporter.py` that exposes `export(surface)` and supports `BUFFER` (default) and `ARRAY` strategies. 
- Introduce `FrameExportStrategy` enum and `Configuration.frame_export_strategy()` in `src/heart/utilities/env` with the `HEART_FRAME_EXPORT_STRATEGY` environment variable. 
- Route `FramePresenter` through `FrameExporter` so both presentation-from-render-surface and presentation-from-screen use the chosen strategy. 
- Add a research note `docs/research/frame_export_strategy.md` and unit tests in `tests/display/test_frame_exporter.py` and update env tests in `tests/utilities/test_env.py` to validate the new configuration.

### Testing

- Ran the full test suite with `make test`; the run completed with `192 passed, 1 skipped`.
- Added `tests/display/test_frame_exporter.py` which validates pixel orientation for both `BUFFER` and `ARRAY` strategies and it passed.
- Updated `tests/utilities/test_env.py` to assert the `frame_export_strategy` default and invalid config handling and these assertions passed.
- Formatting checks were applied with `make format` before running tests and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ca81ed070832198853aaa94f18ca3)