### PR TITLE
Log UART listener thread failures

### DIFF
--- a/src/heart/peripheral/bluetooth.py
+++ b/src/heart/peripheral/bluetooth.py
@@ -63,8 +63,16 @@ class UartListener:
 
     def start(self) -> None:
         self._logger.debug("Starting UART listener thread for %s", self.device.address)
+
+        def _run_listener() -> None:
+            try:
+                asyncio.run(self.connect_and_listen())
+            except Exception:
+                self.disconnected = True
+                self._logger.exception("UART listener thread terminated unexpectedly.")
+
         t = threading.Thread(
-            target=lambda: asyncio.run(self.connect_and_listen()),
+            target=_run_listener,
             daemon=True,
             name=f"UartListener-{self.device.address}",
         )


### PR DESCRIPTION
### Motivation

- Prevent silent failures in the Bluetooth UART listener thread by surfacing unexpected exceptions to logs.
- Ensure the listener's disconnected state is set when the background thread terminates unexpectedly.
- Improve observability and recovery behavior for the Bluetooth switch event loop.

### Description

- Wrap the thread target in a new `_run_listener` function that calls `asyncio.run(self.connect_and_listen())` inside a `try/except` block.
- On exception the code now sets `self.disconnected = True` and calls `self._logger.exception("UART listener thread terminated unexpectedly.")` to record the traceback.
- Use `_run_listener` as the `threading.Thread` target instead of the previous lambda to avoid swallowed exceptions.
- Applied formatting fixes via `make format`.

### Testing

- Ran `make format`, which completed successfully.
- No unit tests were modified or added in this change.
- No other automated test suites were executed as part of this rollout.
- Changes were committed to `src/heart/peripheral/bluetooth.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dee38dab08321a2dec25145a752fc)