### PR TITLE
Refactor renderer surface cache handling

### DIFF
--- a/src/heart/peripheral/core/__init__.py
+++ b/src/heart/peripheral/core/__init__.py
@@ -10,7 +10,7 @@ import reactivex
 from reactivex import operators as ops
 
 from heart.utilities.logging import get_logger
-from heart.utilities.reactivex import share_stream
+from heart.utilities.reactivex.sharing import share_stream
 
 
 @dataclass(slots=True)

--- a/src/heart/peripheral/core/manager.py
+++ b/src/heart/peripheral/core/manager.py
@@ -14,7 +14,7 @@ from heart.peripheral.registry import PeripheralConfigurationRegistry
 from heart.peripheral.switch import FakeSwitch, SwitchState
 from heart.utilities.env import Configuration, ReactivexEventBusScheduler
 from heart.utilities.logging import get_logger
-from heart.utilities.reactivex import share_stream
+from heart.utilities.reactivex.sharing import share_stream
 from heart.utilities.reactivex_threads import (background_scheduler,
                                                input_scheduler)
 

--- a/src/heart/renderers/surface_cache.py
+++ b/src/heart/renderers/surface_cache.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import pygame
+
+from heart import DeviceDisplayMode
+from heart.device import Layout, Orientation
+from heart.utilities.env import Configuration, RenderTileStrategy
+
+
+class RendererSurfaceCache:
+    def __init__(self) -> None:
+        self._surface_cache: dict[tuple[int, int], pygame.Surface] = {}
+        self._tiled_surface_cache: dict[tuple[int, int, int, int], pygame.Surface] = {}
+        self._tile_positions_cache: dict[tuple[int, int, int, int], list[tuple[int, int]]] = {}
+
+    def get_input_screen(
+        self,
+        window: pygame.Surface,
+        orientation: Orientation,
+        display_mode: DeviceDisplayMode,
+    ) -> pygame.Surface:
+        window_x, window_y = window.get_size()
+        match display_mode:
+            case DeviceDisplayMode.MIRRORED:
+                layout: Layout = orientation.layout
+                screen_size = (window_x // layout.columns, window_y // layout.rows)
+            case DeviceDisplayMode.FULL | DeviceDisplayMode.OPENGL:
+                # The screen is the full size of the device
+                screen_size = (window_x, window_y)
+        if Configuration.render_surface_cache_enabled():
+            cached = self._surface_cache.get(screen_size)
+            if cached is None:
+                cached = pygame.Surface(screen_size, pygame.SRCALPHA)
+                self._surface_cache[screen_size] = cached
+            else:
+                cached.fill((0, 0, 0, 0))
+            return cached
+        return pygame.Surface(screen_size, pygame.SRCALPHA)
+
+    def postprocess_input_screen(
+        self,
+        screen: pygame.Surface,
+        orientation: Orientation,
+        display_mode: DeviceDisplayMode,
+    ) -> pygame.Surface:
+        match display_mode:
+            case DeviceDisplayMode.MIRRORED:
+                layout: Layout = orientation.layout
+                screen = self.tile_surface(
+                    screen=screen, rows=layout.rows, cols=layout.columns
+                )
+            case DeviceDisplayMode.FULL:
+                pass
+        return screen
+
+    def tile_surface(
+        self, screen: pygame.Surface, rows: int, cols: int
+    ) -> pygame.Surface:
+        tile_width, tile_height = screen.get_size()
+        target_size = (tile_width * cols, tile_height * rows)
+        if Configuration.render_surface_cache_enabled():
+            cache_key = (tile_width, tile_height, rows, cols)
+            tiled_surface = self._tiled_surface_cache.get(cache_key)
+            if tiled_surface is None:
+                tiled_surface = pygame.Surface(target_size, pygame.SRCALPHA)
+                self._tiled_surface_cache[cache_key] = tiled_surface
+            else:
+                tiled_surface.fill((0, 0, 0, 0))
+        else:
+            tiled_surface = pygame.Surface(target_size, pygame.SRCALPHA)
+
+        if Configuration.render_tile_strategy() == RenderTileStrategy.BLITS:
+            positions_key = (tile_width, tile_height, rows, cols)
+            positions = self._tile_positions_cache.get(positions_key)
+            if positions is None:
+                positions = [
+                    (col * tile_width, row * tile_height)
+                    for row in range(rows)
+                    for col in range(cols)
+                ]
+                self._tile_positions_cache[positions_key] = positions
+            tiled_surface.blits([(screen, pos) for pos in positions])
+            return tiled_surface
+
+        for row in range(rows):
+            for col in range(cols):
+                dest_pos = (col * tile_width, row * tile_height)
+                tiled_surface.blit(screen, dest_pos)
+
+        return tiled_surface

--- a/src/heart/utilities/reactivex_streams.py
+++ b/src/heart/utilities/reactivex_streams.py
@@ -6,6 +6,7 @@ from heart.utilities.reactivex.instrumentation import \
     _STATS_SCHEDULER  # noqa: F401
 from heart.utilities.reactivex.settings import \
     StreamShareSettings  # noqa: F401
-from heart.utilities.reactivex.sharing import (_GRACE_SCHEDULER,  # noqa: F401
-                                               _REPLAY_SCHEDULER, share_stream)
+from heart.utilities.reactivex.sharing import _GRACE_SCHEDULER  # noqa: F401
+from heart.utilities.reactivex.sharing import _REPLAY_SCHEDULER  # noqa: F401
+from heart.utilities.reactivex.sharing import share_stream  # noqa: F401
 from heart.utilities.reactivex.types import ConnectableStream  # noqa: F401


### PR DESCRIPTION
### Motivation
- Centralize renderer surface caching and tiling logic to reduce duplication and improve clarity.
- Move renderer-specific cache responsibilities out of `BaseRenderer` and `AtomicBaseRenderer` to enforce single-responsibility.
- Resolve reactivex sharing import/export inconsistencies to make stream helpers explicit and reliable.

### Description
- Added `src/heart/renderers/surface_cache.py` which implements `RendererSurfaceCache` with `get_input_screen`, `postprocess_input_screen`, and `tile_surface` methods.
- Updated `src/heart/renderers/base.py` to delegate surface creation/postprocessing/tiling to `RendererSurfaceCache` and removed duplicated cache fields and logic.
- Replaced indirect reactivex sharing imports with direct imports of `share_stream` in `src/heart/peripheral/core/__init__.py` and `src/heart/peripheral/core/manager.py`, and restored compatibility re-exports in `src/heart/utilities/reactivex_streams.py` by re-exporting `_REPLAY_SCHEDULER` and `share_stream`.
- Performed formatting cleanups and minor adjustments to keep code style consistent (`make format`).

### Testing
- Ran `make format` and the formatters reported "All checks passed".
- Ran the test suite with `make test` and the results were: `192 passed, 1 skipped`.
- All automated tests completed successfully (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d1da4d3e083218067679f51ee05c7)