### PR TITLE
Improve optional import handling

### DIFF
--- a/src/heart/peripheral/ir_sensor_array.py
+++ b/src/heart/peripheral/ir_sensor_array.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import importlib
 import json
 import math
 import threading
@@ -15,15 +14,12 @@ from typing import Any, Callable, Iterator, Mapping, Sequence, cast
 import numpy as np
 
 from heart.peripheral.core import Input, Peripheral
+from heart.utilities.imports import optional_import
 from heart.utilities.logging import get_logger
 
 LeastSquaresCallable = Callable[..., Any]
 
-_optimize_module: ModuleType | None
-try:  # pragma: no cover - optional dependency
-    _optimize_module = importlib.import_module("scipy.optimize")
-except Exception:  # pragma: no cover - optional dependency may be absent
-    _optimize_module = None
+_optimize_module: ModuleType | None = optional_import("scipy.optimize")
 
 if _optimize_module is not None:
     least_squares = cast(LeastSquaresCallable, getattr(_optimize_module, "least_squares"))

--- a/src/heart/peripheral/phone_text.py
+++ b/src/heart/peripheral/phone_text.py
@@ -6,28 +6,15 @@ null terminator (`\0`).  The most-recent message is available via
 `PhoneText.get_last_text()` for inspection by other code/tests.
 """
 
-import importlib
-import importlib.util
 from collections.abc import Iterator
-from types import ModuleType
 from typing import Any, Self
 
 from heart.peripheral.core import Peripheral
+from heart.utilities.imports import optional_import
 from heart.utilities.logging import get_logger
 
-
-def _load_optional_module(module_name: str) -> ModuleType | None:
-    try:
-        module_spec = importlib.util.find_spec(module_name)
-    except ModuleNotFoundError:  # pragma: no cover - optional
-        module_spec = None
-    if module_spec is None:  # pragma: no cover - optional
-        return None
-    return importlib.import_module(module_name)
-
-
-adapter = _load_optional_module("bluezero.adapter")
-bz_peripheral = _load_optional_module("bluezero.peripheral")
+adapter = optional_import("bluezero.adapter")
+bz_peripheral = optional_import("bluezero.peripheral")
 
 # UUIDs shared with the legacy test script so that existing iOS/Mac apps keep
 # working without any change.

--- a/src/heart/peripheral/radio.py
+++ b/src/heart/peripheral/radio.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import importlib
-import importlib.util
 import json
 import os
 import threading
@@ -12,16 +10,10 @@ from typing import Any, Iterator, Mapping
 
 from heart.peripheral.core import Peripheral
 from heart.peripheral.input_payloads.radio import RadioPacket
+from heart.utilities.imports import optional_import
 from heart.utilities.logging import get_logger
 
-
-def _load_optional_module(module_name: str) -> Any | None:
-    if importlib.util.find_spec(module_name) is None:  # pragma: no cover - optional
-        return None
-    return importlib.import_module(module_name)
-
-
-serial = _load_optional_module("serial")
+serial = optional_import("serial")
 
 logger = get_logger(__name__)
 

--- a/src/heart/utilities/imports.py
+++ b/src/heart/utilities/imports.py
@@ -1,0 +1,33 @@
+"""Helpers for optional imports."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from types import ModuleType
+
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def optional_import(module_name: str) -> ModuleType | None:
+    """Return the imported module if available, otherwise ``None``."""
+
+    try:
+        spec = importlib.util.find_spec(module_name)
+    except (ImportError, ModuleNotFoundError) as exc:
+        logger.debug("Optional dependency lookup failed for %s: %s", module_name, exc)
+        return None
+
+    if spec is None:
+        return None
+
+    try:
+        return importlib.import_module(module_name)
+    except ImportError as exc:
+        logger.debug("Optional dependency %s failed to import: %s", module_name, exc)
+        return None
+    except Exception as exc:
+        logger.warning("Optional dependency %s failed to initialize: %s", module_name, exc)
+        return None

--- a/src/heart/utilities/signal.py
+++ b/src/heart/utilities/signal.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from importlib import import_module
 from typing import Callable, Sequence, cast
 
 import numpy as np
+
+from heart.utilities.imports import optional_import
 
 _scipy_hilbert: Callable[[np.ndarray], np.ndarray] | None = None
 _FFT_CORRELATION_THRESHOLD = 50_000
@@ -15,11 +16,8 @@ def _load_scipy_hilbert() -> Callable[[np.ndarray], np.ndarray] | None:
     global _scipy_hilbert
     if _scipy_hilbert is not None:
         return _scipy_hilbert
-    try:  # pragma: no cover - optional dependency
-        module = import_module("scipy.signal")
-        hilbert_fn = getattr(module, "hilbert", None)
-    except Exception:  # pragma: no cover - optional dependency
-        hilbert_fn = None
+    module = optional_import("scipy.signal")
+    hilbert_fn = getattr(module, "hilbert", None) if module else None
     if callable(hilbert_fn):
         _scipy_hilbert = hilbert_fn
     else:


### PR DESCRIPTION
### Motivation
- Reduce duplicated ad-hoc optional import patterns scattered across modules by centralising the logic. 
- Provide consistent logging and safer lookup semantics for optional dependencies. 
- Make dependency fallbacks and error messages clearer for runtime-disabled features. 

### Description
- Add `heart.utilities.imports.optional_import` to encapsulate `find_spec` + `import_module` with structured logging. 
- Replace ad-hoc optional imports in `src/heart/utilities/signal.py` to use `optional_import` for `scipy.signal` and streamline the Hilbert lookup. 
- Replace ad-hoc optional imports in `src/heart/peripheral/ir_sensor_array.py`, `src/heart/peripheral/phone_text.py`, and `src/heart/peripheral/radio.py` to use the new helper for `scipy.optimize`, `bluezero.*`, and `serial` respectively. 
- Simplify import error handling and preserve existing behaviour when dependencies are absent. 

### Testing
- Ran `make format` to apply repository formatting rules and fixes, which completed successfully. 
- Ran the test suite with `make test`, resulting in `202 passed, 1 skipped`. 
- No new tests were added for the helper since changes are behaviour-preserving for absent dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d50ebab448321ab74e4a58c4e46c9)