### PR TITLE
Add protobuf decoding helpers for Beats stream envelopes

### DIFF
--- a/docs/beats-websocket-protobuf.md
+++ b/docs/beats-websocket-protobuf.md
@@ -26,3 +26,7 @@ Define the protobuf envelope used to stream frames and peripheral updates into t
 ## Client decoding
 
 The Beats UI uses `protobufjs` to parse `StreamEnvelope` frames and emits a typed `StreamEvent` into the RxJS stream. Frame bytes are converted directly into PNG blobs, and peripheral payloads are decoded from UTF-8 JSON when the payload encoding signals `JSON_UTF8`. Protobuf payloads set `payload_type` to the fully-qualified message name and set the encoding to `PROTOBUF`.
+
+## Python decoding helpers
+
+`heart.device.beats.websocket.decode_stream_envelope` provides the Python mirror for decoding envelopes. It returns a `(kind, payload)` tuple for `frame` and `peripheral` payloads, and uses `decode_peripheral_payload` from `heart.peripheral.core.encoding` to decode JSON or protobuf payload bytes. Protobuf decoding resolves the `payload_type` with `google.protobuf.symbol_database.Default()`, so the relevant message modules must be imported before decoding.


### PR DESCRIPTION
### Motivation

- Ensure the Beats websocket path can both emit and consume protobuf payloads so typed clients can round-trip messages.  
- Provide symmetric decoding to the existing `encode_peripheral_payload` so binary envelopes received in Python can be parsed into native structures or protobuf messages.  
- Reconstruct peripheral metadata (ids and tags) when decoding so runtime consumers receive the same envelope shape produced by the runtime.  
- Surface decoding errors with a clear exception type for callers to handle programmatically.

### Description

- Added `decode_peripheral_payload` and `PeripheralPayloadDecodingError` to `src/heart/peripheral/core/encoding.py`, and wired `google.protobuf.symbol_database.Default()` for resolving protobuf message types.  
- Introduced `decode_stream_envelope` and `_decode_peripheral_payload_encoding` in `src/heart/device/beats/websocket.py` to parse `StreamEnvelope` bytes into either a raw frame or a `PeripheralMessageEnvelope` with decoded payloads.  
- Reused `PeripheralInfo` / `PeripheralTag` types when reconstructing decoded peripheral envelopes and added logging around decode failures.  
- Expanded tests in `tests/device/test_beats_websocket.py` to cover JSON and protobuf encoding/decoding and added documentation in `docs/beats-websocket-protobuf.md` describing the Python helpers.

### Testing

- Ran formatting with `make format` and applied repository formatters successfully.  
- Executed the full test suite with `make test`; automated tests passed (`222 passed, 1 skipped`).  
- Added unit tests exercising `decode_peripheral_payload` and `decode_stream_envelope`, which passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dca9bd2288321a432689b097bf6db)