### PR TITLE
Extract RendererProcessor to handle renderer preparation and metrics

### DIFF
--- a/docs/code_flow.md
+++ b/docs/code_flow.md
@@ -12,7 +12,7 @@ Describe how a `totem run` execution traverses configuration services, the runti
 
 ## Technical Approach
 
-Represent each execution stage as a node in a Mermaid flowchart. Colour code orchestration components, service layers, inputs, and outputs so reviewers can trace transitions. The diagram captures call sequencing between the CLI, configuration registry, runtime loop, app routing, peripheral managers, and display drivers. The goal is to surface every point where the runtime crosses a service boundary or hardware interface. Frame composition is split between surface preparation (display-mode coordination and caching) and composition management (merge-strategy selection plus parallel merge coordination).
+Represent each execution stage as a node in a Mermaid flowchart. Colour code orchestration components, service layers, inputs, and outputs so reviewers can trace transitions. The diagram captures call sequencing between the CLI, configuration registry, runtime loop, app routing, peripheral managers, and display drivers. The goal is to surface every point where the runtime crosses a service boundary or hardware interface. Frame processing is split between renderer preparation (initialization, surface preparation, and metrics logging) and composition management (merge-strategy selection plus parallel merge coordination).
 
 ## Flow Diagram
 
@@ -37,6 +37,7 @@ flowchart LR
         AppRouter["AppController / Mode Router"]
         ModeServices["Mode Services & Renderers"]
         RenderPipeline["Render Pipeline"]
+        RendererProcessor["Renderer Processor\n(renderer prep + metrics)"]
         SurfaceProvider["Surface Provider\n(display mode + surface cache)"]
         CompositionManager["Composition Manager\n(merge strategy + parallel loops)"]
     end
@@ -68,7 +69,7 @@ flowchart LR
     Loop --> AppRouter
     Loop --> RenderPipeline
     AppRouter --> ModeServices --> RenderPipeline --> CompositionManager --> DisplaySvc
-    RenderPipeline --> SurfaceProvider
+    RenderPipeline --> RendererProcessor --> SurfaceProvider
     DisplaySvc --> LocalScreen
     DisplaySvc --> Capture --> DeviceBridge --> LedMatrix
     Capture --> AverageMirror --> SingleLED
@@ -80,7 +81,7 @@ flowchart LR
     RxScheduler --> HeartRate --> AppRouter
     RxScheduler --> PhoneText --> AppRouter
 
-    class CLI,Registry,Configurer,ModeServices,RenderPipeline,SurfaceProvider,CompositionManager service;
+    class CLI,Registry,Configurer,ModeServices,RenderPipeline,RendererProcessor,SurfaceProvider,CompositionManager service;
     class Loop,AppRouter orchestrator;
     class PeripheralMgr,RxScheduler,Switch,Gamepad,Sensors,HeartRate,PhoneText input;
     class DisplaySvc,LocalScreen,Capture,DeviceBridge,LedMatrix,AverageMirror,SingleLED output;

--- a/docs/research/render_pipeline_composition_refactor.md
+++ b/docs/research/render_pipeline_composition_refactor.md
@@ -8,6 +8,7 @@ Document the render pipeline refactor that separates surface preparation, cachin
 
 - Local checkout of the Heart repository.
 - `src/heart/runtime/render_pipeline.py` for pipeline orchestration changes.
+- `src/heart/runtime/rendering/renderer_processor.py` for renderer preparation and metrics logging.
 - `src/heart/runtime/rendering/surface_provider.py` for surface preparation and caching.
 - `src/heart/runtime/rendering/surface_merge.py` for merge strategy selection and parallel merge coordination.
 - `docs/code_flow.md` for the updated runtime flow diagram and narrative.
@@ -15,12 +16,14 @@ Document the render pipeline refactor that separates surface preparation, cachin
 ## Notes
 
 - Surface preparation now lives in a dedicated provider that owns display-mode enforcement and cached surface reuse, keeping `RenderPipeline` focused on orchestration.
+- Renderer initialization, frame processing, and metrics logging are centralized in `RendererProcessor` to keep per-renderer concerns out of the pipeline orchestration loop.
 - Merge strategy selection and the parallel reduction loop are centralized in the composition manager so serial and parallel rendering share the same strategy controls.
 - `RenderPipeline.merge_surfaces` remains as the pairwise merge hook, allowing tests to override the merge function while using the shared composition manager.
 
 ## Source references
 
 - `src/heart/runtime/render_pipeline.py`
+- `src/heart/runtime/rendering/renderer_processor.py`
 - `src/heart/runtime/rendering/surface_provider.py`
 - `src/heart/runtime/rendering/surface_merge.py`
 - `docs/code_flow.md`

