### PR TITLE
Integrate Lagom runtime container wiring

### DIFF
--- a/docs/research/lagom_runtime_container_integration.md
+++ b/docs/research/lagom_runtime_container_integration.md
@@ -1,0 +1,23 @@
+# Lagom Runtime Container Integration Notes
+
+## Problem Statement
+
+Runtime services were wired manually in `GameLoop`, and provider registrations relied on a global container living in the peripheral providers package. This split wiring made it difficult to override dependencies consistently and obscured ownership of runtime services.
+
+## Materials
+
+- Source modules under `src/heart/runtime/` and `src/heart/peripheral/core/providers/`.
+- CLI entry point in `src/heart/cli/commands/game_loop.py`.
+- Runtime flow diagram in `docs/code_flow.md`.
+
+## Source Review
+
+- `src/heart/runtime/container.py` defines the Lagom container builder used for runtime service registration.
+- `src/heart/runtime/game_loop_components.py` resolves `GameLoop` dependencies from the container instead of constructing them inline.
+- `src/heart/runtime/game_loop.py` accepts the container instance and keeps orchestration logic in one place.
+- `src/heart/peripheral/core/providers/registry.py` tracks provider registrations and applies them to registered containers.
+- `src/heart/cli/commands/game_loop.py` builds the container before creating the loop to keep wiring consistent.
+
+## Integration Notes
+
+The container builder registers `Device`, `RendererVariant`, and runtime singletons so they can be resolved wherever needed. Provider registration is now centralized in a registry that can apply to any runtime container, allowing late imports (such as renderer modules) to update active containers without a global `Container` instance. This keeps Lagom integration consistent across runtime components while still allowing tests to override dependencies in a single place.

--- a/src/heart/cli/commands/game_loop.py
+++ b/src/heart/cli/commands/game_loop.py
@@ -1,5 +1,5 @@
 from heart.device.selection import select_device
-from heart.peripheral.core.providers import container
+from heart.runtime.container import build_runtime_container
 from heart.runtime.game_loop import GameLoop
 from heart.runtime.render_pipeline import RendererVariant
 from heart.utilities.env import Configuration
@@ -7,8 +7,13 @@ from heart.utilities.env import Configuration
 
 def build_game_loop(*, x11_forward: bool) -> GameLoop:
     render_variant = RendererVariant.parse(Configuration.render_variant())
+    device = select_device(x11_forward=x11_forward)
+    resolver = build_runtime_container(
+        device=device,
+        render_variant=render_variant,
+    )
     return GameLoop(
-        device=select_device(x11_forward=x11_forward),
-        resolver=container,
+        device=device,
+        resolver=resolver,
         render_variant=render_variant,
     )

--- a/src/heart/peripheral/core/providers/__init__.py
+++ b/src/heart/peripheral/core/providers/__init__.py
@@ -2,13 +2,17 @@ from abc import abstractmethod
 from typing import Generic, TypeVar
 
 import reactivex
-from lagom import Container
 from reactivex import operators as ops
 
 from heart.peripheral.core import InputDescriptor
-from heart.peripheral.core.manager import PeripheralManager
+from heart.peripheral.core.providers import registry as providers_registry
+
+apply_provider_registrations = providers_registry.apply_provider_registrations
+register_provider = providers_registry.register_provider
+registered_providers = providers_registry.registered_providers
 
 T = TypeVar("T")
+
 
 class ObservableProvider(Generic[T]):
     @abstractmethod
@@ -20,6 +24,7 @@ class ObservableProvider(Generic[T]):
 
         return ()
 
+
 class StaticStateProvider(ObservableProvider[T]):
     def __init__(self, state: T) -> None:
         self._state = state
@@ -30,6 +35,3 @@ class StaticStateProvider(ObservableProvider[T]):
 
     def observable(self) -> reactivex.Observable[T]:
         return reactivex.just(self._state).pipe(ops.share())
-
-container = Container()
-container[PeripheralManager] = PeripheralManager()

