### PR TITLE
Extract render planning into RenderPlanner helper

### DIFF
--- a/docs/research/render_pipeline_planner_refactor.md
+++ b/docs/research/render_pipeline_planner_refactor.md
@@ -1,0 +1,30 @@
+# Render pipeline planning helper extraction
+
+## Summary
+
+Move render-variant selection, merge-strategy selection, and planning logs into a
+`RenderPlanner` helper so `RenderPipeline` stays focused on dispatch and surface
+composition.
+
+## Motivation
+
+`RenderPipeline` was handling variant selection, merge-strategy resolution, and
+planning logs alongside executor management and surface composition. Consolidating
+these decisions into a planner keeps render dispatch easier to follow while
+preserving the same timing-based decisions and structured logs.
+
+## Implementation notes
+
+- Added `RenderPlanner` to resolve render variants and merge strategies using
+  timing snapshots and configuration thresholds.
+- Centralized render-plan logging in the planner so the same log payload is
+  emitted after a plan is selected.
+- Updated `RenderPipeline` to delegate merge-strategy selection to the planner
+  while continuing to apply the chosen strategy via the composition manager.
+
+## Materials
+
+- `src/heart/runtime/render_pipeline.py`
+- `src/heart/runtime/render_planner.py`
+- `src/heart/runtime/rendering/timing.py`
+- `src/heart/runtime/rendering/variants.py`

--- a/src/heart/runtime/render_pipeline.py
+++ b/src/heart/runtime/render_pipeline.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, cast
 
@@ -9,20 +8,18 @@ from PIL import Image
 
 from heart.device import Device
 from heart.peripheral.core.manager import PeripheralManager
+from heart.runtime.render_planner import RenderPlanner
 from heart.runtime.rendering.constants import RGBA_IMAGE_FORMAT
 from heart.runtime.rendering.renderer_processor import RendererProcessor
 from heart.runtime.rendering.surface_merge import SurfaceCompositionManager
 from heart.runtime.rendering.variants import RendererVariant, RenderMethod
 from heart.utilities.env import Configuration
-from heart.utilities.env.enums import RenderMergeStrategy
 from heart.utilities.logging import get_logger
-from heart.utilities.logging_control import get_logging_controller
 
 if TYPE_CHECKING:
     from heart.renderers import StatefulBaseRenderer
 
 logger = get_logger(__name__)
-log_controller = get_logging_controller()
 
 
 class RenderPipeline:
@@ -36,12 +33,12 @@ class RenderPipeline:
         self.peripheral_manager = peripheral_manager
         self.renderer_variant = render_variant
         self.clock: pygame.time.Clock | None = None
-        self._current_merge_strategy = Configuration.render_merge_strategy()
-        self._composition_manager = SurfaceCompositionManager(
-            strategy_provider=self._get_merge_strategy
-        )
         self._renderer_processor = RendererProcessor(device, peripheral_manager)
         self._timing_tracker = self._renderer_processor.timing_tracker
+        self._planner = RenderPlanner(self._timing_tracker, render_variant)
+        self._composition_manager = SurfaceCompositionManager(
+            strategy_provider=self._planner.get_merge_strategy
+        )
 
         binary_method = cast(RenderMethod, self._render_surfaces_binary)
         iterative_method = cast(RenderMethod, self._render_surface_iterative)
@@ -91,82 +88,6 @@ class RenderPipeline:
     ) -> pygame.Surface:
         return self._composition_manager.merge_in_place(surface1, surface2)
 
