### PR TITLE
Extract render planning into RenderPlanner

### DIFF
--- a/docs/research/render-planner-refactor.md
+++ b/docs/research/render-planner-refactor.md
@@ -1,0 +1,15 @@
+# Render planner refactor notes
+
+## Problem
+
+The render pipeline mixed render strategy selection, logging, and surface composition in one class, which made it harder to track the decision logic separately from frame assembly.
+
+## Approach
+
+Extracted render planning responsibilities into a dedicated planner object so the pipeline focuses on orchestrating renderers and composing surfaces while the planner handles strategy selection and logging.
+
+## Materials
+
+- `src/heart/runtime/render_pipeline.py`
+- `src/heart/runtime/rendering/planner.py`
+- `src/heart/runtime/rendering/timing.py`

--- a/src/heart/runtime/render_pipeline.py
+++ b/src/heart/runtime/render_pipeline.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, cast
 
@@ -10,19 +9,15 @@ from PIL import Image
 from heart.device import Device
 from heart.peripheral.core.manager import PeripheralManager
 from heart.runtime.rendering.constants import RGBA_IMAGE_FORMAT
+from heart.runtime.rendering.planner import RenderPlanner
 from heart.runtime.rendering.renderer_processor import RendererFrameProcessor
 from heart.runtime.rendering.surface_merge import SurfaceCompositionManager
 from heart.runtime.rendering.variants import RendererVariant, RenderMethod
 from heart.utilities.env import Configuration
 from heart.utilities.env.enums import RenderMergeStrategy
-from heart.utilities.logging import get_logger
-from heart.utilities.logging_control import get_logging_controller
 
 if TYPE_CHECKING:
     from heart.renderers import StatefulBaseRenderer
-
-logger = get_logger(__name__)
-log_controller = get_logging_controller()
 
 
 class RenderPipeline:
@@ -42,6 +37,7 @@ class RenderPipeline:
         )
         self._renderer_processor = RendererFrameProcessor(device, peripheral_manager)
         self._timing_tracker = self._renderer_processor.timing_tracker
+        self._planner = RenderPlanner(self._timing_tracker)
 
         binary_method = cast(RenderMethod, self._render_surfaces_binary)
         iterative_method = cast(RenderMethod, self._render_surface_iterative)
@@ -97,21 +93,7 @@ class RenderPipeline:
     def _resolve_merge_strategy(
         self, renderers: list["StatefulBaseRenderer[Any]"]
     ) -> RenderMergeStrategy:
-        configured = Configuration.render_merge_strategy()
-        if configured != RenderMergeStrategy.ADAPTIVE:
-            return configured
-        surface_threshold = Configuration.render_merge_surface_threshold()
-        if len(renderers) < surface_threshold:
-            return RenderMergeStrategy.IN_PLACE
-        cost_threshold_ms = Configuration.render_merge_cost_threshold_ms()
-        estimated_cost_ms, has_samples = self._timing_tracker.estimate_total_ms(
-            renderers
-        )
-        if cost_threshold_ms == 0:
-            return RenderMergeStrategy.BATCHED
-        if has_samples and estimated_cost_ms >= cost_threshold_ms:
-            return RenderMergeStrategy.BATCHED
-        return RenderMergeStrategy.IN_PLACE
+        return self._planner.resolve_merge_strategy(renderers)
 
     def _update_merge_strategy(
         self, renderers: list["StatefulBaseRenderer[Any]"]
@@ -123,49 +105,7 @@ class RenderPipeline:
         renderers: list["StatefulBaseRenderer[Any]"],
         variant: RendererVariant,
     ) -> None:
-        estimated_cost_ms, has_samples = self._timing_tracker.estimate_total_ms(
-            renderers
-        )
-        snapshots, missing = self._timing_tracker.snapshot(renderers)
-        snapshot_payload = [
-            {
-                "renderer": snapshot.name,
-                "average_ms": snapshot.average_ms,
-                "last_ms": snapshot.last_ms,
-                "samples": snapshot.sample_count,
-            }
-            for snapshot in snapshots
-        ]
-        log_message = (
-            "render.plan variant=%s merge_strategy=%s renderer_count=%s "
-            "estimated_cost_ms=%.2f has_samples=%s"
-        )
-        log_args = (
-            variant.name,
-            self._current_merge_strategy.value,
-            len(renderers),
-            estimated_cost_ms,
-            has_samples,
-        )
-        log_extra = {
-            "variant": variant.name,
-            "merge_strategy": self._current_merge_strategy.value,
-            "renderer_count": len(renderers),
-            "estimated_cost_ms": estimated_cost_ms,
-            "has_samples": has_samples,
-            "renderer_timings": snapshot_payload,
-            "renderer_timings_missing": missing,
-        }
-
-        log_controller.log(
-            key="render.plan",
-            logger=logger,
-            level=logging.INFO,
-            msg=log_message,
-            args=log_args,
-            extra=log_extra,
-            fallback_level=logging.DEBUG,
-        )
+        self._planner.log_plan(renderers, variant, self._current_merge_strategy)
 
     def _collect_surfaces_serial(
         self,
@@ -221,21 +161,9 @@ class RenderPipeline:
         renderers: list["StatefulBaseRenderer[Any]"],
         override_renderer_variant: RendererVariant | None,
     ) -> RendererVariant:
-        variant = override_renderer_variant or self.renderer_variant
-        if variant == RendererVariant.AUTO:
-            threshold = Configuration.render_parallel_threshold()
-            if len(renderers) < threshold:
-                return RendererVariant.ITERATIVE
-            cost_threshold_ms = Configuration.render_parallel_cost_threshold_ms()
-            estimated_cost_ms, has_samples = self._timing_tracker.estimate_total_ms(
-                renderers
-            )
-            if cost_threshold_ms == 0:
-                return RendererVariant.BINARY
-            if has_samples and estimated_cost_ms >= cost_threshold_ms:
-                return RendererVariant.BINARY
-            return RendererVariant.ITERATIVE
-        return variant
+        return self._planner.resolve_variant(
+            renderers, override_renderer_variant, self.renderer_variant
+        )
 
     def _render_fn(
         self,

--- a/src/heart/runtime/rendering/planner.py
+++ b/src/heart/runtime/rendering/planner.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from heart.runtime.rendering.timing import RendererTimingTracker
+from heart.runtime.rendering.variants import RendererVariant
+from heart.utilities.env import Configuration
+from heart.utilities.env.enums import RenderMergeStrategy
+from heart.utilities.logging import get_logger
+from heart.utilities.logging_control import get_logging_controller
+
+if TYPE_CHECKING:
+    from heart.renderers import StatefulBaseRenderer
+
+logger = get_logger(__name__)
+log_controller = get_logging_controller()
+
+
+class RenderPlanner:
+    def __init__(self, timing_tracker: RendererTimingTracker) -> None:
+        self._timing_tracker = timing_tracker
+
+    def resolve_merge_strategy(
+        self, renderers: list["StatefulBaseRenderer[Any]"]
+    ) -> RenderMergeStrategy:
+        configured = Configuration.render_merge_strategy()
+        if configured != RenderMergeStrategy.ADAPTIVE:
+            return configured
+        surface_threshold = Configuration.render_merge_surface_threshold()
+        if len(renderers) < surface_threshold:
+            return RenderMergeStrategy.IN_PLACE
+        cost_threshold_ms = Configuration.render_merge_cost_threshold_ms()
+        estimated_cost_ms, has_samples = self._timing_tracker.estimate_total_ms(
+            renderers
+        )
+        if cost_threshold_ms == 0:
+            return RenderMergeStrategy.BATCHED
+        if has_samples and estimated_cost_ms >= cost_threshold_ms:
+            return RenderMergeStrategy.BATCHED
+        return RenderMergeStrategy.IN_PLACE
+
+    def resolve_variant(
+        self,
+        renderers: list["StatefulBaseRenderer[Any]"],
+        override_renderer_variant: RendererVariant | None,
+        default_variant: RendererVariant,
+    ) -> RendererVariant:
+        variant = override_renderer_variant or default_variant
+        if variant == RendererVariant.AUTO:
+            threshold = Configuration.render_parallel_threshold()
+            if len(renderers) < threshold:
+                return RendererVariant.ITERATIVE
+            cost_threshold_ms = Configuration.render_parallel_cost_threshold_ms()
+            estimated_cost_ms, has_samples = self._timing_tracker.estimate_total_ms(
+                renderers
+            )
+            if cost_threshold_ms == 0:
+                return RendererVariant.BINARY
+            if has_samples and estimated_cost_ms >= cost_threshold_ms:
+                return RendererVariant.BINARY
+            return RendererVariant.ITERATIVE
+        return variant
+
+    def log_plan(
+        self,
+        renderers: list["StatefulBaseRenderer[Any]"],
+        variant: RendererVariant,
+        merge_strategy: RenderMergeStrategy,
+    ) -> None:
+        estimated_cost_ms, has_samples = self._timing_tracker.estimate_total_ms(
+            renderers
+        )
+        snapshots, missing = self._timing_tracker.snapshot(renderers)
+        snapshot_payload = [
+            {
+                "renderer": snapshot.name,
+                "average_ms": snapshot.average_ms,
+                "last_ms": snapshot.last_ms,
+                "samples": snapshot.sample_count,
+            }
+            for snapshot in snapshots
+        ]
+        log_message = (
+            "render.plan variant=%s merge_strategy=%s renderer_count=%s "
+            "estimated_cost_ms=%.2f has_samples=%s"
+        )
+        log_args = (
+            variant.name,
+            merge_strategy.value,
+            len(renderers),
+            estimated_cost_ms,
+            has_samples,
+        )
+        log_extra = {
+            "variant": variant.name,
+            "merge_strategy": merge_strategy.value,
+            "renderer_count": len(renderers),
+            "estimated_cost_ms": estimated_cost_ms,
+            "has_samples": has_samples,
+            "renderer_timings": snapshot_payload,
+            "renderer_timings_missing": missing,
+        }
+
+        log_controller.log(
+            key="render.plan",
+            logger=logger,
+            level=logging.INFO,
+            msg=log_message,
+            args=log_args,
+            extra=log_extra,
+            fallback_level=logging.DEBUG,
+        )


### PR DESCRIPTION
### Motivation

- The `RenderPipeline` mixed variant/merge selection, logging, and surface composition which made the decision logic hard to reason about. 
- Isolating planning logic improves separation of concerns and makes the render orchestration simpler to maintain. 
- Moving logging and heuristic decisions to a single helper centralises tuning and observability. 
- The change prepares the codebase for clearer tests and future planner enhancements.

### Description

- Added `src/heart/runtime/rendering/planner.py` which implements `RenderPlanner` with `resolve_merge_strategy`, `resolve_variant`, and `log_plan` to encapsulate merge/variant heuristics and logging. 
- Updated `src/heart/runtime/render_pipeline.py` to instantiate and delegate planning responsibilities to `RenderPlanner` and keep pipeline code focused on orchestration and composition. 
- Added a research note at `docs/research/render-planner-refactor.md` describing the rationale and materials. 
- Applied formatting updates as part of the change (project format tooling was run).

### Testing

- Ran `make format` and formatting checks completed successfully. 
- Ran `make test` and the full Pytest suite completed with all automated tests passing (`201 passed, 1 skipped`). 
- No automated test regressions observed in rendering or timing-related test cases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d262bfe98832184576453530fbc6d)