### PR TITLE
Add configurable Life rule strategy, table-driven fast path, and seeded RNG

### DIFF
--- a/docs/performance/life_update_strategy.md
+++ b/docs/performance/life_update_strategy.md
@@ -7,7 +7,7 @@ Reduce the per-frame cost of the Game of Life update while keeping the rules ide
 ## Materials
 
 - Python environment with `numpy` and `scipy` installed.
-- `heart.modules.life.state.LifeState` for the update loop.
+- `heart.renderers.life.state.LifeState` for the update loop.
 - `heart.utilities.env.Configuration` for environment-driven settings.
 
 ## Update Strategy Options
@@ -24,8 +24,23 @@ The Life module supports selecting the update algorithm via environment variable
 meets or exceeds the configured cell count. Set it to a positive integer to prefer convolution for large
 grids while keeping the slice-based path for smaller updates.
 
+## Rule Application Options
+
+The Life module also supports selecting the rule-application path independently of neighbor counting:
+
+- `HEART_LIFE_RULE_STRATEGY=auto` (default) uses the table-driven rule path for the default kernel and falls
+  back to direct rule evaluation when custom kernels are provided.
+- `HEART_LIFE_RULE_STRATEGY=direct` always applies the rules with boolean comparisons.
+- `HEART_LIFE_RULE_STRATEGY=table` uses a lookup table when valid, falling back to direct evaluation if the
+  neighbor counts are outside the standard 0-8 range.
+
+`HEART_LIFE_RANDOM_SEED` optionally sets the RNG seed used when generating new Life grids so initial states
+and reseeds can be reproduced.
+
 ## Operational Notes
 
 - Slice-based updates avoid repeated padding allocations while preserving the same rules on the same grid boundaries.
 - Padding-based updates are still available if you want to preserve the original neighbor count implementation.
 - When using custom kernels, keep the strategy at `auto` or `convolve` so the kernel is applied correctly.
+- Table-driven rule application is safe for the default kernel; custom kernels automatically fall back to the
+  direct path so rule evaluation remains correct.

--- a/docs/research/life_rule_table.md
+++ b/docs/research/life_rule_table.md
@@ -1,0 +1,31 @@
+# Life Rule Lookup Table
+
+## Context
+
+The Life renderer now supports applying the Game of Life rules via a lookup table in
+`heart.renderers.life.state.LifeState` when the default kernel is in use. The table
+encodes the standard B3/S23 rules for neighbor counts 0-8 so the update step can avoid
+repeated boolean comparisons while preserving identical outcomes.
+
+## Table Layout
+
+The table is a 2x9 integer array indexed by `[current_state, neighbor_count]`:
+
+- `current_state=0` (dead) only produces a live cell when `neighbor_count=3`.
+- `current_state=1` (alive) stays alive when `neighbor_count` is 2 or 3.
+
+This mapping is implemented in `src/heart/renderers/life/state.py` as `LIFE_RULE_TABLE`
+and applied through `_apply_table_rules`.
+
+## Fallback Behavior
+
+When custom kernels are used, the neighbor counts may exceed 8. In that case the update
+logic falls back to direct rule evaluation so the Life rules remain accurate regardless
+of kernel shape or weighting. Tests in `tests/modules/test_life_state.py` validate that
+table-driven rules match the direct path and that custom kernels are handled safely.
+
+## Materials
+
+- `src/heart/renderers/life/state.py` for the rule table and application logic.
+- `src/heart/utilities/env/rendering.py` for environment configuration.
+- `tests/modules/test_life_state.py` for parity and fallback coverage.

--- a/src/heart/peripheral/core/__init__.py
+++ b/src/heart/peripheral/core/__init__.py
@@ -10,7 +10,7 @@ import reactivex
 from reactivex import operators as ops
 
 from heart.utilities.logging import get_logger
-from heart.utilities.reactivex import share_stream
+from heart.utilities.reactivex.sharing import share_stream
 
 
 @dataclass(slots=True)

--- a/src/heart/peripheral/core/manager.py
+++ b/src/heart/peripheral/core/manager.py
@@ -14,7 +14,7 @@ from heart.peripheral.registry import PeripheralConfigurationRegistry
 from heart.peripheral.switch import FakeSwitch, SwitchState
 from heart.utilities.env import Configuration, ReactivexEventBusScheduler
 from heart.utilities.logging import get_logger
