### PR TITLE
Use monotonic clocks for peripheral timeouts

### DIFF
--- a/src/heart/peripheral/AGENTS.md
+++ b/src/heart/peripheral/AGENTS.md
@@ -1,0 +1,6 @@
+# Peripheral Agent Instructions
+
+## Timing and clocks
+- Use `time.monotonic()` for elapsed-time comparisons such as timeouts, retry
+  windows, or input debouncing. Reserve `time.time()` for wall-clock
+  timestamps that need to be shared outside the process.

--- a/src/heart/peripheral/heart_rates.py
+++ b/src/heart/peripheral/heart_rates.py
@@ -110,7 +110,7 @@ class HeartRateManager(Peripheral[Any]):
                 device_id = f"{hrm.device_id:05X}"
                 with _mutex:
                     current_bpms[device_id] = data.heart_rate
-                    last_seen[device_id] = time.time()
+                    last_seen[device_id] = time.monotonic()
                     if hasattr(data, "battery_percentage"):
                         battery_status[device_id] = data.battery_percentage * 100 / 256
 
@@ -123,7 +123,7 @@ class HeartRateManager(Peripheral[Any]):
     def _cleanup_loop(self) -> None:
         """Drop straps that have been quiet for DEVICE_TIMEOUT seconds."""
         while not self._stop_evt.wait(CLEANUP_INTERVAL):
-            now = time.time()
+            now = time.monotonic()
             stale: List[str] = []
             with _mutex:
                 for dev_id, ts in list(last_seen.items()):

--- a/src/heart/peripheral/keyboard.py
+++ b/src/heart/peripheral/keyboard.py
@@ -83,7 +83,7 @@ class KeyboardKey(Peripheral[KeyboardEvent]):
 
     def _check_if_pressed(self) -> KeyboardEvent | None:
         keys = pygame.key.get_pressed()
-        now = time.time() * 1000
+        now = time.monotonic() * 1000
         current = self.state
         event: KeyboardEvent | None = None
         key_name = pygame.key.name(self.key)


### PR DESCRIPTION
### Motivation
- Peripheral code used `time.time()` for elapsed-time logic which can be affected by system clock changes and diverges from the repository guidance to use monotonic clocks.
- Replace wall-clock-based elapsed-time checks with monotonic timestamps to make timeouts, debouncing, and janitor loops robust to clock adjustments.

### Description
- Add `src/heart/peripheral/AGENTS.md` documenting the rule to prefer `time.monotonic()` for elapsed-time comparisons and reserve `time.time()` for wall-clock timestamps.
- Replace `time.time()` with `time.monotonic()` in `src/heart/peripheral/heart_rates.py` for `last_seen` updates and the janitor loop `now` calculation.
- Replace `time.time()` with `time.monotonic()` in `src/heart/peripheral/keyboard.py` for debounce/edge-timestamping logic.
- Run formatting as part of the change to ensure code style consistency with repository guidelines.

### Testing
- Ran `make format` and the formatter reported success.
- Ran `make test` and the test suite completed successfully with `226 passed, 1 skipped`.
- All automated tests passed after the modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694df22e8b50832186e4ab872e289815)