### PR TITLE
Introduce RendererFrameProcessor and delegate per-renderer work

### DIFF
--- a/docs/research/render_pipeline_refactor.md
+++ b/docs/research/render_pipeline_refactor.md
@@ -1,19 +1,31 @@
-# Render pipeline refactor note
+# Render pipeline frame processor refactor
 
 ## Summary
 
-The render-loop composition and surface-merging logic now lives in a dedicated
-`RenderPipeline` helper so `GameLoop` can focus on initialization, event handling,
-and device updates. The pipeline retains the renderer scheduling, surface caching,
-and render-variant selection behaviors previously embedded in the loop.
+Refactor per-renderer frame preparation, execution, and logging into a dedicated
+`RendererFrameProcessor`. The goal is to keep `RenderPipeline` focused on
+render dispatch, executor management, and surface composition while preserving
+existing timing and logging behavior.
 
-## Sources
+## Motivation
 
-- `src/heart/runtime/render_pipeline.py` (new render pipeline helper)
-- `src/heart/runtime/game_loop.py` (game loop orchestration)
-- `src/heart/loop.py` (renderer variant selection)
-- `src/heart/environment.py` (legacy import shim updates)
+`RenderPipeline` previously mixed composition orchestration with low-level
+renderer frame handling and logging. Splitting the frame processing logic into a
+separate module reduces the number of concerns inside the pipeline and makes it
+simpler to evolve per-renderer behavior without touching dispatch logic.
+
+## Implementation notes
+
+- Added `RendererFrameProcessor` to encapsulate surface preparation, renderer
+  initialization, per-frame execution, timing updates, and per-renderer logging.
+- Updated `RenderPipeline` to delegate per-renderer work and queue depth updates
+  to the new processor while keeping merge strategy selection and composition
+  behavior intact.
+- Preserved timing snapshots by sharing the same `RendererTimingTracker`
+  instance between the processor and the pipeline.
 
 ## Materials
 
-- None
+- `src/heart/runtime/render_pipeline.py`
+- `src/heart/runtime/rendering/renderer_processor.py`
+- `src/heart/runtime/rendering/timing.py`

--- a/src/heart/runtime/render_pipeline.py
+++ b/src/heart/runtime/render_pipeline.py
@@ -1,20 +1,17 @@
 from __future__ import annotations
 
 import logging
-import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, cast
 
 import pygame
 from PIL import Image
 
-from heart import DeviceDisplayMode
 from heart.device import Device
 from heart.peripheral.core.manager import PeripheralManager
 from heart.runtime.rendering.constants import RGBA_IMAGE_FORMAT
+from heart.runtime.rendering.renderer_processor import RendererFrameProcessor
 from heart.runtime.rendering.surface_merge import SurfaceCompositionManager
-from heart.runtime.rendering.surface_provider import RendererSurfaceProvider
-from heart.runtime.rendering.timing import RendererTimingTracker
 from heart.runtime.rendering.variants import RendererVariant, RenderMethod
 from heart.utilities.env import Configuration
 from heart.utilities.env.enums import RenderMergeStrategy
@@ -39,12 +36,12 @@ class RenderPipeline:
         self.peripheral_manager = peripheral_manager
         self.renderer_variant = render_variant
         self.clock: pygame.time.Clock | None = None
-        self._surface_provider = RendererSurfaceProvider(device)
         self._current_merge_strategy = Configuration.render_merge_strategy()
         self._composition_manager = SurfaceCompositionManager(
             strategy_provider=self._get_merge_strategy
         )
-        self._timing_tracker = RendererTimingTracker()
+        self._renderer_processor = RendererFrameProcessor(device, peripheral_manager)
+        self._timing_tracker = self._renderer_processor.timing_tracker
 
         binary_method = cast(RenderMethod, self._render_surfaces_binary)
         iterative_method = cast(RenderMethod, self._render_surface_iterative)
@@ -56,10 +53,9 @@ class RenderPipeline:
         }
         self._render_executor: ThreadPoolExecutor | None = None
 
-        self._render_queue_depth = 0
-
     def set_clock(self, clock: pygame.time.Clock | None) -> None:
         self.clock = clock
+        self._renderer_processor.set_clock(clock)
 
     def shutdown(self) -> None:
         if self._render_executor is not None:
@@ -73,84 +69,10 @@ class RenderPipeline:
             )
         return self._render_executor
 