-from heart.utilities.reactivex import share_stream
+from heart.utilities.reactivex.sharing import share_stream
 from heart.utilities.reactivex_threads import (background_scheduler,
                                                input_scheduler)
 

--- a/src/heart/renderers/life/provider.py
+++ b/src/heart/renderers/life/provider.py
@@ -1,4 +1,3 @@
-
 from typing import Callable
 
 import numpy as np
@@ -8,6 +7,7 @@ from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.providers.switch import MainSwitchProvider
 from heart.peripheral.uwb import ops
 from heart.renderers.life.state import LifeState
+from heart.utilities.env import Configuration
 
 
 class LifeStateProvider:
@@ -19,8 +19,10 @@ class LifeStateProvider:
         self,
     ) -> reactivex.Observable[LifeState]:
         StateOp = Callable[[LifeState], LifeState]
-        def create_new_grid(size):
-            return np.random.choice([0, 1], size=size)
+        rng = LifeState.resolve_rng(Configuration.life_random_seed())
+
+        def create_new_grid(size: tuple[int, int]) -> np.ndarray:
+            return LifeState.random_grid(size, rng)
 
         def create_state(x: np.ndarray) -> LifeState:
             return LifeState(grid=x)

--- a/src/heart/utilities/env/__init__.py
+++ b/src/heart/utilities/env/__init__.py
@@ -5,6 +5,7 @@ from heart.utilities.env.enums import DeviceLayoutMode as DeviceLayoutMode
 from heart.utilities.env.enums import FrameArrayStrategy as FrameArrayStrategy
 from heart.utilities.env.enums import \
     FrameExportStrategy as FrameExportStrategy
+from heart.utilities.env.enums import LifeRuleStrategy as LifeRuleStrategy
 from heart.utilities.env.enums import LifeUpdateStrategy as LifeUpdateStrategy
 from heart.utilities.env.enums import \
     ReactivexEventBusScheduler as ReactivexEventBusScheduler

--- a/src/heart/utilities/env/enums.py
+++ b/src/heart/utilities/env/enums.py
@@ -34,6 +34,12 @@ class LifeUpdateStrategy(StrEnum):
     SHIFTED = "shifted"
 
 
+class LifeRuleStrategy(StrEnum):
+    AUTO = "auto"
+    DIRECT = "direct"
+    TABLE = "table"
+
+
 class DeviceLayoutMode(StrEnum):
     CUBE = "cube"
     RECTANGLE = "rectangle"

--- a/src/heart/utilities/env/rendering.py
+++ b/src/heart/utilities/env/rendering.py
@@ -2,8 +2,8 @@ import os
 
 from heart.device.rgb_display.isolated_render import DEFAULT_SOCKET_PATH
 from heart.utilities.env.enums import (FrameArrayStrategy, FrameExportStrategy,
-                                       LifeUpdateStrategy, RenderMergeStrategy,
-                                       RenderTileStrategy)
+                                       LifeRuleStrategy, LifeUpdateStrategy,
+                                       RenderMergeStrategy, RenderTileStrategy)
 from heart.utilities.env.parsing import _env_flag, _env_int, _env_optional_int
 
 
@@ -111,5 +111,19 @@ class RenderingConfiguration:
             ) from exc
 
     @classmethod
+    def life_rule_strategy(cls) -> LifeRuleStrategy:
+        strategy = os.environ.get("HEART_LIFE_RULE_STRATEGY", "auto").strip().lower()
+        try:
+            return LifeRuleStrategy(strategy)
+        except ValueError as exc:
+            raise ValueError(
+                "HEART_LIFE_RULE_STRATEGY must be 'auto', 'direct', or 'table'"
+            ) from exc
+
+    @classmethod
     def life_convolve_threshold(cls) -> int:
         return _env_int("HEART_LIFE_CONVOLVE_THRESHOLD", default=0, minimum=0)
+
+    @classmethod
+    def life_random_seed(cls) -> int | None:
+        return _env_optional_int("HEART_LIFE_RANDOM_SEED")

--- a/src/heart/utilities/reactivex_streams.py
+++ b/src/heart/utilities/reactivex_streams.py
@@ -6,6 +6,5 @@ from heart.utilities.reactivex.instrumentation import \
     _STATS_SCHEDULER  # noqa: F401
 from heart.utilities.reactivex.settings import \
     StreamShareSettings  # noqa: F401
