### PR TITLE
Refine reactive stream imports and exports

### DIFF
--- a/src/heart/utilities/reactivex/__init__.py
+++ b/src/heart/utilities/reactivex/__init__.py
@@ -1,5 +1,1 @@
 """Helpers for sharing and tuning reactive streams."""
-
-from heart.utilities.reactivex.settings import \
-    StreamShareSettings  # noqa: F401
-from heart.utilities.reactivex.sharing import share_stream  # noqa: F401

--- a/src/heart/utilities/reactivex_streams.py
+++ b/src/heart/utilities/reactivex_streams.py
@@ -1,12 +1,5 @@
 """Compatibility wrapper for reactive stream sharing helpers."""
 
-from heart.utilities.reactivex.coalescing import \
-    _COALESCE_SCHEDULER  # noqa: F401
-from heart.utilities.reactivex.instrumentation import \
-    _STATS_SCHEDULER  # noqa: F401
 from heart.utilities.reactivex.settings import \
     StreamShareSettings  # noqa: F401
-from heart.utilities.reactivex.sharing import _GRACE_SCHEDULER  # noqa: F401
-from heart.utilities.reactivex.sharing import _REPLAY_SCHEDULER  # noqa: F401
 from heart.utilities.reactivex.sharing import share_stream  # noqa: F401
-from heart.utilities.reactivex.types import ConnectableStream  # noqa: F401

--- a/tests/utilities/test_reactivex_streams.py
+++ b/tests/utilities/test_reactivex_streams.py
@@ -6,7 +6,7 @@ import reactivex
 from reactivex.disposable import Disposable
 from reactivex.subject import Subject
 
-from heart.utilities.reactivex import share_stream
+from heart.utilities.reactivex.sharing import share_stream
 
 
 class TestShareStreamStrategy:


### PR DESCRIPTION
### Motivation

- Reduce permissive re-exports so static analysis and typing resolve concrete symbols instead of relying on package-level forwarding.  
- Ensure compatibility wrappers only expose the helpers that are actually used by the codebase to keep the surface area small.  
- Satisfy export expectations by importing `share_stream` from its concrete module instead of relying on re-exported names.  
- Keep repository formatting and linting rules enforced prior to running tests.

### Description

- Removed unused re-exports from `src/heart/utilities/reactivex/__init__.py`.  
- Trimmed `src/heart/utilities/reactivex_streams.py` to only re-export `StreamShareSettings` and `share_stream`.  
- Updated tests to import `share_stream` directly from `heart.utilities.reactivex.sharing` instead of the permissive package initializer.  
- Ran repository formatting to apply styling fixes to modified modules with `make format`.

### Testing

- Ran `make format` and formatting fixes completed successfully.  
- Ran the full test suite with `make test` and the run completed with `192 passed, 1 skipped`.  
- No new test files were added and all existing tests referencing the changed imports continued to pass.  
- Linting/format checks applied as part of the formatting step succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d20b13b3c832195e627312a136d7c)