### PR TITLE
Use explicit reactive stream imports and logger output

### DIFF
--- a/src/heart/peripheral/core/__init__.py
+++ b/src/heart/peripheral/core/__init__.py
@@ -10,7 +10,7 @@ import reactivex
 from reactivex import operators as ops
 
 from heart.utilities.logging import get_logger
-from heart.utilities.reactivex import share_stream
+from heart.utilities.reactivex.sharing import share_stream
 
 
 @dataclass(slots=True)

--- a/src/heart/peripheral/core/manager.py
+++ b/src/heart/peripheral/core/manager.py
@@ -14,7 +14,7 @@ from heart.peripheral.registry import PeripheralConfigurationRegistry
 from heart.peripheral.switch import FakeSwitch, SwitchState
 from heart.utilities.env import Configuration, ReactivexEventBusScheduler
 from heart.utilities.logging import get_logger
-from heart.utilities.reactivex import share_stream
+from heart.utilities.reactivex.sharing import share_stream
 from heart.utilities.reactivex_threads import (background_scheduler,
                                                input_scheduler)
 

--- a/src/heart/utilities/reactivex_streams.py
+++ b/src/heart/utilities/reactivex_streams.py
@@ -6,6 +6,5 @@ from heart.utilities.reactivex.instrumentation import \
     _STATS_SCHEDULER  # noqa: F401
 from heart.utilities.reactivex.settings import \
     StreamShareSettings  # noqa: F401
-from heart.utilities.reactivex.sharing import (_GRACE_SCHEDULER,  # noqa: F401
-                                               _REPLAY_SCHEDULER, share_stream)
+from heart.utilities.reactivex.sharing import _GRACE_SCHEDULER  # noqa: F401
 from heart.utilities.reactivex.types import ConnectableStream  # noqa: F401

--- a/tests/simulation/ir_sensor_array_simulation.py
+++ b/tests/simulation/ir_sensor_array_simulation.py
@@ -20,6 +20,9 @@ from typing import Iterable, Sequence
 import numpy as np
 
 from heart.peripheral.ir_sensor_array import radial_layout
+from heart.utilities.logging import get_logger
+
+LOGGER = get_logger(__name__)
 
 
 @dataclass(slots=True)
@@ -173,17 +176,22 @@ def main() -> None:
         f"{'Line point':<36} | {'Line dir.':<36} | Error (deg)"
     )
     divider = "-" * len(header)
-    print(header)
-    print(divider)
+    LOGGER.info(header)
+    LOGGER.info(divider)
     for result in results:
-        error = f"{result.angular_error_deg:10.4f}" if result.angular_error_deg is not None else "    --    "
-        print(
-            f"{result.scenario.name:<12} | "
-            f"{list(result.active_indices)!s:<12} | "
-            f"{_format_vector(result.view_direction):<36} | "
-            f"{_format_vector(result.line_point):<36} | "
-            f"{_format_vector(result.line_direction):<36} | "
-            f"{error}"
+        error = (
+            f"{result.angular_error_deg:10.4f}"
+            if result.angular_error_deg is not None
+            else "    --    "
+        )
+        LOGGER.info(
+            "%-12s | %-12s | %-36s | %-36s | %-36s | %s",
+            result.scenario.name,
+            list(result.active_indices),
+            _format_vector(result.view_direction),
+            _format_vector(result.line_point),
+            _format_vector(result.line_direction),
+            error,
         )
 
 


### PR DESCRIPTION
### Motivation

- Ensure code follows repository guidance to prefer the shared logger instead of `print` for runtime diagnostics.
- Satisfy static typing and export expectations by importing `share_stream` from its concrete module rather than relying on permissive re-exports.
- Keep compatibility wrappers small and avoid exposing unused re-exports.
- Maintain repository formatting and linting expectations before running tests.

### Description

- Replaced ad-hoc `print` output in `tests/simulation/ir_sensor_array_simulation.py` with the shared logger obtained via `get_logger` and emit lines with `LOGGER.info`.
- Imported `share_stream` directly from `heart.utilities.reactivex.sharing` in `src/heart/peripheral/core/__init__.py` and `src/heart/peripheral/core/manager.py` to avoid relying on top-level re-exports.
- Removed unused compatibility re-exports from `src/heart/utilities/reactivex_streams.py` to reduce surface area and align with explicit export expectations.
- Ran repository formatting fixes (`make format`) and applied the resulting style/mypy fixes.

### Testing

- Ran `make format`, which completed and applied fixes successfully.
- Ran `make test`, with the full test suite result: `192 passed, 1 skipped`.
- Linters/type-checkers invoked as part of `make format` completed without remaining errors after fixes.
- No automated tests failed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d1d98b1688321a7b1d2492c604c6c)