### PR TITLE
Refactor render pipeline with RendererProcessor

### DIFF
--- a/docs/code_flow.md
+++ b/docs/code_flow.md
@@ -12,7 +12,7 @@ Describe how a `totem run` execution traverses configuration services, the runti
 
 ## Technical Approach
 
-Represent each execution stage as a node in a Mermaid flowchart. Colour code orchestration components, service layers, inputs, and outputs so reviewers can trace transitions. The diagram captures call sequencing between the CLI, configuration registry, runtime loop, app routing, peripheral managers, and display drivers. The goal is to surface every point where the runtime crosses a service boundary or hardware interface. Frame composition is split between surface preparation (display-mode coordination and caching) and composition management (merge-strategy selection plus parallel merge coordination).
+Represent each execution stage as a node in a Mermaid flowchart. Colour code orchestration components, service layers, inputs, and outputs so reviewers can trace transitions. The diagram captures call sequencing between the CLI, configuration registry, runtime loop, app routing, peripheral managers, and display drivers. The goal is to surface every point where the runtime crosses a service boundary or hardware interface. Frame composition is split between renderer processing (surface preparation plus per-renderer execution), surface preparation (display-mode coordination and caching), and composition management (merge-strategy selection plus parallel merge coordination).
 
 ## Flow Diagram
 
@@ -37,6 +37,7 @@ flowchart LR
         AppRouter["AppController / Mode Router"]
         ModeServices["Mode Services & Renderers"]
         RenderPipeline["Render Pipeline"]
+        RendererProcessor["Renderer Processor\n(surface prep + renderer execution)"]
         SurfaceProvider["Surface Provider\n(display mode + surface cache)"]
         CompositionManager["Composition Manager\n(merge strategy + parallel loops)"]
     end
@@ -68,7 +69,7 @@ flowchart LR
     Loop --> AppRouter
     Loop --> RenderPipeline
     AppRouter --> ModeServices --> RenderPipeline --> CompositionManager --> DisplaySvc
-    RenderPipeline --> SurfaceProvider
+    RenderPipeline --> RendererProcessor --> SurfaceProvider
     DisplaySvc --> LocalScreen
     DisplaySvc --> Capture --> DeviceBridge --> LedMatrix
     Capture --> AverageMirror --> SingleLED
@@ -80,7 +81,7 @@ flowchart LR
     RxScheduler --> HeartRate --> AppRouter
     RxScheduler --> PhoneText --> AppRouter
 
-    class CLI,Registry,Configurer,ModeServices,RenderPipeline,SurfaceProvider,CompositionManager service;
+    class CLI,Registry,Configurer,ModeServices,RenderPipeline,RendererProcessor,SurfaceProvider,CompositionManager service;
     class Loop,AppRouter orchestrator;
     class PeripheralMgr,RxScheduler,Switch,Gamepad,Sensors,HeartRate,PhoneText input;
     class DisplaySvc,LocalScreen,Capture,DeviceBridge,LedMatrix,AverageMirror,SingleLED output;

--- a/docs/research/render_pipeline_composition_refactor.md
+++ b/docs/research/render_pipeline_composition_refactor.md
@@ -1,26 +1,23 @@
-# Render pipeline composition refactor note
+# Render Pipeline Composition Refactor
 
-## Problem statement
+## Problem Statement
 
-Document the render pipeline refactor that separates surface preparation, caching, and merge coordination so future contributors can reason about composition responsibilities and extend merge behavior safely.
+Describe the responsibilities of the new renderer-processing stage so the runtime pipeline keeps composition logic separate from per-renderer execution and logging.
 
 ## Materials
 