--- a/src/heart/peripheral/core/providers/registry.py
+++ b/src/heart/peripheral/core/providers/registry.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any
+
+from lagom import Container
+
+ProviderKey = type[Any]
+ProviderValue = Any
+
+_registry: dict[ProviderKey, ProviderValue] = {}
+_containers: list[Container] = []
+
+
+def register_provider(key: ProviderKey, provider: ProviderValue) -> None:
+    _registry[key] = provider
+    for container in _containers:
+        _register_container_provider(container, key, provider)
+
+
+def apply_provider_registrations(container: Container) -> None:
+    for key, provider in _registry.items():
+        _register_container_provider(container, key, provider)
+    if container not in _containers:
+        _containers.append(container)
+
+
+def registered_providers() -> dict[ProviderKey, ProviderValue]:
+    return dict(_registry)
+
+
+def _register_container_provider(
+    container: Container,
+    key: ProviderKey,
+    provider: ProviderValue,
+) -> None:
+    if key in container.defined_types:
+        return
+    container[key] = provider

--- a/src/heart/peripheral/providers/acceleration/__init__.py
+++ b/src/heart/peripheral/providers/acceleration/__init__.py
@@ -1,5 +1,5 @@
-from heart.peripheral.core.providers import container
+from heart.peripheral.core.providers import register_provider
 
 from .provider import AllAccelerometersProvider
 
-container[AllAccelerometersProvider] = AllAccelerometersProvider
+register_provider(AllAccelerometersProvider, AllAccelerometersProvider)

--- a/src/heart/peripheral/providers/switch/__init__.py
+++ b/src/heart/peripheral/providers/switch/__init__.py
@@ -1,5 +1,5 @@
-from heart.peripheral.core.providers import container
+from heart.peripheral.core.providers import register_provider
 
 from .provider import MainSwitchProvider
 
-container[MainSwitchProvider] = MainSwitchProvider
+register_provider(MainSwitchProvider, MainSwitchProvider)

--- a/src/heart/renderers/combined_bpm_screen/__init__.py
+++ b/src/heart/renderers/combined_bpm_screen/__init__.py
@@ -1,4 +1,4 @@
-from heart.peripheral.core.providers import container
+from heart.peripheral.core.providers import register_provider
 from heart.renderers.combined_bpm_screen.provider import \
     CombinedBpmScreenStateProvider
 from heart.renderers.combined_bpm_screen.renderer import \
@@ -6,4 +6,4 @@ from heart.renderers.combined_bpm_screen.renderer import \
 from heart.renderers.combined_bpm_screen.state import \
     CombinedBpmScreenState  # noqa: F401
 
-container[CombinedBpmScreenStateProvider] = CombinedBpmScreenStateProvider
+register_provider(CombinedBpmScreenStateProvider, CombinedBpmScreenStateProvider)

--- a/src/heart/renderers/heart_title_screen/__init__.py
+++ b/src/heart/renderers/heart_title_screen/__init__.py
@@ -1,7 +1,7 @@
-from heart.peripheral.core.providers import container
+from heart.peripheral.core.providers import register_provider
 from heart.renderers.heart_title_screen.provider import \
     HeartTitleScreenStateProvider
 from heart.renderers.heart_title_screen.renderer import \
     HeartTitleScreen  # noqa: F401
 
-container[HeartTitleScreenStateProvider] = HeartTitleScreenStateProvider
+register_provider(HeartTitleScreenStateProvider, HeartTitleScreenStateProvider)

--- a/src/heart/renderers/l_system/__init__.py
+++ b/src/heart/renderers/l_system/__init__.py
@@ -1,7 +1,7 @@
-from heart.peripheral.core.providers import container
+from heart.peripheral.core.providers import register_provider
 from heart.renderers.l_system.provider import \
     LSystemStateProvider  # noqa: F401
 from heart.renderers.l_system.renderer import LSystem  # noqa: F401
 from heart.renderers.l_system.state import LSystemState  # noqa: F401
 
