### PR TITLE
Use f-strings in shader utilities

### DIFF
--- a/src/heart/display/shaders/util.py
+++ b/src/heart/display/shaders/util.py
@@ -41,26 +41,18 @@ def to_str(x):
 
 def float_str(x):
     if type(x) is str:
-        return "_" + x
+        return f"_{x}"
     else:
         return str(x)
 
 
 def vec3_str(v):
     if type(v) is str:
-        return "_" + v
+        return f"_{v}"
     elif isinstance(v, (float, int)):
-        return "vec3(" + str(v) + ")"
+        return f"vec3({v})"
     else:
-        return (
-            "vec3("
-            + float_str(v[0])
-            + ","
-            + float_str(v[1])
-            + ","
-            + float_str(v[2])
-            + ")"
-        )
+        return f"vec3({float_str(v[0])},{float_str(v[1])},{float_str(v[2])})"
 
 
 def vec3_eq(v, val):
@@ -107,21 +99,21 @@ def set_global_vec3(k):
 
 def cond_offset(p):
     if type(p) is str or np.count_nonzero(p) > 0:
-        return " - vec4(" + vec3_str(p) + ", 0)"
+        return f" - vec4({vec3_str(p)}, 0)"
     return ""
 
 
 def cond_subtract(p):
     if type(p) is str or p > 0:
-        return " - " + float_str(p)
+        return f" - {float_str(p)}"
     return ""
 
 
 def make_color(geo):
     if type(geo.color) is tuple or type(geo.color) is np.ndarray:
-        return "vec4(" + vec3_str(geo.color) + ", " + geo.glsl() + ")"
+        return f"vec4({vec3_str(geo.color)}, {geo.glsl()})"
     elif geo.color == "orbit" or geo.color == "o":
-        return "vec4(orbit, " + geo.glsl() + ")"
+        return f"vec4(orbit, {geo.glsl()})"
     else:
         raise ValueError("Invalid coloring type")
 


### PR DESCRIPTION
### Motivation
- Improve readability and consistency when constructing GLSL-related strings in the shader utilities.
- Follow repository guidance to prefer f-strings over manual string concatenation for clarity and maintainability.
- Reduce the surface area for small concatenation bugs and make the code easier to scan for future changes.

### Description
- Replaced manual string concatenations with f-strings in `src/heart/display/shaders/util.py` for functions including `float_str`, `vec3_str`, `cond_offset`, `cond_subtract`, and `make_color`.
- Simplified `vec3_str` formatting to a single f-string that leverages `float_str` for component formatting.
- Changes are purely syntactic and do not alter the logic or public API of the module.

### Testing
- Ran `make format` to apply and verify formatting, which completed successfully.
- Ran the test suite with `make test`, resulting in `226 passed, 1 skipped`.
- No test failures were observed after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694df414e7bc83219d7b8f8aad8d8fdd)