### PR TITLE
Schedule microphone events off audio callback

### DIFF
--- a/docs/research/microphone_event_threading.md
+++ b/docs/research/microphone_event_threading.md
@@ -1,0 +1,22 @@
+# Microphone event dispatch threading
+
+## Summary
+
+The microphone peripheral was dispatching `Subject.on_next` directly from the
+sounddevice audio callback. Because reactive subscriptions are synchronous by
+default, downstream I/O (notably WebSocket sends in the runtime) could run on the
+callback thread and stall audio capture. The microphone event stream now
+schedules notifications onto the shared input scheduler so the callback remains
+non-blocking.
+
+## Impacted code
+
+- `src/heart/peripheral/microphone.py` (`Microphone._event_stream`)
+- `src/heart/runtime/peripheral_runtime.py` (subscription that may perform I/O)
+- `src/heart/peripheral/core/manager.py` (event bus scheduling behavior)
+
+## Materials
+
+- Source inspection of `src/heart/peripheral/microphone.py`
+- Source inspection of `src/heart/runtime/peripheral_runtime.py`
+- Source inspection of `src/heart/peripheral/core/manager.py`

--- a/src/heart/peripheral/microphone.py
+++ b/src/heart/peripheral/microphone.py
@@ -11,12 +11,15 @@ from types import TracebackType
 from typing import Any, Self, cast
 
 import numpy as np
+import reactivex
+from reactivex import operators as ops
 from reactivex.subject import Subject
 
 from heart.peripheral.core import Peripheral
 from heart.peripheral.input_payloads.audio import MicrophoneLevel
 from heart.utilities.logging import get_logger
 from heart.utilities.optional_imports import optional_import
+from heart.utilities.reactivex_threads import input_scheduler
 
 logger = get_logger(__name__)
 
@@ -81,8 +84,8 @@ class Microphone(Peripheral[MicrophoneLevel]):
 
         return self._latest_level
 
-    def _event_stream(self) -> Subject[MicrophoneLevel]:
-        return self._level_subject
+    def _event_stream(self) -> reactivex.Observable[MicrophoneLevel]:
+        return self._level_subject.pipe(ops.observe_on(input_scheduler()))
 
     def stop(self) -> None:
         """Signal the run-loop to stop on the next iteration."""


### PR DESCRIPTION
### Motivation

- Prevent synchronous subscriber I/O from executing on the sounddevice audio callback thread and stalling audio capture.
- Downstream subscribers (e.g., the runtime WebSocket send in `PeripheralRuntime.configure_streaming`) can perform blocking I/O, which may cause buffer underruns when invoked inline from `Subject.on_next`.

### Description

- Schedule microphone notifications off the audio callback by piping the microphone subject through `ops.observe_on(input_scheduler())` in `Microphone._event_stream`.
- Adjust imports and the observable return type in `src/heart/peripheral/microphone.py` to use `reactivex`, `ops`, and `input_scheduler`.
- Add a research note `docs/research/microphone_event_threading.md` documenting the threading rationale and impacted modules.

### Testing

- Ran `make format` and formatting/lint checks completed successfully.
- Ran `make test` and the test suite completed with `212 passed, 1 skipped`.
- Verified that the modified `Microphone._event_stream` returns a scheduled `reactivex.Observable[MicrophoneLevel]` and that no tests regressed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d633d166c8321a1d313b8d2717ebe)