-from heart.utilities.reactivex.sharing import (_GRACE_SCHEDULER,  # noqa: F401
-                                               _REPLAY_SCHEDULER, share_stream)
+from heart.utilities.reactivex.sharing import _GRACE_SCHEDULER  # noqa: F401
 from heart.utilities.reactivex.types import ConnectableStream  # noqa: F401

--- a/tests/modules/test_life_state.py
+++ b/tests/modules/test_life_state.py
@@ -61,3 +61,70 @@ class TestLifeUpdateStrategies:
 
         with pytest.raises(ValueError, match="default kernel"):
             LifeState(grid=grid, kernel=kernel)._update_grid()
+
+
+class TestLifeRuleStrategies:
+    """Validate Life rule application strategies to maintain correctness with performance options."""
+
+    def test_rule_table_matches_direct_rules(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify table-driven rules match direct rules so fast paths preserve correctness."""
+
+        grid = np.array(
+            [
+                [0, 1, 0, 0, 1],
+                [1, 1, 0, 1, 0],
+                [0, 0, 1, 0, 0],
+                [1, 0, 0, 1, 1],
+                [0, 1, 0, 0, 0],
+            ],
+            dtype=int,
+        )
+
+        monkeypatch.setenv("HEART_LIFE_UPDATE_STRATEGY", "convolve")
+        monkeypatch.setenv("HEART_LIFE_RULE_STRATEGY", "direct")
+        expected = LifeState(grid=grid)._update_grid().grid
+
+        monkeypatch.setenv("HEART_LIFE_RULE_STRATEGY", "table")
+        result = LifeState(grid=grid)._update_grid().grid
+
+        assert np.array_equal(
+            expected,
+            result,
+        ), "Table-driven rules should match direct rule application."
+
+    def test_rule_table_falls_back_for_custom_kernel(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Ensure custom kernels fall back to direct rules to avoid invalid tables."""
+
+        grid = np.array(
+            [
+                [1, 1, 0, 0],
+                [0, 1, 1, 0],
+                [1, 0, 1, 1],
+                [0, 1, 0, 1],
+            ],
+            dtype=int,
+        )
+        kernel = np.array(
+            [
+                [0, 1, 0],
+                [2, 0, 2],
+                [0, 1, 0],
+            ],
+            dtype=int,
+        )
+
+        monkeypatch.setenv("HEART_LIFE_UPDATE_STRATEGY", "convolve")
+        monkeypatch.setenv("HEART_LIFE_RULE_STRATEGY", "direct")
+        expected = LifeState(grid=grid, kernel=kernel)._update_grid().grid
+
+        monkeypatch.setenv("HEART_LIFE_RULE_STRATEGY", "table")
+        result = LifeState(grid=grid, kernel=kernel)._update_grid().grid
+
+        assert np.array_equal(
+            expected,
+            result,
+        ), "Table rules should fall back for custom kernels."


### PR DESCRIPTION
### Motivation

- Reduce per-frame cost of Game of Life updates while preserving identical rule outcomes to the convolution implementation. 
- Provide a fast, table-driven rule application for the default kernel while safely handling custom kernels. 
- Make initial grid generation deterministic when desired by exposing a seeded RNG path for reproducible reseeds and initial states.

### Description

- Add a `LifeRuleStrategy` enum and `HEART_LIFE_RULE_STRATEGY` configuration via `RenderingConfiguration` to choose between `auto`, `direct`, and `table` rule application. 
- Implement a 2x9 `LIFE_RULE_TABLE` and table-driven rule application in `src/heart/renderers/life/state.py` with safe fallbacks to direct boolean rules when custom kernels or out-of-range neighbor counts are detected. 
- Introduce RNG helpers `LifeState.resolve_rng` and `LifeState.random_grid`, wire `HEART_LIFE_RANDOM_SEED` into `LifeStateProvider` for seeded initial/reseeded grids, and preserve existing neighbor-count strategy knobs. 
- Update documentation (`docs/performance/life_update_strategy.md`, `docs/research/life_rule_table.md`) and extend tests (`tests/modules/test_life_state.py`) to validate parity and fallback behaviour.

### Testing

- Ran `make format` successfully to apply code style fixes. 
- Ran the test suite with `make test`, resulting in all tests passing: `194 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d205138cc8321a8b89fbcb2439358)