### PR TITLE
Normalize sensor bus payload framing

### DIFF
--- a/drivers/AGENTS.md
+++ b/drivers/AGENTS.md
@@ -10,6 +10,7 @@
 - When adding diagnostic output, use `print` statements guarded behind a module-level `DEBUG` flag rather than logging frameworks that CircuitPython does not ship with by default.
 - Keep exception handling minimal; allow errors to propagate so they can be inspected over the serial REPL. Only catch exceptions when you can recover or to add chip-specific hints.
 - Include docstrings that describe how to reproduce hardware issues via the REPL so that future debugging does not require the full game runtime.
+- Keep serial payload framing to a single trailing newline to avoid redundant whitespace on constrained links.
 
 ## Testing philosophy
 - Provide a pure-Python shim or simulator whenever practical so unit tests can run on CI. Hardware-specific modules should be isolated behind thin adapters that can be mocked.

--- a/drivers/sensor_bus/code.py
+++ b/drivers/sensor_bus/code.py
@@ -67,7 +67,7 @@ def _form_payload(name: str, data) -> str:
 
     """
     payload = {"event_type": name, "data": data}
-    return "\n" + json.dumps(payload) + "\n"
+    return f"{json.dumps(payload)}\n"
 
 
 def form_tuple_payload(name: str, data: tuple) -> str:

--- a/tests/drivers/test_sensor_bus_driver.py
+++ b/tests/drivers/test_sensor_bus_driver.py
@@ -71,7 +71,8 @@ class TestDriversSensorBusDriver:
     def test_form_tuple_payload_returns_json(self, sensor_bus):
         """Verify that form_tuple_payload encodes sensor tuples into the expected JSON string. This keeps bus messages compatible with consumers that parse structured telemetry."""
         payload = sensor_bus.form_tuple_payload("rotation", (1.0, 2.0, 3.0))
-        assert payload.startswith("\n")
+        assert payload.startswith("{")
+        assert payload.endswith("\n")
         decoded = json.loads(payload.strip())
         assert decoded == {"event_type": "rotation", "data": {"x": 1.0, "y": 2.0, "z": 3.0}}
 


### PR DESCRIPTION
### Motivation
- Ensure serial payloads emitted by drivers use consistent framing to avoid redundant whitespace on constrained links.
- Keep driver behavior predictable so host consumers can parse telemetry without fragile trimming logic.
- Align driver implementation with repository guidance for CircuitPython-friendly drivers.

### Description
- Add a guideline to `drivers/AGENTS.md` recommending a single trailing newline for serial payload framing.
- Change `_form_payload` in `drivers/sensor_bus/code.py` to emit `json.dumps(payload)` followed by a single `\n` instead of surrounding newlines.
- Update `tests/drivers/test_sensor_bus_driver.py` to assert the payload starts with `{` and ends with `\n` to match the new framing.

### Testing
- Ran `make format` to apply project formatting, which completed successfully.
- Ran `make test`, which passed with `230 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dfb05a22483219035495bf17b416f)