### PR TITLE
Standardize logger naming with module context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - Prefer mixins or composition over direct inheritance.
 - Prefer `StrEnum` values over raw strings for strategy/configuration mode selections.
 - Use `heart.utilities.logging.get_logger` for internal logging so handlers and log levels stay consistent across modules.
+- Prefer `get_logger(__name__)` so loggers include their module path and stay consistent in telemetry.
 - Prefer module-level constants for tunable loop intervals instead of embedding sleep literals in long-running loops.
 - Prefer module-level constants for retry thresholds in reconnect or recovery loops instead of inline numeric literals.
 - When reading or writing text files, specify an explicit encoding (prefer `utf-8`) to keep behavior consistent across platforms.

--- a/src/heart/peripheral/heart_rates.py
+++ b/src/heart/peripheral/heart_rates.py
@@ -28,7 +28,7 @@ last_seen: Dict[str, float] = {}  # NEW: last packet time-stamp
 _mutex = threading.Lock()  # protects the three dicts above
 # ──────────────────────────────────────────────────────────────────────────────
 
-logger = get_logger("HeartRateManager")
+logger = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # OpenANT sometimes has race conditions where it receives broadcast data

--- a/src/heart/renderers/metadata_screen/renderer.py
+++ b/src/heart/renderers/metadata_screen/renderer.py
@@ -18,7 +18,7 @@ from heart.renderers.metadata_screen.state import (DEFAULT_HEART_COLORS,
                                                    MetadataScreenState)
 from heart.utilities.logging import get_logger
 
-logger = get_logger("HeartRateManager")
+logger = get_logger(__name__)
 
 
 class MetadataScreen(StatefulBaseRenderer[MetadataScreenState]):
@@ -47,7 +47,7 @@ class MetadataScreen(StatefulBaseRenderer[MetadataScreenState]):
                     Path("avatars") / f"{name}_16.png"
                 )
             except Exception:
-                logger.warning(f"Could not load avatar for {name}")
+                logger.warning("Could not load avatar for %s", name)
 
         self.provider = provider or MetadataScreenStateProvider(colors=self.colors)
         super().__init__(builder=self.provider)


### PR DESCRIPTION
### Motivation

- Make logger names include their module path so telemetry and filtering are consistent across the codebase.
- Align runtime modules with the existing `get_logger` helper and avoid ad-hoc string names for loggers.
- Use structured logging instead of f-strings to keep log messages parseable by downstream tooling.

### Description

- Add a guideline to `AGENTS.md` recommending `get_logger(__name__)` for module-scoped loggers.
- Replace `get_logger("HeartRateManager")` with `get_logger(__name__)` in `src/heart/peripheral/heart_rates.py` and `src/heart/renderers/metadata_screen/renderer.py`.
- Convert an avatar-load warning from an f-string to structured logging (`logger.warning("Could not load avatar for %s", name)`).
- Run repository formatting (`make format`) to apply project style rules.

### Testing

- Ran `make format`, which completed successfully.
- Ran `make test`; the suite produced 224 passed, 1 failed, and 1 skipped test.
- The failing test is `tests/utilities/test_reactivex_streams.py::TestShareStreamFlowControl::test_share_stream_coalesces_latest_when_configured` and it remains failing after these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dee40b6bc8321bb05cb1d5a669756)