-container[LSystemStateProvider] = LSystemStateProvider
+register_provider(LSystemStateProvider, LSystemStateProvider)

--- a/src/heart/renderers/led_wave_boat/__init__.py
+++ b/src/heart/renderers/led_wave_boat/__init__.py
@@ -1,5 +1,5 @@
-from heart.peripheral.core.providers import container
+from heart.peripheral.core.providers import register_provider
 from heart.renderers.led_wave_boat.provider import LedWaveBoatStateProvider
 from heart.renderers.led_wave_boat.renderer import LedWaveBoat  # noqa: F401
 
-container[LedWaveBoatStateProvider] = LedWaveBoatStateProvider
+register_provider(LedWaveBoatStateProvider, LedWaveBoatStateProvider)

--- a/src/heart/renderers/life/__init__.py
+++ b/src/heart/renderers/life/__init__.py
@@ -1,4 +1,4 @@
-from heart.peripheral.core.providers import container
+from heart.peripheral.core.providers import register_provider
 from heart.renderers.life.provider import LifeStateProvider
 
-container[LifeStateProvider] = LifeStateProvider
+register_provider(LifeStateProvider, LifeStateProvider)

--- a/src/heart/renderers/metadata_screen/__init__.py
+++ b/src/heart/renderers/metadata_screen/__init__.py
@@ -1,4 +1,4 @@
-from heart.peripheral.core.providers import container
+from heart.peripheral.core.providers import register_provider
 from heart.renderers.metadata_screen.provider import \
     MetadataScreenStateProvider
 from heart.renderers.metadata_screen.renderer import \
@@ -6,4 +6,4 @@ from heart.renderers.metadata_screen.renderer import \
 from heart.renderers.metadata_screen.state import \
     MetadataScreenState  # noqa: F401
 
-container[MetadataScreenStateProvider] = MetadataScreenStateProvider
+register_provider(MetadataScreenStateProvider, MetadataScreenStateProvider)

--- a/src/heart/renderers/porthole_window/__init__.py
+++ b/src/heart/renderers/porthole_window/__init__.py
@@ -1,7 +1,7 @@
-from heart.peripheral.core.providers import container
+from heart.peripheral.core.providers import register_provider
 from heart.renderers.porthole_window.provider import \
     PortholeWindowStateProvider
 from heart.renderers.porthole_window.renderer import \
     PortholeWindowRenderer  # noqa: F401
 
-container[PortholeWindowStateProvider] = PortholeWindowStateProvider
+register_provider(PortholeWindowStateProvider, PortholeWindowStateProvider)

--- a/src/heart/renderers/sliding_image/__init__.py
+++ b/src/heart/renderers/sliding_image/__init__.py
@@ -1,4 +1,4 @@
-from heart.peripheral.core.providers import container
+from heart.peripheral.core.providers import register_provider
 from heart.renderers.sliding_image.provider import \
     SlidingImageStateProvider as SlidingImageStateProvider
 from heart.renderers.sliding_image.provider import \
@@ -11,5 +11,5 @@ from heart.renderers.sliding_image.state import \
 from heart.renderers.sliding_image.state import \
     SlidingRendererState as SlidingRendererState
 
-container[SlidingImageStateProvider] = SlidingImageStateProvider
-container[SlidingRendererStateProvider] = SlidingRendererStateProvider
+register_provider(SlidingImageStateProvider, SlidingImageStateProvider)
+register_provider(SlidingRendererStateProvider, SlidingRendererStateProvider)

--- a/src/heart/renderers/tixyland/__init__.py
+++ b/src/heart/renderers/tixyland/__init__.py
@@ -1,5 +1,5 @@
-from heart.peripheral.core.providers import container
+from heart.peripheral.core.providers import register_provider
 from heart.renderers.tixyland.provider import TixylandStateProvider
 from heart.renderers.tixyland.renderer import Tixyland  # noqa: F401
 
