### PR TITLE
Name background threads for diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - Prefer `StrEnum` values over raw strings for strategy/configuration mode selections.
 - Use `heart.utilities.logging.get_logger` for internal logging so handlers and log levels stay consistent across modules.
 - Prefer `get_logger(__name__)` so loggers include their module path and stay consistent in telemetry.
+- When starting background threads, provide a descriptive name via `threading.Thread(name=...)` to keep diagnostics readable.
 - Prefer module-level constants for tunable loop intervals instead of embedding sleep literals in long-running loops.
 - Prefer module-level constants for retry thresholds in reconnect or recovery loops instead of inline numeric literals.
 - When reading or writing text files, specify an explicit encoding (prefer `utf-8`) to keep behavior consistent across platforms.

--- a/src/heart/device/beats/websocket.py
+++ b/src/heart/device/beats/websocket.py
@@ -141,6 +141,7 @@ class WebSocket:
         self._thread = threading.Thread(
             target=self._ws_thread_main,
             daemon=True,
+            name="Beats websocket server",
         )
         self._thread.start()
 

--- a/src/heart/renderers/yolisten/renderer.py
+++ b/src/heart/renderers/yolisten/renderer.py
@@ -54,7 +54,11 @@ class YoListenRenderer(StatefulBaseRenderer[YoListenState]):
         self.phyphox_accel_z = 0.0
         self.use_phyphox = False
         if self.use_phyphox:
-            threading.Thread(target=self._poll_phyphox_background, daemon=True).start()
+            threading.Thread(
+                target=self._poll_phyphox_background,
+                daemon=True,
+                name="YoListen phyphox poller",
+            ).start()
         self.sim_accel_x = 0.0
         self.sim_accel_y = 0.0
         self.sim_accel_step = 0.1


### PR DESCRIPTION
### Motivation
- Improve runtime diagnostics by giving background threads descriptive names to make logs and thread dumps easier to interpret.
- Encode the convention in repository guidance so future contributors follow the same practice.
- Reduce friction when investigating background activity (pollers, servers) in production and in tests.
- Align with existing developer guidance about readable, debuggable runtime behavior.

### Description
- Add a new rule to `AGENTS.md` recommending naming background threads with `threading.Thread(name=...)` for clearer diagnostics.
- Name the YoListen phyphox poller thread in `src/heart/renderers/yolisten/renderer.py` as `"YoListen phyphox poller"` when started.
- Name the Beats websocket server thread in `src/heart/device/beats/websocket.py` as `"Beats websocket server"` when created.
- Run repository formatting to keep code style consistent (`make format`).

### Testing
- Ran `make format` successfully to apply formatting rules. 
- Ran the test suite with `make test` and observed all automated tests passed. 
- Test summary: `229 passed, 1 skipped`.
- No new unit tests were required for this non-functional change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694df806d50c8321889ce6370109a5d7)