### PR TITLE
Extract renderer frame processing from RenderPipeline

### DIFF
--- a/docs/research/render_pipeline_refactor.md
+++ b/docs/research/render_pipeline_refactor.md
@@ -1,19 +1,28 @@
-# Render pipeline refactor note
+# Render pipeline refactor notes
 
 ## Summary
 
-The render-loop composition and surface-merging logic now lives in a dedicated
-`RenderPipeline` helper so `GameLoop` can focus on initialization, event handling,
-and device updates. The pipeline retains the renderer scheduling, surface caching,
-and render-variant selection behaviors previously embedded in the loop.
+- The render pipeline previously managed per-renderer setup, frame timing, and
+  logging alongside orchestration and surface composition.
+- Per-renderer processing now lives in a focused helper so the pipeline can
+  stay centered on scheduling and composition flow.
 
-## Sources
+## Technical motivation
 
-- `src/heart/runtime/render_pipeline.py` (new render pipeline helper)
-- `src/heart/runtime/game_loop.py` (game loop orchestration)
-- `src/heart/loop.py` (renderer variant selection)
-- `src/heart/environment.py` (legacy import shim updates)
+The `RenderPipeline` class handled both orchestration (queue depth decisions,
+surface collection, and composition) and renderer-specific concerns (clock
+validation, renderer initialization, and metrics logging). Splitting the
+renderer-specific work into its own helper clarifies responsibilities and keeps
+each file focused on one concern.
+
+## Implementation notes
+
+- Added `RendererFrameProcessor` to encapsulate renderer surface preparation,
+  frame execution, and metrics logging.
+- Updated `RenderPipeline` to delegate renderer work to the new processor while
+  keeping dispatch and surface composition logic in place.
 
 ## Materials
 
-- None
+- `src/heart/runtime/render_pipeline.py`
+- `src/heart/runtime/rendering/renderer_processor.py`

--- a/src/heart/runtime/render_pipeline.py
+++ b/src/heart/runtime/render_pipeline.py
@@ -1,29 +1,19 @@
 from __future__ import annotations
 
-import logging
-import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, cast
 
 import pygame
-from PIL import Image
 
-from heart import DeviceDisplayMode
 from heart.device import Device
 from heart.peripheral.core.manager import PeripheralManager
-from heart.runtime.rendering.constants import RGBA_IMAGE_FORMAT
+from heart.runtime.rendering.renderer_processor import RendererFrameProcessor
 from heart.runtime.rendering.surface_merge import SurfaceCompositionManager
-from heart.runtime.rendering.surface_provider import RendererSurfaceProvider
 from heart.runtime.rendering.variants import RendererVariant, RenderMethod
 from heart.utilities.env import Configuration
-from heart.utilities.logging import get_logger
-from heart.utilities.logging_control import get_logging_controller
 
 if TYPE_CHECKING:
     from heart.renderers import StatefulBaseRenderer
-
-logger = get_logger(__name__)
-log_controller = get_logging_controller()
 
 
 class RenderPipeline:
@@ -36,8 +26,7 @@ class RenderPipeline:
         self.device = device
         self.peripheral_manager = peripheral_manager
         self.renderer_variant = render_variant
-        self.clock: pygame.time.Clock | None = None
-        self._surface_provider = RendererSurfaceProvider(device)
+        self._frame_processor = RendererFrameProcessor(device, peripheral_manager)
         self._composition_manager = SurfaceCompositionManager()
 
         binary_method = cast(RenderMethod, self._render_surfaces_binary)
@@ -50,10 +39,8 @@ class RenderPipeline:
         }
         self._render_executor: ThreadPoolExecutor | None = None
 
-        self._render_queue_depth = 0
-
     def set_clock(self, clock: pygame.time.Clock | None) -> None:
-        self.clock = clock
+        self._frame_processor.set_clock(clock)
 
     def shutdown(self) -> None:
         if self._render_executor is not None:
@@ -67,95 +54,10 @@ class RenderPipeline:
             )
         return self._render_executor
 
-    def _require_clock(self) -> pygame.time.Clock:
-        clock = self.clock
-        if clock is None:
-            raise RuntimeError("GameLoop clock is not initialized")
-        return clock
-
-    def _prepare_renderer_surface(
-        self, renderer: "StatefulBaseRenderer[Any]"
-    ) -> pygame.Surface:
-        return self._surface_provider.prepare(renderer)
-
     def process_renderer(
         self, renderer: "StatefulBaseRenderer[Any]"
     ) -> pygame.Surface | None:
