### PR TITLE
Improve optional import attribute handling

### DIFF
--- a/docs/research/optional_imports.md
+++ b/docs/research/optional_imports.md
@@ -1,0 +1,26 @@
+# Optional import handling
+
+## Problem
+
+Optional dependency imports are handled in multiple ways across the codebase. Some
+call sites import a module and then fetch an attribute without a consistent log
+path when the attribute is missing. This makes it harder to understand why a
+feature is unavailable.
+
+## Approach
+
+Add a helper that returns a requested attribute from an optional dependency and
+logs when either the module or the attribute is unavailable. Use it where we
+fetch specific attributes from optional modules.
+
+## Impacted areas
+
+- `src/heart/utilities/optional_imports.py` (`optional_import_attribute`)
+- `src/heart/peripheral/ir_sensor_array.py` (least-squares lookup)
+- `src/heart/firmware_io/bluetooth.py` (BLE class lookups)
+
+## Materials
+
+- `src/heart/utilities/optional_imports.py`
+- `src/heart/peripheral/ir_sensor_array.py`
+- `src/heart/firmware_io/bluetooth.py`

--- a/src/heart/firmware_io/bluetooth.py
+++ b/src/heart/firmware_io/bluetooth.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from heart.utilities.logging import get_logger
-from heart.utilities.optional_imports import optional_import
+from heart.utilities.optional_imports import optional_import_attribute
 
 logger = get_logger(__name__)
 
@@ -11,20 +11,17 @@ BLERadio: type[Any] | None = None
 ProvideServicesAdvertisement: type[Any] | None = None
 UARTService: type[Any] | None = None
 
-ble_module = optional_import("adafruit_ble", logger=logger)
-advertising_module = optional_import(
+BLERadio = optional_import_attribute("adafruit_ble", "BLERadio", logger=logger)
+ProvideServicesAdvertisement = optional_import_attribute(
     "adafruit_ble.advertising.standard",
+    "ProvideServicesAdvertisement",
     logger=logger,
 )
-services_module = optional_import(
+UARTService = optional_import_attribute(
     "adafruit_ble.services.nordic",
+    "UARTService",
     logger=logger,
 )
-
-if ble_module is not None and advertising_module is not None and services_module is not None:
-    BLERadio = getattr(ble_module, "BLERadio", None)
-    ProvideServicesAdvertisement = getattr(advertising_module, "ProvideServicesAdvertisement", None)
-    UARTService = getattr(services_module, "UARTService", None)
 
 
 if BLERadio is not None and UARTService is not None and ProvideServicesAdvertisement is not None:

--- a/src/heart/peripheral/ir_sensor_array.py
+++ b/src/heart/peripheral/ir_sensor_array.py
@@ -8,29 +8,30 @@ import threading
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from types import ModuleType
 from typing import Any, Callable, Iterator, Mapping, Sequence, cast
 
 import numpy as np
 
 from heart.peripheral.core import Input, Peripheral
 from heart.utilities.logging import get_logger
-from heart.utilities.optional_imports import optional_import
+from heart.utilities.optional_imports import optional_import_attribute
 
 LeastSquaresCallable = Callable[..., Any]
 
 logger = get_logger(__name__)
 
-_optimize_module = cast(
-    ModuleType | None,
-    optional_import("scipy.optimize", logger=logger),
+_least_squares = cast(
+    LeastSquaresCallable | None,
+    optional_import_attribute("scipy.optimize", "least_squares", logger=logger),
 )
 
-if _optimize_module is not None:
-    least_squares = cast(LeastSquaresCallable, getattr(_optimize_module, "least_squares"))
-else:
+if _least_squares is None:
+
     def least_squares(*args: Any, **kwargs: Any) -> Any:
         raise RuntimeError("scipy.optimize.least_squares is not available")
+
+else:
+    least_squares = _least_squares
 
 SPEED_OF_LIGHT = 299_792_458.0  # metres per second
 

--- a/src/heart/utilities/optional_imports.py
+++ b/src/heart/utilities/optional_imports.py
@@ -36,3 +36,24 @@ def optional_import(
             "Optional dependency %s failed to import: %s", module_name, exc
         )
         return None
+
+
+def optional_import_attribute(
+    module_name: str,
+    attribute: str,
+    *,
+    logger: Logger | None = None,
+) -> Any | None:
+    """Return ``attribute`` from ``module_name`` if available, otherwise ``None``."""
+
+    resolved_logger = logger or get_logger(__name__)
+    module = optional_import(module_name, logger=resolved_logger)
+    if module is None:
+        return None
+    try:
+        return getattr(module, attribute)
+    except AttributeError:
+        resolved_logger.warning(
+            "Optional dependency %s is missing attribute %s.", module_name, attribute
+        )
+        return None


### PR DESCRIPTION
### Motivation
- Existing call sites imported optional modules and then accessed attributes in an ad-hoc way, producing inconsistent logging and error paths.
- Fetching attributes from optional dependencies should provide clear logs when either the module or attribute is missing to make failures easier to diagnose.
- Reduce repeated boilerplate around `getattr` and module availability checks across the codebase.

### Description
- Add `optional_import_attribute` in `src/heart/utilities/optional_imports.py` to fetch a named attribute from an optional module with consistent logging.
- Use the new helper in `src/heart/peripheral/ir_sensor_array.py` to obtain `scipy.optimize.least_squares` and provide a clear runtime error when unavailable.
- Use the new helper in `src/heart/firmware_io/bluetooth.py` to obtain BLE classes (`BLERadio`, `ProvideServicesAdvertisement`, `UARTService`) directly.
- Add a short research note at `docs/research/optional_imports.md` documenting the approach.

### Testing
- Ran `make format` and formatting checks passed successfully.
- Ran the test suite with `make test` and the run completed with automated results of `202 passed, 1 skipped`.
- All unit tests that exercise the modified code paths passed in the CI-local run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d510d54c48321901cf1f747f75f69)