### PR TITLE
Centralize render plan metadata

### DIFF
--- a/docs/research/render-plan-centralization.md
+++ b/docs/research/render-plan-centralization.md
@@ -1,0 +1,16 @@
+# Render plan centralization note
+
+## Summary
+
+The render planning flow now carries a structured plan object that bundles the chosen renderer variant, merge strategy, and the timing data used for logging. The intent is to keep render selection and logging decisions aligned with a single snapshot of the rendering context.
+
+## Details
+
+- `RenderPlanner.plan` now captures the variant, merge strategy, and timing snapshots together so the logged metadata reflects the exact plan used for the frame.
+- `RenderPipeline.render` continues to select the render helper based on the plan, while the helper methods no longer update merge strategy independently.
+
+## Materials
+
+- Source files:
+  - `src/heart/runtime/render_planner.py`
+  - `src/heart/runtime/render_pipeline.py`


### PR DESCRIPTION
### Motivation
- Ensure render variant selection, merge-strategy decision, and the timing data used for logging are captured together so logged metadata reflects the exact plan used for a frame.
- Avoid helper methods updating merge strategy independently so composition behaviour is consistent with the planner's decision.
- Make the render flow easier to reason about by carrying a single plan object through selection and execution.

### Description
- Add a `RenderPlan` dataclass with `variant`, `merge_strategy`, `estimated_cost_ms`, `has_samples`, `timing_snapshots`, and `timing_missing` and populate it in `RenderPlanner.plan`.
- Change planner logging to accept a `RenderPlan` and emit timing/merge metadata from the plan instead of recomputing snapshots inline.
- Introduce `_active_plan` and `_ensure_plan` in `RenderPipeline` so render helpers use the active plan for merge strategy decisions and the plan lifecycle is scoped to `render`.
- Add a short research note at `docs/research/render-plan-centralization.md` and update `src/heart/runtime/render_planner.py` and `src/heart/runtime/render_pipeline.py` accordingly.

### Testing
- Ran `make format` and formatting checks completed successfully.
- Ran the full test suite with `make test` and the automated tests completed with `208 passed, 1 skipped`.
- Fixes were iterated until composition and unit tests for render planning and merging passed.
- No additional automated test failures were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d5b1289808321ba1c760834213dbd)