### PR TITLE
Introduce shared optional_import helper and refactor optional imports

### DIFF
--- a/src/heart/firmware_io/bluetooth.py
+++ b/src/heart/firmware_io/bluetooth.py
@@ -1,40 +1,21 @@
 from __future__ import annotations
 
-import importlib
-import importlib.util
 from typing import Any
 
-from heart.utilities.logging import get_logger
-
-logger = get_logger(__name__)
+from heart.utilities.imports import optional_import
 
 BLERadio: type[Any] | None = None
 ProvideServicesAdvertisement: type[Any] | None = None
 UARTService: type[Any] | None = None
 
-def _safe_find_spec(module_name: str) -> bool:
-    try:
-        return importlib.util.find_spec(module_name) is not None
-    except Exception:
-        logger.debug("BLE dependency lookup failed for %s.", module_name)
-        return False
+ble_module = optional_import("adafruit_ble")
+advertising_module = optional_import("adafruit_ble.advertising.standard")
+services_module = optional_import("adafruit_ble.services.nordic")
 
-
-if (
-    _safe_find_spec("adafruit_ble")
-    and _safe_find_spec("adafruit_ble.advertising.standard")
-    and _safe_find_spec("adafruit_ble.services.nordic")
-):
-    try:
-        ble_module = importlib.import_module("adafruit_ble")
-        advertising_module = importlib.import_module("adafruit_ble.advertising.standard")
-        services_module = importlib.import_module("adafruit_ble.services.nordic")
-    except Exception:
-        logger.debug("BLE dependencies failed to import. BLE support is disabled.")
-    else:
-        BLERadio = getattr(ble_module, "BLERadio", None)
-        ProvideServicesAdvertisement = getattr(advertising_module, "ProvideServicesAdvertisement", None)
-        UARTService = getattr(services_module, "UARTService", None)
+if ble_module is not None and advertising_module is not None and services_module is not None:
+    BLERadio = getattr(ble_module, "BLERadio", None)
+    ProvideServicesAdvertisement = getattr(advertising_module, "ProvideServicesAdvertisement", None)
+    UARTService = getattr(services_module, "UARTService", None)
 
 
 if BLERadio is not None and UARTService is not None and ProvideServicesAdvertisement is not None:

--- a/src/heart/peripheral/phone_text.py
+++ b/src/heart/peripheral/phone_text.py
@@ -6,24 +6,15 @@ null terminator (`\0`).  The most-recent message is available via
 `PhoneText.get_last_text()` for inspection by other code/tests.
 """
 
-import importlib
-import importlib.util
 from collections.abc import Iterator
-from types import ModuleType
 from typing import Any, Self
 
 from heart.peripheral.core import Peripheral
+from heart.utilities.imports import optional_import
 from heart.utilities.logging import get_logger
 
-
-def _load_optional_module(module_name: str) -> ModuleType | None:
-    if importlib.util.find_spec(module_name) is None:  # pragma: no cover - optional
-        return None
-    return importlib.import_module(module_name)
-
-
-adapter = _load_optional_module("bluezero.adapter")
-bz_peripheral = _load_optional_module("bluezero.peripheral")
+adapter = optional_import("bluezero.adapter")
+bz_peripheral = optional_import("bluezero.peripheral")
 
 # UUIDs shared with the legacy test script so that existing iOS/Mac apps keep
 # working without any change.

--- a/src/heart/peripheral/radio.py
+++ b/src/heart/peripheral/radio.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import importlib
-import importlib.util
 import json
 import os
 import threading
@@ -12,16 +10,10 @@ from typing import Any, Iterator, Mapping
 
 from heart.peripheral.core import Peripheral
 from heart.peripheral.input_payloads.radio import RadioPacket
+from heart.utilities.imports import optional_import
 from heart.utilities.logging import get_logger
 
-
-def _load_optional_module(module_name: str) -> Any | None:
-    if importlib.util.find_spec(module_name) is None:  # pragma: no cover - optional
-        return None
-    return importlib.import_module(module_name)
-
-
-serial = _load_optional_module("serial")
+serial = optional_import("serial")
 
 logger = get_logger(__name__)
 

--- a/src/heart/utilities/imports.py
+++ b/src/heart/utilities/imports.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from importlib import import_module, util
+from types import ModuleType
+
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def module_available(module_name: str) -> bool:
+    """Return whether a module can be imported in this runtime."""
+
+    try:
+        return util.find_spec(module_name) is not None
+    except Exception as exc:  # pragma: no cover - defensive: invalid specs/platform quirks
+        logger.debug("Failed to check module availability for %s: %s", module_name, exc)
+        return False
+
+
+def optional_import(module_name: str) -> ModuleType | None:
+    """Import an optional dependency, returning ``None`` when unavailable."""
+
+    if not module_available(module_name):
+        return None
+    try:
+        return import_module(module_name)
+    except Exception as exc:  # pragma: no cover - optional dependencies may fail at import time
+        logger.debug("Optional dependency %s failed to import: %s", module_name, exc)
+        return None


### PR DESCRIPTION
### Motivation

- Reduce duplication and make optional dependency checks more idiomatic by centralising `importlib` usage into a small helper module.
- Provide a consistent logging and failure-safe behaviour when probing for runtime-only dependencies.

### Description

- Add `src/heart/utilities/imports.py` implementing `module_available` and `optional_import` to encapsulate `importlib` checks and guarded imports.
- Replace ad-hoc `importlib`/`importlib.util` usage in `src/heart/firmware_io/bluetooth.py`, `src/heart/peripheral/phone_text.py`, and `src/heart/peripheral/radio.py` to use `optional_import` instead.
- Simplify module availability logic and avoid repeated try/except/find_spec patterns across modules.

### Testing

- Ran `make format` to apply repository formatting rules and the formatter reported that all checks passed.
- Ran `make test` and the test suite completed successfully with `201 passed, 1 skipped`.
- Unit tests exercised the updated import paths for Bluetooth and peripheral modules and all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d26d4cca88321bb1c5797aa291765)