### PR TITLE
Specify encodings for text file reads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - Prefer `StrEnum` values over raw strings for strategy/configuration mode selections.
 - Use `heart.utilities.logging.get_logger` for internal logging so handlers and log levels stay consistent across modules.
 - Prefer module-level constants for tunable loop intervals instead of embedding sleep literals in long-running loops.
+- When reading or writing text files, specify an explicit encoding (prefer `utf-8`) to keep behavior consistent across platforms.
 
 ## Error Handling
 

--- a/src/heart/assets/loader.py
+++ b/src/heart/assets/loader.py
@@ -112,7 +112,7 @@ class Loader:
             cached = cache.get(resolved_path)
             if cached is not None:
                 return dict(cached)
-        with resolved_path.open("r") as fp:
+        with resolved_path.open("r", encoding="utf-8") as fp:
             payload = json.load(fp)
         if cache is not None:
             cache.set(resolved_path, payload)

--- a/src/heart/display/shaders/shader.py
+++ b/src/heart/display/shaders/shader.py
@@ -46,10 +46,11 @@ class Shader:
         return None
 
     def create(self):
-        with open(Path(template_location).parent / "vert.glsl") as f:
+        template_path = Path(template_location).parent
+        with (template_path / "vert.glsl").open(encoding="utf-8") as f:
             vert_shader = f.read()
 
-        with open(Path(template_location).parent / "frag_gen.glsl") as f:
+        with (template_path / "frag_gen.glsl").open(encoding="utf-8") as f:
             frag_shader = f.read()
 
         program = self.compile_program(vert_shader, frag_shader)

--- a/src/heart/manage/driver_update/mounts.py
+++ b/src/heart/manage/driver_update/mounts.py
@@ -55,7 +55,7 @@ def circuitpy_mounts(
 
 
 def _parse_board_id(boot_out_path: Path) -> str:
-    with boot_out_path.open("r") as file_handle:
+    with boot_out_path.open("r", encoding="utf-8") as file_handle:
         for line in file_handle:
             if "Board ID:" in line:
                 return line.split("Board ID:")[1].strip()


### PR DESCRIPTION
### Motivation
- Ensure consistent cross-platform behavior when reading text files by requiring an explicit encoding.
- Align repository code with a new guideline to prefer `utf-8` for text I/O.
- Remove a latent policy gap where shader sources, JSON assets, and boot output files were read without an explicit encoding.

### Description
- Add a guideline to `AGENTS.md`: "When reading or writing text files, specify an explicit encoding (prefer `utf-8`)."
- Read shader templates with `encoding="utf-8"` in `src/heart/display/shaders/shader.py` and introduce a `template_path` helper variable.
- Read JSON asset metadata with `encoding="utf-8"` in `src/heart/assets/loader.py` and read `boot_out.txt` with `encoding="utf-8"` in `src/heart/manage/driver_update/mounts.py`.

### Testing
- Ran `make format`, and formatting checks passed.
- Ran `make test`, which produced `211 passed, 1 failed, 1 skipped` and a single failing test: `tests/experimental/test_shared_memory.py::TestExperimentalSharedMemory::test_shared_memory_roundtrip_updates_frame_buffer`.
- No other automated test failures were observed during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694db175dbe48321b490977b45961a9d)