### PR TITLE
Remove microphone detect stub and add AGENTS rule to avoid placeholder early returns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 
 - Avoid catching `BaseException`; catch `Exception` or more specific error types so system-exiting signals propagate.
 - Avoid swallowing recoverable exceptions; log them with the shared logger (use debug-level logging for high-frequency loops).
+- Avoid placeholder early returns or unreachable docstrings in production methods; remove stubs once real implementations are available.
 
 ## Testing
 

--- a/src/heart/peripheral/microphone.py
+++ b/src/heart/peripheral/microphone.py
@@ -59,7 +59,6 @@ class Microphone(Peripheral[MicrophoneLevel]):
     # ------------------------------------------------------------------
     @classmethod
     def detect(cls) -> Iterator[Self]:
-        return
         """Yield a microphone peripheral if audio backends are available."""
 
         if sd is None:


### PR DESCRIPTION
### Motivation

- Prevent placeholder early returns or unreachable docstrings in production methods so detection and runtime checks actually execute.
- Restore the intended detection lifecycle for the microphone peripheral so availability checks and `yield` behavior run.

### Description

- Add an AGENTS guideline recommending avoidance of placeholder early returns and unreachable docstrings.
- Remove the stray stub `return` from `Microphone.detect` so the method performs backend availability checks and can `yield` a `Microphone` instance when appropriate.
- No other functional changes were made to audio processing or run-loop logic.

### Testing

- Ran `make format`, which completed successfully.
- Ran `make test`; the suite produced `191 passed, 1 failed, 1 skipped`.
- The single failing test is `tests/utilities/test_reactivex_streams.py::TestShareStreamStrategy::test_share_stream_refcount_grace_delays_disconnect` and caused the overall test run to fail.
- The new changes themselves did not trigger additional test failures beyond the preexisting failing test reported above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d230dda508321930148ff100bc7e4)