### PR TITLE
Use module-level time import in Bluetooth bridge

### DIFF
--- a/drivers/bluetooth-bridge/code.py
+++ b/drivers/bluetooth-bridge/code.py
@@ -15,6 +15,7 @@ the real hardware modules.
 from __future__ import annotations
 
 import json
+import time
 from collections import deque
 from dataclasses import dataclass, field
 from typing import Callable, Deque, Iterable, Protocol
@@ -141,8 +142,6 @@ def create_runtime(
     led = led or _ensure_output_led()
 
     if sleeper is None:
-        import time
-
         sleeper = time
 
     return BluetoothBridgeRuntime(


### PR DESCRIPTION
### Motivation
- Remove a dynamic `import time` inside `create_runtime` to avoid runtime imports that complicate static analysis and CircuitPython compatibility.
- Prefer module-level imports to make dependencies explicit and easier to inspect by tooling and test harnesses.
- Keep the runtime construction simple so test doubles can be injected without surprising import side-effects.

### Description
- Added a module-level `import time` and set the default `sleeper` to the module `time` when `sleeper is None` in `create_runtime`.
- Removed the inline `import time` previously performed inside `create_runtime` and replaced it with a direct assignment to `sleeper`.
- No behavioural changes to `BluetoothBridgeRuntime` logic or public API were introduced.

### Testing
- Ran `make format` and formatting/lint checks completed successfully.
- No automated unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694def8860548321b4a2e5b7e98ce42e)