### PR TITLE
Prefer Path.read_text for asset JSON loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - Prefer `get_logger(__name__)` so loggers include their module path and stay consistent in telemetry.
 - Prefer module-level constants for tunable loop intervals instead of embedding sleep literals in long-running loops.
 - Prefer module-level constants for retry thresholds in reconnect or recovery loops instead of inline numeric literals.
+- Prefer `pathlib.Path.read_text`/`write_text` helpers for straightforward text file I/O.
 - When reading or writing text files, specify an explicit encoding (prefer `utf-8`) to keep behavior consistent across platforms.
 
 ## Error Handling

--- a/src/heart/assets/loader.py
+++ b/src/heart/assets/loader.py
@@ -112,8 +112,7 @@ class Loader:
             cached = cache.get(resolved_path)
             if cached is not None:
                 return dict(cached)
-        with resolved_path.open("r", encoding="utf-8") as fp:
-            payload = json.load(fp)
+        payload = json.loads(resolved_path.read_text(encoding="utf-8"))
         if cache is not None:
             cache.set(resolved_path, payload)
         return dict(payload)


### PR DESCRIPTION
### Motivation
- Prefer `pathlib.Path` helpers for straightforward text I/O to follow repository guidance and reduce boilerplate.  
- Ensure explicit `encoding="utf-8"` is used when reading asset metadata to keep cross-platform behavior consistent.  
- Document the pattern in the repository guidance so contributors follow the same convention.  

### Description
- Add guidance to `AGENTS.md` recommending `pathlib.Path.read_text`/`write_text` for simple text file I/O.  
- Replace a `with resolved_path.open(...): json.load(...)` pattern in `src/heart/assets/loader.py::Loader.load_json` with `json.loads(resolved_path.read_text(encoding="utf-8"))`.  
- Preserve the existing metadata caching behavior while changing the text read implementation.  

### Testing
- Ran `make format`, which completed successfully.  
- Ran the test suite via `make test`, which produced 228 passed, 1 skipped, and 1 failed.  
- The failing test is `tests/utilities/test_reactivex_streams.py::TestShareStreamFlowControl::test_share_stream_coalesces_latest_when_configured`.  
- All other automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694df9c241388321bdf8733e63145bf8)