### PR TITLE
Inject peripheral configuration loader into runtime container

### DIFF
--- a/docs/research/lagom_peripheral_configuration_integration.md
+++ b/docs/research/lagom_peripheral_configuration_integration.md
@@ -1,0 +1,26 @@
+# Lagom Peripheral Configuration Integration Note
+
+## Problem Statement
+
+The runtime container previously built `PeripheralManager` without injecting the peripheral configuration registry or loader. That made it harder to override configuration loading in tests and obscured how configuration discovery participates in Lagom wiring.
+
+## Materials
+
+- `src/heart/runtime/container.py` for Lagom container bindings.
+- `src/heart/peripheral/core/manager.py` for peripheral manager construction.
+- `src/heart/peripheral/configuration_loader.py` and `src/heart/peripheral/registry.py` for configuration resolution.
+- `tests/runtime/test_container.py` for container override coverage.
+
+## Source Review
+
+- The runtime container binds shared services, including `PeripheralManager`, for dependency resolution.
+- `PeripheralManager` uses a `PeripheralConfigurationLoader` to discover and cache configuration factories.
+- The loader depends on `PeripheralConfigurationRegistry` to locate configuration modules.
+
+## Integration Notes
+
+The Lagom container now registers `PeripheralConfigurationRegistry` and `PeripheralConfigurationLoader` as singletons before constructing `PeripheralManager`. `PeripheralManager` accepts an injected loader, so tests can override configuration resolution via container overrides without altering runtime wiring. This keeps configuration discovery aligned with the same container that supplies other runtime services.
+
+## Test Notes
+
+The runtime container test suite includes an override check that injects a stub loader and asserts the resolved `PeripheralManager` uses it. This validates that configuration wiring respects container overrides.

--- a/src/heart/peripheral/core/manager.py
+++ b/src/heart/peripheral/core/manager.py
@@ -31,14 +31,21 @@ class PeripheralManager:
         self,
         *,
         configuration: str | None = None,
+        configuration_loader: PeripheralConfigurationLoader | None = None,
         configuration_registry: PeripheralConfigurationRegistry | None = None,
     ) -> None:
         self._peripherals: list[Peripheral[Any]] = []
         self._started = False
-        self._configuration_loader = PeripheralConfigurationLoader(
+        self._configuration_loader = configuration_loader or PeripheralConfigurationLoader(
             configuration=configuration,
             registry=configuration_registry,
         )
+
+    @property
+    def configuration_loader(self) -> PeripheralConfigurationLoader:
+        """Expose the configuration loader for container wiring diagnostics."""
+
+        return self._configuration_loader
 
     @property
     def peripherals(self) -> tuple[Peripheral[Any], ...]:

--- a/src/heart/runtime/container.py
+++ b/src/heart/runtime/container.py
@@ -6,8 +6,10 @@ from lagom import Container, Singleton
 
 from heart.device import Device
 from heart.navigation import AppController
+from heart.peripheral.configuration_loader import PeripheralConfigurationLoader
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import apply_provider_registrations
+from heart.peripheral.registry import PeripheralConfigurationRegistry
 from heart.runtime.display_context import DisplayContext
 from heart.runtime.frame_presenter import FramePresenter
 from heart.runtime.peripheral_runtime import PeripheralRuntime
@@ -23,7 +25,32 @@ def build_runtime_container(
     container = Container()
     _bind(container, overrides, Device, device)
     _bind(container, overrides, RendererVariant, render_variant)
-    _bind(container, overrides, PeripheralManager, Singleton(PeripheralManager))
+    _bind(
+        container,
+        overrides,
+        PeripheralConfigurationRegistry,
+        Singleton(PeripheralConfigurationRegistry),
+    )
+    _bind(
+        container,
+        overrides,
+        PeripheralConfigurationLoader,
+        Singleton(
+            lambda resolver: PeripheralConfigurationLoader(
+                registry=resolver[PeripheralConfigurationRegistry]
+            )
+        ),
+    )
+    _bind(
+        container,
+        overrides,
+        PeripheralManager,
+        Singleton(
+            lambda resolver: PeripheralManager(
+                configuration_loader=resolver[PeripheralConfigurationLoader]
+            )
+        ),
+    )
     _bind(
         container,
         overrides,

--- a/tests/runtime/test_container.py
+++ b/tests/runtime/test_container.py
@@ -1,3 +1,4 @@
+from heart.peripheral.configuration_loader import PeripheralConfigurationLoader
 from heart.peripheral.core.manager import PeripheralManager
 from heart.runtime.container import build_runtime_container
 from heart.runtime.display_context import DisplayContext
@@ -35,3 +36,16 @@ class TestRuntimeContainer:
         loop = GameLoop(device=device, resolver=container)
 
         assert loop.peripheral_manager is stub_manager
+
+    def test_container_overrides_configuration_loader(self, device) -> None:
+        """Confirm configuration loader overrides flow into PeripheralManager so tests can swap config wiring safely."""
+        stub_loader = PeripheralConfigurationLoader(configuration="stubbed")
+        container = build_runtime_container(
+            device=device,
+            render_variant=RendererVariant.BINARY,
+            overrides={PeripheralConfigurationLoader: stub_loader},
+        )
+
+        manager = container.resolve(PeripheralManager)
+
+        assert manager.configuration_loader is stub_loader


### PR DESCRIPTION
### Motivation
- Allow tests and runtime to override peripheral configuration resolution by wiring the configuration loader through the Lagom container rather than constructing it inside `PeripheralManager`.
- Reduce mixed responsibilities by moving configuration discovery into container-provided singletons for clearer ownership and easier overrides.
- Improve observability of wiring by exposing the injected loader on `PeripheralManager` for diagnostics.

### Description
- Register `PeripheralConfigurationRegistry` and `PeripheralConfigurationLoader` as singletons in `build_runtime_container` and make `PeripheralManager` receive the loader from the container via injection.
- Update `PeripheralManager` constructor to accept an optional `configuration_loader` and add a `configuration_loader` property to expose the resolved loader.
- Add `test_container_overrides_configuration_loader` to `tests/runtime/test_container.py` to verify container overrides propagate into `PeripheralManager`.
- Add `docs/research/lagom_peripheral_configuration_integration.md` documenting the integration and rationale.

### Testing
- Ran `make format` to apply formatting and lint fixes, which completed successfully.
- Ran `make test` and the full test suite completed successfully with `227 passed, 1 skipped`.
- The new container override test `test_container_overrides_configuration_loader` was executed and passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694df453441c8321874c0688ee1781ac)