### PR TITLE
Add protobuf typing stubs for mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dev = [
     "Pillow",
     "scipy",
     "mypy",
+    "types-protobuf",
     "types-requests",
     "types-toml",
     # Git
@@ -181,6 +182,7 @@ lint = [
     "isort>=7.0.0",
     "mdformat>=1.0.0",
     "mypy>=1.13.0",
+    "types-protobuf",
     "ruff>=0.14.3",
     "semgrep>=1.115.0",
 ]


### PR DESCRIPTION
### Motivation
- Provide mypy with typing stubs for protobuf-generated code to reduce `# type: ignore` usage and improve static checking.
- The repository currently ships protobuf-generated modules that are not typed for mypy, causing noise in type checks.

### Description
- Added `types-protobuf` to the `dev` optional dependencies in `pyproject.toml` to make protobuf stubs available during development.
- Added `types-protobuf` to the `lint` dependency group in `pyproject.toml` so tooling runs (e.g., mypy) can access the stubs.
- No source code changes beyond dependency metadata were made; the lockfile update was attempted but not applied due to network errors and was reverted.

### Testing
- Ran `uv lock` to refresh the lockfile which failed due to inability to reach `https://pypi.org/simple/` and so no lockfile changes were committed (failed).
- Ran `make format` to apply formatting hooks which failed while fetching packages from PyPI (network/tunnel error).
- Did not run `make test` as part of this change; no unit test suite executions were performed.
- The `pyproject.toml` change is limited to dependency metadata and does not alter runtime behaviour.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694db1f0bda0832191501b06b2056344)