### PR TITLE
Handle CLI configuration lookup errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - Avoid swallowing recoverable exceptions; log them with the shared logger (use debug-level logging for high-frequency loops).
 - When logging caught exceptions at error level, include traceback context with `logger.exception` (or `exc_info=True`) unless you intentionally suppress it.
 - Avoid placeholder early returns or unreachable docstrings in production methods; remove stubs once real implementations are available.
+- For CLI commands, log expected user-facing errors and exit with `typer.Exit` instead of raising generic exceptions.
 
 ## Testing
 

--- a/src/heart/cli/commands/run.py
+++ b/src/heart/cli/commands/run.py
@@ -4,6 +4,9 @@ import typer
 
 from heart.cli.commands.game_loop import build_game_loop
 from heart.programs.registry import ConfigurationRegistry
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def run_command(
@@ -18,7 +21,8 @@ def run_command(
     registry = ConfigurationRegistry()
     configuration_fn = registry.get(configuration)
     if configuration_fn is None:
-        raise ValueError(f"Configuration '{configuration}' not found in registry")
+        logger.error("Configuration '%s' not found in registry", configuration)
+        raise typer.Exit(code=1)
     loop = build_game_loop(x11_forward=x11_forward)
     configuration_fn(loop)
 


### PR DESCRIPTION
### Motivation
- Ensure CLI behavior follows repository guidance for user-facing errors by logging them and exiting cleanly.
- Avoid raising generic exceptions from CLI commands which can produce noisy tracebacks for expected user mistakes.
- Keep runtime logging consistent by using the shared `heart.utilities.logging.get_logger` helper.

### Description
- Add a new AGENTS rule: "For CLI commands, log expected user-facing errors and exit with `typer.Exit` instead of raising generic exceptions.".
- Update `src/heart/cli/commands/run.py` to import `get_logger`, instantiate a `logger`, and replace a `ValueError` with `logger.error(...)` followed by `raise typer.Exit(code=1)`.

### Testing
- Ran `make format` to apply repository formatting rules and the command completed successfully.
- Ran `make test` and the test suite completed with all automated tests passing (`218 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dbc2637ec8321afd6f0bf55658574)