### PR TITLE
Fix protobuf registration loop and log Bluetooth switch errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,10 @@ module = [
 ]
 follow_imports = "skip"
 
+[[tool.mypy.overrides]]
+module = ["heart.peripheral.proto.peripheral_payloads_pb2"]
+ignore_errors = true
+
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 testpaths = ["tests"]

--- a/src/heart/peripheral/core/protobuf_catalog.py
+++ b/src/heart/peripheral/core/protobuf_catalog.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from heart.peripheral.core.protobuf_registry import protobuf_registry
-
 BEATS_STREAMING_PACKAGE = "heart.beats.streaming"
 BEATS_STREAMING_MODULE = "heart.device.beats.proto.beats_streaming_pb2"
 PERIPHERAL_PAYLOADS_PACKAGE = "heart.peripheral.payloads"
@@ -32,6 +30,8 @@ PROTOBUF_CATALOG: tuple[ProtobufCatalogEntry, ...] = (
 
 
 def register_protobuf_catalog() -> None:
+    from heart.peripheral.core.protobuf_registry import protobuf_registry
+
     for entry in PROTOBUF_CATALOG:
         protobuf_registry.register_type_prefix(entry.package_prefix, entry.module_path)
 

--- a/src/heart/peripheral/switch.py
+++ b/src/heart/peripheral/switch.py
@@ -307,12 +307,19 @@ class BluetoothSwitch(BaseSwitch):
                     logger.info("Program terminated")
                 except Exception:
                     self.connected = False
-                    pass
+                    logger.debug(
+                        "Bluetooth switch event loop failed; reconnecting.",
+                        exc_info=True,
+                    )
                 finally:
                     self.connected = False
                     self.listener.close()
             except Exception:
                 self.connected = False
+                logger.debug(
+                    "Bluetooth switch listener setup failed; retrying.",
+                    exc_info=True,
+                )
                 number_of_retries_without_success += 1
                 if number_of_retries_without_success > BLUETOOTH_MAX_RETRY_ATTEMPTS:
                     slow_poll = True


### PR DESCRIPTION
### Motivation

- Prevent silent failures in the Bluetooth switch event loop by surfacing exceptions to logs instead of swallowing them.
- Break a circular import between the protobuf catalog and registry that caused partial module initialization and runtime ImportError.
- Suppress spurious mypy errors originating from generated protobuf code so strict type checks can run without noise.

### Description

- Replace an empty `except Exception: pass` in `src/heart/peripheral/switch.py` with `logger.debug(..., exc_info=True)` to log failures during the Bluetooth event loop and listener setup.
- Move the import of `protobuf_registry` into `register_protobuf_catalog()` in `src/heart/peripheral/core/protobuf_catalog.py` to avoid a circular import during module initialization.
- Add a mypy override in `pyproject.toml` to `ignore_errors` for `heart.peripheral.proto.peripheral_payloads_pb2` so generated protobuf code does not fail the strict type checks.

### Testing

- Ran `make format` and formatter/lint checks; the formatting step completed with all checks passed.
- Ran `make test`; the test suite completed with `224 passed, 1 skipped`.
- Verified the package builds/install step during the format run completed successfully.
- Confirmed that the previous mypy/type errors observed during format were resolved by the new mypy override for the generated protobuf module.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694deb9a3c4083218d1d14f7dceb32df)