-    def _get_merge_strategy(self) -> RenderMergeStrategy:
-        return self._current_merge_strategy
-
-    def _resolve_merge_strategy(
-        self, renderers: list["StatefulBaseRenderer[Any]"]
-    ) -> RenderMergeStrategy:
-        configured = Configuration.render_merge_strategy()
-        if configured != RenderMergeStrategy.ADAPTIVE:
-            return configured
-        surface_threshold = Configuration.render_merge_surface_threshold()
-        if len(renderers) < surface_threshold:
-            return RenderMergeStrategy.IN_PLACE
-        cost_threshold_ms = Configuration.render_merge_cost_threshold_ms()
-        estimated_cost_ms, has_samples = self._timing_tracker.estimate_total_ms(
-            renderers
-        )
-        if cost_threshold_ms == 0:
-            return RenderMergeStrategy.BATCHED
-        if has_samples and estimated_cost_ms >= cost_threshold_ms:
-            return RenderMergeStrategy.BATCHED
-        return RenderMergeStrategy.IN_PLACE
-
-    def _update_merge_strategy(
-        self, renderers: list["StatefulBaseRenderer[Any]"]
-    ) -> None:
-        self._current_merge_strategy = self._resolve_merge_strategy(renderers)
-
-    def _log_render_plan(
-        self,
-        renderers: list["StatefulBaseRenderer[Any]"],
-        variant: RendererVariant,
-    ) -> None:
-        estimated_cost_ms, has_samples = self._timing_tracker.estimate_total_ms(
-            renderers
-        )
-        snapshots, missing = self._timing_tracker.snapshot(renderers)
-        snapshot_payload = [
-            {
-                "renderer": snapshot.name,
-                "average_ms": snapshot.average_ms,
-                "last_ms": snapshot.last_ms,
-                "samples": snapshot.sample_count,
-            }
-            for snapshot in snapshots
-        ]
-        log_message = (
-            "render.plan variant=%s merge_strategy=%s renderer_count=%s "
-            "estimated_cost_ms=%.2f has_samples=%s"
-        )
-        log_args = (
-            variant.name,
-            self._current_merge_strategy.value,
-            len(renderers),
-            estimated_cost_ms,
-            has_samples,
-        )
-        log_extra = {
-            "variant": variant.name,
-            "merge_strategy": self._current_merge_strategy.value,
-            "renderer_count": len(renderers),
-            "estimated_cost_ms": estimated_cost_ms,
-            "has_samples": has_samples,
-            "renderer_timings": snapshot_payload,
-            "renderer_timings_missing": missing,
-        }
-
-        log_controller.log(
-            key="render.plan",
-            logger=logger,
-            level=logging.INFO,
-            msg=log_message,
-            args=log_args,
-            extra=log_extra,
-            fallback_level=logging.DEBUG,
-        )
-
     def _collect_surfaces_serial(
         self,
         renderers: list["StatefulBaseRenderer[Any]"],
@@ -197,7 +118,6 @@ class RenderPipeline:
         self, renderers: list["StatefulBaseRenderer[Any]"]
     ) -> pygame.Surface | None:
         self._renderer_processor.set_queue_depth(len(renderers))
-        self._update_merge_strategy(renderers)
         surfaces = self._collect_surfaces_serial(renderers)
         return self._composition_manager.compose_serial(
             surfaces, merge_fn=self.merge_surfaces
@@ -207,7 +127,6 @@ class RenderPipeline:
         self, renderers: list["StatefulBaseRenderer[Any]"]
     ) -> pygame.Surface | None:
         self._renderer_processor.set_queue_depth(len(renderers))
-        self._update_merge_strategy(renderers)
         if len(renderers) == 1:
             return self.process_renderer(renderers[0])
         surfaces = self._collect_surfaces_parallel(renderers)
@@ -216,33 +135,14 @@ class RenderPipeline:
             surfaces, executor, merge_fn=self.merge_surfaces
         )
 
-    def _resolve_render_variant(
-        self,
-        renderers: list["StatefulBaseRenderer[Any]"],
-        override_renderer_variant: RendererVariant | None,
-    ) -> RendererVariant:
-        variant = override_renderer_variant or self.renderer_variant
-        if variant == RendererVariant.AUTO:
-            threshold = Configuration.render_parallel_threshold()
-            if len(renderers) < threshold:
-                return RendererVariant.ITERATIVE
-            cost_threshold_ms = Configuration.render_parallel_cost_threshold_ms()
-            estimated_cost_ms, has_samples = self._timing_tracker.estimate_total_ms(
-                renderers
-            )
-            if cost_threshold_ms == 0:
-                return RendererVariant.BINARY
-            if has_samples and estimated_cost_ms >= cost_threshold_ms:
-                return RendererVariant.BINARY
-            return RendererVariant.ITERATIVE
-        return variant
-
     def _render_fn(
         self,
         renderers: list["StatefulBaseRenderer[Any]"],
         override_renderer_variant: RendererVariant | None,
     ) -> RenderMethod:
