### PR TITLE
Add Life rule strategies, RNG seeding, and table-driven rule application

### DIFF
--- a/docs/performance/life_update_strategy.md
+++ b/docs/performance/life_update_strategy.md
@@ -7,12 +7,12 @@ Reduce the per-frame cost of the Game of Life update while keeping the rules ide
 ## Materials
 
 - Python environment with `numpy` and `scipy` installed.
-- `heart.modules.life.state.LifeState` for the update loop.
+- `heart.renderers.life.state.LifeState` for the update loop.
 - `heart.utilities.env.Configuration` for environment-driven settings.
 
 ## Update Strategy Options
 
-The Life module supports selecting the update algorithm via environment variable:
+The Life module supports selecting the neighbor-count update algorithm via environment variable:
 
 - `HEART_LIFE_UPDATE_STRATEGY=auto` (default) uses a slice-based neighbor count for the default kernel unless a
   convolution threshold is configured.
@@ -23,6 +23,19 @@ The Life module supports selecting the update algorithm via environment variable
 `HEART_LIFE_CONVOLVE_THRESHOLD` (default `0`) optionally switches `auto` to convolution when the grid size
 meets or exceeds the configured cell count. Set it to a positive integer to prefer convolution for large
 grids while keeping the slice-based path for smaller updates.
+
+## Rule Application Options
+
+Rule application can be configured separately from neighbor counting:
+
+- `HEART_LIFE_RULE_STRATEGY=auto` (default) selects the table lookup when the default kernel is used and
+  neighbor counts remain within the 0-8 range, falling back to boolean rules otherwise.
+- `HEART_LIFE_RULE_STRATEGY=direct` always applies the boolean rules.
+- `HEART_LIFE_RULE_STRATEGY=table` prefers the table lookup but falls back to boolean rules if custom
+  kernels or unexpected neighbor counts are detected.
+
+`HEART_LIFE_RANDOM_SEED` optionally pins the RNG used by the Life renderer for reproducible initial and
+reseeded grids.
 
 ## Operational Notes
 

--- a/docs/research/life_rule_table.md
+++ b/docs/research/life_rule_table.md
@@ -1,0 +1,18 @@
+# Life Rule Table Application
+
+## Purpose
+
+Document the rule-table option used by the Life renderer and the conditions that trigger fallbacks to the direct boolean rules.
+
+## Materials
+
+- `src/heart/renderers/life/state.py` for `LIFE_RULE_TABLE` and the rule-application helpers.
+- `src/heart/utilities/env/rendering.py` for `HEART_LIFE_RULE_STRATEGY` configuration.
+- `tests/modules/test_life_state.py` for parity and fallback coverage.
+
+## Notes
+
+- The rule table is a 2x9 array where rows represent dead/alive cells and columns represent neighbor counts.
+- Table lookups are used when the default kernel is active and neighbor counts stay within the 0-8 range.
+- If a custom kernel is supplied or the neighbor count falls outside the supported range, the implementation
+  falls back to the direct boolean rule application so updates remain safe and predictable.

--- a/src/heart/renderers/life/provider.py
+++ b/src/heart/renderers/life/provider.py
@@ -8,6 +8,7 @@ from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.providers.switch import MainSwitchProvider
 from heart.peripheral.uwb import ops
 from heart.renderers.life.state import LifeState
+from heart.utilities.env import Configuration
 
 
 class LifeStateProvider:
@@ -19,8 +20,10 @@ class LifeStateProvider:
         self,
     ) -> reactivex.Observable[LifeState]:
         StateOp = Callable[[LifeState], LifeState]
-        def create_new_grid(size):
-            return np.random.choice([0, 1], size=size)
+        rng = LifeState.resolve_rng(Configuration.life_random_seed())
+
+        def create_new_grid(size: tuple[int, int]) -> np.ndarray:
+            return LifeState.random_grid(size, rng)
 
         def create_state(x: np.ndarray) -> LifeState:
             return LifeState(grid=x)

--- a/src/heart/utilities/env/__init__.py
+++ b/src/heart/utilities/env/__init__.py
@@ -5,6 +5,7 @@ from heart.utilities.env.enums import DeviceLayoutMode as DeviceLayoutMode
 from heart.utilities.env.enums import FrameArrayStrategy as FrameArrayStrategy
 from heart.utilities.env.enums import \
     FrameExportStrategy as FrameExportStrategy
