### PR TITLE
Route IR sensor array simulation output through shared logger

### DIFF
--- a/tests/simulation/ir_sensor_array_simulation.py
+++ b/tests/simulation/ir_sensor_array_simulation.py
@@ -20,6 +20,9 @@ from typing import Iterable, Sequence
 import numpy as np
 
 from heart.peripheral.ir_sensor_array import radial_layout
+from heart.utilities.logging import get_logger
+
+LOGGER = get_logger(__name__)
 
 
 @dataclass(slots=True)
@@ -173,11 +176,11 @@ def main() -> None:
         f"{'Line point':<36} | {'Line dir.':<36} | Error (deg)"
     )
     divider = "-" * len(header)
-    print(header)
-    print(divider)
+    LOGGER.info(header)
+    LOGGER.info(divider)
     for result in results:
         error = f"{result.angular_error_deg:10.4f}" if result.angular_error_deg is not None else "    --    "
-        print(
+        LOGGER.info(
             f"{result.scenario.name:<12} | "
             f"{list(result.active_indices)!s:<12} | "
             f"{_format_vector(result.view_direction):<36} | "


### PR DESCRIPTION
### Motivation
- Align the simulation demo with repository diagnostics guidance by avoiding `print` for runtime output.
- Ensure logging is consistent across modules by using the shared `heart.utilities.logging.get_logger` facility.
- Preserve the existing formatted summary table while making output integrate with the project logger.

### Description
- Add `from heart.utilities.logging import get_logger` and create a module-level `LOGGER = get_logger(__name__)`.
- Replace `print` calls in `main()` with `LOGGER.info()` for the header, divider, and per-result lines while keeping the formatting intact.
- Leave the demo hook (`if __name__ == "__main__"`) unchanged so the script remains runnable as a manual simulation.

### Testing
- Ran `make format` and it completed successfully with all formatting checks passing. 
- No pytest suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d849db0e083219c67104a2e08ffbd)