### PR TITLE
Add explicit UTF-8 encoding to device ID test file I/O

### DIFF
--- a/tests/test_device_id.py
+++ b/tests/test_device_id.py
@@ -17,7 +17,7 @@ class TestDeviceId:
     def test_persistent_device_id_reads_existing_file(self, tmp_path, monkeypatch):
         """Verify file-backed device IDs are reused to keep provisioning deterministic for operators."""
         storage_path = tmp_path / "device_id.txt"
-        storage_path.write_text("existing-id")
+        storage_path.write_text("existing-id", encoding="utf-8")
         monkeypatch.setenv(device_id.DEVICE_ID_PATH_ENV_VAR, str(storage_path))
 
         result = device_id.persistent_device_id()
@@ -33,7 +33,7 @@ class TestDeviceId:
         result = device_id.persistent_device_id()
 
         assert result == "env-id-123"
-        assert storage_path.read_text() == "env-id-123"
+        assert storage_path.read_text(encoding="utf-8") == "env-id-123"
 
     def test_persistent_device_id_uses_hardware_uid(self, tmp_path, monkeypatch):
         """Verify hardware UIDs seed persistence so hardware boots align with fleet identity tracking."""
@@ -45,7 +45,7 @@ class TestDeviceId:
         result = device_id.persistent_device_id(microcontroller_module=stub_microcontroller)
 
         assert result == "01ab"
-        assert storage_path.read_text() == "01ab"
+        assert storage_path.read_text(encoding="utf-8") == "01ab"
 
     def test_persistent_device_id_generates_when_no_sources(self, tmp_path, monkeypatch):
         """Verify random IDs are generated as a fallback to keep devices identifiable in emergencies."""
@@ -57,4 +57,4 @@ class TestDeviceId:
         result = device_id.persistent_device_id()
 
         assert result == "feedbeef"
-        assert storage_path.read_text() == "feedbeef"
+        assert storage_path.read_text(encoding="utf-8") == "feedbeef"


### PR DESCRIPTION
### Motivation
- Conform to repository guidance to explicitly specify text encoding when reading and writing files to ensure consistent cross-platform behaviour.
- Prevent flaky tests caused by platform-default encodings when persisting device ID values.
- Make the test intent explicit by using `utf-8` for all text I/O in device ID tests.

### Description
- Updated `tests/test_device_id.py` to pass `encoding="utf-8"` to `storage_path.write_text` and all `storage_path.read_text` calls.
- Change is limited to test I/O and does not modify production code paths.
- The modification ensures file reads/writes in tests are deterministic regardless of system locale.

### Testing
- Ran `make format` and formatting checks passed.  
- No other automated test runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694def7e22a88321be0cc87fd4c956d0)