### PR TITLE
Extract pygame event pump from GameLoop

### DIFF
--- a/docs/code_flow.md
+++ b/docs/code_flow.md
@@ -12,7 +12,7 @@ Describe how a `totem run` execution traverses configuration services, the runti
 
 ## Technical Approach
 
-Represent each execution stage as a node in a Mermaid flowchart. Colour code orchestration components, service layers, inputs, and outputs so reviewers can trace transitions. The diagram captures call sequencing between the CLI, configuration registry, runtime loop, app routing, peripheral managers, and display drivers. The goal is to surface every point where the runtime crosses a service boundary or hardware interface. Frame composition is split between surface preparation (display-mode coordination and caching) and composition management (merge-strategy selection plus parallel merge coordination).
+Represent each execution stage as a node in a Mermaid flowchart. Colour code orchestration components, service layers, inputs, and outputs so reviewers can trace transitions. The diagram captures call sequencing between the CLI, configuration registry, runtime loop, app routing, peripheral managers, and display drivers. The goal is to surface every point where the runtime crosses a service boundary or hardware interface. Frame composition is split between surface preparation (display-mode coordination and caching) and composition management (merge-strategy selection plus parallel merge coordination). The runtime loop calls an event pump to drain pygame events and manage shutdown or joystick resets.
 
 ## Flow Diagram
 
@@ -35,6 +35,7 @@ flowchart LR
         direction TB
         Loop["GameLoop Service\n(heart.runtime.game_loop.GameLoop)"]
         AppRouter["AppController / Mode Router"]
+        EventPump["Event Pump\n(pygame.event.get)"]
         ModeServices["Mode Services & Renderers"]
         RenderPipeline["Render Pipeline"]
         SurfaceProvider["Surface Provider\n(display mode + surface cache)"]
@@ -66,6 +67,7 @@ flowchart LR
     CLI --> Registry --> Configurer --> Loop
     Configurer --> AppRouter
     Loop --> AppRouter
+    Loop --> EventPump
     Loop --> RenderPipeline
     AppRouter --> ModeServices --> RenderPipeline --> CompositionManager --> DisplaySvc
     RenderPipeline --> SurfaceProvider
@@ -80,7 +82,7 @@ flowchart LR
     RxScheduler --> HeartRate --> AppRouter
     RxScheduler --> PhoneText --> AppRouter
 
-    class CLI,Registry,Configurer,ModeServices,RenderPipeline,SurfaceProvider,CompositionManager service;
+    class CLI,Registry,Configurer,ModeServices,RenderPipeline,SurfaceProvider,CompositionManager,EventPump service;
     class Loop,AppRouter orchestrator;
     class PeripheralMgr,RxScheduler,Switch,Gamepad,Sensors,HeartRate,PhoneText input;
     class DisplaySvc,LocalScreen,Capture,DeviceBridge,LedMatrix,AverageMirror,SingleLED output;

--- a/docs/research/event_pump.md
+++ b/docs/research/event_pump.md
@@ -1,0 +1,23 @@
+# Event Pump Extraction Research Note
+
+## Problem Statement
+
+Document the runtime change that separates pygame event processing from the main loop so the control flow is easier to audit and mypy can track the event handling surface area.
+
+## Materials
+
+- Local checkout of the Heart repository.
+- Python environment with the dependencies listed in `pyproject.toml` installed.
+- `src/heart/runtime/game_loop.py` and `src/heart/runtime/event_pump.py`.
+
+## Notes
+
+- The main loop now delegates pygame event draining and joystick reset handling to `EventPump`, keeping `GameLoop` focused on orchestration and rendering.
+- `EventPump` is responsible for detecting `pygame.QUIT` and joystick reset events and reporting back to the loop via a boolean running flag.
+- The runtime diagram in `docs/code_flow.md` includes the event pump alongside the loop and other runtime services for future audits.
+
+## Sources
+
+- `src/heart/runtime/event_pump.py`
+- `src/heart/runtime/game_loop.py`
+- `docs/code_flow.md`

--- a/src/heart/peripheral/core/__init__.py
+++ b/src/heart/peripheral/core/__init__.py
@@ -10,7 +10,7 @@ import reactivex
 from reactivex import operators as ops
 
 from heart.utilities.logging import get_logger
-from heart.utilities.reactivex import share_stream
+from heart.utilities.reactivex.sharing import share_stream
 
 
 @dataclass(slots=True)