-    def _require_clock(self) -> pygame.time.Clock:
-        clock = self.clock
-        if clock is None:
-            raise RuntimeError("GameLoop clock is not initialized")
-        return clock
-
-    def _prepare_renderer_surface(
-        self, renderer: "StatefulBaseRenderer[Any]"
-    ) -> pygame.Surface:
-        return self._surface_provider.prepare(renderer)
-
     def process_renderer(
         self, renderer: "StatefulBaseRenderer[Any]"
     ) -> pygame.Surface | None:
-        try:
-            start_ns = time.perf_counter_ns()
-            screen = self._render_renderer_frame(renderer)
-            duration_ms = (time.perf_counter_ns() - start_ns) / 1_000_000
-            self._timing_tracker.record(renderer.name, duration_ms)
-            self._log_renderer_metrics(renderer, duration_ms)
-            return screen
-        except Exception:
-            logger.exception("Error processing renderer")
-            return None
-
-    def _render_renderer_frame(
-        self, renderer: "StatefulBaseRenderer[Any]"
-    ) -> pygame.Surface:
-        clock = self._require_clock()
-        screen = self._prepare_renderer_surface(renderer)
-        if not renderer.initialized:
-            renderer.initialize(
-                window=screen,
-                clock=clock,
-                peripheral_manager=self.peripheral_manager,
-                orientation=self.device.orientation,
-            )
-        renderer._internal_process(
-            window=screen,
-            clock=clock,
-            peripheral_manager=self.peripheral_manager,
-            orientation=self.device.orientation,
-        )
-        return screen
-
-    def _log_renderer_metrics(
-        self, renderer: "StatefulBaseRenderer[Any]", duration_ms: float
-    ) -> None:
-        log_message = (
-            "render.loop renderer=%s duration_ms=%.2f queue_depth=%s "
-            "display_mode=%s uses_opengl=%s initialized=%s"
-        )
-        log_args = (
-            renderer.name,
-            duration_ms,
-            self._render_queue_depth,
-            renderer.device_display_mode.name,
-            renderer.device_display_mode == DeviceDisplayMode.OPENGL,
-            renderer.is_initialized(),
-        )
-        log_extra = {
-            "renderer": renderer.name,
-            "duration_ms": duration_ms,
-            "queue_depth": self._render_queue_depth,
-            "display_mode": renderer.device_display_mode.name,
-            "uses_opengl": renderer.device_display_mode == DeviceDisplayMode.OPENGL,
-            "initialized": renderer.is_initialized(),
-        }
-
-        log_controller.log(
-            key="render.loop",
-            logger=logger,
-            level=logging.INFO,
-            msg=log_message,
-            args=log_args,
-            extra=log_extra,
-            fallback_level=logging.DEBUG,
-        )
+        return self._renderer_processor.process_renderer(renderer)
 
     def finalize_rendering(self, screen: pygame.Surface) -> Image.Image:
         image_bytes = pygame.image.tostring(screen, RGBA_IMAGE_FORMAT)
@@ -274,7 +196,7 @@ class RenderPipeline:
     def _render_surface_iterative(
         self, renderers: list["StatefulBaseRenderer[Any]"]
     ) -> pygame.Surface | None:
