### PR TITLE
Stabilize reactive stream coalescing

### DIFF
--- a/src/heart/utilities/reactivex/coalescing.py
+++ b/src/heart/utilities/reactivex/coalescing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from threading import RLock
+from threading import RLock, Timer
 from typing import Any, TypeVar
 
 import reactivex
@@ -30,32 +30,39 @@ def coalesce_latest(
         lock = RLock()
         pending: Any = _NO_PENDING
         timer: Any | None = None
+        fallback_timer: Timer | None = None
         due_time: float | None = None
         window_seconds = window_ms / 1000
 
         def _flush() -> None:
-            nonlocal pending, timer, due_time
+            nonlocal pending, timer, fallback_timer, due_time
             with lock:
                 value = pending
                 pending = _NO_PENDING
                 timer = None
+                if fallback_timer is not None:
+                    fallback_timer.cancel()
+                    fallback_timer = None
                 due_time = None
             if value is _NO_PENDING:
                 return
             observer.on_next(value)
 
         def _schedule_flush(now: float) -> None:
-            nonlocal timer, due_time
-            if timer is not None:
+            nonlocal timer, fallback_timer, due_time
+            if timer is not None or fallback_timer is not None:
                 return
             due_time = now + window_seconds
             timer = _COALESCE_SCHEDULER.schedule_relative(
                 window_seconds,
                 lambda *_: _flush(),
             )
+            fallback_timer = Timer(window_seconds, _flush)
+            fallback_timer.daemon = True
+            fallback_timer.start()
 
         def _on_next(value: Any) -> None:
-            nonlocal pending, timer, due_time
+            nonlocal pending, timer, fallback_timer, due_time
             now = time.monotonic()
             flush_value: Any = _NO_PENDING
             with lock:
@@ -65,6 +72,9 @@ def coalesce_latest(
                     if timer is not None:
                         timer.dispose()
                         timer = None
+                    if fallback_timer is not None:
+                        fallback_timer.cancel()
+                        fallback_timer = None
                     due_time = None
                 pending = value
                 _schedule_flush(now)
@@ -72,21 +82,27 @@ def coalesce_latest(
                 observer.on_next(flush_value)
 
         def _on_error(err: Exception) -> None:
-            nonlocal pending, timer, due_time
+            nonlocal pending, timer, fallback_timer, due_time
             with lock:
                 if timer is not None:
                     timer.dispose()
                     timer = None
+                if fallback_timer is not None:
+                    fallback_timer.cancel()
+                    fallback_timer = None
                 pending = _NO_PENDING
                 due_time = None
             observer.on_error(err)
 
         def _on_completed() -> None:
-            nonlocal timer, due_time
+            nonlocal timer, fallback_timer, due_time
             with lock:
                 if timer is not None:
                     timer.dispose()
                     timer = None
+                if fallback_timer is not None:
+                    fallback_timer.cancel()
+                    fallback_timer = None
                 due_time = None
             _flush()
             observer.on_completed()
@@ -99,13 +115,16 @@ def coalesce_latest(
         )
 
         def _dispose() -> None:
-            nonlocal pending, timer, due_time
+            nonlocal pending, timer, fallback_timer, due_time
             subscription.dispose()
             with lock:
                 pending = _NO_PENDING
                 if timer is not None:
                     timer.dispose()
                     timer = None
+                if fallback_timer is not None:
+                    fallback_timer.cancel()
+                    fallback_timer = None
                 due_time = None
 
         logger.debug(


### PR DESCRIPTION
### Motivation
- Tests observing shared reactive streams were flaky due to missed coalesced flushes when the scheduler path did not run in time. 
- The `coalesce_latest` implementation needs a reliable fallback to ensure pending values are emitted even if the reactive scheduler is delayed or skipped. 
- Timers created for coalescing must be cleaned up on error, completion, and disposal to avoid leaked threads or spurious emissions. 

### Description
- Add a fallback `Timer` (from `threading`) in `src/heart/utilities/reactivex/coalescing.py` so `coalesce_latest` flushes pending values reliably. 
- Cancel the fallback timer on flush, error, completion, and disposal to ensure proper cleanup. 
- Update local state handling inside `coalesce_latest` to track and clear both the scheduler timer and the fallback `Timer`. 
- Keep the public API unchanged and only modify internal scheduling/cleanup behavior for robustness. 

### Testing
- Ran `make format` and formatting checks passed. 
- Ran the test suite with `make test` and automated tests passed: `198 passed, 1 skipped`. 
- Verified coalescing-related unit tests in `tests/utilities/test_reactivex_streams.py` exercising overdue and completion scenarios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d24c58d608321b34756ba6e960eec)