### PR TITLE
Use Lagom container resolution in renderer configurations

### DIFF
--- a/docs/research/lagom_renderer_provider_integration.md
+++ b/docs/research/lagom_renderer_provider_integration.md
@@ -15,6 +15,8 @@ DI concerns.
   `src/heart/renderers/cloth_sail/`,
   `src/heart/renderers/three_fractal/`,
   `src/heart/programs/configurations/lib_2025.py`,
+  `src/heart/programs/configurations/l_system.py`,
+  `src/heart/programs/configurations/porthole_window.py`,
   `src/heart/programs/configurations/cloth_sail.py`.
 
 ## Notes
@@ -26,3 +28,8 @@ renderers through `GameLoop.context_container` instead of manually constructing 
 Fractal scene provider now takes a `Device` dependency from the container, which keeps device
 wiring centralized in `build_runtime_container` and avoids leaking device plumbing into
 configuration modules.
+
+`LSystem` and `PortholeWindowRenderer` configurations now rely on
+`ComposedRenderer.resolve_renderer_from_container` so Lagom supplies the registered state
+providers. This reduces direct provider construction in configuration modules while keeping the
+runtime container responsible for provider wiring.

--- a/src/heart/programs/configurations/l_system.py
+++ b/src/heart/programs/configurations/l_system.py
@@ -1,9 +1,7 @@
-from heart.renderers.l_system import LSystem, LSystemStateProvider
+from heart.renderers.l_system import LSystem
 from heart.runtime.game_loop import GameLoop
 
 
 def configure(loop: GameLoop) -> None:
     mode = loop.add_mode()
-    mode.add_renderer(
-        LSystem(builder=loop.context_container.resolve(LSystemStateProvider))
-    )
+    mode.resolve_renderer_from_container(LSystem)

--- a/src/heart/programs/configurations/porthole_window.py
+++ b/src/heart/programs/configurations/porthole_window.py
@@ -1,14 +1,9 @@
 """Configuration for the brass porthole window renderer."""
 
-from heart.renderers.porthole_window import (PortholeWindowRenderer,
-                                             PortholeWindowStateProvider)
+from heart.renderers.porthole_window import PortholeWindowRenderer
 from heart.runtime.game_loop import GameLoop
 
 
 def configure(loop: GameLoop) -> None:
     mode = loop.add_mode("porthole_window")
-    mode.add_renderer(
-        PortholeWindowRenderer(
-            builder=loop.context_container.resolve(PortholeWindowStateProvider)
-        )
-    )
+    mode.resolve_renderer_from_container(PortholeWindowRenderer)


### PR DESCRIPTION
### Motivation
- Centralize renderer and provider wiring through the Lagom runtime container so configuration modules stop constructing provider-backed renderers directly.
- Reduce duplicated DI plumbing and make it easier to swap implementations via container overrides in tests.
- Keep runtime ownership of `Device` and provider singletons inside the container for more predictable lifecycle and resolution.

### Description
- Replace manual provider-backed construction in `src/heart/programs/configurations/l_system.py` with `mode.resolve_renderer_from_container(LSystem)` so the renderer is resolved from the runtime container.
- Replace manual provider-backed construction in `src/heart/programs/configurations/porthole_window.py` with `mode.resolve_renderer_from_container(PortholeWindowRenderer)` and remove the explicit provider import.
- Update `docs/research/lagom_renderer_provider_integration.md` to document that `LSystem` and `PortholeWindowRenderer` now rely on container-backed resolution.

### Testing
- Ran `make format` and it completed successfully.
- Ran `make test` and collection failed due to a circular import during test collection originating from `heart.peripheral.core.protobuf_catalog`, so the test suite did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694deb7bca988321824b353c8a9a50e1)