--- a/src/heart/runtime/render_pipeline.py
+++ b/src/heart/runtime/render_pipeline.py
@@ -1,29 +1,22 @@
 from __future__ import annotations
 
-import logging
-import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, cast
 
 import pygame
 from PIL import Image
 
-from heart import DeviceDisplayMode
 from heart.device import Device
 from heart.peripheral.core.manager import PeripheralManager
 from heart.runtime.rendering.constants import RGBA_IMAGE_FORMAT
+from heart.runtime.rendering.renderer_processor import RendererProcessor
 from heart.runtime.rendering.surface_merge import SurfaceCompositionManager
 from heart.runtime.rendering.surface_provider import RendererSurfaceProvider
 from heart.runtime.rendering.variants import RendererVariant, RenderMethod
 from heart.utilities.env import Configuration
-from heart.utilities.logging import get_logger
-from heart.utilities.logging_control import get_logging_controller
 
 if TYPE_CHECKING:
     from heart.renderers import StatefulBaseRenderer
-
-logger = get_logger(__name__)
-log_controller = get_logging_controller()
 
 
 class RenderPipeline:
@@ -39,6 +32,11 @@ class RenderPipeline:
         self.clock: pygame.time.Clock | None = None
         self._surface_provider = RendererSurfaceProvider(device)
         self._composition_manager = SurfaceCompositionManager()
+        self._renderer_processor = RendererProcessor(
+            device=device,
+            peripheral_manager=peripheral_manager,
+            surface_provider=self._surface_provider,
+        )
 
         binary_method = cast(RenderMethod, self._render_surfaces_binary)
         iterative_method = cast(RenderMethod, self._render_surface_iterative)
@@ -73,76 +71,14 @@ class RenderPipeline:
             raise RuntimeError("GameLoop clock is not initialized")
         return clock
 
-    def _prepare_renderer_surface(
-        self, renderer: "StatefulBaseRenderer[Any]"
-    ) -> pygame.Surface:
-        return self._surface_provider.prepare(renderer)
-
     def process_renderer(
         self, renderer: "StatefulBaseRenderer[Any]"
     ) -> pygame.Surface | None:
-        try:
-            start_ns = time.perf_counter_ns()
-            screen = self._render_renderer_frame(renderer)
-            duration_ms = (time.perf_counter_ns() - start_ns) / 1_000_000
-            self._log_renderer_metrics(renderer, duration_ms)
-            return screen
-        except Exception:
-            logger.exception("Error processing renderer")
-            return None
-
-    def _render_renderer_frame(
-        self, renderer: "StatefulBaseRenderer[Any]"
-    ) -> pygame.Surface:
         clock = self._require_clock()