-        variant = self._resolve_render_variant(renderers, override_renderer_variant)
+        variant = self._planner.plan(
+            renderers, override_renderer_variant
+        ).variant
         return self._render_dispatch.get(
             variant, self._render_dispatch[RendererVariant.ITERATIVE]
         )
@@ -252,10 +152,8 @@ class RenderPipeline:
         renderers: list["StatefulBaseRenderer[Any]"],
         override_renderer_variant: RendererVariant | None = None,
     ) -> pygame.Surface | None:
-        variant = self._resolve_render_variant(renderers, override_renderer_variant)
-        self._update_merge_strategy(renderers)
-        self._log_render_plan(renderers, variant)
+        plan = self._planner.plan(renderers, override_renderer_variant)
         render_fn = self._render_dispatch.get(
-            variant, self._render_dispatch[RendererVariant.ITERATIVE]
+            plan.variant, self._render_dispatch[RendererVariant.ITERATIVE]
         )
         return render_fn(renderers)

--- a/src/heart/runtime/render_planner.py
+++ b/src/heart/runtime/render_planner.py
@@ -35,15 +35,31 @@ class RenderPlanner:
     def get_merge_strategy(self) -> RenderMergeStrategy:
         return self._current_merge_strategy
 
+    def set_default_variant(self, default_variant: RendererVariant) -> None:
+        self._default_variant = default_variant
+
+    def update_merge_strategy(
+        self, renderers: list["StatefulBaseRenderer[Any]"]
+    ) -> RenderMergeStrategy:
+        self._current_merge_strategy = self._resolve_merge_strategy(renderers)
+        return self._current_merge_strategy
+
     def plan(
         self,
         renderers: list["StatefulBaseRenderer[Any]"],
         override_renderer_variant: RendererVariant | None,
     ) -> RenderPlan:
-        variant = self._resolve_render_variant(renderers, override_renderer_variant)
+        variant = self.resolve_variant(renderers, override_renderer_variant)
         self._current_merge_strategy = self._resolve_merge_strategy(renderers)
         self._log_render_plan(renderers, variant)
         return RenderPlan(variant=variant, merge_strategy=self._current_merge_strategy)
