### PR TITLE
Delegate pygame event handling to PygameEventHandler and simplify GameLoop state

### DIFF
--- a/docs/research/game_loop_event_handling.md
+++ b/docs/research/game_loop_event_handling.md
@@ -1,0 +1,19 @@
+# Game loop event handling helper
+
+## Problem
+
+`GameLoop` owned both the runtime loop and the pygame event handling logic, which made
+the core loop harder to scan and hid event-specific responsibilities inside the main
+orchestration class.
+
+## Notes
+
+- The pygame event handling has been moved into a dedicated helper so the main loop can
+  focus on scheduling peripheral ticks, preprocessing, rendering, and frame pacing.
+- The runtime loop now consumes the helper's boolean result to decide when to stop,
+  keeping shutdown logic in one place.
+
+## Materials
+
+- `src/heart/runtime/game_loop.py`
+- `src/heart/runtime/pygame_event_handler.py`

--- a/src/heart/runtime/game_loop.py
+++ b/src/heart/runtime/game_loop.py
@@ -8,12 +8,12 @@ from lagom import Container
 
 from heart.device import Device
 from heart.navigation import AppController, ComposedRenderer, MultiScene
-from heart.peripheral.core import events
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import container
 from heart.runtime.display_context import DisplayContext
 from heart.runtime.frame_presenter import FramePresenter
 from heart.runtime.peripheral_runtime import PeripheralRuntime
+from heart.runtime.pygame_event_handler import PygameEventHandler
 from heart.runtime.render_pipeline import RendererVariant, RenderPipeline
 from heart.utilities.logging import get_logger
 
@@ -52,15 +52,7 @@ class GameLoop:
             display=self.display,
             render_pipeline=self.render_pipeline,
         )
-
-        # jank slide animation state machine
-        self.mode_change: tuple[int, int] = (0, 0)
-        self._last_mode_offset = 0
-        self._last_offset_on_change = 0
-        self._current_offset_on_change = 0
-        self.renderers_cache: list["StatefulBaseRenderer[Any]"] | None = None
-
-        self._active_mode_index = 0
+        self.event_handler = PygameEventHandler()
 
         # Lampe controller
         self.feedback_buffer: np.ndarray | None = None
@@ -150,21 +142,6 @@ class GameLoop:
             self.display.screen.blit(render_surface, (0, 0))
         self.frame_presenter.present(renderers, render_surface)
 
-    def _handle_events(self) -> None:
-        try:
-            for event in pygame.event.get():
-                if event.type == pygame.QUIT:
-                    self.running = False
-                if event.type == events.REQUEST_JOYSTICK_MODULE_RESET:
-                    logger.info("resetting joystick module")
-                    pygame.joystick.quit()
-                    pygame.joystick.init()
-        except SystemError:
-            # (clem): gamepad shit is weird and can randomly put caught segfault
-            #   events on queue, I see allusions to this online, people say
-            #   try pygame-ce instead
-            logger.exception("Encountered segfaulted event")
-
     def _preprocess_setup(self) -> None:
         self._dim_display()
 
@@ -218,7 +195,7 @@ class GameLoop:
         clock = self.display.clock
         while self.running:
             self.peripheral_runtime.tick()
-            self._handle_events()
+            self.running = self.event_handler.handle_events()
             self._preprocess_setup()
             renderers = self._select_renderers()
             self._one_loop(renderers)

--- a/src/heart/runtime/pygame_event_handler.py
+++ b/src/heart/runtime/pygame_event_handler.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pygame
+
+from heart.peripheral.core import events
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class PygameEventHandler:
+    def handle_events(self) -> bool:
+        running = True
+        try:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    running = False
+                elif event.type == events.REQUEST_JOYSTICK_MODULE_RESET:
+                    logger.info("resetting joystick module")
+                    pygame.joystick.quit()
+                    pygame.joystick.init()
+        except SystemError:
+            # (clem): gamepad shit is weird and can randomly put caught segfault
+            #   events on queue, I see allusions to this online, people say
+            #   try pygame-ce instead
+            logger.exception("Encountered segfaulted event")
+        return running


### PR DESCRIPTION
### Motivation

- Reduce complexity in the runtime loop by moving pygame event processing out of `GameLoop` so the main loop focuses on scheduling, rendering, and pacing.
- Remove unused transition/animation fields from `GameLoop` to clarify and simplify the runtime state model.
- Improve separation of concerns so event-specific logic is easier to test and evolve independently.

### Description

- Add a new helper `src/heart/runtime/pygame_event_handler.py` which implements `PygameEventHandler.handle_events()` and returns a boolean `running` flag.
- Replace inline event loop in `GameLoop` with an `event_handler` instance and update the main loop to use `self.running = self.event_handler.handle_events()`.
- Remove unused fields from `GameLoop`: `mode_change`, `_last_mode_offset`, `_last_offset_on_change`, `_current_offset_on_change`, `renderers_cache`, and `_active_mode_index`.
- Add a short research note at `docs/research/game_loop_event_handling.md` documenting the rationale and materials changed.

### Testing

- Ran `make format` to apply repository formatting rules and it completed successfully.
- No automated unit test changes were added as part of this refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d213b19fc8321926c56b1018444db)