### PR TITLE
Add configurable Beats websocket streaming

### DIFF
--- a/docs/research/beats_streaming_io_tuning.md
+++ b/docs/research/beats_streaming_io_tuning.md
@@ -1,0 +1,45 @@
+# Beats streaming IO tuning
+
+## Problem statement
+
+Beats websocket streaming can accumulate outbound frames when clients are slow
+or temporarily disconnected. Without bounded queues and overflow control, the
+server risks memory growth and added latency for downstream consumers.
+
+## Observations
+
+- `heart.device.beats.websocket.WebSocket` streams frames from the peripheral
+  event bus to websocket clients.
+- The websocket send loop previously enqueued frames without bounds and waited
+  for enqueue completion, which could stall upstream producers.
+- Per-client send operations ran sequentially, increasing backpressure when one
+  client is slow.
+
+## Configuration additions
+
+The streaming settings are now configurable through environment variables,
+exposed via `heart.utilities.env.streaming.StreamingConfiguration` and the
+aggregate `heart.utilities.env.Configuration`.
+
+- `HEART_BEATS_STREAM_QUEUE_SIZE`: Maximum number of frames buffered in the
+  websocket queue. Use `0` for an unbounded queue.
+- `HEART_BEATS_STREAM_OVERFLOW`: Overflow policy when the queue is full.
+  Supported values are `drop_newest` and `drop_oldest`.
+- `HEART_BEATS_STREAM_JSON_SORT_KEYS`: Toggle JSON key sorting for outbound
+  frames.
+- `HEART_BEATS_STREAM_JSON_INDENT`: Optional JSON indentation. Set to `none` or
+  `null` to disable indentation.
+
+## Behaviour changes
+
+- Frame enqueues are now scheduled without blocking the calling thread.
+- Queue overflow handling either drops new frames or drops the oldest buffered
+  frame before enqueueing the latest one.
+- Frame broadcasts fan out with concurrent sends to reduce IO backpressure
+  created by slow websocket clients.
+
+## Materials
+
+- `src/heart/device/beats/websocket.py`
+- `src/heart/utilities/env/streaming.py`
+- `src/heart/utilities/env/enums.py`

--- a/src/heart/device/beats/websocket.py
+++ b/src/heart/device/beats/websocket.py
@@ -11,6 +11,8 @@ from uuid import UUID
 import websockets
 from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 
+from heart.utilities.env import Configuration
+from heart.utilities.env.enums import BeatsStreamOverflowStrategy
 from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
@@ -49,6 +51,12 @@ class WebSocket:
     _thread: threading.Thread | None = field(default=None, init=False)
     _loop: asyncio.AbstractEventLoop | None = field(default=None, init=False)
     _broadcast_queue: asyncio.Queue[bytes] | None = field(default=None, init=False)
+    _queue_maxsize: int = field(default=0, init=False)
+    _overflow_strategy: BeatsStreamOverflowStrategy = field(
+        default=BeatsStreamOverflowStrategy.DROP_NEWEST, init=False
+    )
+    _json_sort_keys: bool = field(default=True, init=False)
+    _json_indent: int | None = field(default=0, init=False)
 
     def __new__(cls, *args: Any, **kwargs: Any) -> "WebSocket":
         if cls._instance is None:
@@ -61,6 +69,10 @@ class WebSocket:
         if getattr(self, "_initialized", False):
             return
         self._initialized = True
+        self._queue_maxsize = Configuration.beats_stream_queue_size()
+        self._overflow_strategy = Configuration.beats_stream_overflow_strategy()
+        self._json_sort_keys = Configuration.beats_stream_json_sort_keys()
+        self._json_indent = Configuration.beats_stream_json_indent()
 
         self._thread = threading.Thread(
             target=self._ws_thread_main,
@@ -68,10 +80,27 @@ class WebSocket:
         )
         self._thread.start()
 
