### PR TITLE
Add protobuf payload decoder for peripheral messages

### DIFF
--- a/docs/beats-websocket-protobuf.md
+++ b/docs/beats-websocket-protobuf.md
@@ -26,3 +26,7 @@ Define the protobuf envelope used to stream frames and peripheral updates into t
 ## Client decoding
 
 The Beats UI uses `protobufjs` to parse `StreamEnvelope` frames and emits a typed `StreamEvent` into the RxJS stream. Frame bytes are converted directly into PNG blobs, and peripheral payloads are decoded from UTF-8 JSON when the payload encoding signals `JSON_UTF8`. Protobuf payloads set `payload_type` to the fully-qualified message name and set the encoding to `PROTOBUF`.
+
+## Python decoding helper
+
+`heart.peripheral.core.encoding.decode_peripheral_payload` mirrors the envelope rules when decoding payloads in Python. JSON payloads return mappings, while protobuf payloads are parsed using the `payload_type` message name. Import the relevant `*_pb2` modules before decoding so the message classes are registered with the protobuf symbol database.


### PR DESCRIPTION
### Motivation

- Provide a Python-side decoder that mirrors the Beats websocket envelope rules so receivers can reconstruct peripheral payloads consistently.
- Make protobuf-encoded peripheral payloads recoverable by name via the protobuf symbol database instead of forcing consumers to reimplement parsing logic. 
- Surface clear errors for malformed or unknown protobuf payload types to aid integration debugging. 

### Description

- Add `decode_peripheral_payload` and `PeripheralPayloadDecodeError` to `src/heart/peripheral/core/encoding.py` to decode `JSON_UTF8` and `PROTOBUF` payloads and to look up message classes via `google.protobuf.symbol_database`. 
- Keep `encode_peripheral_payload` unchanged and rely on `payload_type` set for protobuf messages; the decoder parses into the registered `*_pb2` message class. 
- Extend `tests/device/test_beats_websocket.py` with `TestPeripheralPayloadDecoding` tests that validate JSON decoding, protobuf message reconstruction, and error raising for unknown types. 
- Document the Python decoding helper in `docs/beats-websocket-protobuf.md` and instruct consumers to import the relevant `*_pb2` modules so types are registered with the symbol database. 

### Testing

- Ran `make format` to apply repository formatting rules and the formatter completed successfully. 
- Ran the test suite with `make test` and observed all tests passing: `221 passed, 1 skipped`. 
- New unit tests in `tests/device/test_beats_websocket.py` executed as part of the suite and passed. 
- No additional integration or build steps were required for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dbc15579c8321a0b27c47fb5dafbc)