### PR TITLE
Refactor game loop component assembly

### DIFF
--- a/src/heart/runtime/game_loop.py
+++ b/src/heart/runtime/game_loop.py
@@ -8,10 +8,7 @@ from lagom import Container
 
 from heart.device import Device
 from heart.navigation import ComposedRenderer, MultiScene
-from heart.peripheral.core.manager import PeripheralManager
-from heart.peripheral.core.providers import container
 from heart.runtime.game_loop_components import build_game_loop_components
-from heart.runtime.peripheral_runtime import PeripheralRuntime
 from heart.runtime.render_pipeline import RendererVariant
 from heart.utilities.logging import get_logger
 
@@ -34,13 +31,11 @@ class GameLoop:
         self.context_container = resolver
         self.initialized = False
         self.device = device
-        self.peripheral_manager = container.resolve(PeripheralManager)
-        self.peripheral_runtime = PeripheralRuntime(self.peripheral_manager)
 
         self.max_fps = max_fps
         components = build_game_loop_components(
+            resolver=resolver,
             device=device,
-            peripheral_manager=self.peripheral_manager,
             render_variant=render_variant,
         )
         self.app_controller = components.app_controller
@@ -48,6 +43,8 @@ class GameLoop:
         self.render_pipeline = components.render_pipeline
         self.frame_presenter = components.frame_presenter
         self.event_handler = components.event_handler
+        self.peripheral_manager = components.peripheral_manager
+        self.peripheral_runtime = components.peripheral_runtime
 
         # Lampe controller
         self.feedback_buffer: np.ndarray | None = None

--- a/src/heart/runtime/game_loop_components.py
+++ b/src/heart/runtime/game_loop_components.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from lagom import Container
+
 from heart.device import Device
 from heart.navigation import AppController
 from heart.peripheral.core.manager import PeripheralManager
 from heart.runtime.display_context import DisplayContext
 from heart.runtime.frame_presenter import FramePresenter
+from heart.runtime.peripheral_runtime import PeripheralRuntime
 from heart.runtime.pygame_event_handler import PygameEventHandler
 from heart.runtime.render_pipeline import RendererVariant, RenderPipeline
 
@@ -18,13 +21,16 @@ class GameLoopComponents:
     render_pipeline: RenderPipeline
     frame_presenter: FramePresenter
     event_handler: PygameEventHandler
+    peripheral_manager: PeripheralManager
+    peripheral_runtime: PeripheralRuntime
 
 
 def build_game_loop_components(
+    resolver: Container,
     device: Device,
-    peripheral_manager: PeripheralManager,
     render_variant: RendererVariant,
 ) -> GameLoopComponents:
+    peripheral_manager = resolver.resolve(PeripheralManager)
     display = DisplayContext(device=device)
     render_pipeline = RenderPipeline(
         device=device,
@@ -36,10 +42,13 @@ def build_game_loop_components(
         display=display,
         render_pipeline=render_pipeline,
     )
+    peripheral_runtime = PeripheralRuntime(peripheral_manager)
     return GameLoopComponents(
         app_controller=AppController(),
         display=display,
         render_pipeline=render_pipeline,
         frame_presenter=frame_presenter,
         event_handler=PygameEventHandler(),
+        peripheral_manager=peripheral_manager,
+        peripheral_runtime=peripheral_runtime,
     )


### PR DESCRIPTION
### Motivation

- Centralize runtime dependency assembly to make the `GameLoop` initialization simpler and clearer.  
- Resolve peripheral services from the Lagom container in one place to reduce scattered wiring.  
- Provide a single factory for constructing display, rendering and peripheral runtime pieces to improve separation of concerns.  

### Description

- Add a `resolver: Container` parameter to `build_game_loop_components` and resolve `PeripheralManager` there.  
- Create `PeripheralRuntime` in the component builder and add `peripheral_manager` and `peripheral_runtime` fields to the `GameLoopComponents` dataclass.  
- Trim `GameLoop.__init__` to receive assembled components from the builder and assign `self.peripheral_manager` / `self.peripheral_runtime` from `components`.  
- Update imports and minor wiring to reflect the new dependency flow (use `lagom.Container` in the builder).  

### Testing

- Ran `make format` which applied formatting fixes and passed.  
- Ran `make test` which executed the full Pytest suite and overall produced many passing tests.  
- Two tests failed during the run: `tests/renderers/test_sliding_state_provider.py::TestSlidingStateProviderTransitions::test_advance_state_uses_expected_width[spec0]` and `tests/utilities/test_reactivex_streams.py::TestShareStreamFlowControl::test_share_stream_coalesce_cancels_stale_scheduler_after_fallback`.  
- The remaining tests passed or were skipped as reported by the test run (210 passed, 2 failed, 1 skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d845ecc6c83218b0f959f1885f01e)