-        self._render_queue_depth = len(renderers)
+        self._renderer_processor.set_queue_depth(len(renderers))
         self._update_merge_strategy(renderers)
         surfaces = self._collect_surfaces_serial(renderers)
         return self._composition_manager.compose_serial(
@@ -284,7 +206,7 @@ class RenderPipeline:
     def _render_surfaces_binary(
         self, renderers: list["StatefulBaseRenderer[Any]"]
     ) -> pygame.Surface | None:
-        self._render_queue_depth = len(renderers)
+        self._renderer_processor.set_queue_depth(len(renderers))
         self._update_merge_strategy(renderers)
         if len(renderers) == 1:
             return self.process_renderer(renderers[0])

--- a/src/heart/runtime/rendering/renderer_processor.py
+++ b/src/heart/runtime/rendering/renderer_processor.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+import pygame
+
+from heart import DeviceDisplayMode
+from heart.runtime.rendering.surface_provider import RendererSurfaceProvider
+from heart.runtime.rendering.timing import RendererTimingTracker
+from heart.utilities.logging import get_logger
+from heart.utilities.logging_control import get_logging_controller
+
+if TYPE_CHECKING:
+    from heart.device import Device
+    from heart.peripheral.core.manager import PeripheralManager
+    from heart.renderers import StatefulBaseRenderer
+
+logger = get_logger(__name__)
+log_controller = get_logging_controller()
+
+
+class RendererFrameProcessor:
+    def __init__(self, device: Device, peripheral_manager: PeripheralManager) -> None:
+        self.device = device
+        self.peripheral_manager = peripheral_manager
+        self.clock: pygame.time.Clock | None = None
+        self._surface_provider = RendererSurfaceProvider(device)
+        self._timing_tracker = RendererTimingTracker()
+        self._render_queue_depth = 0
+
+    @property
+    def timing_tracker(self) -> RendererTimingTracker:
+        return self._timing_tracker
+
+    def set_clock(self, clock: pygame.time.Clock | None) -> None:
+        self.clock = clock
+
+    def set_queue_depth(self, depth: int) -> None:
+        self._render_queue_depth = depth
+
+    def process_renderer(
+        self, renderer: "StatefulBaseRenderer[Any]"
+    ) -> pygame.Surface | None:
+        try:
+            start_ns = time.perf_counter_ns()
+            screen = self._render_renderer_frame(renderer)
+            duration_ms = (time.perf_counter_ns() - start_ns) / 1_000_000
+            self._timing_tracker.record(renderer.name, duration_ms)
+            self._log_renderer_metrics(renderer, duration_ms)
+            return screen
+        except Exception:
+            logger.exception("Error processing renderer")
+            return None
+
+    def _require_clock(self) -> pygame.time.Clock:
+        clock = self.clock
+        if clock is None:
+            raise RuntimeError("GameLoop clock is not initialized")
+        return clock
+
+    def _prepare_renderer_surface(
+        self, renderer: "StatefulBaseRenderer[Any]"
+    ) -> pygame.Surface:
+        return self._surface_provider.prepare(renderer)
+
+    def _render_renderer_frame(
+        self, renderer: "StatefulBaseRenderer[Any]"
+    ) -> pygame.Surface:
+        clock = self._require_clock()
+        screen = self._prepare_renderer_surface(renderer)
+        if not renderer.initialized:
+            renderer.initialize(
+                window=screen,
+                clock=clock,
+                peripheral_manager=self.peripheral_manager,
+                orientation=self.device.orientation,
+            )
+        renderer._internal_process(
+            window=screen,
+            clock=clock,
+            peripheral_manager=self.peripheral_manager,
+            orientation=self.device.orientation,
+        )
+        return screen
+
+    def _log_renderer_metrics(
+        self, renderer: "StatefulBaseRenderer[Any]", duration_ms: float
+    ) -> None:
+        log_message = (
+            "render.loop renderer=%s duration_ms=%.2f queue_depth=%s "
+            "display_mode=%s uses_opengl=%s initialized=%s"
+        )
+        log_args = (
+            renderer.name,
+            duration_ms,
+            self._render_queue_depth,
+            renderer.device_display_mode.name,
+            renderer.device_display_mode == DeviceDisplayMode.OPENGL,
+            renderer.is_initialized(),
+        )
+        log_extra = {
+            "renderer": renderer.name,
+            "duration_ms": duration_ms,
+            "queue_depth": self._render_queue_depth,
+            "display_mode": renderer.device_display_mode.name,
+            "uses_opengl": renderer.device_display_mode == DeviceDisplayMode.OPENGL,
+            "initialized": renderer.is_initialized(),
+        }
+
+        log_controller.log(
+            key="render.loop",
+            logger=logger,
+            level=logging.INFO,
+            msg=log_message,
+            args=log_args,
+            extra=log_extra,
+            fallback_level=logging.DEBUG,
+        )


### PR DESCRIPTION
### Motivation

- Reduce the responsibilities of `RenderPipeline` by extracting per-renderer surface preparation, execution, timing, and logging into a focused helper.
- Keep render dispatch, executor management, and surface composition logic isolated from low-level renderer frame handling.
- Preserve existing timing snapshots and logging semantics while making per-renderer behavior easier to evolve.

### Description

- Added `src/heart/runtime/rendering/renderer_processor.py` with `RendererFrameProcessor` to encapsulate surface preparation, renderer initialization, per-frame execution, timing updates, and per-renderer logging.
- Updated `src/heart/runtime/render_pipeline.py` to delegate `process_renderer`, `set_clock`, and queue depth handling to the new `RendererFrameProcessor` and to share the `RendererTimingTracker` instance from the processor.
- Removed inlined clock/surface-provider/timing/logging code from `RenderPipeline` while keeping merge strategy selection and composition behavior unchanged.
- Added a research note at `docs/research/render_pipeline_refactor.md` documenting motivation and implementation notes for the refactor.

### Testing

- Ran `make format` and formatting/lint checks completed successfully.
- Ran the test suite with `make test` and all automated tests passed (198 passed, 1 skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d2437e5e08321a012bbbeec552813)