### PR TITLE
Align renderer resolution with Lagom container

### DIFF
--- a/docs/research/lagom_renderer_resolution.md
+++ b/docs/research/lagom_renderer_resolution.md
@@ -1,0 +1,27 @@
+# Lagom Renderer Resolution Note
+
+## Problem Statement
+
+Renderer configuration modules sometimes attempted to resolve renderers from the `GameLoop`
+instance directly, even though the shared Lagom container lives on
+`GameLoop.context_container`. This masked where dependency resolution actually happened and
+made it easier to bypass the container when new renderers were added.
+
+## Materials
+
+- Python 3.11 environment with `uv` for dependency resolution.
+- Lagom dependency (`lagom` in `pyproject.toml`).
+- Source modules: `src/heart/navigation/composed_renderer.py`,
+  `src/heart/programs/configurations/`.
+
+## Notes
+
+`ComposedRenderer.resolve_renderer` now accepts a resolver protocol that only requires a
+`resolve()` method. This keeps the API aligned with Lagom while clarifying that the shared
+container is the intended source of renderer instances. Configuration modules now pass
+`GameLoop.context_container` directly when resolving renderer classes (for example, in
+`src/heart/programs/configurations/halloween_2024.py` and
+`src/heart/programs/configurations/life.py`), which avoids accidental container bypasses.
+
+This change keeps renderer wiring consistent with the runtime container built in
+`src/heart/runtime/container.py` and helps ensure future renderers resolve through Lagom.

--- a/src/heart/navigation/composed_renderer.py
+++ b/src/heart/navigation/composed_renderer.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Protocol, TypeVar
 
 import pygame
-from lagom import Container
 
 from heart.device import Orientation
 from heart.peripheral.core.manager import PeripheralManager
 from heart.renderers import StatefulBaseRenderer
+
+RendererT = TypeVar("RendererT", bound=StatefulBaseRenderer)
+
+
+class RendererResolver(Protocol):
+    def resolve(self, dependency: type[RendererT]) -> RendererT:
+        """Resolve renderer instances from the shared container."""
 
 
 @dataclass
@@ -62,9 +69,9 @@ class ComposedRenderer(StatefulBaseRenderer[ComposedRendererState]):
                 )
 
     def resolve_renderer(
-        self, container: Container, renderer: type[StatefulBaseRenderer]
+        self, resolver: RendererResolver, renderer: type[StatefulBaseRenderer]
     ) -> None:
-        resolved = container.resolve(renderer)
+        resolved = resolver.resolve(renderer)
         self.renderers.append(resolved)
         if self.is_initialized():
             resolved.initialize(

--- a/src/heart/peripheral/core/encoding.py
+++ b/src/heart/peripheral/core/encoding.py
@@ -8,7 +8,7 @@ from enum import Enum, StrEnum
 from typing import Mapping, Sequence
 from uuid import UUID
 
-from google.protobuf.message import Message  # type: ignore[import-untyped]
+from google.protobuf.message import Message
 
 
 class PeripheralPayloadEncoding(StrEnum):

--- a/src/heart/programs/configurations/halloween_2024.py
+++ b/src/heart/programs/configurations/halloween_2024.py
@@ -59,7 +59,7 @@ def configure(loop: GameLoop) -> None:
 
     # Game of Life
     mode = loop.add_mode()
-    mode.resolve_renderer(container=loop, renderer=Life)
+    mode.resolve_renderer(loop.context_container, Life)
 
     mode = loop.add_mode()
     # MANDELBROT
@@ -119,4 +119,4 @@ def configure(loop: GameLoop) -> None:
 
     # Game of Life
     mode = loop.add_mode()
-    mode.resolve_renderer(container=loop, renderer=Life)
+    mode.resolve_renderer(loop.context_container, Life)

--- a/src/heart/programs/configurations/life.py
+++ b/src/heart/programs/configurations/life.py
@@ -4,4 +4,4 @@ from heart.runtime.game_loop import GameLoop
 
 def configure(loop: GameLoop) -> None:
     mode = loop.add_mode()
-    mode.resolve_renderer(container=loop, renderer=Life)
+    mode.resolve_renderer(loop.context_container, Life)

--- a/src/heart/programs/configurations/water.py
+++ b/src/heart/programs/configurations/water.py
@@ -4,4 +4,4 @@ from heart.runtime.game_loop import GameLoop
 
 def configure(loop: GameLoop) -> None:
     mode = loop.add_mode("water")
-    mode.resolve_renderer(container=loop.context_container, renderer=WaterCube)
+    mode.resolve_renderer(loop.context_container, WaterCube)


### PR DESCRIPTION
### Motivation
- Renderer resolution was inconsistent: some configuration code resolved renderers off the `GameLoop` instance rather than the shared Lagom container, which hid dependency ownership and made overrides harder to use. 
- Centralizing resolution through the runtime container improves testability and makes lifecycle ownership explicit. 
- The change also removes a stale typing ignore in peripheral encoding discovered during formatting. 
- A short research note records the intent and observed pattern for future contributors.

### Description
- Introduce a `RendererResolver` `Protocol` and update `ComposedRenderer.resolve_renderer` to accept a resolver and call `resolver.resolve(...)` instead of depending on a `Container` directly. 
- Update program configuration modules to resolve renderers via `GameLoop.context_container` (e.g., `src/heart/programs/configurations/*` now pass `loop.context_container` to `resolve_renderer`). 
- Remove an unused `# type: ignore` in `src/heart/peripheral/core/encoding.py` and tidy imports. 
- Add `docs/research/lagom_renderer_resolution.md` documenting the change and rationale.

### Testing
- Ran `make format` and automatic formatting/lint fixes completed successfully. 
- Ran `make test`; the suite ran with most tests passing but one failure occurred. 
- Test summary: `217 passed, 1 failed, 1 skipped`. 
- The failing test is `tests/experimental/test_shared_memory.py::TestExperimentalSharedMemory::test_shared_memory_roundtrip_updates_frame_buffer`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dbc1cd6748321a4b2231d50b1bc62)