### PR TITLE
Use container-bound renderer resolution in configs

### DIFF
--- a/docs/research/lagom_renderer_resolution.md
+++ b/docs/research/lagom_renderer_resolution.md
@@ -2,10 +2,9 @@
 
 ## Problem Statement
 
-Renderer configuration modules sometimes attempted to resolve renderers from the `GameLoop`
-instance directly, even though the shared Lagom container lives on
-`GameLoop.context_container`. This masked where dependency resolution actually happened and
-made it easier to bypass the container when new renderers were added.
+Renderer configuration modules relied on passing `GameLoop.context_container` around when
+resolving renderers, which duplicated container plumbing and made it easier to sidestep the
+resolver baked into `ComposedRenderer`.
 
 ## Materials
 
@@ -16,12 +15,12 @@ made it easier to bypass the container when new renderers were added.
 
 ## Notes
 
-`ComposedRenderer.resolve_renderer` now accepts a resolver protocol that only requires a
-`resolve()` method. This keeps the API aligned with Lagom while clarifying that the shared
-container is the intended source of renderer instances. Configuration modules now pass
-`GameLoop.context_container` directly when resolving renderer classes (for example, in
-`src/heart/programs/configurations/halloween_2024.py` and
-`src/heart/programs/configurations/life.py`), which avoids accidental container bypasses.
+`ComposedRenderer.resolve_renderer` accepts a resolver protocol that only requires a
+`resolve()` method, and `ComposedRenderer.resolve_renderer_from_container` uses the resolver
+provided by `AppController`. Configuration modules now call
+`resolve_renderer_from_container()` on the modes returned by `GameLoop.add_mode`, so the
+container linkage stays inside the navigation layer instead of being threaded through every
+configuration.
 
 This change keeps renderer wiring consistent with the runtime container built in
 `src/heart/runtime/container.py` and helps ensure future renderers resolve through Lagom.

--- a/src/heart/programs/configurations/cloth_sail.py
+++ b/src/heart/programs/configurations/cloth_sail.py
@@ -6,4 +6,4 @@ from heart.runtime.game_loop import GameLoop
 
 def configure(loop: GameLoop) -> None:
     mode = loop.add_mode("cloth_sail")
-    mode.resolve_renderer(loop.context_container, ClothSailRenderer)
+    mode.resolve_renderer_from_container(ClothSailRenderer)

--- a/src/heart/programs/configurations/halloween_2024.py
+++ b/src/heart/programs/configurations/halloween_2024.py
@@ -34,7 +34,7 @@ def configure(loop: GameLoop) -> None:
     # PacMan
     mode = loop.add_mode()
     mode.add_renderer(RandomPixel(color=Color(187, 10, 30), num_pixels=50))
-    mode.resolve_renderer(loop.context_container, PacmanGhostRenderer)
+    mode.resolve_renderer_from_container(PacmanGhostRenderer)
     mode.add_renderer(Border(width=2, color=Color(187, 10, 30)))
 
     # SpookyEye
@@ -59,11 +59,11 @@ def configure(loop: GameLoop) -> None:
 
     # Game of Life
     mode = loop.add_mode()
-    mode.resolve_renderer(loop.context_container, Life)
+    mode.resolve_renderer_from_container(Life)
 
     mode = loop.add_mode()
     # MANDELBROT
-    mode.resolve_renderer(loop.context_container, MandelbrotMode)
+    mode.resolve_renderer_from_container(MandelbrotMode)
 
     width = 64
     height = 64
@@ -90,7 +90,7 @@ def configure(loop: GameLoop) -> None:
     # PacMan
     mode = loop.add_mode()
     mode.add_renderer(RandomPixel(color=Color(187, 10, 30), num_pixels=50))
-    mode.resolve_renderer(loop.context_container, PacmanGhostRenderer)
+    mode.resolve_renderer_from_container(PacmanGhostRenderer)
     mode.add_renderer(Border(width=2, color=Color(187, 10, 30)))
 
     # SpookyEye
@@ -119,4 +119,4 @@ def configure(loop: GameLoop) -> None:
 
     # Game of Life
     mode = loop.add_mode()
