### PR TITLE
Add optional_import helper and adopt for optional dependencies

### DIFF
--- a/src/heart/firmware_io/bluetooth.py
+++ b/src/heart/firmware_io/bluetooth.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import importlib
-import importlib.util
 from typing import Any
 
 from heart.utilities.logging import get_logger
+from heart.utilities.optional_imports import optional_import
 
 logger = get_logger(__name__)
 
@@ -12,29 +11,20 @@ BLERadio: type[Any] | None = None
 ProvideServicesAdvertisement: type[Any] | None = None
 UARTService: type[Any] | None = None
 
-def _safe_find_spec(module_name: str) -> bool:
-    try:
-        return importlib.util.find_spec(module_name) is not None
-    except Exception:
-        logger.debug("BLE dependency lookup failed for %s.", module_name)
-        return False
+ble_module = optional_import("adafruit_ble", logger=logger)
+advertising_module = optional_import(
+    "adafruit_ble.advertising.standard",
+    logger=logger,
+)
+services_module = optional_import(
+    "adafruit_ble.services.nordic",
+    logger=logger,
+)
 
-
-if (
-    _safe_find_spec("adafruit_ble")
-    and _safe_find_spec("adafruit_ble.advertising.standard")
-    and _safe_find_spec("adafruit_ble.services.nordic")
-):
-    try:
-        ble_module = importlib.import_module("adafruit_ble")
-        advertising_module = importlib.import_module("adafruit_ble.advertising.standard")
-        services_module = importlib.import_module("adafruit_ble.services.nordic")
-    except Exception:
-        logger.debug("BLE dependencies failed to import. BLE support is disabled.")
-    else:
-        BLERadio = getattr(ble_module, "BLERadio", None)
-        ProvideServicesAdvertisement = getattr(advertising_module, "ProvideServicesAdvertisement", None)
-        UARTService = getattr(services_module, "UARTService", None)
+if ble_module is not None and advertising_module is not None and services_module is not None:
+    BLERadio = getattr(ble_module, "BLERadio", None)
+    ProvideServicesAdvertisement = getattr(advertising_module, "ProvideServicesAdvertisement", None)
+    UARTService = getattr(services_module, "UARTService", None)
 
 
 if BLERadio is not None and UARTService is not None and ProvideServicesAdvertisement is not None:

--- a/src/heart/peripheral/ir_sensor_array.py
+++ b/src/heart/peripheral/ir_sensor_array.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import importlib
 import json
 import math
 import threading
@@ -16,22 +15,22 @@ import numpy as np
 
 from heart.peripheral.core import Input, Peripheral
 from heart.utilities.logging import get_logger
+from heart.utilities.optional_imports import optional_import
 
 LeastSquaresCallable = Callable[..., Any]
 
-_optimize_module: ModuleType | None
-try:  # pragma: no cover - optional dependency
-    _optimize_module = importlib.import_module("scipy.optimize")
-except Exception:  # pragma: no cover - optional dependency may be absent
-    _optimize_module = None
+logger = get_logger(__name__)
+
+_optimize_module = cast(
+    ModuleType | None,
+    optional_import("scipy.optimize", logger=logger),
+)
 
 if _optimize_module is not None:
     least_squares = cast(LeastSquaresCallable, getattr(_optimize_module, "least_squares"))
 else:
     def least_squares(*args: Any, **kwargs: Any) -> Any:
         raise RuntimeError("scipy.optimize.least_squares is not available")
-
-logger = get_logger(__name__)
 
 SPEED_OF_LIGHT = 299_792_458.0  # metres per second
 

--- a/src/heart/peripheral/microphone.py
+++ b/src/heart/peripheral/microphone.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import contextlib
 import ctypes.util
-import importlib
-import importlib.util
 import threading
 import time
 from collections.abc import Iterator
@@ -17,19 +15,13 @@ import numpy as np
 from heart.peripheral.core import Peripheral
 from heart.peripheral.input_payloads.audio import MicrophoneLevel
 from heart.utilities.logging import get_logger
+from heart.utilities.optional_imports import optional_import
 
 logger = get_logger(__name__)
 
 sd: Any | None = None
-if (
-    importlib.util.find_spec("sounddevice") is not None
-    and ctypes.util.find_library("portaudio") is not None
-):  # pragma: no cover - optional dependency
-    try:
-        sd = cast(Any | None, importlib.import_module("sounddevice"))
-    except Exception as exc:
-        logger.warning("sounddevice import failed; disabling microphone support: %s", exc)
-        sd = None
+if ctypes.util.find_library("portaudio") is not None:  # pragma: no cover - optional dependency
+    sd = optional_import("sounddevice", logger=logger)
 
 
 class Microphone(Peripheral[MicrophoneLevel]):

