### PR TITLE
Guard optional module lookup in PhoneText

### DIFF
--- a/src/heart/peripheral/phone_text.py
+++ b/src/heart/peripheral/phone_text.py
@@ -17,7 +17,11 @@ from heart.utilities.logging import get_logger
 
 
 def _load_optional_module(module_name: str) -> ModuleType | None:
-    if importlib.util.find_spec(module_name) is None:  # pragma: no cover - optional
+    try:
+        module_spec = importlib.util.find_spec(module_name)
+    except ModuleNotFoundError:  # pragma: no cover - optional
+        module_spec = None
+    if module_spec is None:  # pragma: no cover - optional
         return None
     return importlib.import_module(module_name)
 


### PR DESCRIPTION
### Motivation
- `importlib.util.find_spec` can raise `ModuleNotFoundError` when a dotted parent package is missing, which made optional imports non-optional and caused imports to fail on hosts without the parent package.
- The `PhoneText` peripheral should tolerate missing optional dependencies like `bluezero` so the module can be imported on systems where the package is not installed.

### Description
- Update `_load_optional_module` in `src/heart/peripheral/phone_text.py` to wrap `importlib.util.find_spec` in a `try/except ModuleNotFoundError` and treat failures as `None` so optional modules remain optional.
- Return `None` when the spec is not found, preserving the prior behavior of optional imports, and continue to use `importlib.import_module` when a spec exists.
- Mark the guarded branch with `# pragma: no cover - optional` to indicate optional dependency behavior.

### Testing
- Ran `make format` to apply code formatting and linting, and it completed successfully.
- No automated unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d26c1ac0c8321ae5dd83d83dbd431)