-        screen = self._prepare_renderer_surface(renderer)
-        if not renderer.initialized:
-            renderer.initialize(
-                window=screen,
-                clock=clock,
-                peripheral_manager=self.peripheral_manager,
-                orientation=self.device.orientation,
-            )
-        renderer._internal_process(
-            window=screen,
+        return self._renderer_processor.process_renderer(
+            renderer=renderer,
             clock=clock,
-            peripheral_manager=self.peripheral_manager,
-            orientation=self.device.orientation,
-        )
-        return screen
-
-    def _log_renderer_metrics(
-        self, renderer: "StatefulBaseRenderer[Any]", duration_ms: float
-    ) -> None:
-        log_message = (
-            "render.loop renderer=%s duration_ms=%.2f queue_depth=%s "
-            "display_mode=%s uses_opengl=%s initialized=%s"
-        )
-        log_args = (
-            renderer.name,
-            duration_ms,
-            self._render_queue_depth,
-            renderer.device_display_mode.name,
-            renderer.device_display_mode == DeviceDisplayMode.OPENGL,
-            renderer.is_initialized(),
-        )
-        log_extra = {
-            "renderer": renderer.name,
-            "duration_ms": duration_ms,
-            "queue_depth": self._render_queue_depth,
-            "display_mode": renderer.device_display_mode.name,
-            "uses_opengl": renderer.device_display_mode == DeviceDisplayMode.OPENGL,
-            "initialized": renderer.is_initialized(),
-        }
-
-        log_controller.log(
-            key="render.loop",
-            logger=logger,
-            level=logging.INFO,
-            msg=log_message,
-            args=log_args,
-            extra=log_extra,
-            fallback_level=logging.DEBUG,
+            queue_depth=self._render_queue_depth,
         )
 
     def finalize_rendering(self, screen: pygame.Surface) -> Image.Image:

--- a/src/heart/runtime/rendering/renderer_processor.py
+++ b/src/heart/runtime/rendering/renderer_processor.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+import pygame
+
+from heart import DeviceDisplayMode
+from heart.device import Device
+from heart.peripheral.core.manager import PeripheralManager
+from heart.runtime.rendering.surface_provider import RendererSurfaceProvider
+from heart.utilities.logging import get_logger
+from heart.utilities.logging_control import get_logging_controller
+
+if TYPE_CHECKING:
+    from heart.renderers import StatefulBaseRenderer
+
+logger = get_logger(__name__)
+log_controller = get_logging_controller()
+
+
+class RendererProcessor:
+    def __init__(
+        self,
+        device: Device,
+        peripheral_manager: PeripheralManager,
+        surface_provider: RendererSurfaceProvider,
+    ) -> None:
+        self.device = device
+        self.peripheral_manager = peripheral_manager
+        self._surface_provider = surface_provider
+
+    def _prepare_renderer_surface(
+        self, renderer: "StatefulBaseRenderer[Any]"
+    ) -> pygame.Surface:
+        return self._surface_provider.prepare(renderer)
+
+    def _render_renderer_frame(
+        self, renderer: "StatefulBaseRenderer[Any]", clock: pygame.time.Clock
+    ) -> pygame.Surface:
+        screen = self._prepare_renderer_surface(renderer)
+        if not renderer.initialized:
+            renderer.initialize(
+                window=screen,
+                clock=clock,
+                peripheral_manager=self.peripheral_manager,
+                orientation=self.device.orientation,
+            )
+        renderer._internal_process(
+            window=screen,
+            clock=clock,
+            peripheral_manager=self.peripheral_manager,
+            orientation=self.device.orientation,
+        )
+        return screen
+
+    def _log_renderer_metrics(
+        self,
+        renderer: "StatefulBaseRenderer[Any]",
+        duration_ms: float,
+        queue_depth: int,
+    ) -> None:
+        log_message = (
+            "render.loop renderer=%s duration_ms=%.2f queue_depth=%s "
+            "display_mode=%s uses_opengl=%s initialized=%s"
+        )
+        log_args = (
+            renderer.name,
+            duration_ms,
+            queue_depth,
+            renderer.device_display_mode.name,
+            renderer.device_display_mode == DeviceDisplayMode.OPENGL,
+            renderer.is_initialized(),
+        )
+        log_extra = {
+            "renderer": renderer.name,
+            "duration_ms": duration_ms,
+            "queue_depth": queue_depth,
+            "display_mode": renderer.device_display_mode.name,
+            "uses_opengl": renderer.device_display_mode == DeviceDisplayMode.OPENGL,
+            "initialized": renderer.is_initialized(),
+        }
+
+        log_controller.log(
+            key="render.loop",
+            logger=logger,
+            level=logging.INFO,
+            msg=log_message,
+            args=log_args,
+            extra=log_extra,
+            fallback_level=logging.DEBUG,
+        )
+
+    def process_renderer(
+        self,
+        renderer: "StatefulBaseRenderer[Any]",
+        clock: pygame.time.Clock,
+        queue_depth: int,
+    ) -> pygame.Surface | None:
+        try:
+            start_ns = time.perf_counter_ns()
+            screen = self._render_renderer_frame(renderer, clock)
+            duration_ms = (time.perf_counter_ns() - start_ns) / 1_000_000
+            self._log_renderer_metrics(renderer, duration_ms, queue_depth)
+            return screen
+        except Exception:
+            logger.exception("Error processing renderer")
+            return None


### PR DESCRIPTION
### Motivation

- Separate per-renderer responsibilities (surface preparation, initialization, and metrics) from pipeline orchestration to improve clarity and testability.  
- Keep `RenderPipeline` focused on queue depth tracking and surface composition rather than renderer lifecycle details.  
- Make the runtime flow and research notes reflect the updated responsibilities so contributors can reason about boundaries.  

### Description

- Add `src/heart/runtime/rendering/renderer_processor.py` implementing `RendererProcessor` that prepares surfaces, initializes renderers, runs `_internal_process`, and logs metrics.  
- Update `src/heart/runtime/render_pipeline.py` to instantiate and delegate per-renderer work to `RendererProcessor` and retain composition/merge logic.  
- Update `docs/code_flow.md` and `docs/research/render_pipeline_composition_refactor.md` to document the new `RendererProcessor` role and regenerate the flow SVG.  

### Testing

- Ran `make format` to apply formatting and linting fixes and it completed successfully.  
- Ran `make test`; the test run produced mostly green results but one automated test failed: `tests/utilities/test_reactivex_streams.py::TestShareStreamFlowControl::test_share_stream_coalesces_latest_when_configured` (result: 1 failed, 191 passed, 1 skipped).  
- The failing test appears unrelated to the render-processing refactor but is included here for visibility.  
- No additional automated tests were added in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d235130c483219902f0518a204cab)