### PR TITLE
Define shared memory polling constants

### DIFF
--- a/experimental/isolated_rendering/src/isolated_rendering/shared_memory.py
+++ b/experimental/isolated_rendering/src/isolated_rendering/shared_memory.py
@@ -39,6 +39,8 @@ _HEADER = struct.Struct("<4sHHQ")  # magic, width, height, version
 _HEADER_SIZE = _HEADER.size
 _VERSION_SIZE = struct.calcsize("<Q")
 _VERSION_OFFSET = _HEADER_SIZE - _VERSION_SIZE
+READ_RETRY_SLEEP_SECONDS = 0.0005
+DEFAULT_POLL_INTERVAL_SECONDS = 0.002
 
 
 def _pixel_stride(mode: str) -> int:
@@ -151,7 +153,7 @@ class SharedMemoryFile:
             version = self._read_version(mm)
             if version % 2 == 1:
                 # Writer in progress. Give it a moment.
-                time.sleep(0.0005)
+                time.sleep(READ_RETRY_SLEEP_SECONDS)
                 continue
             if version == last_version:
                 return version, None
@@ -193,7 +195,7 @@ class SharedMemoryWatcher:
         self,
         path: Path,
         frame_buffer: FrameBuffer,
-        poll_interval: float = 0.002,
+        poll_interval: float = DEFAULT_POLL_INTERVAL_SECONDS,
     ) -> None:
         self._file = SharedMemoryFile(path, size=frame_buffer.size, mode=frame_buffer.mode)
         self._frame_buffer = frame_buffer


### PR DESCRIPTION
### Motivation

- Conform to repository guidance that prefers module-level constants for tunable loop intervals instead of embedding sleep literals.  
- Avoid scattered magic numeric literals in the shared-memory reader/watcher logic so timing can be tuned and audited easily.  
- Make the polling/retry behaviour explicit and discoverable for future maintenance and CircuitPython constraints.  

### Description

- Add `READ_RETRY_SLEEP_SECONDS` and `DEFAULT_POLL_INTERVAL_SECONDS` module-level constants to `shared_memory.py`.  
- Replace inline `time.sleep(0.0005)` and the hardcoded `poll_interval` default with the new constants.  
- Leave behaviour unchanged other than replacing literals with named constants to improve readability and align with `AGENTS.md` rules.  
- Run repository formatting via `make format` to ensure style consistency.  

### Testing

- Ran `make format`, which completed successfully.  
- No automated unit tests (`make test`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694de707b99c8321a5c3103e3683e794)