+
+    def resolve_variant(
+        self,
+        renderers: list["StatefulBaseRenderer[Any]"],
+        override_renderer_variant: RendererVariant | None,
+    ) -> RendererVariant:
+        return self._resolve_render_variant(renderers, override_renderer_variant)
 
     def _resolve_merge_strategy(
         self, renderers: list["StatefulBaseRenderer[Any]"]

--- a/src/heart/runtime/render_planner.py
+++ b/src/heart/runtime/render_planner.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from heart.runtime.rendering.timing import RendererTimingTracker
+from heart.runtime.rendering.variants import RendererVariant
+from heart.utilities.env import Configuration
+from heart.utilities.env.enums import RenderMergeStrategy
+from heart.utilities.logging import get_logger
+from heart.utilities.logging_control import get_logging_controller
+
+if TYPE_CHECKING:
+    from heart.renderers import StatefulBaseRenderer
+
+logger = get_logger(__name__)
+log_controller = get_logging_controller()
+
+
+@dataclass(frozen=True)
+class RenderPlan:
+    variant: RendererVariant
+    merge_strategy: RenderMergeStrategy
+
+
+class RenderPlanner:
+    def __init__(
+        self, timing_tracker: RendererTimingTracker, default_variant: RendererVariant
+    ) -> None:
+        self._timing_tracker = timing_tracker
+        self._default_variant = default_variant
+        self._current_merge_strategy = Configuration.render_merge_strategy()
+
+    def get_merge_strategy(self) -> RenderMergeStrategy:
+        return self._current_merge_strategy
+
+    def plan(
+        self,
+        renderers: list["StatefulBaseRenderer[Any]"],
+        override_renderer_variant: RendererVariant | None,
+    ) -> RenderPlan:
+        variant = self._resolve_render_variant(renderers, override_renderer_variant)
+        self._current_merge_strategy = self._resolve_merge_strategy(renderers)
+        self._log_render_plan(renderers, variant)
+        return RenderPlan(variant=variant, merge_strategy=self._current_merge_strategy)
+
+    def _resolve_merge_strategy(
+        self, renderers: list["StatefulBaseRenderer[Any]"]
+    ) -> RenderMergeStrategy:
+        configured = Configuration.render_merge_strategy()
+        if configured != RenderMergeStrategy.ADAPTIVE:
+            return configured
+        surface_threshold = Configuration.render_merge_surface_threshold()
+        if len(renderers) < surface_threshold:
+            return RenderMergeStrategy.IN_PLACE
+        cost_threshold_ms = Configuration.render_merge_cost_threshold_ms()
+        estimated_cost_ms, has_samples = self._timing_tracker.estimate_total_ms(
+            renderers
+        )
+        if cost_threshold_ms == 0:
+            return RenderMergeStrategy.BATCHED
+        if has_samples and estimated_cost_ms >= cost_threshold_ms:
+            return RenderMergeStrategy.BATCHED
+        return RenderMergeStrategy.IN_PLACE
+
+    def _resolve_render_variant(
+        self,
+        renderers: list["StatefulBaseRenderer[Any]"],
+        override_renderer_variant: RendererVariant | None,
+    ) -> RendererVariant:
+        variant = override_renderer_variant or self._default_variant
+        if variant == RendererVariant.AUTO:
+            threshold = Configuration.render_parallel_threshold()
+            if len(renderers) < threshold:
+                return RendererVariant.ITERATIVE
+            cost_threshold_ms = Configuration.render_parallel_cost_threshold_ms()
+            estimated_cost_ms, has_samples = self._timing_tracker.estimate_total_ms(
+                renderers
+            )
+            if cost_threshold_ms == 0:
+                return RendererVariant.BINARY
+            if has_samples and estimated_cost_ms >= cost_threshold_ms:
+                return RendererVariant.BINARY
+            return RendererVariant.ITERATIVE
+        return variant
+
+    def _log_render_plan(
+        self,
+        renderers: list["StatefulBaseRenderer[Any]"],
+        variant: RendererVariant,
+    ) -> None:
+        estimated_cost_ms, has_samples = self._timing_tracker.estimate_total_ms(
+            renderers
+        )
+        snapshots, missing = self._timing_tracker.snapshot(renderers)
+        snapshot_payload = [
+            {
+                "renderer": snapshot.name,
+                "average_ms": snapshot.average_ms,
+                "last_ms": snapshot.last_ms,
+                "samples": snapshot.sample_count,
+            }
+            for snapshot in snapshots
+        ]
+        log_message = (
+            "render.plan variant=%s merge_strategy=%s renderer_count=%s "
+            "estimated_cost_ms=%.2f has_samples=%s"
+        )
+        log_args = (
+            variant.name,
+            self._current_merge_strategy.value,
+            len(renderers),
+            estimated_cost_ms,
+            has_samples,
+        )
+        log_extra = {
+            "variant": variant.name,
+            "merge_strategy": self._current_merge_strategy.value,
+            "renderer_count": len(renderers),
+            "estimated_cost_ms": estimated_cost_ms,
+            "has_samples": has_samples,
+            "renderer_timings": snapshot_payload,
+            "renderer_timings_missing": missing,
+        }
+
+        log_controller.log(
+            key="render.plan",
+            logger=logger,
+            level=logging.INFO,
+            msg=log_message,
+            args=log_args,
+            extra=log_extra,
+            fallback_level=logging.DEBUG,
+        )


### PR DESCRIPTION
### Motivation

- Separate concerns by moving variant selection, merge-strategy selection, and planning logging out of `RenderPipeline` so the pipeline focuses on dispatch and surface composition.
- Improve clarity of the render flow and make timing-based decisions easier to evolve independently from composition and executor management.
- Preserve existing timing and structured-logging behaviour while reducing code duplication.

### Description

- Added `src/heart/runtime/render_planner.py` introducing `RenderPlanner` and `RenderPlan` to encapsulate variant resolution, merge-strategy resolution, and render-plan logging.
- Updated `src/heart/runtime/render_pipeline.py` to delegate planning to `RenderPlanner` and wired the composition manager to use `RenderPlanner.get_merge_strategy`.
- Removed duplicate variant/merge-strategy and logging logic from `RenderPipeline` so those responsibilities live in the planner.
- Added a research note at `docs/research/render_pipeline_planner_refactor.md` documenting the rationale and referenced materials.

### Testing

- Ran `make format` to apply repository formatting rules, and the formatter completed successfully.
- No runtime unit tests were changed or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d50a2549883218a1d33bb7f7ae8ec)