### PR TITLE
Promote polling delays to constants

### DIFF
--- a/src/heart/manage/driver_update/mounts.py
+++ b/src/heart/manage/driver_update/mounts.py
@@ -11,6 +11,7 @@ from heart.manage.driver_update.filesystem import (DRIVER_FILES, copy_file,
 from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
+UF2_INSTALL_DELAY_SECONDS = 10
 
 
 def mount_points(media_directory: Path) -> list[Path]:
@@ -33,7 +34,7 @@ def install_uf2_if_available(
     if uf2_destination.is_dir():
         downloaded_file_path = download_file(config.uf2_url, config.uf2_checksum)
         copy_file(downloaded_file_path, uf2_destination)
-        time.sleep(10)
+        time.sleep(UF2_INSTALL_DELAY_SECONDS)
     else:
         logger.info(
             "Skipping CircuitPython UF2 installation as no device is in boot mode currently"

--- a/src/heart/peripheral/bluetooth.py
+++ b/src/heart/peripheral/bluetooth.py
@@ -21,6 +21,7 @@ NOTIFICATION_CHANNEL = "6e400003-b5a3-f393-e0a9-e50e24dcca9e"
 
 SINGLE_CLIENT_TIMEOUT_SECONDS = 60 * 60 * 12  # 12 hours
 OBJECT_SEPARATOR = b"\n"
+RECONNECT_DELAY_SECONDS = 1.0
 
 
 class UartListener:
@@ -108,10 +109,9 @@ class UartListener:
                 await client.start_notify(
                     NOTIFICATION_CHANNEL, callback=self.__callback
                 )
-
                 await asyncio.sleep(SINGLE_CLIENT_TIMEOUT_SECONDS)
             # On failure, wait a bit before retrying
-            time.sleep(1.0)
+            time.sleep(RECONNECT_DELAY_SECONDS)
 
     @functools.cache
     def __get_client(self, device: BLEDevice) -> BleakClient:

--- a/src/heart/peripheral/gamepad/gamepad.py
+++ b/src/heart/peripheral/gamepad/gamepad.py
@@ -16,6 +16,7 @@ from heart.utilities.logging import get_logger
 from heart.utilities.reactivex_threads import input_scheduler
 
 logger = get_logger(__name__)
+INITIALIZATION_DELAY_SECONDS = 1.5
 
 
 class GamepadIdentifier(Enum):
@@ -229,7 +230,7 @@ class Gamepad(Peripheral[Any]):
     def run(self) -> None:
         # Give pygame and USB subsystems time to fully initialize
         # TODO: Is this needed?
-        time.sleep(1.5)
+        time.sleep(INITIALIZATION_DELAY_SECONDS)
 
         # check every 1 second for controller state, so that we can attempt to connect
         scheduler = input_scheduler()

--- a/src/heart/peripheral/sensor.py
+++ b/src/heart/peripheral/sensor.py
@@ -17,6 +17,7 @@ from heart.utilities.logging import get_logger
 from heart.utilities.logging_control import get_logging_controller
 
 logger = get_logger(__name__)
+RECONNECT_DELAY_SECONDS = 1.0
 
 
 @dataclass
@@ -71,7 +72,7 @@ class Accelerometer(Peripheral[Acceleration | None]):
                 raise
             except Exception:
                 logger.exception("Accelerometer stream failed; reconnecting")
-                time.sleep(1.0)
+                time.sleep(RECONNECT_DELAY_SECONDS)
 
     def _process_data(self, data: bytes) -> None:
         bus_data = data.decode("utf-8").rstrip()

--- a/src/heart/peripheral/switch.py
+++ b/src/heart/peripheral/switch.py
@@ -25,6 +25,10 @@ from heart.utilities.logging import get_logger
 from heart.utilities.reactivex_threads import input_scheduler
 
 logger = get_logger(__name__)
+SERIAL_RECONNECT_DELAY_SECONDS = 0.1
+BLUETOOTH_EVENT_POLL_DELAY_SECONDS = 0.1
+BLUETOOTH_RETRY_DELAY_SECONDS = 5
+BLUETOOTH_SLOW_RETRY_DELAY_SECONDS = 30
 
 
 @dataclass(frozen=True, slots=True)
@@ -204,7 +208,7 @@ class Switch(BaseSwitch):
             except Exception:
                 pass
 
-            time.sleep(0.1)
+            time.sleep(SERIAL_RECONNECT_DELAY_SECONDS)
         return Disposable()
 
     def run(self) -> None:
@@ -297,7 +301,7 @@ class BluetoothSwitch(BaseSwitch):
                     while True:
                         for event in self.listener.consume_events():
                             self.update_due_to_data(event)
-                        time.sleep(0.1)
+                        time.sleep(BLUETOOTH_EVENT_POLL_DELAY_SECONDS)
                 except KeyboardInterrupt:
                     logger.info("Program terminated")
                 except Exception:
@@ -312,4 +316,8 @@ class BluetoothSwitch(BaseSwitch):
                 if number_of_retries_without_success > 5:
                     slow_poll = True
 
-            time.sleep(30 if slow_poll else 5)
+            time.sleep(
+                BLUETOOTH_SLOW_RETRY_DELAY_SECONDS
+                if slow_poll
+                else BLUETOOTH_RETRY_DELAY_SECONDS
+            )

--- a/src/heart/renderers/yolisten/renderer.py
+++ b/src/heart/renderers/yolisten/renderer.py
@@ -15,6 +15,8 @@ from heart.renderers.yolisten.state import YoListenState
 from heart.utilities.logging import get_logger
 
 PHYPOX_URL = "http://192.168.1.50/get?accY&accX&accZ&dB"
+PHYPOX_POLL_INTERVAL_SECONDS = 0.05
+PHYPOX_LOG_POLL_INTERVAL_SECONDS = 0.1
 logger = get_logger(__name__)
 
 
@@ -127,7 +129,7 @@ class YoListenRenderer(StatefulBaseRenderer[YoListenState]):
                 self.phyphox_db = data["buffer"]["dB"]["buffer"][-1]
             except Exception:
                 logger.exception("Failed to poll phyphox data")
-            time.sleep(0.05)
+            time.sleep(PHYPOX_POLL_INTERVAL_SECONDS)
 
     def real_process(
         self,
@@ -261,4 +263,4 @@ def poll_phyphox():
             logger.info("Phyphox acceleration x=%s, y=%s, z=%s", x, y, z)
         except Exception:
             logger.exception("Error")
-        time.sleep(0.1)
+        time.sleep(PHYPOX_LOG_POLL_INTERVAL_SECONDS)


### PR DESCRIPTION
### Motivation

- Conform to repository guidance to prefer module-level constants for tunable loop intervals instead of embedding literal `sleep` values. 
- Make retry/poll timing easier to tune and audit across peripherals, drivers, and renderers. 
- Reduce magic numbers in long-running loops to improve maintainability and clarity. 

### Description

- Replaced inline `time.sleep(...)` literals with module-level constants in `src/heart/peripheral/switch.py`, `src/heart/peripheral/sensor.py`, `src/heart/peripheral/bluetooth.py`, `src/heart/peripheral/gamepad/gamepad.py`, and `src/heart/manage/driver_update/mounts.py` and added descriptive constant names. 
- Added `PHYPOX_POLL_INTERVAL_SECONDS` and `PHYPOX_LOG_POLL_INTERVAL_SECONDS` to `src/heart/renderers/yolisten/renderer.py` and used them in the Phyphox polling loops. 
- Introduced `SERIAL_RECONNECT_DELAY_SECONDS`, `BLUETOOTH_EVENT_POLL_DELAY_SECONDS`, `BLUETOOTH_RETRY_DELAY_SECONDS`, and `BLUETOOTH_SLOW_RETRY_DELAY_SECONDS` in `switch.py` to clarify Bluetooth retry behavior. 
- Small formatting/whitespace fix in `src/heart/peripheral/bluetooth.py` to keep the async block aligned and readable.

### Testing

- Ran the test suite with `make test`, which completed successfully with `212 passed, 1 skipped`.
- Ran `make format` as part of the workflow and resolved formatting; `make format` checks passed during the change cycle.
- Noted intermittent `mypy` complaints about missing protobuf stubs in `src/heart/device/beats/proto/beats_streaming_pb2.py` that are unrelated to these changes and stem from generated proto stubs; these did not affect the unit test run.
- Changes were committed after formatting and the codebase tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d85601bd083218d4c5ecac7eab931)