### PR TITLE
Fix coalescing fallback scheduler cancellation

### DIFF
--- a/src/heart/utilities/reactivex/coalescing.py
+++ b/src/heart/utilities/reactivex/coalescing.py
@@ -39,7 +39,9 @@ def coalesce_latest(
             with lock:
                 value = pending
                 pending = _NO_PENDING
-                timer = None
+                if timer is not None:
+                    timer.dispose()
+                    timer = None
                 if fallback_timer is not None:
                     fallback_timer.cancel()
                     fallback_timer = None


### PR DESCRIPTION
### Motivation

- Prevent a race where the fallback `Timer` clears `timer = None` without disposing the reactive scheduler `timer`, allowing a stale scheduled callback to run later and emit early.  
- This bug appears when the fallback fires before the reactive scheduler due to scheduler delay/lag, breaking the coalescing window.  
- Ensure coalescing windows remain consistent even when the reactive `TimeoutScheduler` is laggy.  

### Description

- In `src/heart/utilities/reactivex/coalescing.py` update `_flush` to explicitly call `timer.dispose()` when `timer` is present and then set `timer = None`.  
- Add `tests/utilities/test_reactivex_streams.py::TestShareStreamFlowControl::test_share_stream_coalesce_cancels_stale_scheduler_after_fallback` to simulate scheduler lag and verify stale scheduler disposables are canceled after the fallback flush.  
- The test stubs `_COALESCE_SCHEDULER.schedule_relative` to return a disposable-like object and asserts the disposable is marked disposed after the fallback.  

### Testing

- Ran `make format` to apply code formatting and linting with no issues.  
- Ran `make test` and the full test suite passed with `202 passed, 1 skipped`.  
- The new test `test_share_stream_coalesce_cancels_stale_scheduler_after_fallback` executes as part of the suite and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d26ea70f08321b0756dbcef880a82)