-container[TixylandStateProvider] = TixylandStateProvider
+register_provider(TixylandStateProvider, TixylandStateProvider)

--- a/src/heart/renderers/water_cube/__init__.py
+++ b/src/heart/renderers/water_cube/__init__.py
@@ -1,4 +1,4 @@
-from heart.peripheral.core.providers import container
+from heart.peripheral.core.providers import register_provider
 from heart.renderers.water_cube.provider import WaterCubeStateProvider
 
-container[WaterCubeStateProvider] = WaterCubeStateProvider
+register_provider(WaterCubeStateProvider, WaterCubeStateProvider)

--- a/src/heart/renderers/water_title_screen/__init__.py
+++ b/src/heart/renderers/water_title_screen/__init__.py
@@ -1,7 +1,7 @@
-from heart.peripheral.core.providers import container
+from heart.peripheral.core.providers import register_provider
 from heart.renderers.water_title_screen.provider import \
     WaterTitleScreenStateProvider
 from heart.renderers.water_title_screen.renderer import \
     WaterTitleScreen  # noqa: F401
 
-container[WaterTitleScreenStateProvider] = WaterTitleScreenStateProvider
+register_provider(WaterTitleScreenStateProvider, WaterTitleScreenStateProvider)

--- a/src/heart/runtime/container.py
+++ b/src/heart/runtime/container.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from lagom import Container, Singleton
+
+from heart.device import Device
+from heart.navigation import AppController
+from heart.peripheral.core.manager import PeripheralManager
+from heart.peripheral.core.providers import apply_provider_registrations
+from heart.runtime.display_context import DisplayContext
+from heart.runtime.frame_presenter import FramePresenter
+from heart.runtime.peripheral_runtime import PeripheralRuntime
+from heart.runtime.pygame_event_handler import PygameEventHandler
+from heart.runtime.render_pipeline import RendererVariant, RenderPipeline
+
+
+def build_runtime_container(
+    device: Device,
+    render_variant: RendererVariant,
+    overrides: Mapping[type[Any], object] | None = None,
+) -> Container:
+    container = Container()
+    _bind(container, overrides, Device, device)
+    _bind(container, overrides, RendererVariant, render_variant)
+    _bind(container, overrides, PeripheralManager, Singleton(PeripheralManager))
+    _bind(
+        container,
+        overrides,
+        DisplayContext,
+        Singleton(lambda resolver: DisplayContext(device=resolver[Device])),
+    )
+    _bind(
+        container,
+        overrides,
+        RenderPipeline,
+        Singleton(
+            lambda resolver: RenderPipeline(
+                device=resolver[Device],
+                peripheral_manager=resolver[PeripheralManager],
+                render_variant=resolver[RendererVariant],
+            )
+        ),
+    )
+    _bind(
+        container,
+        overrides,
+        FramePresenter,
+        Singleton(
+            lambda resolver: FramePresenter(
+                device=resolver[Device],
+                display=resolver[DisplayContext],
+                render_pipeline=resolver[RenderPipeline],
+            )
+        ),
+    )
+    _bind(
+        container,
+        overrides,
+        PeripheralRuntime,
+        Singleton(lambda resolver: PeripheralRuntime(resolver[PeripheralManager])),
+    )
+    _bind(container, overrides, AppController, Singleton(AppController))
+    _bind(container, overrides, PygameEventHandler, Singleton(PygameEventHandler))
+    apply_provider_registrations(container)
+    return container
+
+
+def _bind(
+    container: Container,
+    overrides: Mapping[type[Any], object] | None,
+    key: type[Any],
+    value: object,
+) -> None:
+    if overrides and key in overrides:
+        container[key] = overrides[key]
+        return
+    container[key] = value

--- a/src/heart/runtime/game_loop.py
+++ b/src/heart/runtime/game_loop.py
@@ -8,6 +8,7 @@ from lagom import Container
 
 from heart.device import Device
 from heart.navigation import ComposedRenderer, MultiScene
