### PR TITLE
Add module-level default threshold for sensor bus and document driver guideline

### DIFF
--- a/drivers/AGENTS.md
+++ b/drivers/AGENTS.md
@@ -4,6 +4,7 @@
 - Assume these drivers will run under CircuitPython first and CPython second. Keep dependencies to the built-ins that ship with CircuitPython or a clearly documented external bundle.
 - Avoid dynamic imports, reflection, or heavy use of Python metaprogramming features that CircuitPython omits.
 - Prefer small, synchronous functions. CircuitPython lacks threads and has very limited heap space, so do not allocate large temporary buffers or rely on recursion.
+- Keep tunable thresholds as module-level constants so they are easy to discover and adjust.
 
 ## Debugging guidance
 - When adding diagnostic output, use `print` statements guarded behind a module-level `DEBUG` flag rather than logging frameworks that CircuitPython does not ship with by default.

--- a/drivers/sensor_bus/code.py
+++ b/drivers/sensor_bus/code.py
@@ -20,6 +20,7 @@ from heart.firmware_io import constants, device_id, identity
 
 WAIT_BEFORE_TRYING_TO_CONNECT_TO_SENSOR_SECONDS: float = 1.0
 DEFAULT_WAIT_BETWEEN_PAYLOADS_SECONDS: float = 0.1
+DEFAULT_MIN_CHANGE_THRESHOLD: float = 0.1
 DEBUG = False
 DEVICE_NAME = "sensor-bus"
 
@@ -125,7 +126,7 @@ def connect_to_sensors(i2c):
 class SensorReader:
     """Tracks last values and determines when updates are significant."""
 
-    def __init__(self, sensors, min_change: float = 0.1) -> None:
+    def __init__(self, sensors, min_change: float = DEFAULT_MIN_CHANGE_THRESHOLD) -> None:
         self.sensors = sensors
         self.min_change = min_change
 
@@ -185,7 +186,7 @@ def main() -> None:
     else:
         wait_between_payloads_seconds = min(sample_rates)
 
-    sr = SensorReader(sensors=sensors, min_change=0.1)
+    sr = SensorReader(sensors=sensors, min_change=DEFAULT_MIN_CHANGE_THRESHOLD)
 
     while True:
         try:


### PR DESCRIPTION
### Motivation
- Make tunable thresholds easy to discover and adjust by encouraging module-level constants.
- Standardize driver guidance to avoid magic numerics scattered through code.
- Provide a named, reusable default for the sensor bus change-detection threshold.

### Description
- Documented the guideline to keep tunable thresholds as module-level constants in `drivers/AGENTS.md`.
- Added `DEFAULT_MIN_CHANGE_THRESHOLD: float = 0.1` to `drivers/sensor_bus/code.py`.
- Updated `SensorReader.__init__` default `min_change` to `DEFAULT_MIN_CHANGE_THRESHOLD` and replaced the hardcoded instantiation value with the constant.

### Testing
- Ran `make format` and it completed successfully.
- Ran `make test` and the test suite completed with `225 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694def949aac8321ae0d080638394d88)