### PR TITLE
Centralize firmware device name constants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Use the tooling in this repository to manage environments. Prefer `uv` for Pytho
 Run `make format` before committing changes. This applies Ruff fixes, isort, Black, docformatter, and mdformat to Python sources and documentation. Documentation updates should avoid marketing language, state the technical problem in plain terms, and include a materials list when relevant.
 
 - Avoid declaring module-level `__all__` exports. Prefer explicit imports at call sites instead of curating export lists.
+- Define device identifiers (such as firmware `device_name` values) as module-level constants instead of inline literals.
 - Avoid building filesystem paths via string concatenation. Use `os.path.join` or `pathlib.Path` instead.
 - Prefer `pathlib.Path` over `os.path.join` when constructing paths, and ensure functions annotated to return a `Path` return a `Path` object.
 - When CLI arguments accept file paths, parse them as `pathlib.Path` objects and ensure parent directories exist before writing.

--- a/drivers/bluetooth-bridge/code.py
+++ b/drivers/bluetooth-bridge/code.py
@@ -43,9 +43,10 @@ MINIMUM_LIGHT_ON_SECONDS = 0.05
 
 END_OF_MESSAGE_DELIMETER = "\n"
 ENCODING = "utf-8"
+DEVICE_NAME = "bluetooth-bridge"
 
 IDENTITY = identity.Identity(
-    device_name="bluetooth-bridge",
+    device_name=DEVICE_NAME,
     firmware_commit=identity.default_firmware_commit(),
     device_id=device_id.persistent_device_id(),
 )

--- a/drivers/lampe-controller/code.py
+++ b/drivers/lampe-controller/code.py
@@ -12,10 +12,11 @@ import digitalio
 from heart.firmware_io import bluetooth, device_id, identity, rotary_encoder
 
 MINIMUM_LIGHT_ON_SECONDS = 0.05
+DEVICE_NAME = "lampe-controller"
 
 
 IDENTITY = identity.Identity(
-    device_name="lampe-controller",
+    device_name=DEVICE_NAME,
     firmware_commit=identity.default_firmware_commit(),
     device_id=device_id.persistent_device_id(),
 )

--- a/drivers/radio_bridge/code.py
+++ b/drivers/radio_bridge/code.py
@@ -10,8 +10,9 @@ from typing import Callable, Mapping
 from heart.firmware_io import device_id, identity
 from heart.firmware_io.constants import RADIO_PACKET
 
+DEVICE_NAME = "radio-bridge"
 IDENTITY = identity.Identity(
-    device_name="radio-bridge",
+    device_name=DEVICE_NAME,
     firmware_commit=identity.default_firmware_commit(),
     device_id=device_id.persistent_device_id(),
 )

--- a/drivers/rotary_encoder/code.py
+++ b/drivers/rotary_encoder/code.py
@@ -15,8 +15,9 @@ from digitalio import DigitalInOut, Direction, Pull
 
 from heart.firmware_io import device_id, identity, rotary_encoder
 
+DEVICE_NAME = "rotary-encoder"
 IDENTITY = identity.Identity(
-    device_name="rotary-encoder",
+    device_name=DEVICE_NAME,
     firmware_commit=identity.default_firmware_commit(),
     device_id=device_id.persistent_device_id(),
 )

--- a/drivers/sensor_bus/code.py
+++ b/drivers/sensor_bus/code.py
@@ -20,6 +20,7 @@ from heart.firmware_io import constants, device_id, identity
 
 WAIT_BEFORE_TRYING_TO_CONNECT_TO_SENSOR_SECONDS: float = 1.0
 DEBUG = False
+DEVICE_NAME = "sensor-bus"
 
 
 def _debug(message: str) -> None:
@@ -27,7 +28,7 @@ def _debug(message: str) -> None:
         print(message)
 
 IDENTITY = identity.Identity(
-    device_name="sensor-bus",
+    device_name=DEVICE_NAME,
     firmware_commit=identity.default_firmware_commit(),
     device_id=device_id.persistent_device_id(),
 )


### PR DESCRIPTION
### Motivation
- Introduce a repository guideline to avoid inline string literals for firmware device identifiers and centralize them as module-level constants.
- Reduce duplication and make device identity configuration clearer and easier to change across firmware drivers.
- Align driver modules with the repository's style guidance for module-level constants and clearer configuration.

### Description
- Add a new rule to `AGENTS.md` recommending device identifiers (firmware `device_name` values) be defined as module-level constants.
- Introduce `DEVICE_NAME` constants and update `IDENTITY` construction to use them in firmware drivers `drivers/bluetooth-bridge/code.py`, `drivers/lampe-controller/code.py`, `drivers/radio_bridge/code.py`, `drivers/rotary_encoder/code.py`, and `drivers/sensor_bus/code.py`.
- Run repository formatting to ensure style and lint consistency by invoking `make format`.

### Testing
- Ran `make format`, which completed successfully and reported "All checks passed!".
- No additional automated test suite runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dcab173c083219661ba49d3adf6d7)