### PR TITLE
Centralize peripheral payload encoding for protobuf

### DIFF
--- a/docs/beats-websocket-protobuf.md
+++ b/docs/beats-websocket-protobuf.md
@@ -7,6 +7,7 @@ Define the protobuf envelope used to stream frames and peripheral updates into t
 ## Sources
 
 - `src/heart/device/beats/websocket.py`
+- `src/heart/peripheral/core/encoding.py`
 - `src/heart/device/beats/proto/beats_streaming.proto`
 - `experimental/beats/src/actions/ws/protocol.ts`
 
@@ -20,7 +21,7 @@ Define the protobuf envelope used to stream frames and peripheral updates into t
 `StreamEnvelope` wraps the payload in a `oneof` so clients can switch on the message type without JSON parsing:
 
 - `frame`: contains raw PNG bytes in `png_data`.
-- `peripheral`: includes `PeripheralInfo`, an encoded payload, a payload encoding enum, and an optional payload type string for protobuf payloads.
+- `peripheral`: includes `PeripheralInfo`, an encoded payload, a payload encoding enum, and an optional payload type string for protobuf payloads. `encode_peripheral_payload` in `heart.peripheral.core.encoding` centralizes the encoding logic so other integrations can reuse the same protobuf-aware rules.
 
 ## Client decoding
 

--- a/src/heart/peripheral/core/encoding.py
+++ b/src/heart/peripheral/core/encoding.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+from dataclasses import dataclass
+from datetime import date, datetime
+from enum import Enum, StrEnum
+from typing import Mapping, Sequence
+from uuid import UUID
+
+from google.protobuf.message import Message  # type: ignore[import-untyped]
+
+
+class PeripheralPayloadEncoding(StrEnum):
+    JSON_UTF8 = "json_utf8"
+    PROTOBUF = "protobuf"
+
+
+@dataclass(frozen=True, slots=True)
+class PeripheralPayload:
+    payload: bytes
+    encoding: PeripheralPayloadEncoding
+    payload_type: str = ""
+
+
+def _normalize_payload(payload: object) -> object:
+    if dataclasses.is_dataclass(payload):
+        return dataclasses.asdict(payload)  # type: ignore[arg-type]
+
+    if isinstance(payload, Enum):
+        return payload.value
+
+    if isinstance(payload, UUID):
+        return str(payload)
+
+    if isinstance(payload, (datetime, date)):
+        return payload.isoformat()
+
+    if isinstance(payload, bytes):
+        return payload.hex()
+
+    if isinstance(payload, Mapping):
+        return {
+            str(key): _normalize_payload(value)
+            for key, value in payload.items()
+        }
+
+    if isinstance(payload, Sequence) and not isinstance(payload, (str, bytes, bytearray)):
+        return [_normalize_payload(value) for value in payload]
+
+    return payload
+
+
+def encode_peripheral_payload(payload: object) -> PeripheralPayload:
+    if isinstance(payload, Message):
+        return PeripheralPayload(
+            payload=payload.SerializeToString(),
+            encoding=PeripheralPayloadEncoding.PROTOBUF,
+            payload_type=payload.DESCRIPTOR.full_name,
+        )
+
+    normalized = _normalize_payload(payload)
+    encoded_payload = json.dumps(
+        normalized,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return PeripheralPayload(
+        payload=encoded_payload,
+        encoding=PeripheralPayloadEncoding.JSON_UTF8,
+        payload_type="",
+    )


### PR DESCRIPTION
### Motivation
- Provide a single, protobuf-aware encoder for peripheral payloads so multiple integrations share consistent encoding rules.
- Ensure websocket streaming emits a stable `payload_encoding` and `payload_type` metadata for typed clients to decode binary payloads safely.
- Reduce duplicated normalization logic and make it easier to extend encoding behaviour in one place.
- Document the encoding scheme so UI and downstream consumers can rely on a single contract.

### Description
- Add `src/heart/peripheral/core/encoding.py` implementing `encode_peripheral_payload`, `PeripheralPayload`, and `PeripheralPayloadEncoding` with dataclass, enum, UUID, datetime, bytes, mapping, and sequence normalization. 
- Replace ad-hoc normalization in `src/heart/device/beats/websocket.py` with a call to `encode_peripheral_payload` and map the result into the `StreamEnvelope` fields. 
- Add unit tests in `tests/device/test_beats_websocket.py` covering dataclass -> JSON encoding and protobuf message encoding with `payload_type` metadata. 
- Update `docs/beats-websocket-protobuf.md` to reference the new encoder and describe the centralized protobuf-aware behaviour.

### Testing
- Ran formatting via `make format` and applied fixes successfully. 
- Executed the full test suite with `make test` which completed with `216 passed, 1 skipped` in ~24s. 
- Added focused unit tests for `encode_peripheral_payload` which passed as part of the suite. 
- No automated tests failed during the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694db1e709688321b7f7739d7e8b6e6a)