### PR TITLE
Use specific error types in runtime startup and shader validation

### DIFF
--- a/src/heart/display/shaders/util.py
+++ b/src/heart/display/shaders/util.py
@@ -123,7 +123,7 @@ def make_color(geo):
     elif geo.color == "orbit" or geo.color == "o":
         return "vec4(orbit, " + geo.glsl() + ")"
     else:
-        raise Exception("Invalid coloring type")
+        raise ValueError("Invalid coloring type")
 
 
 _UNIFORMS: dict[str, UniformValue] = {}

--- a/src/heart/runtime/game_loop.py
+++ b/src/heart/runtime/game_loop.py
@@ -89,7 +89,7 @@ class GameLoop:
             logger.info("Finished initializing GameLoop.")
 
         if self.app_controller.is_empty():
-            raise Exception("Unable to start as no GameModes were added.")
+            raise RuntimeError("Unable to start as no GameModes were added.")
 
         # Initialize all renderers
 


### PR DESCRIPTION
### Motivation

- Replace broad `Exception` raises with specific exception types to make error handling clearer and more actionable.
- Ensure runtime and shader validation failures produce the appropriate built-in exception semantics for callers and tooling.

### Description

- Raise `RuntimeError` in `src/heart/runtime/game_loop.py` when `GameLoop.start` is called with no registered game modes via `self.app_controller.is_empty()`.
- Raise `ValueError` in `src/heart/display/shaders/util.py` for invalid shader coloring types in `make_color`.
- Run repository formatting to keep code style consistent using `make format`.

### Testing

- Ran `make format` and the formatting checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d5b62fd608321a63c20968b7d01e3)