### PR TITLE
Deepen Lagom integration in configuration helpers

### DIFF
--- a/docs/research/lagom_configuration_helpers.md
+++ b/docs/research/lagom_configuration_helpers.md
@@ -1,0 +1,27 @@
+# Lagom configuration helper integration
+
+## Problem Statement
+
+Configuration modules still reached into `GameLoop.context_container` directly and
+manually constructed `ComposedRenderer` groups without the shared resolver.
+That left some renderer bundles outside the Lagom resolution path and duplicated
+container access in multiple configuration files.
+
+## Materials
+
+- Python 3.11 with `uv` for dependency resolution.
+- Lagom dependency (`lagom` in `pyproject.toml`).
+- Source modules: `src/heart/runtime/game_loop.py`,
+  `src/heart/programs/configurations/lib_2024.py`,
+  `src/heart/programs/configurations/lib_2025.py`,
+  `src/heart/programs/configurations/tixyland.py`.
+
+## Notes
+
+`GameLoop` now exposes `resolve` and `compose` helpers so configuration modules
+can resolve Lagom-managed dependencies and build `ComposedRenderer` groups with a
+shared resolver. The loop also applies peripheral provider registrations when a
+custom container is supplied, keeping renderer provider bindings consistent even
+outside the default builder. Configuration modules now call these helpers
+instead of reaching into the container directly, keeping Lagom usage centralized
+in the runtime layer.

--- a/src/heart/programs/configurations/lib_2024.py
+++ b/src/heart/programs/configurations/lib_2024.py
@@ -1,5 +1,5 @@
 from heart.display.color import Color
-from heart.navigation import ComposedRenderer, MultiScene
+from heart.navigation import MultiScene
 from heart.renderers.hilbert_curve import HilbertScene
 from heart.renderers.kirby import KirbyScene
 from heart.renderers.mandelbrot.scene import MandelbrotMode
@@ -13,7 +13,7 @@ def configure(loop: GameLoop) -> None:
     kirby_mode.resolve_renderer_from_container(KirbyScene)
 
     modelbrot = loop.add_mode(
-        ComposedRenderer(
+        loop.compose(
             [
                 MandelbrotTitle(),
                 TextRendering(

--- a/src/heart/programs/configurations/lib_2025.py
+++ b/src/heart/programs/configurations/lib_2025.py
@@ -3,7 +3,7 @@ from typing import Callable
 import numpy as np
 
 from heart.display.color import Color
-from heart.navigation import ComposedRenderer, MultiScene
+from heart.navigation import MultiScene
 from heart.renderers.artist import ArtistScene
 from heart.renderers.combined_bpm_screen import CombinedBpmScreen
 from heart.renderers.heart_title_screen import HeartTitleScreen
@@ -37,7 +37,7 @@ def configure(loop: GameLoop) -> None:
     kirby_mode.resolve_renderer_from_container(KirbyScene)
 
     modelbrot = loop.add_mode(
-        ComposedRenderer(
+        loop.compose(
             [
                 MandelbrotTitle(),
                 TextRendering(
@@ -59,7 +59,7 @@ def configure(loop: GameLoop) -> None:
     hilbert_mode.resolve_renderer_from_container(HilbertScene)
 
     mario_mode = loop.add_mode(
-        ComposedRenderer(
+        loop.compose(
             [
                 RenderImage(image_file="mario_still.png"),
                 TextRendering(
@@ -75,10 +75,10 @@ def configure(loop: GameLoop) -> None:
     mario_mode.resolve_renderer_from_container(MarioRenderer)
 
     def multicolor_renderer() -> MulticolorRenderer:
-        return loop.context_container.resolve(MulticolorRenderer)
+        return loop.resolve(MulticolorRenderer)
 
     shroomed_mode = loop.add_mode(
-        ComposedRenderer(
+        loop.compose(
             [
                 multicolor_renderer(),
                 TextRendering(
@@ -92,7 +92,7 @@ def configure(loop: GameLoop) -> None:
         )
     )
     shroomed_mode.add_renderer(
-        ComposedRenderer(
+        loop.compose(
             [
                 multicolor_renderer(),
                 SpritesheetLoop("ness.png", "ness.json"),
@@ -101,9 +101,9 @@ def configure(loop: GameLoop) -> None:
     )
 
     heart_rate_mode = loop.add_mode(
-        ComposedRenderer(
+        loop.compose(
             [
-                loop.context_container.resolve(HeartTitleScreen),
+                loop.resolve(HeartTitleScreen),
                 TextRendering(
                     text=["heart rate"],
                     font="Roboto",
@@ -117,9 +117,9 @@ def configure(loop: GameLoop) -> None:
     heart_rate_mode.resolve_renderer_from_container(CombinedBpmScreen)
 
     water_mode = loop.add_mode(
-        ComposedRenderer(
+        loop.compose(
             [
-                loop.context_container.resolve(WaterTitleScreen),
+                loop.resolve(WaterTitleScreen),
                 TextRendering(
                     text=["water"],
                     font="Roboto",
@@ -180,7 +180,7 @@ def configure(loop: GameLoop) -> None:
 
     # Some random ones
     tixyland = loop.add_mode("tixyland")
-    tixyland_factory = loop.context_container.resolve(TixylandFactory)
+    tixyland_factory = loop.resolve(TixylandFactory)
 
     def build_tixyland(
         fn: Callable[[float, np.ndarray, np.ndarray, np.ndarray], np.ndarray]
@@ -223,7 +223,7 @@ def configure(loop: GameLoop) -> None:
 
     confetti = loop.add_mode("confetti")
     confetti.add_renderer(
-        ComposedRenderer(
+        loop.compose(
             [
                 RandomPixel(num_pixels=40000, brightness=0.05),
                 RandomPixel(num_pixels=4000, brightness=0.10),

--- a/src/heart/programs/configurations/tixyland.py
+++ b/src/heart/programs/configurations/tixyland.py
@@ -14,7 +14,7 @@ def pattern_numpy(t: float, X: np.ndarray, Y: np.ndarray) -> np.ndarray:
 
 
 def configure(loop: GameLoop) -> None:
-    tixyland_factory = loop.context_container.resolve(TixylandFactory)
+    tixyland_factory = loop.resolve(TixylandFactory)
 
     def build_tixyland(
         fn: Callable[[float, np.ndarray, np.ndarray, np.ndarray], np.ndarray]


### PR DESCRIPTION
### Motivation

- Centralize Lagom-based dependency resolution so configuration code stops reaching into `GameLoop.context_container` directly.  
- Ensure peripheral provider registrations are applied when a custom container is supplied so renderer/provider bindings stay consistent.  
- Reduce duplicated container plumbing in configuration modules and keep renderer composition within the runtime layer.  

### Description

- Add `GameLoop.resolve` and `GameLoop.compose` helpers to resolve dependencies from the loop's Lagom container and build `ComposedRenderer` groups with the shared resolver.  
- Apply `apply_provider_registrations(container)` when a custom `resolver: Container` is provided to `GameLoop` so provider bindings are applied to external containers.  
- Update configuration modules to use the new helpers instead of `loop.context_container.resolve` or constructing `ComposedRenderer` directly in `lib_2024.py`, `lib_2025.py`, and `tixyland.py`.  
- Add a research note `docs/research/lagom_configuration_helpers.md` documenting the integration approach.  

### Testing

- Ran `make format` and the formatting checks passed.  
- Ran the test suite with `make test` and observed `229 passed, 1 skipped`.  
- Updated unit tests that validate container wiring remained green (`tests/runtime/test_container.py` covered container overrides).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694df7efa6c48321b52c8047ebd43898)