### PR TITLE
Refine CLI config error handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 ## Error Handling
 
 - Avoid catching `BaseException`; catch `Exception` or more specific error types so system-exiting signals propagate.
+- Avoid raising bare `Exception` values; raise more specific exception types instead.
 - Avoid swallowing recoverable exceptions; log them with the shared logger (use debug-level logging for high-frequency loops).
 - Avoid placeholder early returns or unreachable docstrings in production methods; remove stubs once real implementations are available.
 

--- a/src/heart/cli/commands/run.py
+++ b/src/heart/cli/commands/run.py
@@ -18,7 +18,7 @@ def run_command(
     registry = ConfigurationRegistry()
     configuration_fn = registry.get(configuration)
     if configuration_fn is None:
-        raise Exception(f"Configuration '{configuration}' not found in registry")
+        raise ValueError(f"Configuration '{configuration}' not found in registry")
     loop = build_game_loop(x11_forward=x11_forward)
     configuration_fn(loop)
 


### PR DESCRIPTION
### Motivation
- Avoid using bare `Exception` values so callers can handle specific error types.
- Make CLI behaviour clearer by returning a standard, descriptive error when a configuration is missing.

### Description
- Add guidance in `AGENTS.md` to avoid raising bare `Exception` values and prefer specific exception types.
- Replace a bare `Exception` with `ValueError` in `src/heart/cli/commands/run.py` when a requested configuration is not found.

### Testing
- Ran `make format` to apply formatting and linting changes and the command completed successfully.
- No other automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d4f256e188321910bbd5ce044c381)