+from heart.runtime.container import build_runtime_container
 from heart.runtime.game_loop_components import build_game_loop_components
 from heart.runtime.render_pipeline import RendererVariant
 from heart.utilities.logging import get_logger
@@ -24,20 +25,19 @@ class GameLoop:
     def __init__(
         self,
         device: Device,
-        resolver: Container,
+        resolver: Container | None = None,
         max_fps: int = 500,
         render_variant: RendererVariant = RendererVariant.ITERATIVE,
     ) -> None:
-        self.context_container = resolver
+        self.context_container = resolver or build_runtime_container(
+            device=device,
+            render_variant=render_variant,
+        )
         self.initialized = False
         self.device = device
 
         self.max_fps = max_fps
-        components = build_game_loop_components(
-            resolver=resolver,
-            device=device,
-            render_variant=render_variant,
-        )
+        components = build_game_loop_components(resolver=self.context_container)
         self.app_controller = components.app_controller
         self.display = components.display
         self.render_pipeline = components.render_pipeline

--- a/src/heart/runtime/game_loop_components.py
+++ b/src/heart/runtime/game_loop_components.py
@@ -4,14 +4,13 @@ from dataclasses import dataclass
 
 from lagom import Container
 
-from heart.device import Device
 from heart.navigation import AppController
 from heart.peripheral.core.manager import PeripheralManager
 from heart.runtime.display_context import DisplayContext
 from heart.runtime.frame_presenter import FramePresenter
 from heart.runtime.peripheral_runtime import PeripheralRuntime
 from heart.runtime.pygame_event_handler import PygameEventHandler
-from heart.runtime.render_pipeline import RendererVariant, RenderPipeline
+from heart.runtime.render_pipeline import RenderPipeline
 
 
 @dataclass(frozen=True)
@@ -27,28 +26,13 @@ class GameLoopComponents:
 
 def build_game_loop_components(
     resolver: Container,
-    device: Device,
-    render_variant: RendererVariant,
 ) -> GameLoopComponents:
