### PR TITLE
Decode InputEvent protobuf payloads into Input

### DIFF
--- a/docs/beats-websocket-protobuf.md
+++ b/docs/beats-websocket-protobuf.md
@@ -35,6 +35,8 @@ The Beats UI uses `protobufjs` to parse `StreamEnvelope` frames and emits a type
 
 `heart.device.beats.websocket.decode_stream_envelope` provides the Python mirror for decoding envelopes. It returns a `(kind, payload)` tuple for `frame` and `peripheral` payloads, and uses `decode_peripheral_payload` from `heart.peripheral.core.encoding` to decode JSON or protobuf payload bytes. Protobuf decoding resolves the `payload_type` with `google.protobuf.symbol_database.Default()`. The `heart.peripheral.core.protobuf_registry` helper can import modules registered to a package prefix when a symbol is missing, and `heart.peripheral.core.protobuf_catalog` registers the Beats and peripheral packages so decoding can succeed without manual imports.
 
+When the payload type is `heart.peripheral.input.InputEvent`, `decode_peripheral_payload` returns a `heart.peripheral.core.Input` instance with the decoded event data and timestamp. This keeps Python-side handlers aligned with the same input model used by the peripheral manager.
+
 ## Schema catalog and generation
 
 `heart.peripheral.core.protobuf_catalog` centralizes protobuf package registration. Add new schema packages there so the registry can resolve types without bespoke imports. Use `scripts/generate_protobuf.py` to regenerate `*_pb2.py` modules after editing `.proto` files. For example:

--- a/tests/device/test_beats_websocket.py
+++ b/tests/device/test_beats_websocket.py
@@ -1,5 +1,6 @@
 import json
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 from heart.device.beats.proto import beats_streaming_pb2
 from heart.device.beats.websocket import (_encode_peripheral_message,
@@ -117,6 +118,27 @@ class TestPeripheralPayloadDecoding:
 
         assert isinstance(decoded, beats_streaming_pb2.Frame)
         assert decoded == message
+
+    def test_decodes_input_payloads_into_inputs(self) -> None:
+        """Verify Input protobuf payloads decode into Input instances so event routing stays consistent."""
+        timestamp = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        payload = Input(
+            event_type="peripheral.switch.tick",
+            data={"rotation": 1},
+            timestamp=timestamp,
+        )
+        encoded = encode_peripheral_payload(payload)
+
+        decoded = decode_peripheral_payload(
+            encoded.payload,
+            encoding=encoded.encoding,
+            payload_type=encoded.payload_type,
+        )
+
+        assert isinstance(decoded, Input)
+        assert decoded.event_type == payload.event_type
+        assert decoded.data == payload.data
+        assert decoded.timestamp == payload.timestamp
 
 
 class TestStreamEnvelopeDecoding:


### PR DESCRIPTION
### Motivation
- Make protobuf-based peripheral payloads first-class by returning native runtime types instead of raw protobuf messages for known schemas.
- Ensure `heart.peripheral.input.InputEvent` payloads route through the same `Input` model used by the peripheral manager and downstream handlers.
- Make timestamp and JSON data parsing explicit and timezone-aware so decoded events are consistent across components.

### Description
- Add `INPUT_EVENT_TYPE` constant and a `_decode_input_event` helper in `src/heart/peripheral/core/encoding.py` to transform `InputEvent` protobufs into `heart.peripheral.core.Input` instances.
- Extend `decode_peripheral_payload` to return an `Input` for payloads whose type matches the `InputEvent` schema, including JSON `data_json` parsing and ISO timestamp handling (UTC fallback).
- Add `test_decodes_input_payloads_into_inputs` to `tests/device/test_beats_websocket.py` to cover the new decoding behavior.
- Update `docs/beats-websocket-protobuf.md` to document that `InputEvent` protobufs are decoded into `Input` instances.

### Testing
- Ran `make format` to apply repository formatting tools and it completed successfully.
- Ran `make test` to execute the Pytest suite.
- The test run completed with all tests passing: `226 passed, 1 skipped`.
- Protobuf-related unit tests (new and existing) passed without regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dee6e3fb48321b88b32559d3320a1)