### PR TITLE
Register PeripheralConfigurationRegistry in runtime container and inject into PeripheralManager

### DIFF
--- a/docs/research/lagom_peripheral_registry_integration.md
+++ b/docs/research/lagom_peripheral_registry_integration.md
@@ -1,0 +1,26 @@
+# Lagom peripheral configuration registry injection
+
+## Problem statement
+
+The runtime container created `PeripheralManager` without exposing the shared
+`PeripheralConfigurationRegistry`. That made it difficult to validate or
+override configuration lookup because the registry instance was hidden inside
+the manager and its loader.
+
+## Notes
+
+- Registered `PeripheralConfigurationRegistry` in
+  `heart.runtime.container.build_runtime_container` so Lagom can manage a shared
+  instance for runtime overrides.
+- Injected the registry into `PeripheralManager` and surfaced it through
+  `PeripheralConfigurationLoader.registry` and
+  `PeripheralManager.configuration_registry` to support validation and testing.
+- Added container coverage in `tests/runtime/test_container.py` to confirm the
+  registry instance is shared by the manager.
+
+## Materials
+
+- `src/heart/runtime/container.py`
+- `src/heart/peripheral/core/manager.py`
+- `src/heart/peripheral/configuration_loader.py`
+- `tests/runtime/test_container.py`

--- a/src/heart/peripheral/configuration_loader.py
+++ b/src/heart/peripheral/configuration_loader.py
@@ -27,6 +27,10 @@ class PeripheralConfigurationLoader:
     def name(self) -> str:
         return self._configuration_name
 
+    @property
+    def registry(self) -> PeripheralConfigurationRegistry:
+        return self._registry
+
     def load(self) -> PeripheralConfiguration:
         if self._configuration is None:
             self._configuration = self._load_configuration(self._configuration_name)

--- a/src/heart/peripheral/core/manager.py
+++ b/src/heart/peripheral/core/manager.py
@@ -44,6 +44,14 @@ class PeripheralManager:
     def peripherals(self) -> tuple[Peripheral[Any], ...]:
         return tuple(self._peripherals)
 
+    @property
+    def configuration_loader(self) -> PeripheralConfigurationLoader:
+        return self._configuration_loader
+
+    @property
+    def configuration_registry(self) -> PeripheralConfigurationRegistry:
+        return self._configuration_loader.registry
+
     def get_gamepad(self) -> Gamepad:
         """Return the first detected gamepad."""
 

--- a/src/heart/runtime/container.py
+++ b/src/heart/runtime/container.py
@@ -8,6 +8,7 @@ from heart.device import Device
 from heart.navigation import AppController
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import apply_provider_registrations
+from heart.peripheral.registry import PeripheralConfigurationRegistry
 from heart.runtime.display_context import DisplayContext
 from heart.runtime.frame_presenter import FramePresenter
 from heart.runtime.peripheral_runtime import PeripheralRuntime
@@ -23,7 +24,22 @@ def build_runtime_container(
     container = Container()
     _bind(container, overrides, Device, device)
     _bind(container, overrides, RendererVariant, render_variant)
-    _bind(container, overrides, PeripheralManager, Singleton(PeripheralManager))
+    _bind(
+        container,
+        overrides,
+        PeripheralConfigurationRegistry,
+        Singleton(PeripheralConfigurationRegistry),
+    )
+    _bind(
+        container,
+        overrides,
+        PeripheralManager,
+        Singleton(
+            lambda resolver: PeripheralManager(
+                configuration_registry=resolver[PeripheralConfigurationRegistry]
+            )
+        ),
+    )
     _bind(
         container,
         overrides,

--- a/tests/runtime/test_container.py
+++ b/tests/runtime/test_container.py
@@ -1,4 +1,5 @@
 from heart.peripheral.core.manager import PeripheralManager
+from heart.peripheral.registry import PeripheralConfigurationRegistry
 from heart.runtime.container import build_runtime_container
 from heart.runtime.display_context import DisplayContext
 from heart.runtime.game_loop import GameLoop
@@ -23,6 +24,18 @@ class TestRuntimeContainer:
         assert container.resolve(DisplayContext) is container.resolve(DisplayContext)
         assert render_pipeline is container.resolve(RenderPipeline)
         assert render_pipeline.renderer_variant is RendererVariant.BINARY
+
+    def test_container_injects_configuration_registry(self, device) -> None:
+        """Confirm the container shares a registry instance so configuration overrides stay consistent at runtime."""
+        container = build_runtime_container(
+            device=device,
+            render_variant=RendererVariant.BINARY,
+        )
+
+        registry = container.resolve(PeripheralConfigurationRegistry)
+        manager = container.resolve(PeripheralManager)
+
+        assert manager.configuration_registry is registry
 
     def test_game_loop_uses_container_overrides(self, device) -> None:
         """Ensure GameLoop honors container overrides so tests can swap implementations without touching runtime code."""


### PR DESCRIPTION
### Motivation

- Expose the shared peripheral configuration registry from the runtime container so configuration lookup can be validated and overridden at runtime.
- Surface the registry through the configuration loader and manager for clearer ownership and easier testing of peripheral configuration resolution.

### Description

- Register `PeripheralConfigurationRegistry` in `heart.runtime.container.build_runtime_container` and use it to construct `PeripheralManager` via a Lagom `Singleton` lambda.
- Add a `registry` property to `PeripheralConfigurationLoader` and expose `configuration_loader` and `configuration_registry` properties on `PeripheralManager` for access to the shared registry.
- Add a unit test `tests/runtime/test_container.py::TestRuntimeContainer::test_container_injects_configuration_registry` asserting the manager uses the container-managed registry instance.
- Add a research note `docs/research/lagom_peripheral_registry_integration.md` documenting the integration and rationale.

### Testing

- Ran `make format` and the formatting checks passed.
- Ran the full test suite with `make test` which reported one failing test: `tests/utilities/test_reactivex_streams.py::TestShareStreamFlowControl::test_share_stream_coalesces_latest_when_configured`.
- Reproduced the failing case in isolation using the project venv with `.venv/bin/pytest tests/utilities/test_reactivex_streams.py::TestShareStreamFlowControl::test_share_stream_coalesces_latest_when_configured`, which passed.
- The new container injection test `tests/runtime/test_container.py::TestRuntimeContainer::test_container_injects_configuration_registry` passed in the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694df442d3e083219fe684713883810d)