### PR TITLE
Bind Lagom resolver to navigation renderers

### DIFF
--- a/docs/research/lagom_navigation_renderer_resolution.md
+++ b/docs/research/lagom_navigation_renderer_resolution.md
@@ -1,0 +1,24 @@
+# Lagom Navigation Renderer Resolution Note
+
+## Problem Statement
+
+Navigation-generated `ComposedRenderer` instances had no default access to the runtime Lagom
+container, so renderers could only be resolved when configuration modules passed the container
+explicitly. This left navigation-owned renderers outside the shared container context and made it
+harder to resolve renderers inside the controller lifecycle.
+
+## Materials
+
+- Python 3.11 environment with `uv` for dependency resolution.
+- Lagom dependency (`lagom` in `pyproject.toml`).
+- Source modules: `src/heart/navigation/app_controller.py`,
+  `src/heart/navigation/composed_renderer.py`,
+  `src/heart/runtime/container.py`.
+
+## Notes
+
+`AppController` now accepts a renderer resolver and wires it into newly created
+`ComposedRenderer` instances, so navigation-owned renderers can resolve dependencies through the
+shared container without additional plumbing. `ComposedRenderer` exposes
+`resolve_renderer_from_container` to use its bound resolver when available, while the existing
+`resolve_renderer` API remains for explicit resolution in configuration modules.

--- a/src/heart/navigation/app_controller.py
+++ b/src/heart/navigation/app_controller.py
@@ -13,7 +13,7 @@ from heart.renderers.color import RenderColor
 from heart.renderers.spritesheet import SpritesheetLoop
 from heart.renderers.text import TextRendering
 
-from .composed_renderer import ComposedRenderer
+from .composed_renderer import ComposedRenderer, RendererResolver
 from .game_modes import GameModes
 from .multi_scene import MultiScene
 
@@ -24,11 +24,12 @@ class AppControllerState:
 
 
 class AppController(StatefulBaseRenderer[AppControllerState]):
-    def __init__(self) -> None:
+    def __init__(self, renderer_resolver: RendererResolver | None = None) -> None:
         super().__init__()
         self.modes = GameModes()
         self.device_display_mode = DeviceDisplayMode.FULL
         self.warmup = True
+        self._renderer_resolver = renderer_resolver
 
     def _create_initial_state(
         self,
@@ -74,7 +75,7 @@ class AppController(StatefulBaseRenderer[AppControllerState]):
         title: str | list[StatefulBaseRenderer] | StatefulBaseRenderer | None = None,
     ) -> ComposedRenderer:
         # TODO: Add a navigation page back in
-        result = ComposedRenderer([])
+        result = ComposedRenderer([], renderer_resolver=self._renderer_resolver)
         if title is None:
             title = "Untitled"
 
@@ -106,5 +107,5 @@ class AppController(StatefulBaseRenderer[AppControllerState]):
         if isinstance(title, StatefulBaseRenderer):
             return title
         if isinstance(title, list):
-            return ComposedRenderer(title)
+            return ComposedRenderer(title, renderer_resolver=self._renderer_resolver)
         raise ValueError(f"Title must be a string or StatefulBaseRenderer, got: {title}")

--- a/src/heart/navigation/composed_renderer.py
+++ b/src/heart/navigation/composed_renderer.py
@@ -26,9 +26,14 @@ class ComposedRendererState:
 
 
 class ComposedRenderer(StatefulBaseRenderer[ComposedRendererState]):
-    def __init__(self, renderers: list[StatefulBaseRenderer]) -> None:
+    def __init__(
+        self,
+        renderers: list[StatefulBaseRenderer],
+        renderer_resolver: RendererResolver | None = None,
+    ) -> None:
         super().__init__()
         self.renderers: list[StatefulBaseRenderer] = renderers
+        self._renderer_resolver = renderer_resolver
 
     def _real_get_renderers(self) -> list[StatefulBaseRenderer]:
         result: list[StatefulBaseRenderer] = []
@@ -80,6 +85,13 @@ class ComposedRenderer(StatefulBaseRenderer[ComposedRendererState]):
                 self.state.peripheral_manager,
                 self.state.orientation,
             )
+
+    def resolve_renderer_from_container(
+        self, renderer: type[StatefulBaseRenderer]
+    ) -> None:
+        if self._renderer_resolver is None:
+            raise ValueError("ComposedRenderer requires a renderer resolver")
+        self.resolve_renderer(self._renderer_resolver, renderer)
 
     def real_process(
         self,

--- a/src/heart/runtime/container.py
+++ b/src/heart/runtime/container.py
@@ -60,7 +60,12 @@ def build_runtime_container(
         PeripheralRuntime,
         Singleton(lambda resolver: PeripheralRuntime(resolver[PeripheralManager])),
     )
-    _bind(container, overrides, AppController, Singleton(AppController))
+    _bind(
+        container,
+        overrides,
+        AppController,
+        Singleton(lambda resolver: AppController(renderer_resolver=resolver)),
+    )
     _bind(container, overrides, PygameEventHandler, Singleton(PygameEventHandler))
     apply_provider_registrations(container)
     return container


### PR DESCRIPTION
### Motivation

- Navigation-created renderer groups lacked a default path to the runtime Lagom container, forcing configuration code to pass the container explicitly.  
- This ad-hoc wiring duplicated construction logic and made it harder to resolve renderer dependencies consistently across the runtime.  
- Centralizing resolver access reduces the chance of bypassing the container and improves testability.  

### Description

- `AppController` now accepts a `renderer_resolver` and forwards it into new `ComposedRenderer` instances via the constructor.  
- `ComposedRenderer` accepts an optional `RendererResolver`, stores it, and exposes `resolve_renderer_from_container` which resolves types through the bound resolver.  
- The runtime container registration now provides `AppController` as a `Singleton(lambda resolver: AppController(renderer_resolver=resolver))` so navigation components get the shared container automatically.  
- Added `docs/research/lagom_navigation_renderer_resolution.md` documenting the integration and rationale.  

### Testing

- Ran `make format` and the repository formatting checks passed.  
- Ran the full test suite with `make test`.  
- Test run result: `223 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694de6f682008321b2a427550d13e033)