### PR TITLE
Move Phyphox request configuration to module-level constants

### DIFF
--- a/src/heart/peripheral/phyphox.py
+++ b/src/heart/peripheral/phyphox.py
@@ -8,6 +8,9 @@ from heart.peripheral.sensor import Acceleration
 from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
+DEFAULT_PHYPOX_URL = "http://192.168.1.42"
+PHYPOX_ACCEL_ENDPOINT = "/get?accY&accX&accZ"
+REQUEST_TIMEOUT_SECONDS = 1
 REQUEST_SLEEP_SECONDS = 0.05
 
 
@@ -21,12 +24,15 @@ class Phyphox(Peripheral[Acceleration]):
 
     @classmethod
     def detect(cls) -> Iterator[Self]:
-        yield cls("http://192.168.1.42")
+        yield cls(DEFAULT_PHYPOX_URL)
 
     def run(self) -> NoReturn:
         while True:
             try:
-                resp = requests.get(f"{self.url}/get?accY&accX&accZ", timeout=1)
+                resp = requests.get(
+                    f"{self.url}{PHYPOX_ACCEL_ENDPOINT}",
+                    timeout=REQUEST_TIMEOUT_SECONDS,
+                )
                 data = resp.json()
                 self.acc_x = float(data["buffer"]["accX"]["buffer"][-1])
                 self.acc_y = float(data["buffer"]["accY"]["buffer"][-1])


### PR DESCRIPTION
### Motivation
- Centralize Phyphox network settings (URL, endpoint, timeout) as module-level constants to avoid inline magic literals.
- Follow repository guidance to keep external request endpoints and timeouts configurable and visible at the top of the module.
- Make the peripheral easier to override, test, and maintain by extracting tunable values.

### Description
- Add `DEFAULT_PHYPOX_URL`, `PHYPOX_ACCEL_ENDPOINT`, and `REQUEST_TIMEOUT_SECONDS` constants to `src/heart/peripheral/phyphox.py`.
- Update `detect` to yield `Phyphox(DEFAULT_PHYPOX_URL)` instead of an inline URL.
- Use `PHYPOX_ACCEL_ENDPOINT` and `REQUEST_TIMEOUT_SECONDS` in the `requests.get` call instead of inline strings/literals.
- Preserve existing behavior while centralizing configuration and improving readability.

### Testing
- Ran `make format` and the formatting checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694df9ce72f08321b3b41c461c429c95)