### PR TITLE
Remove commented debug prints and add guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - When CLI arguments accept file paths, parse them as `pathlib.Path` objects and ensure parent directories exist before writing.
 - Avoid using `print` for runtime diagnostics in CLI commands; use the shared logger.
 - Avoid using `print` for runtime diagnostics in peripheral modules; use the shared logger.
+- Avoid leaving commented debug print statements in production modules; remove them once they are no longer needed.
 - Avoid wildcard imports; use explicit imports so dependencies stay clear and tooling can track usage.
 - Prefer mixins or composition over direct inheritance.
 - Prefer `StrEnum` values over raw strings for strategy/configuration mode selections.

--- a/src/heart/renderers/mandelbrot/scene.py
+++ b/src/heart/renderers/mandelbrot/scene.py
@@ -319,13 +319,6 @@ class MandelbrotMode(StatefulBaseRenderer[AppState]):
             # start_coords = self._clip_line_to_surface_boundary(start_coords, end_coords, width, height)
             # end_coords = self._clip_line_to_surface_boundary(start_coords, end_coords, width, height)
 
-            # print("before", end_coords)
-            # end_coords = (
-            #     int(max(0, min(end_coords[0], width / 2))),
-            #     int(max(0, min(end_coords[1], height / 2)))
-            # )
-            # print("after", end_coords)
-
             if start_coords and end_coords:
                 try:
                     pygame.draw.line(

--- a/src/heart/renderers/three_fractal/renderer.py
+++ b/src/heart/renderers/three_fractal/renderer.py
@@ -663,15 +663,6 @@ class FractalRuntime(StatefulBaseRenderer[FractalRuntimeState]):
             )
         self.key_pressed_last_frame[pygame.K_r] = keys[pygame.K_r]
 
-        # if keys[pygame.K_o] and not self.key_pressed_last_frame[pygame.K_o]:
-        #     print("changing color")
-        #     # self.shader.set("_orbit_color", to_vec3((1, 1, 1)))
-        #     # self.shader.set("s_radius", 3.0)
-        #     self.active_color = (1, 1, 1)
-        #     self.shader.set("_orbit_color", to_vec3(self.active_color))
-
-        # self.key_pressed_last_frame[pygame.K_o] = keys[pygame.K_o]
-
         # "inflate/deflate" sphere on hold/release
         try:
             if keys[pygame.K_SPACE]:
@@ -747,9 +738,6 @@ class FractalRuntime(StatefulBaseRenderer[FractalRuntimeState]):
         else:
             self._process_input(peripheral_manager)
             self._check_enter_auto(peripheral_manager)
-
-        # print(f"\n\n{self.vel=}\n\n")
-        # if not np.allclose(self.vel, 0.0):
 
         self.mat[3, :3] += self.vel * (clock.get_time() / 1000)
         # self._check_switch_auto(peripheral_manager)


### PR DESCRIPTION
### Motivation
- Remove leftover commented `print` debugging blocks from production renderer code to reduce noise and accidental information leakage.
- Make repository guidance explicit by discouraging commented debug prints in `AGENTS.md` so contributors follow a consistent practice.
- Keep renderer modules focused and align with existing logging guidance that prefers the shared logger over `print`-based diagnostics.

### Description
- Add guidance to `AGENTS.md`: "Avoid leaving commented debug print statements in production modules; remove them once they are no longer needed."
- Remove commented debug `print` lines and related commented blocks from `src/heart/renderers/mandelbrot/scene.py`.
- Remove commented debug `print` lines from `src/heart/renderers/three_fractal/renderer.py`.
- Run repository formatting fixes to ensure style consistency after the edits.

### Testing
- Ran `make format` and formatting checks completed successfully.
- Ran the test suite with `make test` and the test run completed with `202 passed, 1 skipped`.
- Tests executed under the repository test configuration (Pytest with xdist) and all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d4f770a64832189a128d62cbb07a3)