+    def _enqueue_frame(self, frame: bytes) -> None:
+        if self._broadcast_queue is None:
+            return
+        if self._queue_maxsize > 0 and self._broadcast_queue.full():
+            if self._overflow_strategy is BeatsStreamOverflowStrategy.DROP_NEWEST:
+                logger.debug("Dropping websocket frame due to full queue")
+                return
+            if self._overflow_strategy is BeatsStreamOverflowStrategy.DROP_OLDEST:
+                try:
+                    self._broadcast_queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+        try:
+            self._broadcast_queue.put_nowait(frame)
+        except asyncio.QueueFull:
+            logger.debug("Dropping websocket frame due to full queue")
+
     def _ws_thread_main(self) -> None:
         self._loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self._loop)
-        self._broadcast_queue = asyncio.Queue()
+        self._broadcast_queue = asyncio.Queue(maxsize=self._queue_maxsize)
         loop = self._loop
         broadcast_queue = self._broadcast_queue
         assert loop is not None
@@ -84,17 +113,23 @@ class WebSocket:
             finally:
                 self.clients.discard(ws)
 
+        async def send_frame(ws: Any, frame: bytes) -> None:
+            try:
+                await ws.send(frame)
+            except (ConnectionClosedOK, ConnectionClosedError):
+                self.clients.discard(ws)
+            except Exception as error:
+                logger.warning("Error sending frame to client: %s", error)
+                self.clients.discard(ws)
+
         async def broadcast_worker() -> None:
             while True:
                 frame = await broadcast_queue.get()