-    mode.resolve_renderer(loop.context_container, Life)
+    mode.resolve_renderer_from_container(Life)

--- a/src/heart/programs/configurations/heart_rate.py
+++ b/src/heart/programs/configurations/heart_rate.py
@@ -5,5 +5,5 @@ from heart.runtime.game_loop import GameLoop
 def configure(loop: GameLoop) -> None:
     mode = loop.add_mode("heart_rate")
 
-    mode.resolve_renderer(loop.context_container, MaxBpmScreen)
+    mode.resolve_renderer_from_container(MaxBpmScreen)
     # mode.add_renderer(MetadataScreen())

--- a/src/heart/programs/configurations/lib_2024.py
+++ b/src/heart/programs/configurations/lib_2024.py
@@ -10,7 +10,7 @@ from heart.runtime.game_loop import GameLoop
 
 def configure(loop: GameLoop) -> None:
     kirby_mode = loop.add_mode(KirbyScene.title_scene())
-    kirby_mode.resolve_renderer(loop.context_container, KirbyScene)
+    kirby_mode.resolve_renderer_from_container(KirbyScene)
 
     modelbrot = loop.add_mode(
         ComposedRenderer(
@@ -26,10 +26,10 @@ def configure(loop: GameLoop) -> None:
             ]
         )
     )
-    modelbrot.resolve_renderer(loop.context_container, MandelbrotMode)
+    modelbrot.resolve_renderer_from_container(MandelbrotMode)
 
     hilbert_mode = loop.add_mode("hilbert")
-    hilbert_mode.resolve_renderer(loop.context_container, HilbertScene)
+    hilbert_mode.resolve_renderer_from_container(HilbertScene)
 
     mode = loop.add_mode("friend\nbeacon")
     text = ["Lost my\nfriends\nagain"]

--- a/src/heart/programs/configurations/lib_2025.py
+++ b/src/heart/programs/configurations/lib_2025.py
@@ -37,7 +37,7 @@ def pattern_numpy(t: float, X: np.ndarray, Y: np.ndarray) -> np.ndarray:
 
 def configure(loop: GameLoop) -> None:
     kirby_mode = loop.add_mode(KirbyScene.title_scene())
-    kirby_mode.resolve_renderer(loop.context_container, KirbyScene)
+    kirby_mode.resolve_renderer_from_container(KirbyScene)
 
     modelbrot = loop.add_mode(
         ComposedRenderer(
@@ -53,13 +53,13 @@ def configure(loop: GameLoop) -> None:
             ]
         )
     )
-    modelbrot.resolve_renderer(loop.context_container, MandelbrotMode)
+    modelbrot.resolve_renderer_from_container(MandelbrotMode)
 
     sphere_mode = loop.add_mode("3d fractal")
-    sphere_mode.resolve_renderer(loop.context_container, FractalScene)
+    sphere_mode.resolve_renderer_from_container(FractalScene)
 
     hilbert_mode = loop.add_mode("hilbert")
-    hilbert_mode.resolve_renderer(loop.context_container, HilbertScene)
+    hilbert_mode.resolve_renderer_from_container(HilbertScene)
 
     mario_mode = loop.add_mode(
         ComposedRenderer(
@@ -78,10 +78,7 @@ def configure(loop: GameLoop) -> None:
     loop.context_container[MarioRendererProvider] = Singleton(
         lambda builder: MarioRendererProvider(accel_stream=builder[AllAccelerometersProvider], sheet_file_path="mario_64.png", metadata_file_path="mario_64.json")
     )
-    mario_mode.resolve_renderer(
-        container=loop.context_container,
-        renderer=MarioRenderer
-    )
+    mario_mode.resolve_renderer_from_container(MarioRenderer)
 
     def multicolor_renderer() -> MulticolorRenderer:
         return loop.context_container.resolve(MulticolorRenderer)
@@ -123,7 +120,7 @@ def configure(loop: GameLoop) -> None:
             ]
         )
     )
-    heart_rate_mode.resolve_renderer(loop.context_container, CombinedBpmScreen)
+    heart_rate_mode.resolve_renderer_from_container(CombinedBpmScreen)
 
     water_mode = loop.add_mode(
         ComposedRenderer(
@@ -140,10 +137,10 @@ def configure(loop: GameLoop) -> None:
         )
     )
 