--- a/src/heart/peripheral/phone_text.py
+++ b/src/heart/peripheral/phone_text.py
@@ -6,35 +6,26 @@ null terminator (`\0`).  The most-recent message is available via
 `PhoneText.get_last_text()` for inspection by other code/tests.
 """
 
-import importlib
-import importlib.util
 from collections.abc import Iterator
 from types import ModuleType
-from typing import Any, Self
+from typing import Any, Self, cast
 
 from heart.peripheral.core import Peripheral
 from heart.utilities.logging import get_logger
+from heart.utilities.optional_imports import optional_import
 
+logger = get_logger(__name__)
 
-def _load_optional_module(module_name: str) -> ModuleType | None:
-    try:
-        module_spec = importlib.util.find_spec(module_name)
-    except ModuleNotFoundError:  # pragma: no cover - optional
-        module_spec = None
-    if module_spec is None:  # pragma: no cover - optional
-        return None
-    return importlib.import_module(module_name)
-
-
-adapter = _load_optional_module("bluezero.adapter")
-bz_peripheral = _load_optional_module("bluezero.peripheral")
+adapter = cast(ModuleType | None, optional_import("bluezero.adapter", logger=logger))
+bz_peripheral = cast(
+    ModuleType | None,
+    optional_import("bluezero.peripheral", logger=logger),
+)
 
 # UUIDs shared with the legacy test script so that existing iOS/Mac apps keep
 # working without any change.
 _SERVICE_UUID = "1235"
 _CHARACTERISTIC_UUID = "5679"
-
-logger = get_logger(__name__)
 
 
 class PhoneText(Peripheral[str]):

--- a/src/heart/peripheral/radio.py
+++ b/src/heart/peripheral/radio.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import importlib
-import importlib.util
 import json
 import os
 import threading
@@ -13,17 +11,11 @@ from typing import Any, Iterator, Mapping
 from heart.peripheral.core import Peripheral
 from heart.peripheral.input_payloads.radio import RadioPacket
 from heart.utilities.logging import get_logger
-
-
-def _load_optional_module(module_name: str) -> Any | None:
-    if importlib.util.find_spec(module_name) is None:  # pragma: no cover - optional
-        return None
-    return importlib.import_module(module_name)
-
-
-serial = _load_optional_module("serial")
+from heart.utilities.optional_imports import optional_import
 
 logger = get_logger(__name__)
+
+serial = optional_import("serial", logger=logger)
 
 @dataclass(slots=True)
 class RawRadioPacket:

--- a/src/heart/utilities/optional_imports.py
+++ b/src/heart/utilities/optional_imports.py
@@ -1,0 +1,38 @@
+"""Helpers for optional dependency imports."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from logging import Logger
+from typing import Any
+
+from heart.utilities.logging import get_logger
+
+
+def optional_import(
+    module_name: str,
+    *,
+    logger: Logger | None = None,
+) -> Any | None:
+    """Return the imported module if available, otherwise ``None``."""
+
+    resolved_logger = logger or get_logger(__name__)
+
+    try:
+        if importlib.util.find_spec(module_name) is None:
+            resolved_logger.debug("Optional dependency %s is unavailable.", module_name)
+            return None
+    except Exception as exc:
+        resolved_logger.debug(
+            "Optional dependency lookup failed for %s: %s", module_name, exc
+        )
+        return None
+
+    try:
+        return importlib.import_module(module_name)
+    except Exception as exc:
+        resolved_logger.warning(
+            "Optional dependency %s failed to import: %s", module_name, exc
+        )
+        return None


### PR DESCRIPTION
### Motivation

- Centralise optional dependency lookup and import logic to provide consistent logging and error handling.
- Reduce duplication of `importlib` checks across peripherals and firmware modules.
- Make optional dependency failures visible via the shared logger rather than ad-hoc debug/warning messages.

### Description

- Add `src/heart/utilities/optional_imports.py` exporting `optional_import(module_name, *, logger)` which performs `find_spec` and imports with logged failure modes.
- Replace inline `importlib`/`importlib.util` patterns with `optional_import` in `src/heart/firmware_io/bluetooth.py`, `src/heart/peripheral/microphone.py`, `src/heart/peripheral/radio.py`, `src/heart/peripheral/ir_sensor_array.py`, and `src/heart/peripheral/phone_text.py`.
- Update modules to use the repository logger when checking optional dependencies and to cast imported modules where appropriate.
- Remove duplicate ad-hoc helper functions and unify behaviour for unavailable or failing optional imports.

### Testing

- Ran `make format` which applied formatting changes and returned `All checks passed!`.
- Fixed a redundant-cast type issue surfaced during formatting and re-ran `make format` successfully.
- No unit test changes were added and the existing test suite was not executed as part of this rollout.
- All modified files were committed after formatting and lint checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d4ecf2c90832199e6c5810d282556)