### PR TITLE
Add RNG-aware state provider helper

### DIFF
--- a/docs/research/rng_state_provider.md
+++ b/docs/research/rng_state_provider.md
@@ -1,0 +1,23 @@
+# RNG-aware state providers
+
+State providers that need random numbers were each creating and storing their
+own `random.Random` instance. That duplicated setup logic and made it harder to
+standardize how providers accept deterministic RNGs for testing.
+
+## Decision
+
+Introduce `RngStateProvider` as a generic base class that stores the RNG and
+exposes it through a `rng` property. Providers that already accept an optional
+`random.Random` now inherit from the helper and call `super().__init__(rng=...)`
+to keep RNG setup consistent.
+
+## Materials
+
+- `src/heart/renderers/state_provider.py`
+- `src/heart/renderers/pacman/provider.py`
+- `src/heart/renderers/pixels/provider.py`
+- `src/heart/renderers/random_pixel/provider.py`
+
+## Sources
+
+- `src/heart/renderers/state_provider.py`

--- a/src/heart/renderers/pacman/provider.py
+++ b/src/heart/renderers/pacman/provider.py
@@ -6,11 +6,11 @@ import reactivex
 from reactivex import operators as ops
 
 from heart.peripheral.core.manager import PeripheralManager
-from heart.peripheral.core.providers import ObservableProvider
 from heart.renderers.pacman.state import PacmanGhostState
+from heart.renderers.state_provider import RngStateProvider
 
 
-class PacmanGhostStateProvider(ObservableProvider[PacmanGhostState]):
+class PacmanGhostStateProvider(RngStateProvider[PacmanGhostState]):
     def __init__(
         self,
         *,
@@ -19,10 +19,10 @@ class PacmanGhostStateProvider(ObservableProvider[PacmanGhostState]):
         peripheral_manager: PeripheralManager,
         rng: random.Random | None = None,
     ) -> None:
+        super().__init__(rng=rng)
         self._width = width
         self._height = height
         self._peripheral_manager = peripheral_manager
-        self._rng = rng or random.Random()
         self._asset_version = 0
 
     def observable(self) -> reactivex.Observable[PacmanGhostState]:
@@ -77,7 +77,7 @@ class PacmanGhostStateProvider(ObservableProvider[PacmanGhostState]):
         pacman_idx: int = 0,
         switch_pacman: bool = True,
     ) -> PacmanGhostState:
