### PR TITLE
Add guidance for tunable loop intervals and use constant in Phyphox driver

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - Prefer mixins or composition over direct inheritance.
 - Prefer `StrEnum` values over raw strings for strategy/configuration mode selections.
 - Use `heart.utilities.logging.get_logger` for internal logging so handlers and log levels stay consistent across modules.
+- Prefer module-level constants for tunable loop intervals instead of embedding sleep literals in long-running loops.
 
 ## Error Handling
 

--- a/src/heart/peripheral/phyphox.py
+++ b/src/heart/peripheral/phyphox.py
@@ -8,6 +8,7 @@ from heart.peripheral.sensor import Acceleration
 from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
+REQUEST_SLEEP_SECONDS = 0.05
 
 
 class Phyphox(Peripheral[Acceleration]):
@@ -32,7 +33,7 @@ class Phyphox(Peripheral[Acceleration]):
                 self.acc_z = float(data["buffer"]["accZ"]["buffer"][-1])
             except Exception as exc:
                 logger.debug("Phyphox request failed: %s", exc)
-            time.sleep(0.05)
+            time.sleep(REQUEST_SLEEP_SECONDS)
 
     def get_acceleration(self) -> Acceleration | None:
         if self.acc_x is None or self.acc_y is None or self.acc_z is None:


### PR DESCRIPTION
### Motivation

- Reduce magic literals in long-running loops by recommending module-level constants for tunable sleep intervals.  
- Make the Phyphox polling loop's interval configurable and clearly named for maintainability and easier tuning.  

### Description

- Added guidance to `AGENTS.md`: "Prefer module-level constants for tunable loop intervals...".  
- Introduced `REQUEST_SLEEP_SECONDS` in `src/heart/peripheral/phyphox.py` and replaced the inline `time.sleep(0.05)` call with `time.sleep(REQUEST_SLEEP_SECONDS)`.  

### Testing

- Ran `make format`, which completed successfully.  
- Ran `make test`, which completed successfully with `212 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d83914f848321bbf89dee5b167f5e)