### PR TITLE
Lazy-initialize IR sensor array logger to avoid import-time side effects

### DIFF
--- a/src/heart/peripheral/ir_sensor_array.py
+++ b/src/heart/peripheral/ir_sensor_array.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import logging
 import math
 import threading
 from collections import deque
@@ -31,7 +32,14 @@ else:
     def least_squares(*args: Any, **kwargs: Any) -> Any:
         raise RuntimeError("scipy.optimize.least_squares is not available")
 
-logger = get_logger(__name__)
+_logger: logging.Logger | None = None
+
+
+def _get_logger() -> logging.Logger:
+    global _logger
+    if _logger is None:
+        _logger = get_logger(__name__)
+    return _logger
 
 SPEED_OF_LIGHT = 299_792_458.0  # metres per second
 
@@ -310,7 +318,7 @@ class IRSensorArray(Peripheral[Input]):
 
         expected_crc = IRArrayDMAQueue._crc_for_samples(packet.samples)
         if expected_crc != packet.crc:
-            logger.warning(
+            _get_logger().warning(
                 "Dropping packet due to CRC mismatch (expected=%s, got=%s)",
                 expected_crc,
                 packet.crc,


### PR DESCRIPTION
### Motivation
- Importing `tests.simulation` triggered `get_logger(__name__)` at module import time which created log directories and files as a side effect.
- Filesystem writes during import make tests and simulation utilities fail in read-only or sandboxed environments.
- Defer logger creation so imports remain side-effect free and safe for test-only modules.

### Description
- In `src/heart/peripheral/ir_sensor_array.py` added `import logging` and removed the module-level `logger = get_logger(__name__)` initialization.
- Introduced a cached `_logger: logging.Logger | None = None` and a `_get_logger()` helper that calls `get_logger(__name__)` on first use.
- Replaced direct uses of `logger` (e.g., `logger.warning`) with `_get_logger().warning` to lazily initialize the logger.
- Run repository formatting to apply style changes to the modified file.

### Testing
- Ran `make format` to apply and verify code formatting, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d2707c5f883219efa3628f33891da)