### PR TITLE
Rename sensor factory variables and document collection/element naming guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ See the following references for deeper analysis:
 - `make test` executes the pytest suite.
 - `make check` verifies formatting and linting without applying fixes.
 - `make doctor` captures a developer experience snapshot for troubleshooting.
+- Keep collection and element variable names distinct (for example, `sensors` and `sensor`).
 
 The repository layout is summarised below:
 ```

--- a/drivers/sensor_bus/code.py
+++ b/drivers/sensor_bus/code.py
@@ -106,17 +106,17 @@ def connect_to_sensors(i2c):
         ISM330DHCX: An instance of the ISM330DHCX sensor.
 
     """
-    sensor_fn = [
+    sensor_factories = [
         LSM303_Accel,
         LIS2MDL,
         ISM330DHCX,
     ]
     sensors = []
-    for sensor_fn in sensor_fn:
+    for sensor_factory in sensor_factories:
         try:
-            sensors.append(sensor_fn(i2c))
+            sensors.append(sensor_factory(i2c))
         except Exception as exc:  # noqa: BLE001
-            _debug(f"Failed to initialize sensor {sensor_fn.__name__}: {exc}")
+            _debug(f"Failed to initialize sensor {sensor_factory.__name__}: {exc}")
     return sensors
 
 


### PR DESCRIPTION
### Motivation
- Enforce a repository naming rule that keeps collection and element variable names distinct to reduce confusion in loops and factory lists.
- Make sensor bus factory usage clearer by using plural names for the collection and singular names for individual factories.

### Description
- Rename the sensor factory list from `sensor_fn` to `sensor_factories` in `drivers/sensor_bus/code.py` and iterate with `sensor_factory` for clarity.
- Update the sensor initialization call sites to use `sensor_factory(i2c)` and improve the debug message to reference `sensor_factory.__name__`.
- Add a brief documentation note to `README.md` recommending distinct collection and element variable names (for example, `sensors` and `sensor`).

### Testing
- Ran `make format` and formatting checks completed successfully.
- Ran `make test` and the Pytest suite completed with `192 passed, 1 skipped` within the local environment.
- No new unit tests were added as this change is a renaming and documentation update.
- All automated checks and test runners exited with success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d22d1fa9c8321a4da1e3a2b58f672)