### PR TITLE
Add module-level default constants for Microphone and update AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - Use `time.monotonic()` for elapsed-time comparisons, and reserve `time.time()` for wall-clock timestamps that leave the process.
 - Prefer `pathlib.Path.read_text`/`write_text` helpers for straightforward text file I/O.
 - When reading or writing text files, specify an explicit encoding (prefer `utf-8`) to keep behavior consistent across platforms.
+- Use module-level constants for public constructor or function default values so shared configuration is easy to discover and adjust.
 
 ## Error Handling
 

--- a/src/heart/peripheral/microphone.py
+++ b/src/heart/peripheral/microphone.py
@@ -27,6 +27,11 @@ sd: Any | None = None
 if ctypes.util.find_library("portaudio") is not None:  # pragma: no cover - optional dependency
     sd = optional_import("sounddevice", logger=logger)
 
+DEFAULT_SAMPLE_RATE = 16_000
+DEFAULT_BLOCK_DURATION_SECONDS = 0.1
+DEFAULT_CHANNELS = 1
+DEFAULT_RETRY_DELAY_SECONDS = 1.0
+
 
 class Microphone(Peripheral[MicrophoneLevel]):
     """Capture audio input and emit loudness metrics"""
@@ -36,10 +41,10 @@ class Microphone(Peripheral[MicrophoneLevel]):
     def __init__(
         self,
         *,
-        samplerate: int = 16_000,
-        block_duration: float = 0.1,
-        channels: int = 1,
-        retry_delay: float = 1.0,
+        samplerate: int = DEFAULT_SAMPLE_RATE,
+        block_duration: float = DEFAULT_BLOCK_DURATION_SECONDS,
+        channels: int = DEFAULT_CHANNELS,
+        retry_delay: float = DEFAULT_RETRY_DELAY_SECONDS,
     ) -> None:
         super().__init__()
         self.samplerate = samplerate


### PR DESCRIPTION
### Motivation

- Enforce repository guidance to prefer module-level constants for shared defaults and reduce inline literals. 
- Address a divergence from the agents guidance by codifying a rule requiring constructor/function defaults be surfaced as module-level constants. 
- Make microphone configuration easier to discover and adjust without changing call sites.

### Description

- Add a new AGENTS guideline: `Use module-level constants for public constructor or function default values` in `AGENTS.md`.
- Introduce `DEFAULT_SAMPLE_RATE`, `DEFAULT_BLOCK_DURATION_SECONDS`, `DEFAULT_CHANNELS`, and `DEFAULT_RETRY_DELAY_SECONDS` in `src/heart/peripheral/microphone.py`.
- Wire the `Microphone` constructor defaults to the new module-level constants instead of inline literals.
- Minor formatting applied to stay consistent with project tooling.

### Testing

- Ran `make format` which completed successfully.
- Ran `make test` which completed successfully and reported `230 passed, 1 skipped`.
- No new unit tests were added, and existing test suite passed after the change.
- Lint/format checks were validated as part of `make format`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dfd0743448321972cdf189c3ba6b9)