+from heart.utilities.env.enums import LifeRuleStrategy as LifeRuleStrategy
 from heart.utilities.env.enums import LifeUpdateStrategy as LifeUpdateStrategy
 from heart.utilities.env.enums import \
     ReactivexEventBusScheduler as ReactivexEventBusScheduler

--- a/src/heart/utilities/env/enums.py
+++ b/src/heart/utilities/env/enums.py
@@ -34,6 +34,12 @@ class LifeUpdateStrategy(StrEnum):
     SHIFTED = "shifted"
 
 
+class LifeRuleStrategy(StrEnum):
+    AUTO = "auto"
+    DIRECT = "direct"
+    TABLE = "table"
+
+
 class DeviceLayoutMode(StrEnum):
     CUBE = "cube"
     RECTANGLE = "rectangle"

--- a/src/heart/utilities/env/rendering.py
+++ b/src/heart/utilities/env/rendering.py
@@ -2,8 +2,8 @@ import os
 
 from heart.device.rgb_display.isolated_render import DEFAULT_SOCKET_PATH
 from heart.utilities.env.enums import (FrameArrayStrategy, FrameExportStrategy,
-                                       LifeUpdateStrategy, RenderMergeStrategy,
-                                       RenderTileStrategy)
+                                       LifeRuleStrategy, LifeUpdateStrategy,
+                                       RenderMergeStrategy, RenderTileStrategy)
 from heart.utilities.env.parsing import _env_flag, _env_int, _env_optional_int
 
 
@@ -113,3 +113,17 @@ class RenderingConfiguration:
     @classmethod
     def life_convolve_threshold(cls) -> int:
         return _env_int("HEART_LIFE_CONVOLVE_THRESHOLD", default=0, minimum=0)
+
+    @classmethod
+    def life_rule_strategy(cls) -> LifeRuleStrategy:
+        strategy = os.environ.get("HEART_LIFE_RULE_STRATEGY", "auto").strip().lower()
+        try:
+            return LifeRuleStrategy(strategy)
+        except ValueError as exc:
+            raise ValueError(
+                "HEART_LIFE_RULE_STRATEGY must be 'auto', 'direct', or 'table'"
+            ) from exc
+
+    @classmethod
+    def life_random_seed(cls) -> int | None:
+        return _env_optional_int("HEART_LIFE_RANDOM_SEED", minimum=0)


### PR DESCRIPTION
### Motivation

- Provide configurable rule-application modes for the Game of Life renderer to enable a fast table lookup path or fall back to the direct boolean rules when unsafe.
- Allow deterministic seeding of initial/reseeded Life grids so reproducible simulations are possible via configuration.
- Keep the existing neighbor-count strategy knobs (convolve/pad/shifted/auto) while adding a separate knob for rule application.

### Description

- Add `LifeRuleStrategy` enum and expose `HEART_LIFE_RULE_STRATEGY` and `HEART_LIFE_RANDOM_SEED` via `RenderingConfiguration` (in `src/heart/utilities/env/enums.py` and `src/heart/utilities/env/rendering.py`).
- Implement a 2x9 `LIFE_RULE_TABLE` and table-driven rule application with safe fallbacks in `src/heart/renderers/life/state.py`, including `_apply_rules`, `_apply_table_rules`, `_apply_direct_rules`, and `_can_use_rule_table`.
- Introduce RNG helpers `LifeState.resolve_rng` and `LifeState.random_grid` and wire `Configuration.life_random_seed()` into `LifeStateProvider` so initial/reseeded grids can be seeded (in `src/heart/renderers/life/provider.py`).
- Update docs (`docs/performance/life_update_strategy.md`, add `docs/research/life_rule_table.md`) and extend tests (`tests/modules/test_life_state.py`) to cover parity and fallback behaviour.

### Testing

- Ran `make format` to apply repository formatting, which completed successfully.
- Ran `make test` for the full Pytest suite and it completed successfully with `195 passed, 1 skipped`.
- New and updated unit tests in `tests/modules/test_life_state.py` were executed and passed, validating parity between table and direct rules and fallback scenarios.
- No automated test failures remain after fixes; the suite is green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d228d37f08321a842221963f66655)