### PR TITLE
Add retry-threshold guidance and use module-level constant for Bluetooth reconnect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - Prefer `StrEnum` values over raw strings for strategy/configuration mode selections.
 - Use `heart.utilities.logging.get_logger` for internal logging so handlers and log levels stay consistent across modules.
 - Prefer module-level constants for tunable loop intervals instead of embedding sleep literals in long-running loops.
+- Prefer module-level constants for retry thresholds in reconnect or recovery loops instead of inline numeric literals.
 - When reading or writing text files, specify an explicit encoding (prefer `utf-8`) to keep behavior consistent across platforms.
 
 ## Error Handling

--- a/src/heart/peripheral/switch.py
+++ b/src/heart/peripheral/switch.py
@@ -29,6 +29,7 @@ SERIAL_RECONNECT_DELAY_SECONDS = 0.1
 BLUETOOTH_EVENT_POLL_DELAY_SECONDS = 0.1
 BLUETOOTH_RETRY_DELAY_SECONDS = 5
 BLUETOOTH_SLOW_RETRY_DELAY_SECONDS = 30
+BLUETOOTH_MAX_RETRY_ATTEMPTS = 5
 
 
 @dataclass(frozen=True, slots=True)
@@ -313,7 +314,7 @@ class BluetoothSwitch(BaseSwitch):
             except Exception:
                 self.connected = False
                 number_of_retries_without_success += 1
-                if number_of_retries_without_success > 5:
+                if number_of_retries_without_success > BLUETOOTH_MAX_RETRY_ATTEMPTS:
                     slow_poll = True
 
             time.sleep(


### PR DESCRIPTION
### Motivation
- Avoid inline numeric literals for reconnect/recovery thresholds so behavior is explicit and configurable.
- Document the recommended pattern for retry thresholds in the repository `AGENTS.md` guidance.

### Description
- Added guidance to `AGENTS.md`: "Prefer module-level constants for retry thresholds in reconnect or recovery loops instead of inline numeric literals.".
- Introduced `BLUETOOTH_MAX_RETRY_ATTEMPTS = 5` in `src/heart/peripheral/switch.py` and replaced the hard-coded `5` retry check with the new constant.

### Testing
- Ran `make format` which completed successfully to apply code formatting.
- Ran the full test suite with `make test` which resulted in `222 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dcc923e04832185966ab6067041ef)