### PR TITLE
Add Lagom-backed Tixyland factory

### DIFF
--- a/docs/research/lagom_tixyland_factory_integration.md
+++ b/docs/research/lagom_tixyland_factory_integration.md
@@ -1,0 +1,23 @@
+# Lagom Tixyland Factory Integration Note
+
+## Problem Statement
+
+Tixyland scenes were created by directly resolving `TixylandStateProvider` in each configuration
+module. This repeated container access in multiple places and did not provide a dedicated
+factory abstraction for building Tixyland scenes from the runtime container.
+
+## Materials
+
+- Python 3.11 with `uv` for dependency management.
+- Lagom dependency (`lagom` in `pyproject.toml`).
+- Source files: `src/heart/renderers/tixyland/factory.py`,
+  `src/heart/renderers/tixyland/__init__.py`,
+  `src/heart/programs/configurations/tixyland.py`,
+  `src/heart/programs/configurations/lib_2025.py`.
+
+## Notes
+
+`TixylandFactory` is registered with the provider registry so Lagom can resolve a container-backed
+factory. Configuration modules now resolve the factory once and reuse it to build Tixyland scenes,
+keeping provider wiring inside the container registration and reducing repeated provider
+resolution calls in the configurations.

--- a/src/heart/programs/configurations/lib_2025.py
+++ b/src/heart/programs/configurations/lib_2025.py
@@ -20,7 +20,7 @@ from heart.renderers.spritesheet import SpritesheetLoop
 from heart.renderers.spritesheet_random import SpritesheetLoopRandom
 from heart.renderers.text import TextRendering
 from heart.renderers.three_fractal import FractalScene
-from heart.renderers.tixyland import Tixyland, TixylandStateProvider
+from heart.renderers.tixyland import Tixyland, TixylandFactory
 from heart.renderers.water_cube.renderer import WaterCube
 from heart.renderers.water_title_screen import WaterTitleScreen
 from heart.runtime.game_loop import GameLoop
@@ -180,14 +180,12 @@ def configure(loop: GameLoop) -> None:
 
     # Some random ones
     tixyland = loop.add_mode("tixyland")
+    tixyland_factory = loop.context_container.resolve(TixylandFactory)
 
     def build_tixyland(
         fn: Callable[[float, np.ndarray, np.ndarray, np.ndarray], np.ndarray]
     ) -> Tixyland:
-        return Tixyland(
-            builder=loop.context_container.resolve(TixylandStateProvider),
-            fn=fn,
-        )
+        return tixyland_factory(fn)
 
     tixyland.add_renderer(
         MultiScene(

--- a/src/heart/programs/configurations/tixyland.py
+++ b/src/heart/programs/configurations/tixyland.py
@@ -3,7 +3,7 @@ from typing import Callable
 import numpy as np
 
 from heart.navigation import MultiScene
-from heart.renderers.tixyland import Tixyland, TixylandStateProvider
+from heart.renderers.tixyland import Tixyland, TixylandFactory
 from heart.runtime.game_loop import GameLoop
 
 
@@ -14,13 +14,12 @@ def pattern_numpy(t: float, X: np.ndarray, Y: np.ndarray) -> np.ndarray:
 
 
 def configure(loop: GameLoop) -> None:
+    tixyland_factory = loop.context_container.resolve(TixylandFactory)
+
     def build_tixyland(
         fn: Callable[[float, np.ndarray, np.ndarray, np.ndarray], np.ndarray]
     ) -> Tixyland:
-        return Tixyland(
-            builder=loop.context_container.resolve(TixylandStateProvider),
-            fn=fn,
-        )
+        return tixyland_factory(fn)
 
     mode = loop.add_mode()
     mode.add_renderer(

--- a/src/heart/renderers/tixyland/__init__.py
+++ b/src/heart/renderers/tixyland/__init__.py
@@ -1,5 +1,12 @@
+from lagom import Singleton
+
 from heart.peripheral.core.providers import register_provider
+from heart.renderers.tixyland.factory import TixylandFactory  # noqa: F401
 from heart.renderers.tixyland.provider import TixylandStateProvider
 from heart.renderers.tixyland.renderer import Tixyland  # noqa: F401
 
 register_provider(TixylandStateProvider, TixylandStateProvider)
+register_provider(
+    TixylandFactory,
+    Singleton(lambda builder: TixylandFactory(lambda: builder[TixylandStateProvider])),
+)

--- a/src/heart/renderers/tixyland/factory.py
+++ b/src/heart/renderers/tixyland/factory.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+
+from heart.renderers.tixyland.provider import TixylandStateProvider
+from heart.renderers.tixyland.renderer import Tixyland
+
+
+class TixylandFactory:
+    def __init__(self, provider_factory: Callable[[], TixylandStateProvider]) -> None:
+        self._provider_factory = provider_factory
+
+    def __call__(
+        self,
+        fn: Callable[[float, np.ndarray, np.ndarray, np.ndarray], np.ndarray],
+    ) -> Tixyland:
+        return Tixyland(builder=self._provider_factory(), fn=fn)


### PR DESCRIPTION
### Motivation

- Reduce repeated container access when constructing Tixyland scenes by providing a dedicated factory resolved from the runtime container.
- Keep provider wiring (resolution of `TixylandStateProvider`) inside the container registration instead of scattering it across configuration modules.
- Make configuration code simpler and consistent with other provider-backed renderers that rely on Lagom container resolution.

### Description

- Add `TixylandFactory` in `src/heart/renderers/tixyland/factory.py` which builds `Tixyland` instances using a provider factory.
- Register the factory with the provider registry via a Lagom `Singleton` in `src/heart/renderers/tixyland/__init__.py` so it can be resolved from the container as `TixylandFactory`.
- Update configuration modules (`src/heart/programs/configurations/tixyland.py` and `src/heart/programs/configurations/lib_2025.py`) to resolve `TixylandFactory` once from `GameLoop.context_container` and use it to create scenes.
- Add documentation of the integration at `docs/research/lagom_tixyland_factory_integration.md`.

### Testing

- Ran `make format` to apply formatting rules and it completed successfully.
- Ran the test suite with `make test` and the automated tests passed (`226 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694df42f174483218ff548affa2525f7)