### PR TITLE
Harden coalescing timer rescheduling and extract GameLoop components

### DIFF
--- a/src/heart/runtime/game_loop_components.py
+++ b/src/heart/runtime/game_loop_components.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from heart.device import Device
+from heart.navigation import AppController
+from heart.peripheral.core.manager import PeripheralManager
+from heart.runtime.display_context import DisplayContext
+from heart.runtime.frame_presenter import FramePresenter
+from heart.runtime.pygame_event_handler import PygameEventHandler
+from heart.runtime.render_pipeline import RendererVariant, RenderPipeline
+
+
+@dataclass(frozen=True)
+class GameLoopComponents:
+    app_controller: AppController
+    display: DisplayContext
+    render_pipeline: RenderPipeline
+    frame_presenter: FramePresenter
+    event_handler: PygameEventHandler
+
+
+def build_game_loop_components(
+    device: Device,
+    peripheral_manager: PeripheralManager,
+    render_variant: RendererVariant,
+) -> GameLoopComponents:
+    display = DisplayContext(device=device)
+    render_pipeline = RenderPipeline(
+        device=device,
+        peripheral_manager=peripheral_manager,
+        render_variant=render_variant,
+    )
+    frame_presenter = FramePresenter(
+        device=device,
+        display=display,
+        render_pipeline=render_pipeline,
+    )
+    return GameLoopComponents(
+        app_controller=AppController(),
+        display=display,
+        render_pipeline=render_pipeline,
+        frame_presenter=frame_presenter,
+        event_handler=PygameEventHandler(),
+    )

--- a/src/heart/utilities/reactivex/coalescing.py
+++ b/src/heart/utilities/reactivex/coalescing.py
@@ -53,7 +53,16 @@ def coalesce_latest(
         def _schedule_flush(now: float) -> None:
             nonlocal timer, fallback_timer, due_time
             if timer is not None or fallback_timer is not None:
-                return
+                if due_time is not None and now >= due_time:
+                    if timer is not None:
+                        timer.dispose()
+                        timer = None
+                    if fallback_timer is not None:
+                        fallback_timer.cancel()
+                        fallback_timer = None
+                    due_time = None
+                else:
+                    return
             due_time = now + window_seconds
             timer = _COALESCE_SCHEDULER.schedule_relative(
                 window_seconds,


### PR DESCRIPTION
### Motivation

- Reduce initialization clutter in `GameLoop` by centralizing construction of related runtime components. 
- Fix flakiness in reactive coalescing where stale scheduler/fallback timers could block new windows. 
- Improve clarity and single-responsibility for building display, rendering and event-handling pieces. 

### Description

- Add `GameLoopComponents` dataclass and `build_game_loop_components` helper in `src/heart/runtime/game_loop_components.py` and refactor `GameLoop` to use it. 
- Harden coalescing logic in `src/heart/utilities/reactivex/coalescing.py` so overdue scheduler and fallback timers are cancelled and rescheduled when a window is already past due. 
- Replace the generic `Exception` raised when no modes are configured with a `RuntimeError` in `GameLoop.start`.

### Testing

- Ran `make format` and formatting checks passed. 
- Ran the full test suite via `make test` and observed `208 passed, 1 skipped`. 
- Verified that reactive coalescing flow-control tests that previously failed now pass under the updated scheduling logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d52920c988321bd38f2d1a8685422)