### PR TITLE
Add Semgrep rules for shared logger and explicit file-open encodings

### DIFF
--- a/docs/static_analysis.md
+++ b/docs/static_analysis.md
@@ -39,6 +39,9 @@ by default.
 | `heart-no-os-path-join` | Prefer `pathlib.Path` over `os.path.join`. | `src/**/*.py` |
 | `heart-no-baseexception-catch` | Avoid catching `BaseException`. | `src/**/*.py` |
 | `heart-no-bare-exception-raise` | Require specific exception types instead of `Exception`. | `src/**/*.py` |
+| `heart-no-logging-getlogger` | Use the shared logger helper instead of `logging.getLogger`. | `src/**/*.py` |
+| `heart-require-open-encoding-default` | Require `encoding=` for default-mode text file opens. | `src/**/*.py` |
+| `heart-require-open-encoding-text-mode` | Require `encoding=` for text-mode file opens. | `src/**/*.py` |
 
 ## Updating the rules
 

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -73,6 +73,55 @@ rules:
       category: error-handling
       technology:
         - python
+  - id: heart-no-logging-getlogger
+    languages:
+      - python
+    message: Use heart.utilities.logging.get_logger instead of logging.getLogger.
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - pattern: logging.getLogger(...)
+          - pattern: getLogger(...)
+    paths:
+      include:
+        - src/**/*.py
+    metadata:
+      category: style
+      technology:
+        - python
+  - id: heart-require-open-encoding-default
+    languages:
+      - python
+    message: Specify encoding= when opening text files (prefer utf-8).
+    severity: ERROR
+    patterns:
+      - pattern: open($PATH)
+      - pattern-not: open($PATH, encoding=..., ...)
+    paths:
+      include:
+        - src/**/*.py
+    metadata:
+      category: style
+      technology:
+        - python
+  - id: heart-require-open-encoding-text-mode
+    languages:
+      - python
+    message: Specify encoding= when opening text files (prefer utf-8).
+    severity: ERROR
+    patterns:
+      - pattern: open($PATH, $MODE, ...)
+      - pattern-not: open($PATH, $MODE, encoding=..., ...)
+      - metavariable-regex:
+          metavariable: $MODE
+          regex: "^[\"'](?!.*b).*?[\"']$"
+    paths:
+      include:
+        - src/**/*.py
+    metadata:
+      category: style
+      technology:
+        - python
   - id: heart-no-bare-exception-raise
     languages:
       - python


### PR DESCRIPTION
### Motivation

- Enforce project-wide conventions to use the shared logger helper instead of `logging.getLogger` to keep logging configuration consistent.
- Require explicit `encoding=` for text file opens (prefer `utf-8`) to ensure consistent cross-platform behavior.
- Surface these checks as static analysis rules so CI can catch violations earlier.

### Description

- Added three Semgrep rules to `semgrep.yml`: `heart-no-logging-getlogger`, `heart-require-open-encoding-default`, and `heart-require-open-encoding-text-mode` to detect forbidden patterns.
- The logger rule flags uses of `logging.getLogger` (and bare `getLogger`) and suggests `heart.utilities.logging.get_logger` instead.
- The encoding rules flag `open($PATH)` and `open($PATH, $MODE, ...)` when no `encoding=` is supplied, with a regex to ignore binary-mode opens.
- Documented the new rules in `docs/static_analysis.md` under the rule catalog.

### Testing

- Ran `make format` to apply repository formatting, which completed successfully.
- Ran `make test`, which failed due to a preexisting circular import error in the test environment: `AttributeError: partially initialized module 'heart.peripheral.core.protobuf_catalog' has no attribute 'register_protobuf_catalog'`.
- The Semgrep rules can be validated locally with `make semgrep` (not executed as part of the failing test run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ded9a86fc8321970824c0460b7936)