### PR TITLE
Define default sensor payload interval constant

### DIFF
--- a/drivers/sensor_bus/code.py
+++ b/drivers/sensor_bus/code.py
@@ -19,6 +19,7 @@ from adafruit_lsm303_accel import LSM303_Accel
 from heart.firmware_io import constants, device_id, identity
 
 WAIT_BEFORE_TRYING_TO_CONNECT_TO_SENSOR_SECONDS: float = 1.0
+DEFAULT_WAIT_BETWEEN_PAYLOADS_SECONDS: float = 0.1
 DEBUG = False
 DEVICE_NAME = "sensor-bus"
 
@@ -180,7 +181,7 @@ def main() -> None:
     # 2. That actually checking the sensor takes roughly 0 time
     sample_rates = [(1000 / get_sample_rate(sensor)) / 1000 for sensor in sensors]
     if len(sample_rates) == 0:
-        wait_between_payloads_seconds = 0.1
+        wait_between_payloads_seconds = DEFAULT_WAIT_BETWEEN_PAYLOADS_SECONDS
     else:
         wait_between_payloads_seconds = min(sample_rates)
 


### PR DESCRIPTION
### Motivation
- Replace an inline sleep literal with a module-level constant to follow the guideline to prefer module-level constants for tunable loop intervals.
- Make timing behaviour explicit and discoverable for the CircuitPython sensor bus driver.
- Improve maintainability by giving a single location to tune payload frequency.

### Description
- Add `DEFAULT_WAIT_BETWEEN_PAYLOADS_SECONDS: float = 0.1` to `drivers/sensor_bus/code.py`.
- Replace the inline `0.1` fallback with `DEFAULT_WAIT_BETWEEN_PAYLOADS_SECONDS` when computing `wait_between_payloads_seconds`.
- No behavioural changes to the logic that computes sample rates or publishes payloads.

### Testing
- Ran `make format`, which completed successfully.
- No unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694de956521c8321b90398ab321969e9)