-    peripheral_manager = resolver.resolve(PeripheralManager)
-    display = DisplayContext(device=device)
-    render_pipeline = RenderPipeline(
-        device=device,
-        peripheral_manager=peripheral_manager,
-        render_variant=render_variant,
-    )
-    frame_presenter = FramePresenter(
-        device=device,
-        display=display,
-        render_pipeline=render_pipeline,
-    )
-    peripheral_runtime = PeripheralRuntime(peripheral_manager)
     return GameLoopComponents(
-        app_controller=AppController(),
-        display=display,
-        render_pipeline=render_pipeline,
-        frame_presenter=frame_presenter,
-        event_handler=PygameEventHandler(),
-        peripheral_manager=peripheral_manager,
-        peripheral_runtime=peripheral_runtime,
+        app_controller=resolver.resolve(AppController),
+        display=resolver.resolve(DisplayContext),
+        render_pipeline=resolver.resolve(RenderPipeline),
+        frame_presenter=resolver.resolve(FramePresenter),
+        event_handler=resolver.resolve(PygameEventHandler),
+        peripheral_manager=resolver.resolve(PeripheralManager),
+        peripheral_runtime=resolver.resolve(PeripheralRuntime),
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,18 @@
 import sys
 import types
 from collections import deque
-from typing import Callable, Container
+from typing import Callable
 
 import pygame
 import pytest
 from hypothesis import HealthCheck, settings
+from lagom import Container
 
 from heart.device import Cube, Device
 from heart.peripheral.core.manager import PeripheralManager
-from heart.peripheral.core.providers import container
+from heart.runtime.container import build_runtime_container
 from heart.runtime.game_loop import GameLoop
+from heart.runtime.render_pipeline import RendererVariant
 
 settings.register_profile(
     "default",
@@ -148,8 +150,11 @@ def manager() -> PeripheralManager:
     return PeripheralManager()
 
 @pytest.fixture()
-def resolver() -> Container:
-    return container
+def resolver(device: Device) -> Container:
+    return build_runtime_container(
+        device=device,
+        render_variant=RendererVariant.ITERATIVE,
+    )
 
 
 @pytest.fixture()

--- a/tests/runtime/test_container.py
+++ b/tests/runtime/test_container.py
@@ -1,0 +1,37 @@
+from heart.peripheral.core.manager import PeripheralManager
+from heart.runtime.container import build_runtime_container
+from heart.runtime.display_context import DisplayContext
+from heart.runtime.game_loop import GameLoop
+from heart.runtime.render_pipeline import RendererVariant, RenderPipeline
+
+
+class TestRuntimeContainer:
+    """Validate runtime container wiring so core services resolve consistently across the loop lifecycle."""
+
+    def test_container_build_registers_core_singletons(self, device) -> None:
+        """Verify that the runtime container wires core singletons, ensuring consistent service reuse across frames."""
+        container = build_runtime_container(
+            device=device,
+            render_variant=RendererVariant.BINARY,
+        )
+
+        render_pipeline = container.resolve(RenderPipeline)
+
+        assert container.resolve(PeripheralManager) is container.resolve(
+            PeripheralManager
+        )
+        assert container.resolve(DisplayContext) is container.resolve(DisplayContext)
+        assert render_pipeline is container.resolve(RenderPipeline)
+        assert render_pipeline.renderer_variant is RendererVariant.BINARY
+
+    def test_game_loop_uses_container_overrides(self, device) -> None:
+        """Ensure GameLoop honors container overrides so tests can swap implementations without touching runtime code."""
+        stub_manager = PeripheralManager()
+        container = build_runtime_container(
+            device=device,
+            render_variant=RendererVariant.ITERATIVE,
+            overrides={PeripheralManager: stub_manager},
+        )
+        loop = GameLoop(device=device, resolver=container)
+
+        assert loop.peripheral_manager is stub_manager


### PR DESCRIPTION
### Motivation

- Centralize dependency wiring so runtime components are consistently resolved through a single Lagom container and are easier to override in tests.
- Replace ad-hoc construction and a scattered module-level container with an explicit container builder and provider registry to clarify ownership and lifecycle.
- Enable renderer and peripheral providers to register themselves without requiring a global `Container` instance so late imports can apply registrations to any runtime container.

### Description

- Add `src/heart/runtime/container.py` which provides `build_runtime_container(device, render_variant, overrides)` to register core singletons such as `PeripheralManager`, `DisplayContext`, `RenderPipeline`, `FramePresenter`, `PeripheralRuntime`, `AppController`, and `PygameEventHandler`.
- Add provider registry `src/heart/peripheral/core/providers/registry.py` with `register_provider` and `apply_provider_registrations`, and refactor `src/heart/peripheral/core/providers/__init__.py` to expose those helpers.
- Refactor runtime wiring so `GameLoop` accepts an optional `resolver` and `build_game_loop_components` resolves components from the provided container instead of constructing them inline.
- Replace module-level `container[...] = ...` assignments in renderer and peripheral init modules with `register_provider(...)`, add `tests/runtime/test_container.py`, and update docs (`docs/code_flow.md`, `docs/research/lagom_runtime_container_integration.md`) to document the new wiring.

### Testing

- Ran `make format` to apply repository formatting; formatting completed locally though some tooling runs reported transient network fetch errors in the environment.
- Added `tests/runtime/test_container.py` and executed it with `pytest`, confirming container singletons and override behaviour passed.
- Ran the isolated Rx utility test `pytest tests/utilities/test_reactivex_streams.py::TestShareStreamFlowControl::test_share_stream_coalesces_latest_when_configured`, which passed when run in isolation.
- Attempted a full `make test`; many tests ran and passed, but CI/tooling in this environment experienced intermittent PyPI network errors during some formatting/test steps so the full suite execution was not reliably completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694db1dc5cc0832192824f3816f702b4)