### PR TITLE
Make Semgrep targets configurable and document override usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ DOCS_SOURCES = docs
 TOOL_LIST_FILE = scripts/harness_tools.txt
 TOOLS := $(shell scripts/list_harness_tools.sh $(TOOL_LIST_FILE))
 BUILD_ARGS ?=
+SEMGREP_CONFIG ?= semgrep.yml
+SEMGREP_TARGETS ?= src
+SEMGREP_ARGS ?= --config $(SEMGREP_CONFIG) --error
 .PHONY: install pi_install format check semgrep test build check-harness build-info doctor focus focus-watch dev-session
 
 install:
@@ -26,10 +29,10 @@ check:
 	@uvx docformatter --check -r --config ./pyproject.toml $(DOCS_SOURCES)
 	@uvx mdformat --check $(DOCS_SOURCES)
 	@uv run mypy --config-file pyproject.toml
-	@uv run semgrep --config semgrep.yml --error
+	@uv run semgrep $(SEMGREP_ARGS) $(SEMGREP_TARGETS)
 
 semgrep:
-	@uv run semgrep --config semgrep.yml --error
+	@uv run semgrep $(SEMGREP_ARGS) $(SEMGREP_TARGETS)
 
 test:
 	@uv run pytest

--- a/docs/static_analysis.md
+++ b/docs/static_analysis.md
@@ -19,8 +19,10 @@ current rules focus on Python files under `src/` and align with the guidance in
   - `make semgrep`
 - Run with the rest of the linting checks:
   - `make check`
+- Override the default target set (for example, to scan `tests/` too):
+  - `make semgrep SEMGREP_TARGETS="src tests"`
 
-Both targets run `uv run semgrep --config semgrep.yml --error`.
+Both targets run `uv run semgrep --config semgrep.yml --error src` by default.
 
 ## Rule catalog
 
@@ -36,3 +38,9 @@ Both targets run `uv run semgrep --config semgrep.yml --error`.
 1. Edit `semgrep.yml` to add or refine rules.
 1. Keep rule messages aligned with the guidance in `/workspace/heart/AGENTS.md`.
 1. Validate new rules with `make semgrep` before committing changes.
+
+## Materials
+
+- `semgrep.yml`
+- `make semgrep`
+- `make check`


### PR DESCRIPTION
### Motivation

- Limit Semgrep scan scope by default to speed up checks and make runs predictable.
- Allow callers to override Semgrep configuration and target set for ad-hoc scans or CI tuning.
- Keep repository documentation aligned with the Makefile behaviour and usage patterns.
- Provide a quick materials list so contributors can find Semgrep-related artifacts easily.

### Description

- Add `SEMGREP_CONFIG`, `SEMGREP_TARGETS`, and `SEMGREP_ARGS` variables to the `Makefile` and default `SEMGREP_TARGETS` to `src`.
- Change the `check` and `semgrep` Makefile recipes to run `uv run semgrep $(SEMGREP_ARGS) $(SEMGREP_TARGETS)` so targets and args can be overridden.
- Update `docs/static_analysis.md` to document the default Semgrep target, show an override example like `make semgrep SEMGREP_TARGETS="src tests"`, and add a small "Materials" list.

### Testing

- Ran `make format` and formatting/linting checks completed successfully.
- Ran `make test` and the test suite completed successfully with `208 passed, 1 skipped`.
- No automated Semgrep run was executed as part of this change, but `make semgrep` now supports `SEMGREP_TARGETS` overrides.
- The `Makefile` target changes are limited to command argument composition and do not alter other build/test flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d5c95fb848321837da51d968dc7d5)