### PR TITLE
Add Semgrep checks for path concatenation and encoding

### DIFF
--- a/semgrep.yml
+++ b/semgrep.yml
@@ -87,3 +87,37 @@ rules:
       category: error-handling
       technology:
         - python
+  - id: heart-no-text-open-without-encoding
+    languages:
+      - python
+    message: Specify an explicit encoding when reading or writing text files.
+    severity: ERROR
+    patterns:
+      - pattern: open($FILE, $MODE, ...)
+      - metavariable-regex:
+          metavariable: $MODE
+          regex: ^["']?[rwa]([t+])?["']?$
+      - pattern-not: open($FILE, $MODE, ..., encoding=$ENCODING, ...)
+    paths:
+      include:
+        - src/**/*.py
+    metadata:
+      category: style
+      technology:
+        - python
+  - id: heart-no-path-concat
+    languages:
+      - python
+    message: Avoid string concatenation for filesystem paths; use pathlib.Path.
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - pattern: $LEFT + "/" + $RIGHT
+          - pattern: f"{$LEFT}/{$RIGHT}"
+    paths:
+      include:
+        - src/**/*.py
+    metadata:
+      category: style
+      technology:
+        - python


### PR DESCRIPTION
### Motivation
- Enforce repository style guidance to require explicit text encodings when opening files and to discourage string-based filesystem path concatenation.
- Reduce platform-dependent bugs and improve consistency by encouraging `utf-8` usage and `pathlib.Path` for path construction.

### Description
- Add a Semgrep rule `heart-no-text-open-without-encoding` that flags `open($FILE, $MODE, ...)` calls without an explicit `encoding=` and targets `src/**/*.py`.
- Add a Semgrep rule `heart-no-path-concat` that flags common string-based path concatenation patterns (e.g. `$LEFT + "/" + $RIGHT` and `f"{$LEFT}/{$RIGHT}"`) and targets `src/**/*.py`.
- Both rules use `severity: ERROR` and include guidance messages to prefer explicit encodings and `pathlib.Path` respectively.
- Update `semgrep.yml` to include these new checks.

### Testing
- Ran `make format` (the repository format and type-check pipeline) and it failed due to `mypy` errors in the generated protobuf module `src/heart/peripheral/proto/peripheral_payloads_pb2.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694debdac81083219c8a24af30a5dad9)