### PR TITLE
Fix protobuf catalog registration cycle

### DIFF
--- a/src/heart/device/beats/proto/__init__.py
+++ b/src/heart/device/beats/proto/__init__.py
@@ -1,5 +1,6 @@
 """Protocol buffer modules for Beats streaming."""
 
-from heart.peripheral.core.protobuf_catalog import register_protobuf_catalog
+from heart.peripheral.core import protobuf_catalog
+from heart.peripheral.core.protobuf_registry import protobuf_registry
 
-register_protobuf_catalog()
+protobuf_catalog.register_protobuf_catalog(protobuf_registry)

--- a/src/heart/peripheral/core/protobuf_catalog.py
+++ b/src/heart/peripheral/core/protobuf_catalog.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-from heart.peripheral.core.protobuf_registry import protobuf_registry
+if TYPE_CHECKING:
+    from heart.peripheral.core.protobuf_registry import ProtobufTypeRegistry
 
 BEATS_STREAMING_PACKAGE = "heart.beats.streaming"
 BEATS_STREAMING_MODULE = "heart.device.beats.proto.beats_streaming_pb2"
@@ -31,9 +33,6 @@ PROTOBUF_CATALOG: tuple[ProtobufCatalogEntry, ...] = (
 )
 
 
-def register_protobuf_catalog() -> None:
+def register_protobuf_catalog(registry: ProtobufTypeRegistry) -> None:
     for entry in PROTOBUF_CATALOG:
-        protobuf_registry.register_type_prefix(entry.package_prefix, entry.module_path)
-
-
-register_protobuf_catalog()
+        registry.register_type_prefix(entry.package_prefix, entry.module_path)

--- a/src/heart/peripheral/core/protobuf_registry.py
+++ b/src/heart/peripheral/core/protobuf_registry.py
@@ -72,4 +72,4 @@ protobuf_registry = ProtobufTypeRegistry()
 from heart.peripheral.core import \
     protobuf_catalog as _protobuf_catalog  # noqa: E402
 
-_protobuf_catalog.register_protobuf_catalog()
+_protobuf_catalog.register_protobuf_catalog(protobuf_registry)


### PR DESCRIPTION
### Motivation
- Tests were failing during collection due to a circular import between the protobuf catalog and the registry while registering types.
- Module-level registration created import-time side effects that pulled in modules before the shared registry was available.
- Make catalog registration explicit to break the circular import and clarify initialization order.

### Description
- Change `register_protobuf_catalog` to accept a `ProtobufTypeRegistry` instance and stop importing `protobuf_registry` at module runtime.
- Use `typing.TYPE_CHECKING` in `src/heart/peripheral/core/protobuf_catalog.py` to avoid runtime imports of the registry type.
- Update `src/heart/peripheral/core/protobuf_registry.py` to call `_protobuf_catalog.register_protobuf_catalog(protobuf_registry)` with the shared registry.
- Update `src/heart/device/beats/proto/__init__.py` to import `protobuf_registry` and call `protobuf_catalog.register_protobuf_catalog(protobuf_registry)`.

### Testing
- Ran the full test suite with `make test`.
- Test results: `224 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694decca207483219f7f7d98a5bccb97)