### PR TITLE
Refactor device selection into focused helper functions

### DIFF
--- a/src/heart/device/selection.py
+++ b/src/heart/device/selection.py
@@ -9,51 +9,85 @@ logger = get_logger(__name__)
 
 
 def select_device(*, x11_forward: bool) -> Device:
-    layout_mode = Configuration.device_layout_mode()
-    orientation: Orientation
-    if layout_mode == DeviceLayoutMode.CUBE:
-        orientation = Cube.sides()
-    else:
-        orientation = Rectangle.with_layout(
-            columns=Configuration.device_layout_columns(),
-            rows=Configuration.device_layout_rows(),
-        )
+    orientation = _select_orientation()
     panel_width = Configuration.panel_columns()
     panel_height = Configuration.panel_rows()
 
-    if Configuration.forward_to_beats_app():
-        from heart.device.beats import StreamedScreen
+    streamed_device = _select_streamed_device(orientation)
+    if streamed_device is not None:
+        return streamed_device
 
-        return StreamedScreen(orientation=orientation)
+    isolated_device = _select_isolated_renderer_device(
+        orientation=orientation,
+        x11_forward=x11_forward,
+    )
+    if isolated_device is not None:
+        return isolated_device
 
-    if Configuration.use_isolated_renderer():
-        if x11_forward:
-            logger.warning("USE_ISOLATED_RENDERER enabled; ignoring x11_forward flag")
-        from heart.device.rgb_display import LEDMatrix
-
-        return LEDMatrix(orientation=orientation)
-
-    if Configuration.is_pi():
-        os.environ["SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS"] = "1"
-
-        pi_info = Configuration.pi()
-        if pi_info is not None and pi_info.version > 4:
-            logger.warning(
-                f"Shit not guaranteed to work Pi5 and higher. Detected: {pi_info}"
-            )
-
-        if Configuration.is_x11_forward():
-            # This makes it work on Pi when no screens are connected.
-            # You need to setup X11 forwarding with XQuartz to do that.
-            logger.warning("X11_FORWARD set, running with `LocalScreen`")
-            return LocalScreen(
-                width=panel_width,
-                height=panel_height,
-                orientation=orientation,
-            )
-
-        from heart.device.rgb_display import LEDMatrix
-
-        return LEDMatrix(orientation=orientation)
+    pi_device = _select_pi_device(
+        orientation=orientation,
+        panel_width=panel_width,
+        panel_height=panel_height,
+    )
+    if pi_device is not None:
+        return pi_device
 
     return LocalScreen(width=panel_width, height=panel_height, orientation=orientation)
+
+
+def _select_orientation() -> Orientation:
+    layout_mode = Configuration.device_layout_mode()
+    if layout_mode == DeviceLayoutMode.CUBE:
+        return Cube.sides()
+    return Rectangle.with_layout(
+        columns=Configuration.device_layout_columns(),
+        rows=Configuration.device_layout_rows(),
+    )
+
+
+def _select_streamed_device(orientation: Orientation) -> Device | None:
+    if not Configuration.forward_to_beats_app():
+        return None
+    from heart.device.beats import StreamedScreen
+
+    return StreamedScreen(orientation=orientation)
+
+
+def _select_isolated_renderer_device(
+    *, orientation: Orientation, x11_forward: bool
+) -> Device | None:
+    if not Configuration.use_isolated_renderer():
+        return None
+    if x11_forward:
+        logger.warning("USE_ISOLATED_RENDERER enabled; ignoring x11_forward flag")
+    from heart.device.rgb_display import LEDMatrix
+
+    return LEDMatrix(orientation=orientation)
+
+
+def _select_pi_device(
+    *, orientation: Orientation, panel_width: int, panel_height: int
+) -> Device | None:
+    if not Configuration.is_pi():
+        return None
+    os.environ["SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS"] = "1"
+
+    pi_info = Configuration.pi()
+    if pi_info is not None and pi_info.version > 4:
+        logger.warning(
+            f"Shit not guaranteed to work Pi5 and higher. Detected: {pi_info}"
+        )
+
+    if Configuration.is_x11_forward():
+        # This makes it work on Pi when no screens are connected.
+        # You need to setup X11 forwarding with XQuartz to do that.
+        logger.warning("X11_FORWARD set, running with `LocalScreen`")
+        return LocalScreen(
+            width=panel_width,
+            height=panel_height,
+            orientation=orientation,
+        )
+
+    from heart.device.rgb_display import LEDMatrix
+
+    return LEDMatrix(orientation=orientation)


### PR DESCRIPTION
### Motivation

- Make device selection logic easier to read and maintain by separating concerns into small helpers.
- Isolate orientation/layout computation from runtime device choice to simplify reasoning and future tests.
- Encapsulate streamed, isolated-renderer, and Raspberry Pi-specific selection paths for clearer early returns.

### Description

- Extracted `_select_orientation`, `_select_streamed_device`, `_select_isolated_renderer_device`, and `_select_pi_device` and updated `select_device` to compose them.
- Streamed and isolated renderer branches are returned early when selected, preserving lazy imports for device backends.
- Preserved Pi-specific behavior including setting `SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS`, X11-forward handling with `LocalScreen`, and the Pi version warning.
- Simplified top-level flow so the final fallback returns a `LocalScreen` using configured `panel_columns` and `panel_rows`.

### Testing

- Ran formatting and automated formatting/lint hooks via `make format`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d500559608321b280931eca0c5cf3)