### PR TITLE
Align heart rate logging with shared logger

### DIFF
--- a/src/heart/peripheral/heart_rates.py
+++ b/src/heart/peripheral/heart_rates.py
@@ -1,5 +1,4 @@
 # ant_hr_manager.py
-import logging
 import threading
 import time
 from typing import (Any, Callable, Dict, Iterator, List, Optional,
@@ -29,11 +28,6 @@ last_seen: Dict[str, float] = {}  # NEW: last packet time-stamp
 _mutex = threading.Lock()  # protects the three dicts above
 # ──────────────────────────────────────────────────────────────────────────────
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[logging.StreamHandler()],
-)
 logger = get_logger("HeartRateManager")
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- The heart rate peripheral configured logging via `logging.basicConfig`, which conflicts with the repository policy to use the shared logging helper and avoid module-level logging configuration.
- Using local logging setup can interfere with global handlers and structured/fallback logging rules defined elsewhere in the application.

### Description
- Removed the `logging.basicConfig` call and related `import logging` from `src/heart/peripheral/heart_rates.py` so the module relies on the shared `get_logger` mechanism.
- Kept the existing `get_logger("HeartRateManager")` usage to preserve structured logging and integration with the repository’s logging controller.

### Testing
- Ran `make format` to apply formatting rules, which completed successfully.
- Ran the full test suite with `make test`, where all tests passed (`201 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d25ea964083219b52a849eb827d89)