### PR TITLE
Improve semgrep defaults and usage docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ TOOLS := $(shell scripts/list_harness_tools.sh $(TOOL_LIST_FILE))
 BUILD_ARGS ?=
 SEMGREP_CONFIG ?= semgrep.yml
 SEMGREP_TARGETS ?= src
-SEMGREP_ARGS ?= --config $(SEMGREP_CONFIG) --error
+SEMGREP_ARGS ?= --config $(SEMGREP_CONFIG) --error --metrics=off --disable-version-check
+SEMGREP_EXTRA_ARGS ?=
 .PHONY: install pi_install format check semgrep test build check-harness build-info doctor focus focus-watch dev-session
 
 install:
@@ -29,10 +30,10 @@ check:
 	@uvx docformatter --check -r --config ./pyproject.toml $(DOCS_SOURCES)
 	@uvx mdformat --check $(DOCS_SOURCES)
 	@uv run mypy --config-file pyproject.toml
-	@uv run semgrep $(SEMGREP_ARGS) $(SEMGREP_TARGETS)
+	@uv run semgrep $(SEMGREP_ARGS) $(SEMGREP_EXTRA_ARGS) $(SEMGREP_TARGETS)
 
 semgrep:
-	@uv run semgrep $(SEMGREP_ARGS) $(SEMGREP_TARGETS)
+	@uv run semgrep $(SEMGREP_ARGS) $(SEMGREP_EXTRA_ARGS) $(SEMGREP_TARGETS)
 
 test:
 	@uv run pytest

--- a/docs/static_analysis.md
+++ b/docs/static_analysis.md
@@ -11,7 +11,8 @@ patterns such as `print`-based diagnostics, wildcard imports, module-level
 
 Heart uses Semgrep with a repo-local configuration file at `semgrep.yml`. The
 current rules focus on Python files under `src/` and align with the guidance in
-`AGENTS.md`.
+`AGENTS.md`. Semgrep runs with metrics reporting disabled and version checks
+turned off to keep CI and offline runs consistent.
 
 ## Usage
 
@@ -21,8 +22,12 @@ current rules focus on Python files under `src/` and align with the guidance in
   - `make check`
 - Override the default target set (for example, to scan `tests/` too):
   - `make semgrep SEMGREP_TARGETS="src tests"`
+- Pass additional Semgrep options without overriding the defaults:
+  - `make semgrep SEMGREP_EXTRA_ARGS="--exclude tests"`
 
-Both targets run `uv run semgrep --config semgrep.yml --error src` by default.
+Both targets run
+`uv run semgrep --config semgrep.yml --error --metrics=off --disable-version-check src`
+by default.
 
 ## Rule catalog
 


### PR DESCRIPTION
### Motivation
- Semgrep's default runtime can surface noisy metrics and trigger version checks that make CI and offline runs less deterministic.
- Contributors need a safe way to pass additional Semgrep CLI options without overriding the Makefile defaults.
- Documentation should accurately describe how Semgrep is invoked in the repository so maintainers know the defaults and how to override them.

### Description
- Change `Makefile` to set `SEMGREP_ARGS` default to include `--metrics=off` and `--disable-version-check` to stabilize CI and offline runs.  
- Add `SEMGREP_EXTRA_ARGS` to `Makefile` and forward it into the `semgrep` and `check` targets so callers can pass extra options like `--exclude`.  
- Update `docs/static_analysis.md` to document the new defaults and show usage examples including `SEMGREP_EXTRA_ARGS`.  

### Testing
- Ran `make format` (which invokes formatters and `mypy`) and it failed due to `mypy` errors in generated protobuf modules under `src/heart/device/beats/proto/`.
- No repository Semgrep runs were modified beyond wiring the new defaults and `SEMGREP_EXTRA_ARGS` support, so `make semgrep` can be used to validate rules with the new flags.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d620347cc8321b9c011d89c14d9b1)