### PR TITLE
Add Semgrep rules for exception handling

### DIFF
--- a/docs/static_analysis.md
+++ b/docs/static_analysis.md
@@ -37,6 +37,8 @@ by default.
 | `heart-no-wildcard-import` | Avoid wildcard imports. | `src/**/*.py` |
 | `heart-no-module-all` | Avoid module-level `__all__` exports. | `src/**/*.py` |
 | `heart-no-os-path-join` | Prefer `pathlib.Path` over `os.path.join`. | `src/**/*.py` |
+| `heart-no-baseexception-catch` | Avoid catching `BaseException`. | `src/**/*.py` |
+| `heart-no-bare-exception-raise` | Require specific exception types instead of `Exception`. | `src/**/*.py` |
 
 ## Updating the rules
 

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -57,3 +57,33 @@ rules:
       category: style
       technology:
         - python
+  - id: heart-no-baseexception-catch
+    languages:
+      - python
+    message: Avoid catching BaseException so system-exiting signals propagate.
+    severity: ERROR
+    patterns:
+      - pattern: |
+          except BaseException:
+            ...
+    paths:
+      include:
+        - src/**/*.py
+    metadata:
+      category: error-handling
+      technology:
+        - python
+  - id: heart-no-bare-exception-raise
+    languages:
+      - python
+    message: Raise a specific exception type instead of a bare Exception.
+    severity: ERROR
+    patterns:
+      - pattern: raise Exception(...)
+    paths:
+      include:
+        - src/**/*.py
+    metadata:
+      category: error-handling
+      technology:
+        - python


### PR DESCRIPTION
### Motivation
- Enforce repository error-handling guidance to avoid swallowing system-exiting signals and to prefer specific exception types.
- Extend static analysis to catch patterns that are called out in `AGENTS.md` and project coding guidelines.

### Description
- Add two Semgrep rules to `semgrep.yml`: `heart-no-baseexception-catch` to flag `except BaseException:` patterns and `heart-no-bare-exception-raise` to flag `raise Exception(...)` usages.
- Each rule targets `src/**/*.py` and includes messages, severity, and `error-handling` metadata consistent with existing rules.
- Document the new rules in the rule catalog in `docs/static_analysis.md`.

### Testing
- Ran `make format` to apply formatting rules and verify repository style, which completed successfully.
- No other automated test changes were run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694de9b08a94832190c7e9b93b6a75ff)