### PR TITLE
Use module-level constant for Bluetooth UART device name

### DIFF
--- a/src/heart/peripheral/bluetooth.py
+++ b/src/heart/peripheral/bluetooth.py
@@ -22,6 +22,7 @@ NOTIFICATION_CHANNEL = "6e400003-b5a3-f393-e0a9-e50e24dcca9e"
 SINGLE_CLIENT_TIMEOUT_SECONDS = 60 * 60 * 12  # 12 hours
 OBJECT_SEPARATOR = b"\n"
 RECONNECT_DELAY_SECONDS = 1.0
+DEVICE_NAME = "totem-controller"
 
 
 class UartListener:
@@ -58,7 +59,7 @@ class UartListener:
             device
             for device in devices
             # TODO: This should come from somewhere more principled
-            if device.name == "totem-controller"
+            if device.name == DEVICE_NAME
         ]
 
     def start(self) -> None:


### PR DESCRIPTION
### Motivation

- AGENTS.md requires device identifiers be defined as module-level constants rather than inline literals. 
- The Bluetooth UART discovery used a raw string literal for the device name which diverged from that guideline. 

### Description

- Add a module-level constant `DEVICE_NAME = "totem-controller"` to `src/heart/peripheral/bluetooth.py`.
- Replace the inline string literal with the `DEVICE_NAME` constant when filtering discovered devices in `_discover_devices`.
- Run repository formatting as part of the change with `make format`.

### Testing

- Ran `make format`, which completed successfully. 
- Ran `make test`, resulting in `229 passed, 1 failed, 1 skipped` across the test suite. 
- The failing test is `tests/utilities/test_reactivex_streams.py::TestShareStreamStrategy::test_share_stream_refcount_grace_delays_disconnect`. 
- The test failure appears during the suite run and is not tied to any codepaths changed in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dfb0eec60832188c9bdc2e68015f0)