-        corner = self._rng.choice(
+        corner = self.rng.choice(
             ["top_left", "top_right", "bottom_left", "bottom_right"]
         )
         if corner == "top_left":

--- a/src/heart/renderers/pixels/provider.py
+++ b/src/heart/renderers/pixels/provider.py
@@ -11,6 +11,7 @@ from heart.display.color import Color
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import ObservableProvider
 from heart.renderers.pixels.state import BorderState, RainState, SlinkyState
+from heart.renderers.state_provider import RngStateProvider
 
 
 class BorderStateProvider(ObservableProvider[BorderState]):
@@ -27,7 +28,7 @@ class BorderStateProvider(ObservableProvider[BorderState]):
         self._color.on_next(color)
 
 
-class RainStateProvider(ObservableProvider[RainState]):
+class RainStateProvider(RngStateProvider[RainState]):
     def __init__(
         self,
         *,
@@ -36,15 +37,15 @@ class RainStateProvider(ObservableProvider[RainState]):
         peripheral_manager: PeripheralManager,
         rng: random.Random | None = None,
     ) -> None:
+        super().__init__(rng=rng)
         self._width = width
         self._height = height
         self._peripheral_manager = peripheral_manager
-        self._rng = rng or random.Random()
 
     def observable(self) -> reactivex.Observable[RainState]:
         initial_state = RainState(
-            starting_point=self._rng.randint(0, self._width),
-            current_y=self._rng.randint(0, 20),
+            starting_point=self.rng.randint(0, self._width),
+            current_y=self.rng.randint(0, 20),
         )
 
         return self._peripheral_manager.game_tick.pipe(
@@ -58,13 +59,13 @@ class RainStateProvider(ObservableProvider[RainState]):
         if new_y > self._height:
             return replace(
                 state,
-                starting_point=self._rng.randint(0, self._width),
+                starting_point=self.rng.randint(0, self._width),
                 current_y=0,
             )
         return replace(state, current_y=new_y)
 
 
-class SlinkyStateProvider(ObservableProvider[SlinkyState]):
+class SlinkyStateProvider(RngStateProvider[SlinkyState]):
     def __init__(
         self,
         *,
@@ -73,15 +74,15 @@ class SlinkyStateProvider(ObservableProvider[SlinkyState]):
         peripheral_manager: PeripheralManager,
         rng: random.Random | None = None,
     ) -> None:
+        super().__init__(rng=rng)
         self._width = width
         self._height = height
         self._peripheral_manager = peripheral_manager
-        self._rng = rng or random.Random()
 
     def observable(self) -> reactivex.Observable[SlinkyState]:
         initial_state = SlinkyState(
-            starting_point=self._rng.randint(0, self._width),
-            current_y=self._rng.randint(0, 20),
+            starting_point=self.rng.randint(0, self._width),
+            current_y=self.rng.randint(0, 20),
         )
 
         return self._peripheral_manager.game_tick.pipe(
@@ -95,7 +96,7 @@ class SlinkyStateProvider(ObservableProvider[SlinkyState]):
         if new_y > self._height:
             return replace(
                 state,
-                starting_point=self._rng.randint(0, self._width),
+                starting_point=self.rng.randint(0, self._width),
                 current_y=0,
             )
         return replace(state, current_y=new_y)

--- a/src/heart/renderers/random_pixel/provider.py
+++ b/src/heart/renderers/random_pixel/provider.py
@@ -9,11 +9,11 @@ from reactivex.subject import BehaviorSubject
 
 from heart.display.color import Color
 from heart.peripheral.core.manager import PeripheralManager
-from heart.peripheral.core.providers import ObservableProvider
 from heart.renderers.random_pixel.state import RandomPixelState
+from heart.renderers.state_provider import RngStateProvider
 
 
-class RandomPixelStateProvider(ObservableProvider[RandomPixelState]):
+class RandomPixelStateProvider(RngStateProvider[RandomPixelState]):
     def __init__(
         self,
         *,
@@ -24,11 +24,11 @@ class RandomPixelStateProvider(ObservableProvider[RandomPixelState]):
         initial_color: Color | None = None,
         rng: random.Random | None = None,
     ) -> None:
+        super().__init__(rng=rng)
         self._width = width
         self._height = height
         self._num_pixels = num_pixels
         self._peripheral_manager = peripheral_manager
-        self._rng = rng or random.Random()
         self._color = BehaviorSubject(initial_color)
 
     def observable(self) -> reactivex.Observable[RandomPixelState]:
@@ -65,6 +65,6 @@ class RandomPixelStateProvider(ObservableProvider[RandomPixelState]):
 
     def _random_pixels(self) -> tuple[tuple[int, int], ...]:
         return tuple(
-            (self._rng.randrange(self._width), self._rng.randrange(self._height))
+            (self.rng.randrange(self._width), self.rng.randrange(self._height))
             for _ in range(self._num_pixels)
         )

--- a/src/heart/renderers/state_provider.py
+++ b/src/heart/renderers/state_provider.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import random
+from typing import Generic, TypeVar
+
+from heart.peripheral.core.providers import ObservableProvider
+
+StateT = TypeVar("StateT")
+
+
+class RngStateProvider(ObservableProvider[StateT], Generic[StateT]):
+    """Base provider that manages a shared random number generator."""
+
+    def __init__(self, *, rng: random.Random | None = None) -> None:
+        self._rng = rng or random.Random()
+
+    @property
+    def rng(self) -> random.Random:
+        return self._rng


### PR DESCRIPTION
### Motivation
- Multiple state providers each constructed their own `random.Random` instance which duplicated setup logic and made deterministic testing harder.
- Centralizing RNG ownership simplifies dependency injection and standardizes how providers accept an injected RNG for tests.
- Keep provider responsibilities focused on state emission rather than RNG lifecycle.

### Description
- Add `RngStateProvider` in `src/heart/renderers/state_provider.py` which stores an RNG and exposes it via a `rng` property.
- Update providers that accept an optional RNG (`RandomPixelStateProvider`, `RainStateProvider`, `SlinkyStateProvider`, `PacmanGhostStateProvider`) to inherit from `RngStateProvider` and call `super().__init__(rng=...)`.
- Replace local `_rng` usages with the shared `rng` property so providers use the helper-provided RNG.
- Add documentation note `docs/research/rng_state_provider.md` describing the rationale and files involved.

### Testing
- Ran `make format` which applied formatting fixes successfully.
- Ran `make test` and the full test suite completed with `192 passed, 1 skipped`.
- Verified changed providers function as before through existing provider unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d2196d80c8321bdd275ac0a4f5731)