### PR TITLE
Log Bluetooth switch listener and reconnect errors

### DIFF
--- a/src/heart/peripheral/switch.py
+++ b/src/heart/peripheral/switch.py
@@ -307,7 +307,7 @@ class BluetoothSwitch(BaseSwitch):
                     logger.info("Program terminated")
                 except Exception:
                     self.connected = False
-                    pass
+                    logger.exception("Bluetooth switch listener failed; reconnecting.")
                 finally:
                     self.connected = False
                     self.listener.close()
@@ -316,6 +316,11 @@ class BluetoothSwitch(BaseSwitch):
                 number_of_retries_without_success += 1
                 if number_of_retries_without_success > BLUETOOTH_MAX_RETRY_ATTEMPTS:
                     slow_poll = True
+                logger.exception(
+                    "Failed to connect to Bluetooth switch; retrying (%s/%s).",
+                    number_of_retries_without_success,
+                    BLUETOOTH_MAX_RETRY_ATTEMPTS,
+                )
 
             time.sleep(
                 BLUETOOTH_SLOW_RETRY_DELAY_SECONDS


### PR DESCRIPTION
### Motivation
- Prevent silent failure by surfacing exceptions thrown by the Bluetooth switch listener so issues can be diagnosed.
- Provide contextual logging for connection attempts to aid in debugging intermittent Bluetooth connectivity.

### Description
- Replace silent exception swallowing in `BluetoothSwitch.run` with `logger.exception` when the listener loop fails to ensure stack traces are recorded.
- Add a retry-context log using `logger.exception` in the outer connection `except` to report `number_of_retries_without_success` and `BLUETOOTH_MAX_RETRY_ATTEMPTS`.
- Changes were made in `src/heart/peripheral/switch.py` to add the new logging statements.

### Testing
- Ran `make test` and the test suite completed with `223 passed, 1 skipped`.
- Ran `make format` and formatting/lint checks reported success during the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dea91e7b48321aa9d90e9915cb72c)