### PR TITLE
Add REPL reproduction steps to driver docstrings

### DIFF
--- a/drivers/bluetooth-bridge/code.py
+++ b/drivers/bluetooth-bridge/code.py
@@ -1,15 +1,21 @@
 """Bluetooth bridge firmware loop.
 
 The original firmware was written with direct hardware calls that executed on
-import.  That behaviour makes it impossible to exercise in CI because the
-module immediately tries to talk to the board and blocks forever.  The driver
-is now organised around a small runtime object so that unit tests can inject
-test doubles for the BLE stack, LED and timing helpers.
+import. That behaviour makes it impossible to exercise in CI because the module
+immediately tries to talk to the board and blocks forever. The driver is now
+organized around a small runtime object so that unit tests can inject test
+doubles for the BLE stack, LED, and timing helpers.
+
+REPL reproduction:
+    1. Connect to the board REPL and import this module.
+    2. Call ``create_runtime()`` to initialize the BLE stack and UART service.
+    3. Invoke ``runtime.run_once()`` in a loop to observe UART payloads and LED
+       activity without the full game runtime.
 
 When running on the microcontroller the ``main`` function still spins forever,
-but the class based structure means CI can call :meth:`BluetoothBridgeRuntime.run_once`
-with fake values and assert on the produced UART output without needing any of
-the real hardware modules.
+but the class-based structure means CI can call
+:meth:`BluetoothBridgeRuntime.run_once` with fake values and assert on the
+produced UART output without needing any of the real hardware modules.
 """
 
 from __future__ import annotations

--- a/drivers/lampe-controller/code.py
+++ b/drivers/lampe-controller/code.py
@@ -1,4 +1,11 @@
-"""Lampe controller firmware entry point."""
+"""Lampe controller firmware entry point.
+
+REPL reproduction:
+    1. Connect to the board REPL and import this module.
+    2. Call ``create_runtime()`` to initialize the Seesaw controller.
+    3. Invoke ``runtime.run_once()`` to emit encoder events over Bluetooth
+       without running the full game runtime.
+"""
 
 from __future__ import annotations
 

--- a/drivers/radio_bridge/code.py
+++ b/drivers/radio_bridge/code.py
@@ -1,4 +1,12 @@
-"""Minimal firmware stub that forwards radio packets over the USB REPL."""
+"""Minimal firmware stub that forwards radio packets over the USB REPL.
+
+REPL reproduction:
+    1. Connect to the board REPL and import this module.
+    2. Instantiate ``RadioBridgeRuntime`` with a stub ``gather_packet`` callable
+       to simulate packets.
+    3. Call ``runtime.run_once()`` to verify USB payload formatting without the
+       full game runtime.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
### Motivation
- Align driver documentation with the repository `AGENTS.md` guidance for driver debugging and REPL reproduction.
- Make firmware driver modules easier to exercise in CI and during local hardware debugging by documenting how to instantiate and run the runtime objects.
- Reduce friction for writing unit tests and REPL debugging by giving a clear, minimal reproduction recipe per driver.

### Description
- Added REPL reproduction instructions to the module docstrings of `drivers/bluetooth-bridge/code.py`, `drivers/lampe-controller/code.py`, and `drivers/radio_bridge/code.py`.
- Minor docstring reformatting and wording tweaks to improve clarity and consistency across the drivers.
- Ran and applied project formatting via `make format` to keep the repository consistent with formatting rules.

### Testing
- Ran `make format`, which completed successfully and reported "All checks passed!".
- Executed the test suite with `make test`, which resulted in `230 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dfb1331d883218a6cbfd2ff5462a7)