### PR TITLE
Replace wildcard OpenGL imports and add no-wildcard rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - When CLI arguments accept file paths, parse them as `pathlib.Path` objects and ensure parent directories exist before writing.
 - Avoid using `print` for runtime diagnostics in CLI commands; use the shared logger.
 - Avoid using `print` for runtime diagnostics in peripheral modules; use the shared logger.
+- Avoid wildcard imports; use explicit imports so dependencies stay clear and tooling can track usage.
 - Prefer `StrEnum` values over raw strings for strategy/configuration mode selections.
 - Use `heart.utilities.logging.get_logger` for internal logging so handlers and log levels stay consistent across modules.
 

--- a/src/heart/display/shaders/shader.py
+++ b/src/heart/display/shaders/shader.py
@@ -1,7 +1,12 @@
-from ctypes import *
+from ctypes import byref, c_int
 from pathlib import Path
 
-from OpenGL.GL import *
+from OpenGL.GL import (GL_COMPILE_STATUS, GL_FRAGMENT_SHADER,
+                       GL_INFO_LOG_LENGTH, GL_VERTEX_SHADER, glAttachShader,
+                       glBindAttribLocation, glCompileShader, glCreateProgram,
+                       glCreateShader, glDeleteShader, glGetShaderInfoLog,
+                       glGetShaderiv, glGetUniformLocation, glLinkProgram,
+                       glShaderSource, glUniform1f, glUniform3fv)
 
 from heart.display.shaders.template import __file__ as template_location
 from heart.display.shaders.util import _UNIFORMS, to_vec3

--- a/src/heart/renderers/three_fractal/renderer.py
+++ b/src/heart/renderers/three_fractal/renderer.py
@@ -7,7 +7,20 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pygame
 import reactivex
-from OpenGL.GL import *
+from OpenGL.GL import (GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT, GL_FALSE,
+                       GL_FLOAT, GL_LINEAR, GL_MODELVIEW, GL_NEAREST,
+                       GL_PROJECTION, GL_QUADS, GL_RENDERER, GL_RGBA,
+                       GL_SHADING_LANGUAGE_VERSION, GL_TEXTURE_2D,
+                       GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER,
+                       GL_TRIANGLE_STRIP, GL_UNSIGNED_BYTE, GL_VENDOR,
+                       GL_VERSION, glBegin, glBindTexture, glClear, glDisable,
+                       glDrawArrays, glEnable, glEnableVertexAttribArray,
+                       glEnd, glGenTextures, glGetString, glGetUniformLocation,
+                       glLoadIdentity, glMatrixMode, glOrtho, glReadPixels,
+                       glTexCoord2f, glTexImage2D, glTexParameteri,
+                       glTexSubImage2D, glUniform1f, glUniform2fv,
+                       glUniform3fv, glUniformMatrix4fv, glUseProgram,
+                       glVertex2f, glVertexAttribPointer, glViewport)
 from pygame.math import lerp
 
 from heart import DeviceDisplayMode


### PR DESCRIPTION
### Motivation
- The repository guidance discourages wildcard imports so tooling and readability remain precise and maintainable. 
- Several modules used `from ... import *`, which hides dependencies and conflicts with the agent rules. 
- Add an explicit rule to the agent guidance to prevent regressions and make import expectations explicit. 

### Description
- Add rule to `AGENTS.md`: "Avoid wildcard imports; use explicit imports so dependencies stay clear and tooling can track usage.".
- Replace `from ctypes import *` with `from ctypes import byref, c_int` in `src/heart/display/shaders/shader.py`.
- Replace `from OpenGL.GL import *` with explicit OpenGL symbols in `src/heart/display/shaders/shader.py` and `src/heart/renderers/three_fractal/renderer.py`.
- Run repository formatting to apply isort/ruff/black changes so imports are ordered and lint-clean.

### Testing
- Ran `make format` and the formatter completed successfully. 
- Ran `make test` and the test suite completed with `188 passed, 1 skipped`.
- No test regressions introduced by the import changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cbb63021083219feb9cd386dd1f0e)