-                for ws in list(self.clients):
-                    try:
-                        await ws.send(frame)
-                    except (ConnectionClosedOK, ConnectionClosedError):
-                        self.clients.discard(ws)
-                    except Exception as error:
-                        logger.warning("Error sending frame to client: %s", error)
-                        self.clients.discard(ws)
+                if not self.clients:
+                    continue
+                await asyncio.gather(
+                    *(send_frame(ws, frame) for ws in list(self.clients))
+                )
 
         async def main() -> None:
             self._server = await websockets.serve(
@@ -111,15 +146,12 @@ class WebSocket:
     def send(self, kind: str, payload: object) -> None:
         if self._broadcast_queue and self._loop:
             data = {"type": kind, "payload": payload}
-            json_bytes = json.dumps(
-                data,
-                cls=UniversalJSONEncoder,
-                sort_keys=True,
-                indent=0,
-            ).encode()
+            dump_kwargs: dict[str, Any] = {
+                "cls": UniversalJSONEncoder,
+                "sort_keys": self._json_sort_keys,
+            }
+            if self._json_indent is not None:
+                dump_kwargs["indent"] = self._json_indent
+            json_bytes = json.dumps(data, **dump_kwargs).encode()
 
-            fut = asyncio.run_coroutine_threadsafe(
-                self._broadcast_queue.put(json_bytes),
-                self._loop,
-            )
-            fut.result()
+            self._loop.call_soon_threadsafe(self._enqueue_frame, json_bytes)

--- a/src/heart/utilities/env/__init__.py
+++ b/src/heart/utilities/env/__init__.py
@@ -2,6 +2,8 @@
 
 from heart.utilities.env.config import Configuration as Configuration
 from heart.utilities.env.enums import AssetCacheStrategy as AssetCacheStrategy
+from heart.utilities.env.enums import \
+    BeatsStreamOverflowStrategy as BeatsStreamOverflowStrategy
 from heart.utilities.env.enums import DeviceLayoutMode as DeviceLayoutMode
 from heart.utilities.env.enums import FrameArrayStrategy as FrameArrayStrategy
 from heart.utilities.env.enums import \

--- a/src/heart/utilities/env/config.py
+++ b/src/heart/utilities/env/config.py
@@ -3,6 +3,7 @@ from heart.utilities.env.color import ColorConfiguration
 from heart.utilities.env.device_layout import DeviceLayoutConfiguration
 from heart.utilities.env.reactivex import ReactivexConfiguration
 from heart.utilities.env.rendering import RenderingConfiguration
+from heart.utilities.env.streaming import StreamingConfiguration
 from heart.utilities.env.system import SystemConfiguration
 
 
@@ -13,5 +14,6 @@ class Configuration(
     RenderingConfiguration,
     ColorConfiguration,
     AssetsConfiguration,
+    StreamingConfiguration,
 ):
     """Aggregate environment configuration helpers."""

--- a/src/heart/utilities/env/enums.py
+++ b/src/heart/utilities/env/enums.py
@@ -72,3 +72,8 @@ class ReactivexStreamShareStrategy(StrEnum):
 class ReactivexStreamConnectMode(StrEnum):
     LAZY = "lazy"
     EAGER = "eager"
+
+
+class BeatsStreamOverflowStrategy(StrEnum):
+    DROP_NEWEST = "drop_newest"
+    DROP_OLDEST = "drop_oldest"

--- a/src/heart/utilities/env/streaming.py
+++ b/src/heart/utilities/env/streaming.py
@@ -1,0 +1,33 @@
+import os
+
+from heart.utilities.env.enums import BeatsStreamOverflowStrategy
+from heart.utilities.env.parsing import _env_flag, _env_int, _env_optional_int
+
+
+class StreamingConfiguration:
+    @classmethod
+    def beats_stream_queue_size(cls) -> int:
+        return _env_int("HEART_BEATS_STREAM_QUEUE_SIZE", default=0, minimum=0)
+
+    @classmethod
+    def beats_stream_overflow_strategy(cls) -> BeatsStreamOverflowStrategy:
+        strategy = os.environ.get(
+            "HEART_BEATS_STREAM_OVERFLOW", "drop_newest"
+        ).strip().lower()
+        try:
+            return BeatsStreamOverflowStrategy(strategy)
+        except ValueError as exc:
+            raise ValueError(
+                "HEART_BEATS_STREAM_OVERFLOW must be 'drop_newest' or 'drop_oldest'"
+            ) from exc
+
+    @classmethod
+    def beats_stream_json_sort_keys(cls) -> bool:
+        return _env_flag("HEART_BEATS_STREAM_JSON_SORT_KEYS", default=True)
+
+    @classmethod
+    def beats_stream_json_indent(cls) -> int | None:
+        raw = os.environ.get("HEART_BEATS_STREAM_JSON_INDENT")
+        if raw is not None and raw.strip().lower() in {"none", "null"}:
+            return None
+        return _env_optional_int("HEART_BEATS_STREAM_JSON_INDENT", minimum=0)


### PR DESCRIPTION
### Motivation

- Prevent unbounded memory growth and producer stalls caused by the Beats websocket enqueueing frames without bounds.
- Allow operators to tune buffering and overflow behaviour to match deployment requirements.
- Reduce IO backpressure from slow clients by sending concurrently to multiple websocket clients.
- Provide control over JSON formatting for downstream consumers and debugging.

### Description

- Add `StreamingConfiguration` (`src/heart/utilities/env/streaming.py`) and expose it via the aggregate `Configuration` to read `HEART_BEATS_*` environment variables.
- Introduce `BeatsStreamOverflowStrategy` in `src/heart/utilities/env/enums.py` and export it from the env package.
- Update `WebSocket` (`src/heart/device/beats/websocket.py`) to use a bounded `asyncio.Queue(maxsize=...)`, non-blocking enqueue via `_enqueue_frame` scheduled with `call_soon_threadsafe`, overflow policies (`drop_newest`/`drop_oldest`), and concurrent broadcast fan-out using `asyncio.gather`.
- Add documentation `docs/research/beats_streaming_io_tuning.md` describing the problem, new configuration settings, and behaviour changes.

### Testing

- Ran `make format` and formatting checks passed.
- Ran the full test suite with `make test` and observed `208 passed, 1 skipped`.
- Verified package imports and configuration aggregation by importing `Configuration` and the new streaming helpers during tests.
- No automated tests were added or modified for the new streaming behaviour in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d519e9c1483218d62cf2fd8c56a1b)