### PR TITLE
Move SensorReader.read docstrings to method level

### DIFF
--- a/drivers/sensor_bus/code.py
+++ b/drivers/sensor_bus/code.py
@@ -132,8 +132,8 @@ class SensorReader:
         self._last_mag: tuple | None = None
 
     def read(self):
+        """Yield JSON strings for each channel that crossed ``min_change``."""
         for sensor in self.sensors:
-            """Yield JSON strings for each channel that crossed ``min_change``."""
             if hasattr(sensor, "acceleration"):
                 accel = sensor.acceleration  # m/s²
                 if self._changed_enough(accel, self._last_accel, self.min_change):

--- a/src/heart/firmware_io/accel.py
+++ b/src/heart/firmware_io/accel.py
@@ -60,8 +60,8 @@ class SensorReader:
         self._last_gyro: tuple | None = None
 
     def read(self):
+        """Yield JSON strings for each channel that crossed ``min_change``."""
         for sensor in self.sensors:
-            """Yield JSON strings for each channel that crossed ``min_change``."""
             if hasattr(sensor, "acceleration"):
                 accel = sensor.acceleration  # m/s²
                 if self._changed_enough(accel, self._last_accel, self.min_change):


### PR DESCRIPTION
### Motivation

- Avoid unreachable docstrings that were placed inside the `SensorReader.read` function body and follow repository guidance to keep docstrings at the method level.
- Make the `read` method's documentation discoverable to tooling and clearer to readers and maintainers.
- Keep the change minimal and non-functional so behavior remains unchanged.

### Description

- Move the inline docstring that was inside the `for` loop into a proper method-level docstring for `SensorReader.read` in `drivers/sensor_bus/code.py`.
- Apply the same docstring relocation in `src/heart/firmware_io/accel.py`.
- No runtime logic changes were made; only the placement of the `read` docstring was adjusted.
- Run code formatting to ensure style consistency after the edits.

### Testing

- Ran `make format`, which completed successfully.
- No unit tests were added or modified for this change.
- No automated test failures were introduced by this non-functional edit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d5b49e9f88321956de31938fcf94b)