-        try:
-            start_ns = time.perf_counter_ns()
-            screen = self._render_renderer_frame(renderer)
-            duration_ms = (time.perf_counter_ns() - start_ns) / 1_000_000
-            self._log_renderer_metrics(renderer, duration_ms)
-            return screen
-        except Exception:
-            logger.exception("Error processing renderer")
-            return None
-
-    def _render_renderer_frame(
-        self, renderer: "StatefulBaseRenderer[Any]"
-    ) -> pygame.Surface:
-        clock = self._require_clock()
-        screen = self._prepare_renderer_surface(renderer)
-        if not renderer.initialized:
-            renderer.initialize(
-                window=screen,
-                clock=clock,
-                peripheral_manager=self.peripheral_manager,
-                orientation=self.device.orientation,
-            )
-        renderer._internal_process(
-            window=screen,
-            clock=clock,
-            peripheral_manager=self.peripheral_manager,
-            orientation=self.device.orientation,
-        )
-        return screen
-
-    def _log_renderer_metrics(
-        self, renderer: "StatefulBaseRenderer[Any]", duration_ms: float
-    ) -> None:
-        log_message = (
-            "render.loop renderer=%s duration_ms=%.2f queue_depth=%s "
-            "display_mode=%s uses_opengl=%s initialized=%s"
-        )
-        log_args = (
-            renderer.name,
-            duration_ms,
-            self._render_queue_depth,
-            renderer.device_display_mode.name,
-            renderer.device_display_mode == DeviceDisplayMode.OPENGL,
-            renderer.is_initialized(),
-        )
-        log_extra = {
-            "renderer": renderer.name,
-            "duration_ms": duration_ms,
-            "queue_depth": self._render_queue_depth,
-            "display_mode": renderer.device_display_mode.name,
-            "uses_opengl": renderer.device_display_mode == DeviceDisplayMode.OPENGL,
-            "initialized": renderer.is_initialized(),
-        }
-
-        log_controller.log(
-            key="render.loop",
-            logger=logger,
-            level=logging.INFO,
-            msg=log_message,
-            args=log_args,
-            extra=log_extra,
-            fallback_level=logging.DEBUG,
-        )
-
-    def finalize_rendering(self, screen: pygame.Surface) -> Image.Image:
-        image_bytes = pygame.image.tostring(screen, RGBA_IMAGE_FORMAT)
-        return Image.frombuffer(
-            RGBA_IMAGE_FORMAT,
-            screen.get_size(),
-            image_bytes,
-            "raw",
-            RGBA_IMAGE_FORMAT,
-            0,
-            1,
-        )
+        return self._frame_processor.process_renderer(renderer)
 
     def merge_surfaces(
         self, surface1: pygame.Surface, surface2: pygame.Surface
@@ -191,7 +93,7 @@ class RenderPipeline:
     def _render_surface_iterative(
         self, renderers: list["StatefulBaseRenderer[Any]"]
     ) -> pygame.Surface | None:
-        self._render_queue_depth = len(renderers)
+        self._frame_processor.set_queue_depth(len(renderers))
         surfaces = self._collect_surfaces_serial(renderers)
         return self._composition_manager.compose_serial(
             surfaces, merge_fn=self.merge_surfaces
@@ -200,7 +102,7 @@ class RenderPipeline:
     def _render_surfaces_binary(
         self, renderers: list["StatefulBaseRenderer[Any]"]
     ) -> pygame.Surface | None:
-        self._render_queue_depth = len(renderers)
+        self._frame_processor.set_queue_depth(len(renderers))
         if len(renderers) == 1:
             return self.process_renderer(renderers[0])
         surfaces = self._collect_surfaces_parallel(renderers)

--- a/src/heart/runtime/rendering/renderer_processor.py
+++ b/src/heart/runtime/rendering/renderer_processor.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+import pygame
+
+from heart import DeviceDisplayMode
+from heart.device import Device
+from heart.peripheral.core.manager import PeripheralManager
+from heart.runtime.rendering.surface_provider import RendererSurfaceProvider
+from heart.utilities.logging import get_logger
+from heart.utilities.logging_control import get_logging_controller
+
+if TYPE_CHECKING:
+    from heart.renderers import StatefulBaseRenderer
+
+logger = get_logger(__name__)
+log_controller = get_logging_controller()
+
+
+class RendererFrameProcessor:
+    def __init__(
+        self,
+        device: Device,
+        peripheral_manager: PeripheralManager,
+        surface_provider: RendererSurfaceProvider | None = None,
+    ) -> None:
+        self.device = device
+        self.peripheral_manager = peripheral_manager
+        self._surface_provider = surface_provider or RendererSurfaceProvider(device)
+        self._render_queue_depth = 0
+        self.clock: pygame.time.Clock | None = None
+
+    def set_clock(self, clock: pygame.time.Clock | None) -> None:
+        self.clock = clock
+
+    def set_queue_depth(self, queue_depth: int) -> None:
+        self._render_queue_depth = queue_depth
+
+    def process_renderer(
+        self, renderer: "StatefulBaseRenderer[Any]"
+    ) -> pygame.Surface | None:
+        try:
+            start_ns = time.perf_counter_ns()
+            screen = self._render_renderer_frame(renderer)
+            duration_ms = (time.perf_counter_ns() - start_ns) / 1_000_000
+            self._log_renderer_metrics(renderer, duration_ms)
+            return screen
+        except Exception:
+            logger.exception("Error processing renderer")
+            return None
+
+    def _render_renderer_frame(
+        self, renderer: "StatefulBaseRenderer[Any]"
+    ) -> pygame.Surface:
+        clock = self._require_clock()
+        screen = self._prepare_renderer_surface(renderer)
+        if not renderer.initialized:
+            renderer.initialize(
+                window=screen,
+                clock=clock,
+                peripheral_manager=self.peripheral_manager,
+                orientation=self.device.orientation,
+            )
+        renderer._internal_process(
+            window=screen,
+            clock=clock,
+            peripheral_manager=self.peripheral_manager,
+            orientation=self.device.orientation,
+        )
+        return screen
+
+    def _prepare_renderer_surface(
+        self, renderer: "StatefulBaseRenderer[Any]"
+    ) -> pygame.Surface:
+        return self._surface_provider.prepare(renderer)
+
+    def _require_clock(self) -> pygame.time.Clock:
+        clock = self.clock
+        if clock is None:
+            raise RuntimeError("GameLoop clock is not initialized")
+        return clock
+
+    def _log_renderer_metrics(
+        self, renderer: "StatefulBaseRenderer[Any]", duration_ms: float
+    ) -> None:
+        log_message = (
+            "render.loop renderer=%s duration_ms=%.2f queue_depth=%s "
+            "display_mode=%s uses_opengl=%s initialized=%s"
+        )
+        log_args = (
+            renderer.name,
+            duration_ms,
+            self._render_queue_depth,
+            renderer.device_display_mode.name,
+            renderer.device_display_mode == DeviceDisplayMode.OPENGL,
+            renderer.is_initialized(),
+        )
+        log_extra = {
+            "renderer": renderer.name,
+            "duration_ms": duration_ms,
+            "queue_depth": self._render_queue_depth,
+            "display_mode": renderer.device_display_mode.name,
+            "uses_opengl": renderer.device_display_mode == DeviceDisplayMode.OPENGL,
+            "initialized": renderer.is_initialized(),
+        }
+
+        log_controller.log(
+            key="render.loop",
+            logger=logger,
+            level=logging.INFO,
+            msg=log_message,
+            args=log_args,
+            extra=log_extra,
+            fallback_level=logging.DEBUG,
+        )


### PR DESCRIPTION
### Motivation
- Reduce responsibility of the render pipeline by separating per-renderer concerns like clock validation, initialization, and metrics logging into a focused component.
- Improve clarity and single-responsibility so scheduling/composition logic stays distinct from renderer execution details.
- Make the rendering orchestration easier to reason about and to test in isolation.

### Description
- Added `src/heart/runtime/rendering/renderer_processor.py` introducing `RendererFrameProcessor` to encapsulate renderer surface preparation, frame execution, and logging.
- Updated `src/heart/runtime/render_pipeline.py` to delegate per-renderer work to `RendererFrameProcessor` and to keep dispatch, executor management, and composition logic unchanged.
- Replaced direct clock/queue-depth handling in `RenderPipeline` with `set_clock` and `set_queue_depth` delegation to the new processor, and removed inlined logging/initialization code.
- Added a research note `docs/research/render_pipeline_refactor.md` documenting motivation and implementation notes for the refactor.

### Testing
- Ran `make format` to apply formatting checks and the run completed successfully.
- Ran the test suite with `make test`, which completed successfully with `192 passed, 1 skipped`.
- All modified modules were exercised by the existing Pytest suite and no tests failed.
- Formatting and tests were run in CI-like local environment to validate changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d2153da1c83218b44ccce11503692)