--- a/src/heart/peripheral/core/manager.py
+++ b/src/heart/peripheral/core/manager.py
@@ -14,7 +14,7 @@ from heart.peripheral.registry import PeripheralConfigurationRegistry
 from heart.peripheral.switch import FakeSwitch, SwitchState
 from heart.utilities.env import Configuration, ReactivexEventBusScheduler
 from heart.utilities.logging import get_logger
-from heart.utilities.reactivex import share_stream
+from heart.utilities.reactivex.sharing import share_stream
 from heart.utilities.reactivex_threads import (background_scheduler,
                                                input_scheduler)
 

--- a/src/heart/renderers/base.py
+++ b/src/heart/renderers/base.py
@@ -3,8 +3,8 @@ from dataclasses import replace
 from typing import Any, Callable, Generic, TypeVar, final
 
 import pygame
-from reactivex import Observable
 from reactivex.disposable import Disposable
+from reactivex.observable import Observable
 
 from heart import DeviceDisplayMode
 from heart.device import Layout, Orientation

--- a/src/heart/renderers/water_cube/state.py
+++ b/src/heart/renderers/water_cube/state.py
@@ -2,8 +2,8 @@ from dataclasses import dataclass
 from typing import Self, Tuple
 
 import numpy as np
-from reactivex import Observable
 from reactivex import operators as ops
+from reactivex.observable import Observable
 
 from heart.peripheral.sensor import Acceleration
 

--- a/src/heart/runtime/event_pump.py
+++ b/src/heart/runtime/event_pump.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pygame
+
+from heart.peripheral.core import events
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class EventPump:
+    """Process pygame events and update runtime flags."""
+
+    def pump(self, running: bool) -> bool:
+        try:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    running = False
+                if event.type == events.REQUEST_JOYSTICK_MODULE_RESET:
+                    self._reset_joystick()
+        except SystemError:
+            # (clem): gamepad input can leave invalid events on the queue.
+            logger.exception("Encountered segfaulted event")
+        return running
+
+    def _reset_joystick(self) -> None:
+        logger.info("resetting joystick module")
+        pygame.joystick.quit()
+        pygame.joystick.init()

--- a/src/heart/utilities/reactivex_streams.py
+++ b/src/heart/utilities/reactivex_streams.py
@@ -6,6 +6,5 @@ from heart.utilities.reactivex.instrumentation import \
     _STATS_SCHEDULER  # noqa: F401
 from heart.utilities.reactivex.settings import \
     StreamShareSettings  # noqa: F401
-from heart.utilities.reactivex.sharing import (_GRACE_SCHEDULER,  # noqa: F401
-                                               _REPLAY_SCHEDULER, share_stream)
+from heart.utilities.reactivex.sharing import _GRACE_SCHEDULER  # noqa: F401
 from heart.utilities.reactivex.types import ConnectableStream  # noqa: F401


### PR DESCRIPTION
### Motivation

- Simplify the runtime loop by delegating pygame event handling to a focused helper rather than keeping event logic inside `GameLoop`.
- Remove unused transition/animation fields from `GameLoop` to clarify the runtime state model.
- Make reactive stream imports explicit so static checkers like mypy can resolve symbols reliably.
- Document the architectural change so reviewers can audit event handling responsibilities.

### Description

- Added a new `EventPump` (`src/heart/runtime/event_pump.py`) and wired `GameLoop` to call `EventPump.pump` each loop iteration instead of handling events inline.
- Removed unused fields related to slide/transition state from `GameLoop` to reduce surface area and state complexity.
- Replaced ambiguous reactivex imports with explicit module-level imports (e.g. `from reactivex.observable import Observable`, `from reactivex import create`) and switched `share_stream` uses to `heart.utilities.reactivex.sharing.share_stream` where needed.
- Updated runtime documentation (`docs/code_flow.md`) and added a research note (`docs/research/event_pump.md`) describing the extraction and its intent.

### Testing

- Ran formatting (`make format`) and linting fixes, which completed with no remaining errors.
- Ran the full test suite via `make test`, resulting in `192 passed, 1 skipped`.
- Verified the runtime diagram was re-rendered with `scripts/render_code_flow.py` without errors.
- Confirmed changes compile and pass static checks exercised during formatting and tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d1fe4b6ac832198deeb2997899b68)