### PR TITLE
Extract peripheral lifecycle into PeripheralRuntime and delegate from GameLoop

### DIFF
--- a/docs/runtime_overview.md
+++ b/docs/runtime_overview.md
@@ -21,7 +21,7 @@ Explain how the Heart runtime composes configuration modules, orchestrates rende
 At startup the `totem` CLI builds three core subsystems:
 
 1. **Configuration loader** – `heart.programs.registry.ConfigurationRegistry` inspects `heart/programs/configurations` for modules exposing `configure(loop: GameLoop)`. Each callable mutates the loop with modes, renderers, and playlists.
-1. **Game loop orchestration** – `heart.environment.GameLoop` owns the pygame window, timing, and peripheral integration. Its `AppController` routes scene transitions and composes surfaces.
+1. **Game loop orchestration** – `heart.runtime.game_loop.GameLoop` owns the pygame window, timing, and peripheral integration. Its `AppController` routes scene transitions and composes surfaces, while `heart.runtime.peripheral_runtime.PeripheralRuntime` manages peripheral detection, streaming, and tick emission.
 1. **Device abstraction** – Implementations of `heart.device.Device` translate pygame surfaces into concrete outputs. `LocalScreen` targets desktop iteration, while `LEDMatrix` in `heart.device.rgb_display` streams frames through the `rgbmatrix` bindings.
 
 Refer to [code_flow.md](code_flow.md) for the full call graph and service boundaries.
@@ -38,7 +38,7 @@ Renderers extend `heart.renderers.BaseRenderer` (or a specialization) and draw i
 
 ## Peripheral Integration
 
-`heart.peripheral.core.manager.PeripheralManager` spawns background threads for:
+`heart.peripheral.core.manager.PeripheralManager` (coordinated by `heart.runtime.peripheral_runtime.PeripheralRuntime`) spawns background threads for:
 
 - Bluetooth switches and controllers (`heart.peripheral.switch`, `heart.peripheral.gamepad`).
 - Serial-connected sensors (`heart.peripheral.uart`).

--- a/src/heart/runtime/peripheral_runtime.py
+++ b/src/heart/runtime/peripheral_runtime.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from heart.device.beats import WebSocket
+from heart.peripheral.core.manager import PeripheralManager
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class PeripheralRuntime:
+    """Manage peripheral lifecycle and event streaming for the runtime."""
+
+    def __init__(self, peripheral_manager: PeripheralManager) -> None:
+        self._peripheral_manager = peripheral_manager
+
+    def detect_and_start(self) -> None:
+        logger.info("Attempting to detect attached peripherals")
+        self._peripheral_manager.detect()
+        peripherals = self._peripheral_manager.peripherals
+        logger.info(
+            "Detected attached peripherals - found %d. peripherals=%s",
+            len(peripherals),
+            peripherals,
+        )
+        logger.info("Starting all peripherals")
+        self._peripheral_manager.start()
+
+    def configure_streaming(self, websocket: WebSocket | None = None) -> None:
+        ws = websocket or WebSocket()
+        self._peripheral_manager.get_event_bus().subscribe(
+            on_next=lambda x: ws.send(kind="peripheral", payload=x)
+        )
+
+    def tick(self) -> None:
+        self._peripheral_manager.game_tick.on_next(True)


### PR DESCRIPTION
### Motivation
- Separate peripheral detection, streaming, and tick emission from the main loop to improve separation of concerns and reduce `GameLoop` surface area.
- Make peripheral lifecycle easier to test and evolve independently of rendering and display logic.

### Description
- Add `PeripheralRuntime` (`src/heart/runtime/peripheral_runtime.py`) implementing `detect_and_start`, `configure_streaming`, and `tick` to encapsulate peripheral responsibilities.
- Update `GameLoop` (`src/heart/runtime/game_loop.py`) to construct a `PeripheralRuntime` instance and delegate peripheral detection/start, event streaming, and per-frame ticking to it.
- Update runtime docs in `docs/runtime_overview.md` to reference `heart.runtime.peripheral_runtime.PeripheralRuntime` and the adjusted orchestration.
- Run project formatting with `make format` to ensure style consistency.

### Testing
- Ran `make format` and it completed successfully.
- Ran the full test suite with `make test` and the run completed successfully with `188 passed, 1 skipped`.
- All modified code paths exercised by unit tests passed in the automated test run.
- No regressions reported by the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d1c7638288321990cef2aca78c385)