-- Local checkout of the Heart repository.
-- `src/heart/runtime/render_pipeline.py` for pipeline orchestration changes.
-- `src/heart/runtime/rendering/surface_provider.py` for surface preparation and caching.
-- `src/heart/runtime/rendering/surface_merge.py` for merge strategy selection and parallel merge coordination.
-- `docs/code_flow.md` for the updated runtime flow diagram and narrative.
+- Local checkout of this repository.
+- Python environment with the dependencies listed in `pyproject.toml` installed.
+- Source files for the renderer pipeline and rendering utilities.
 
-## Notes
+## Research Notes
 
-- Surface preparation now lives in a dedicated provider that owns display-mode enforcement and cached surface reuse, keeping `RenderPipeline` focused on orchestration.
-- Merge strategy selection and the parallel reduction loop are centralized in the composition manager so serial and parallel rendering share the same strategy controls.
-- `RenderPipeline.merge_surfaces` remains as the pairwise merge hook, allowing tests to override the merge function while using the shared composition manager.
+- `RendererProcessor` in `src/heart/runtime/rendering/renderer_processor.py` owns surface preparation, renderer initialization, internal processing, and per-renderer timing/logging so the pipeline can focus on orchestration.
+- `RenderPipeline` now delegates per-renderer work to `RendererProcessor` while retaining merge-strategy selection, composition, and parallel execution in `src/heart/runtime/render_pipeline.py`.
+- The flow diagram in `docs/code_flow.md` now highlights the processor as a distinct service between the pipeline and surface preparation.
 
-## Source references
+## Sources
 
+- `src/heart/runtime/rendering/renderer_processor.py`
 - `src/heart/runtime/render_pipeline.py`
-- `src/heart/runtime/rendering/surface_provider.py`
-- `src/heart/runtime/rendering/surface_merge.py`
 - `docs/code_flow.md`

--- a/src/heart/runtime/render_pipeline.py
+++ b/src/heart/runtime/render_pipeline.py
@@ -1,19 +1,17 @@
 from __future__ import annotations
 
 import logging
-import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, cast
 
 import pygame
 from PIL import Image
 
-from heart import DeviceDisplayMode
 from heart.device import Device
 from heart.peripheral.core.manager import PeripheralManager
 from heart.runtime.rendering.constants import RGBA_IMAGE_FORMAT
+from heart.runtime.rendering.renderer_processor import RendererProcessor
 from heart.runtime.rendering.surface_merge import SurfaceCompositionManager
-from heart.runtime.rendering.surface_provider import RendererSurfaceProvider
 from heart.runtime.rendering.timing import RendererTimingTracker
 from heart.runtime.rendering.variants import RendererVariant, RenderMethod
 from heart.utilities.env import Configuration
@@ -39,12 +37,16 @@ class RenderPipeline:
         self.peripheral_manager = peripheral_manager
         self.renderer_variant = render_variant
         self.clock: pygame.time.Clock | None = None
-        self._surface_provider = RendererSurfaceProvider(device)
         self._current_merge_strategy = Configuration.render_merge_strategy()
         self._composition_manager = SurfaceCompositionManager(
             strategy_provider=self._get_merge_strategy
         )
         self._timing_tracker = RendererTimingTracker()
+        self._renderer_processor = RendererProcessor(
+            device=device,
+            peripheral_manager=peripheral_manager,
+            timing_tracker=self._timing_tracker,
+        )
 
         binary_method = cast(RenderMethod, self._render_surfaces_binary)
         iterative_method = cast(RenderMethod, self._render_surface_iterative)
@@ -79,77 +81,12 @@ class RenderPipeline:
             raise RuntimeError("GameLoop clock is not initialized")
         return clock
 
-    def _prepare_renderer_surface(
-        self, renderer: "StatefulBaseRenderer[Any]"
-    ) -> pygame.Surface:
-        return self._surface_provider.prepare(renderer)
-
     def process_renderer(
         self, renderer: "StatefulBaseRenderer[Any]"
     ) -> pygame.Surface | None:
-        try:
-            start_ns = time.perf_counter_ns()
-            screen = self._render_renderer_frame(renderer)
-            duration_ms = (time.perf_counter_ns() - start_ns) / 1_000_000
-            self._timing_tracker.record(renderer.name, duration_ms)
-            self._log_renderer_metrics(renderer, duration_ms)
-            return screen
-        except Exception:
-            logger.exception("Error processing renderer")
-            return None
-
-    def _render_renderer_frame(
-        self, renderer: "StatefulBaseRenderer[Any]"
-    ) -> pygame.Surface:
         clock = self._require_clock()
-        screen = self._prepare_renderer_surface(renderer)
-        if not renderer.initialized:
-            renderer.initialize(
-                window=screen,
-                clock=clock,
-                peripheral_manager=self.peripheral_manager,
-                orientation=self.device.orientation,
-            )
-        renderer._internal_process(
-            window=screen,
-            clock=clock,
-            peripheral_manager=self.peripheral_manager,
-            orientation=self.device.orientation,
-        )
-        return screen
-
-    def _log_renderer_metrics(
-        self, renderer: "StatefulBaseRenderer[Any]", duration_ms: float
-    ) -> None:
-        log_message = (
-            "render.loop renderer=%s duration_ms=%.2f queue_depth=%s "
-            "display_mode=%s uses_opengl=%s initialized=%s"
-        )
-        log_args = (
-            renderer.name,
-            duration_ms,
-            self._render_queue_depth,
-            renderer.device_display_mode.name,
-            renderer.device_display_mode == DeviceDisplayMode.OPENGL,
-            renderer.is_initialized(),
-        )
-        log_extra = {
-            "renderer": renderer.name,
-            "duration_ms": duration_ms,
-            "queue_depth": self._render_queue_depth,
-            "display_mode": renderer.device_display_mode.name,
-            "uses_opengl": renderer.device_display_mode == DeviceDisplayMode.OPENGL,
-            "initialized": renderer.is_initialized(),
-        }
-
-        log_controller.log(
-            key="render.loop",
-            logger=logger,
-            level=logging.INFO,
-            msg=log_message,
-            args=log_args,
-            extra=log_extra,
-            fallback_level=logging.DEBUG,
+        return self._renderer_processor.process_renderer(
+            renderer, clock, self._render_queue_depth
         )
 
     def finalize_rendering(self, screen: pygame.Surface) -> Image.Image:

--- a/src/heart/runtime/rendering/renderer_processor.py
+++ b/src/heart/runtime/rendering/renderer_processor.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+import pygame
+
+from heart import DeviceDisplayMode
+from heart.device import Device
+from heart.peripheral.core.manager import PeripheralManager
+from heart.runtime.rendering.surface_provider import RendererSurfaceProvider
+from heart.runtime.rendering.timing import RendererTimingTracker
+from heart.utilities.logging import get_logger
+from heart.utilities.logging_control import get_logging_controller
+
+if TYPE_CHECKING:
+    from heart.renderers import StatefulBaseRenderer
+
+logger = get_logger(__name__)
+log_controller = get_logging_controller()
+
+
+class RendererProcessor:
+    def __init__(
+        self,
+        device: Device,
+        peripheral_manager: PeripheralManager,
+        surface_provider: RendererSurfaceProvider | None = None,
+        timing_tracker: RendererTimingTracker | None = None,
+    ) -> None:
+        self._device = device
+        self._peripheral_manager = peripheral_manager
+        self._surface_provider = surface_provider or RendererSurfaceProvider(device)
+        self._timing_tracker = timing_tracker or RendererTimingTracker()
+
+    def _prepare_renderer_surface(
+        self, renderer: "StatefulBaseRenderer[Any]"
+    ) -> pygame.Surface:
+        return self._surface_provider.prepare(renderer)
+
+    def process_renderer(
+        self,
+        renderer: "StatefulBaseRenderer[Any]",
+        clock: pygame.time.Clock,
+        queue_depth: int,
+    ) -> pygame.Surface | None:
+        try:
+            start_ns = time.perf_counter_ns()
+            screen = self._render_renderer_frame(renderer, clock)
+            duration_ms = (time.perf_counter_ns() - start_ns) / 1_000_000
+            self._timing_tracker.record(renderer.name, duration_ms)
+            self._log_renderer_metrics(renderer, duration_ms, queue_depth)
+            return screen
+        except Exception:
+            logger.exception("Error processing renderer")
+            return None
+
+    def _render_renderer_frame(
+        self,
+        renderer: "StatefulBaseRenderer[Any]",
+        clock: pygame.time.Clock,
+    ) -> pygame.Surface:
+        screen = self._prepare_renderer_surface(renderer)
+        if not renderer.initialized:
+            renderer.initialize(
+                window=screen,
+                clock=clock,
+                peripheral_manager=self._peripheral_manager,
+                orientation=self._device.orientation,
+            )
+        renderer._internal_process(
+            window=screen,
+            clock=clock,
+            peripheral_manager=self._peripheral_manager,
+            orientation=self._device.orientation,
+        )
+        return screen
+
+    def _log_renderer_metrics(
+        self,
+        renderer: "StatefulBaseRenderer[Any]",
+        duration_ms: float,
+        queue_depth: int,
+    ) -> None:
+        log_message = (
+            "render.loop renderer=%s duration_ms=%.2f queue_depth=%s "
+            "display_mode=%s uses_opengl=%s initialized=%s"
+        )
+        log_args = (
+            renderer.name,
+            duration_ms,
+            queue_depth,
+            renderer.device_display_mode.name,
+            renderer.device_display_mode == DeviceDisplayMode.OPENGL,
+            renderer.is_initialized(),
+        )
+        log_extra = {
+            "renderer": renderer.name,
+            "duration_ms": duration_ms,
+            "queue_depth": queue_depth,
+            "display_mode": renderer.device_display_mode.name,
+            "uses_opengl": renderer.device_display_mode == DeviceDisplayMode.OPENGL,
+            "initialized": renderer.is_initialized(),
+        }
+
+        log_controller.log(
+            key="render.loop",
+            logger=logger,
+            level=logging.INFO,
+            msg=log_message,
+            args=log_args,
+            extra=log_extra,
+            fallback_level=logging.DEBUG,
+        )


### PR DESCRIPTION
### Motivation

- Separate per-renderer responsibilities (surface preparation, initialization, processing, and timing/logging) from pipeline orchestration to simplify responsibilities.
- Keep merge-strategy selection, composition, and parallel reduction logic in `RenderPipeline` so composition behavior remains centralised.
- Preserve the existing `RenderPipeline` API surface so tests and callers that patch `process_renderer` continue to work.

### Description

- Add `src/heart/runtime/rendering/renderer_processor.py` implementing `RendererProcessor` which prepares surfaces, initializes renderers, runs `renderer._internal_process`, records timings via `RendererTimingTracker`, and logs per-renderer metrics.
- Update `src/heart/runtime/render_pipeline.py` to instantiate `RendererProcessor` and delegate per-renderer execution to it while retaining merge/compose logic in the pipeline.
- Keep a thin `RenderPipeline.process_renderer` wrapper that delegates to `RendererProcessor.process_renderer` to maintain compatibility with existing tests and call sites.
- Update documentation in `docs/code_flow.md` and add `docs/research/render_pipeline_composition_refactor.md`, then regenerate the flow SVG with `scripts/render_code_flow.py`.

### Testing

- Ran `make format` to apply repository formatting rules and it completed successfully.
- Regenerated the runtime flow diagram with `python scripts/render_code_flow.py --output docs/code_flow.svg`.
- Ran the full test suite via `make test` and all automated tests passed (`198 passed, 1 skipped`).
- Verified formatting and lint checks as part of the test/format run (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d2519f90c8321af7ebc53d19a06a0)