-    water_mode.resolve_renderer(loop.context_container, WaterCube)
+    water_mode.resolve_renderer_from_container(WaterCube)
 
     artist_mode = loop.add_mode(ArtistScene.title_scene())
-    artist_mode.resolve_renderer(loop.context_container, ArtistScene)
+    artist_mode.resolve_renderer_from_container(ArtistScene)
 
     friend_beacon_mode = loop.add_mode("friend\nbeacon")
     friend_beacon_mode.add_renderer(
@@ -219,7 +216,7 @@ def configure(loop: GameLoop) -> None:
     )
 
     life = loop.add_mode("life")
-    life.resolve_renderer(loop.context_container, Life)
+    life.resolve_renderer_from_container(Life)
 
     spooky = loop.add_mode("spook")
     spooky.add_renderer(

--- a/src/heart/programs/configurations/life.py
+++ b/src/heart/programs/configurations/life.py
@@ -4,4 +4,4 @@ from heart.runtime.game_loop import GameLoop
 
 def configure(loop: GameLoop) -> None:
     mode = loop.add_mode()
-    mode.resolve_renderer(loop.context_container, Life)
+    mode.resolve_renderer_from_container(Life)

--- a/src/heart/programs/configurations/mandlebrot.py
+++ b/src/heart/programs/configurations/mandlebrot.py
@@ -4,4 +4,4 @@ from heart.runtime.game_loop import GameLoop
 
 def configure(loop: GameLoop) -> None:
     mode = loop.add_mode()
-    mode.resolve_renderer(loop.context_container, MandelbrotMode)
+    mode.resolve_renderer_from_container(MandelbrotMode)

--- a/src/heart/programs/configurations/pacman.py
+++ b/src/heart/programs/configurations/pacman.py
@@ -8,5 +8,5 @@ from heart.runtime.game_loop import GameLoop
 def configure(loop: GameLoop) -> None:
     mode = loop.add_mode()
     mode.add_renderer(RandomPixel(color=Color(187, 10, 30), num_pixels=50))
-    mode.resolve_renderer(loop.context_container, PacmanGhostRenderer)
+    mode.resolve_renderer_from_container(PacmanGhostRenderer)
     mode.add_renderer(Border(width=2, color=Color(187, 10, 30)))

--- a/src/heart/programs/configurations/water.py
+++ b/src/heart/programs/configurations/water.py
@@ -4,4 +4,4 @@ from heart.runtime.game_loop import GameLoop
 
 def configure(loop: GameLoop) -> None:
     mode = loop.add_mode("water")
-    mode.resolve_renderer(loop.context_container, WaterCube)
+    mode.resolve_renderer_from_container(WaterCube)


### PR DESCRIPTION
### Motivation
- Configuration modules passed `GameLoop.context_container` into renderer resolution, duplicating DI plumbing and making it easy to bypass the navigation-bound resolver.
- Centralise renderer wiring so renderer instances resolve through the shared Lagom container provided to the navigation layer. 
- Keep configuration code simpler and make it easier to swap implementations in tests via container overrides.

### Description
- Replaced occurrences of `mode.resolve_renderer(loop.context_container, ...)` and `mode.resolve_renderer(container=..., renderer=...)` with `mode.resolve_renderer_from_container(...)` across `src/heart/programs/configurations/` so modes use the navigation-bound resolver. 
- Updated the research note at `docs/research/lagom_renderer_resolution.md` to reflect that `ComposedRenderer.resolve_renderer_from_container` uses the resolver supplied by `AppController` and that configuration modules should call the container-bound API. 
- Kept the existing runtime container builder and `ComposedRenderer` APIs as the canonical path for resolving renderers so tests can continue to override bindings. 
- Ran repository formatting (`make format`) to apply style fixes.

### Testing
- Ran `make format` which completed successfully. 
- Executed the test suite with `make test` and the automated tests passed with `223 passed, 1 skipped`. 
- Verified `tests/runtime/test_container.py` coverage for container overrides still succeeds. 
- No new failing tests were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694de94231008321aead088b43bbd10d)