### PR TITLE
Inject PeripheralConfigurationLoader into runtime container

### DIFF
--- a/docs/research/lagom_peripheral_registry_integration.md
+++ b/docs/research/lagom_peripheral_registry_integration.md
@@ -9,14 +9,16 @@ the manager and its loader.
 
 ## Notes
 
-- Registered `PeripheralConfigurationRegistry` in
-  `heart.runtime.container.build_runtime_container` so Lagom can manage a shared
-  instance for runtime overrides.
-- Injected the registry into `PeripheralManager` and surfaced it through
-  `PeripheralConfigurationLoader.registry` and
+- Registered `PeripheralConfigurationRegistry` and
+  `PeripheralConfigurationLoader` in
+  `heart.runtime.container.build_runtime_container` so Lagom can manage shared
+  instances for runtime overrides.
+- Injected the loader into `PeripheralManager` and surfaced registry access
+  through `PeripheralConfigurationLoader.registry` and
   `PeripheralManager.configuration_registry` to support validation and testing.
 - Added container coverage in `tests/runtime/test_container.py` to confirm the
-  registry instance is shared by the manager.
+  registry instance is shared by the manager and that loader overrides flow
+  through the container.
 
 ## Materials
 

--- a/src/heart/peripheral/core/manager.py
+++ b/src/heart/peripheral/core/manager.py
@@ -32,10 +32,15 @@ class PeripheralManager:
         *,
         configuration: str | None = None,
         configuration_registry: PeripheralConfigurationRegistry | None = None,
+        configuration_loader: PeripheralConfigurationLoader | None = None,
     ) -> None:
         self._peripherals: list[Peripheral[Any]] = []
         self._started = False
-        self._configuration_loader = PeripheralConfigurationLoader(
+        if configuration_loader and (configuration or configuration_registry):
+            raise ValueError(
+                "Provide configuration_loader or configuration/configuration_registry, not both."
+            )
+        self._configuration_loader = configuration_loader or PeripheralConfigurationLoader(
             configuration=configuration,
             registry=configuration_registry,
         )

--- a/src/heart/runtime/container.py
+++ b/src/heart/runtime/container.py
@@ -6,6 +6,7 @@ from lagom import Container, Singleton
 
 from heart.device import Device
 from heart.navigation import AppController
+from heart.peripheral.configuration_loader import PeripheralConfigurationLoader
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import apply_provider_registrations
 from heart.peripheral.registry import PeripheralConfigurationRegistry
@@ -34,10 +35,20 @@ def build_runtime_container(
     _bind(
         container,
         overrides,
+        PeripheralConfigurationLoader,
+        Singleton(
+            lambda resolver: PeripheralConfigurationLoader(
+                registry=resolver[PeripheralConfigurationRegistry]
+            )
+        ),
+    )
+    _bind(
+        container,
+        overrides,
         PeripheralManager,
         Singleton(
             lambda resolver: PeripheralManager(
-                configuration_registry=resolver[PeripheralConfigurationRegistry]
+                configuration_loader=resolver[PeripheralConfigurationLoader]
             )
         ),
     )

--- a/tests/runtime/test_container.py
+++ b/tests/runtime/test_container.py
@@ -1,3 +1,4 @@
+from heart.peripheral.configuration_loader import PeripheralConfigurationLoader
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.registry import PeripheralConfigurationRegistry
 from heart.runtime.container import build_runtime_container
@@ -37,6 +38,23 @@ class TestRuntimeContainer:
         manager = container.resolve(PeripheralManager)
 
         assert manager.configuration_registry is registry
+
+    def test_container_allows_configuration_loader_overrides(self, device) -> None:
+        """Ensure configuration loader overrides propagate, so tests can inject loader behavior cleanly."""
+        registry = PeripheralConfigurationRegistry()
+        loader = PeripheralConfigurationLoader(
+            configuration="test-override",
+            registry=registry,
+        )
+        container = build_runtime_container(
+            device=device,
+            render_variant=RendererVariant.BINARY,
+            overrides={PeripheralConfigurationLoader: loader},
+        )
+
+        manager = container.resolve(PeripheralManager)
+
+        assert manager.configuration_loader is loader
 
     def test_game_loop_uses_container_overrides(self, device) -> None:
         """Ensure GameLoop honors container overrides so tests can swap implementations without touching runtime code."""


### PR DESCRIPTION
### Motivation
- Ensure the runtime Lagom container exposes and manages peripheral configuration resolution so tests and runtime code can override and validate configuration lookups.
- Allow `PeripheralManager` to accept an injected loader so the manager focuses on orchestration instead of creating its own loader instance.

### Description
- Register `PeripheralConfigurationLoader` in `build_runtime_container` and inject it into `PeripheralManager` instead of directly wiring a registry into the manager.
- Extend `PeripheralManager.__init__` to accept an optional `configuration_loader` and validate against conflicting `configuration`/`configuration_registry` arguments.
- Add a container override test `test_container_allows_configuration_loader_overrides` in `tests/runtime/test_container.py` to confirm loader overrides propagate to `PeripheralManager`.
- Update the Lagom peripheral integration note in `docs/research/lagom_peripheral_registry_integration.md` to document the loader registration and testing coverage.

### Testing
- Ran `make format` which completed successfully.
- Ran `make test` which completed with all automated tests passing (`230 passed, 1 skipped`).
- The new container override test in `tests/runtime/test_container.py` passed as part of the test suite.
- No automated tests failed during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694df7fdfd348321b0ab1b219ac989bd)