### PR TITLE
Prefer mixins or composition over direct inheritance in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - Avoid using `print` for runtime diagnostics in CLI commands; use the shared logger.
 - Avoid using `print` for runtime diagnostics in peripheral modules; use the shared logger.
 - Avoid wildcard imports; use explicit imports so dependencies stay clear and tooling can track usage.
+- Prefer mixins or composition over direct inheritance.
 - Prefer `StrEnum` values over raw strings for strategy/configuration mode selections.
 - Use `heart.utilities.logging.get_logger` for internal logging so handlers and log levels stay consistent across modules.
 


### PR DESCRIPTION
### Motivation
- Provide a clear coding guideline that encourages using mixins or composition instead of direct inheritance to improve modularity and testability.
- Reduce tight coupling and promote smaller, single-responsibility modules as called out elsewhere in the repository guidance.
- Make contributor expectations explicit for design choices in new and refactored code.

### Description
- Add a new guidance line to `AGENTS.md` that states: "Prefer mixins or composition over direct inheritance." 
- No functional code changes were made; this PR updates only repository documentation in `AGENTS.md`.
- Repository formatting was applied to keep the change consistent with project style using `make format`.

### Testing
- Ran `make format` to apply and verify repository formatting, which completed successfully.
- No unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d2403c2348321918e93cdd900ed39)