### PR TITLE
Move radio bridge loop interval to constant

### DIFF
--- a/drivers/radio_bridge/code.py
+++ b/drivers/radio_bridge/code.py
@@ -11,6 +11,7 @@ from heart.firmware_io import device_id, identity
 from heart.firmware_io.constants import RADIO_PACKET
 
 DEVICE_NAME = "radio-bridge"
+RADIO_BRIDGE_LOOP_INTERVAL_SECONDS = 0.1
 IDENTITY = identity.Identity(
     device_name=DEVICE_NAME,
     firmware_commit=identity.default_firmware_commit(),
@@ -41,7 +42,7 @@ class RadioBridgeRuntime:
     gather_packet: Callable[[], Mapping[str, object]] = _default_packet
     print_fn: Callable[[str], None] = print
     sleep_fn: Callable[[float], None] = time.sleep
-    interval_seconds: float = 0.1
+    interval_seconds: float = RADIO_BRIDGE_LOOP_INTERVAL_SECONDS
 
     def _encode_payload(self, payload: Mapping[str, object]) -> str:
         frame = {"event_type": RADIO_PACKET, "data": dict(payload)}


### PR DESCRIPTION
### Motivation
- Follow repository guidance to define tunable loop intervals as module-level constants rather than inline literals.
- Make the radio bridge runtime interval easy to discover and adjust from the module scope.
- Reduce the chance of duplicating magic numbers across firmware driver code.

### Description
- Add a module-level constant `RADIO_BRIDGE_LOOP_INTERVAL_SECONDS` in `drivers/radio_bridge/code.py` set to `0.1`.
- Replace the inline default `0.1` for the `RadioBridgeRuntime.interval_seconds` default with `RADIO_BRIDGE_LOOP_INTERVAL_SECONDS`.
- No behavioural changes to runtime logic beyond using the named constant as the default loop interval.

### Testing
- Ran `make format` and formatting checks completed successfully.
- Ran `make test` and the suite completed with all tests passing (`229 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694df9b6a5348321a138dc07c0973177)