### PR TITLE
Fix semgrep __all__ rule matching

### DIFF
--- a/semgrep.yml
+++ b/semgrep.yml
@@ -33,8 +33,9 @@ rules:
     message: Avoid module-level __all__ exports; prefer explicit imports at call sites.
     severity: ERROR
     patterns:
-      - pattern: __all__ = [...]
-      - pattern: __all__ = (...)
+      - pattern-either:
+          - pattern: __all__ = [...]
+          - pattern: __all__ = (...)
     paths:
       include:
         - src/**/*.py


### PR DESCRIPTION
### Motivation
- Semgrep rule `heart-no-module-all` was written with multiple `pattern` entries which Semgrep combines with logical AND, so a single `__all__` assignment (list or tuple) would not be matched. 
- The intent is to ban module-level `__all__` exports across `src/**/*.py` regardless of whether the assignment uses a list or tuple. 

### Description
- Update `semgrep.yml` to replace the two separate `pattern` entries with a single `pattern-either` that contains `pattern: __all__ = [...]` and `pattern: __all__ = (...)`. 
- This ensures the rule matches either list- or tuple-style `__all__` assignments in `src/**/*.py` instead of requiring both forms in the same match region. 

### Testing
- Ran `make format` to exercise formatting and static checks. 
- `make format` failed due to mypy errors from missing protobuf stubs and generated-symbol issues in `src/heart/device/beats/proto/beats_streaming_pb2.py`. 
- No Semgrep rule regressions were observed locally for the updated pattern, and only the one configuration file (`semgrep.yml`) was modified. 
- Remaining CI/static issues are unrelated to this Semgrep rule change and stem from generated protobuf typing/stub setup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d636bf6f0832187d8ac70c61b161f)