### PR TITLE
Register Mario renderer provider in Lagom

### DIFF
--- a/docs/research/lagom_renderer_provider_integration.md
+++ b/docs/research/lagom_renderer_provider_integration.md
@@ -14,6 +14,7 @@ DI concerns.
 - Source files: `src/heart/renderers/multicolor/`,
   `src/heart/renderers/cloth_sail/`,
   `src/heart/renderers/three_fractal/`,
+  `src/heart/renderers/mario/`,
   `src/heart/programs/configurations/lib_2025.py`,
   `src/heart/programs/configurations/l_system.py`,
   `src/heart/programs/configurations/porthole_window.py`,
@@ -21,13 +22,13 @@ DI concerns.
 
 ## Notes
 
-`MulticolorStateProvider`, `ClothSailStateProvider`, and `FractalSceneProvider` are now registered
-with the shared provider registry so Lagom can resolve them from the runtime container. The
-corresponding renderers now require injected providers, and configuration modules resolve those
-renderers through `GameLoop.context_container` instead of manually constructing providers. The
-Fractal scene provider now takes a `Device` dependency from the container, which keeps device
-wiring centralized in `build_runtime_container` and avoids leaking device plumbing into
-configuration modules.
+`MulticolorStateProvider`, `ClothSailStateProvider`, `FractalSceneProvider`, and
+`MarioRendererProvider` are now registered with the shared provider registry so Lagom can resolve
+them from the runtime container. The corresponding renderers now require injected providers, and
+configuration modules resolve those renderers through `GameLoop.context_container` instead of
+manually constructing providers. The Fractal scene provider now takes a `Device` dependency from
+the container, which keeps device wiring centralized in `build_runtime_container` and avoids
+leaking device plumbing into configuration modules.
 
 `LSystem` and `PortholeWindowRenderer` configurations now rely on
 `ComposedRenderer.resolve_renderer_from_container` so Lagom supplies the registered state

--- a/src/heart/programs/configurations/lib_2025.py
+++ b/src/heart/programs/configurations/lib_2025.py
@@ -1,11 +1,9 @@
 from typing import Callable
 
 import numpy as np
-from lagom import Singleton
 
 from heart.display.color import Color
 from heart.navigation import ComposedRenderer, MultiScene
-from heart.peripheral.providers.acceleration import AllAccelerometersProvider
 from heart.renderers.artist import ArtistScene
 from heart.renderers.combined_bpm_screen import CombinedBpmScreen
 from heart.renderers.heart_title_screen import HeartTitleScreen
@@ -15,7 +13,6 @@ from heart.renderers.kirby import KirbyScene
 from heart.renderers.life.renderer import Life
 from heart.renderers.mandelbrot.scene import MandelbrotMode
 from heart.renderers.mandelbrot.title import MandelbrotTitle
-from heart.renderers.mario.provider import MarioRendererProvider
 from heart.renderers.mario.renderer import MarioRenderer
 from heart.renderers.multicolor import MulticolorRenderer
 from heart.renderers.random_pixel import RandomPixel
@@ -74,9 +71,6 @@ def configure(loop: GameLoop) -> None:
                 ),
             ]
         )
-    )
-    loop.context_container[MarioRendererProvider] = Singleton(
-        lambda builder: MarioRendererProvider(accel_stream=builder[AllAccelerometersProvider], sheet_file_path="mario_64.png", metadata_file_path="mario_64.json")
     )
     mario_mode.resolve_renderer_from_container(MarioRenderer)
 

--- a/src/heart/renderers/mario/__init__.py
+++ b/src/heart/renderers/mario/__init__.py
@@ -1,0 +1,21 @@
+from lagom import Singleton
+
+from heart.peripheral.core.providers import register_provider
+from heart.peripheral.providers.acceleration import AllAccelerometersProvider
+from heart.renderers.mario.provider import MarioRendererProvider
+from heart.renderers.mario.renderer import MarioRenderer  # noqa: F401
+from heart.renderers.mario.state import MarioRendererState  # noqa: F401
+
+MARIO_METADATA_FILE_PATH = "mario_64.json"
+MARIO_SHEET_FILE_PATH = "mario_64.png"
+
+register_provider(
+    MarioRendererProvider,
+    Singleton(
+        lambda builder: MarioRendererProvider(
+            accel_stream=builder[AllAccelerometersProvider],
+            sheet_file_path=MARIO_SHEET_FILE_PATH,
+            metadata_file_path=MARIO_METADATA_FILE_PATH,
+        )
+    ),
+)


### PR DESCRIPTION
### Motivation

- Centralize provider wiring so renderer-backed providers (Mario) resolve through the shared Lagom container instead of being constructed ad-hoc in configuration code.
- Reduce duplicated DI plumbing and make peripheral/device dependencies available to renderer providers via the runtime container.
- Make it easier to override provider implementations in tests and keep lifecycle ownership consistent across runtime components.

### Description

- Add `src/heart/renderers/mario/__init__.py` which registers `MarioRendererProvider` with the provider registry using `Singleton` and module-level default asset paths (`MARIO_SHEET_FILE_PATH` and `MARIO_METADATA_FILE_PATH`).
- Remove the manual `MarioRendererProvider` binding from `src/heart/programs/configurations/lib_2025.py` so the configuration resolves `MarioRenderer` from the runtime container instead of injecting the provider directly.
- Update `docs/research/lagom_renderer_provider_integration.md` to document the Mario provider registration and reflect the deeper Lagom integration.

### Testing

- Ran `make format` and formatting checks completed successfully.
- Ran `make test` and the full test suite passed (`225 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dee4bd76c8321981e0dff7565b828)