### PR TITLE
Define module-level defaults for run command options

### DIFF
--- a/src/heart/cli/commands/run.py
+++ b/src/heart/cli/commands/run.py
@@ -8,14 +8,22 @@ from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
 
+DEFAULT_CONFIGURATION = "lib_2025"
+DEFAULT_ADD_LOW_POWER_MODE = True
+DEFAULT_X11_FORWARD = False
+
 
 def run_command(
-    configuration: Annotated[str, typer.Option("--configuration")] = "lib_2025",
+    configuration: Annotated[str, typer.Option("--configuration")] = DEFAULT_CONFIGURATION,
     add_low_power_mode: bool = typer.Option(
-        True, "--add-low-power-mode", help="Add a low power mode"
+        DEFAULT_ADD_LOW_POWER_MODE,
+        "--add-low-power-mode",
+        help="Add a low power mode",
     ),
     x11_forward: bool = typer.Option(
-        False, "--x11-forward", help="Use X11 forwarding for RGB display"
+        DEFAULT_X11_FORWARD,
+        "--x11-forward",
+        help="Use X11 forwarding for RGB display",
     ),
 ) -> None:
     registry = ConfigurationRegistry()


### PR DESCRIPTION
### Motivation
- Align with the repository guideline to keep CLI default option values as module-level constants.
- Make the `run_command` defaults easier to reuse and update by centralizing them in one place.
- Improve readability of the `run_command` signature by removing inline literal defaults.

### Description
- Add `DEFAULT_CONFIGURATION`, `DEFAULT_ADD_LOW_POWER_MODE`, and `DEFAULT_X11_FORWARD` to `src/heart/cli/commands/run.py`.
- Replace the inline defaults in `run_command` with the new module-level constants.
- Preserve existing behavior (default configuration `lib_2025`, low power mode enabled, X11 forwarding disabled) while centralizing the values.

### Testing
- Ran `make format`, which completed successfully and reported all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dea7e0be4832199a1d93a508737b9)