### PR TITLE
Replace skidl wildcard import with explicit symbols

### DIFF
--- a/experimental/circuit/main.py
+++ b/experimental/circuit/main.py
@@ -2,7 +2,7 @@ import logging
 import string
 from collections import Counter
 
-from skidl import *
+from skidl import ERC, KICAD8, Net, POWER, Part, Rgx, generate_netlist
 from skidl.pin import pin_types
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
### Motivation

- Replace a wildcard `skidl` import to follow repository guidance that disallows wildcard imports. 
- Make external dependencies explicit so static analysis and tooling can track symbol usage. 
- Reduce accidental namespace pollution and clarify which `skidl` symbols are used by the module. 

### Description

- Updated `experimental/circuit/main.py` to remove `from skidl import *` and import specific symbols instead. 
- The new import line is `from skidl import ERC, KICAD8, Net, POWER, Part, Rgx, generate_netlist`. 
- No functional logic changes were made to the board construction code; this is a purely import-level cleanup. 

### Testing

- Ran `make format` to apply repository formatting rules and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d22e470948321ae7a0b6dec76b2a0)