### PR TITLE
Add logging for firmware accelerometer initialization and failure details

### DIFF
--- a/src/heart/firmware_io/accel.py
+++ b/src/heart/firmware_io/accel.py
@@ -6,6 +6,9 @@ from adafruit_lsm6ds.ism330dhcx import ISM330DHCX
 from adafruit_lsm303_accel import LSM303_Accel
 
 from heart.firmware_io import constants
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def _form_payload(name: str, data) -> str:
@@ -112,9 +115,12 @@ class SensorReader:
         sensors = []
         for sensor_fn in sensor_fn:
             try:
+                logger.info("Initializing firmware sensor: %s", sensor_fn.__name__)
                 sensors.append(sensor_fn(i2c))
             except Exception:
-                pass
+                logger.exception(
+                    "Failed to initialize firmware sensor: %s", sensor_fn.__name__
+                )
         return sensors
 
     def get_sample_rate(self, sensor) -> float:


### PR DESCRIPTION
### Motivation
- Make firmware accelerometer initialization observable to aid debugging when sensors fail to construct under constrained builds.
- Avoid silently swallowing exceptions during sensor construction so failures surface with context and tracebacks.
- Use the project-wide logging utilities for consistent handler and level configuration across modules.

### Description
- Import `get_logger` and create a module-level `logger` with `logger = get_logger(__name__)`.
- Emit an info-level message before attempting to initialize each firmware sensor with the sensor class name.
- Replace the silent `except` that previously swallowed construction errors with `logger.exception(...)` to log the failure and traceback.
- Preserve existing behavior of returning the list of successfully initialized sensors from `SensorReader.connect_to_sensors`.

### Testing
- Ran the formatting checks with `make format`, which reported success (`All checks passed`).
- No automated `pytest` test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dea87b6488321915abe7b084eeef5)