### PR TITLE
Add default retry delay constant for microphone peripheral

### DIFF
--- a/src/heart/peripheral/AGENTS.md
+++ b/src/heart/peripheral/AGENTS.md
@@ -4,3 +4,5 @@
 - Use `time.monotonic()` for elapsed-time comparisons such as timeouts, retry
   windows, or input debouncing. Reserve `time.time()` for wall-clock
   timestamps that need to be shared outside the process.
+- Define default retry/backoff delays as module-level constants, even when they
+  are exposed as constructor defaults, so timing knobs stay discoverable.

--- a/src/heart/peripheral/microphone.py
+++ b/src/heart/peripheral/microphone.py
@@ -23,6 +23,8 @@ from heart.utilities.reactivex_threads import input_scheduler
 
 logger = get_logger(__name__)
 
+DEFAULT_RETRY_DELAY_SECONDS = 1.0
+
 sd: Any | None = None
 if ctypes.util.find_library("portaudio") is not None:  # pragma: no cover - optional dependency
     sd = optional_import("sounddevice", logger=logger)
@@ -39,7 +41,7 @@ class Microphone(Peripheral[MicrophoneLevel]):
         samplerate: int = 16_000,
         block_duration: float = 0.1,
         channels: int = 1,
-        retry_delay: float = 1.0,
+        retry_delay: float = DEFAULT_RETRY_DELAY_SECONDS,
     ) -> None:
         super().__init__()
         self.samplerate = samplerate


### PR DESCRIPTION
### Motivation
- Ensure timing knobs (retry/backoff delays) are discoverable by defining them as module-level constants per peripheral guidelines.
- Bring the microphone implementation into alignment with the `src/heart/peripheral/AGENTS.md` rule about retry thresholds.

### Description
- Add a new guideline to `src/heart/peripheral/AGENTS.md` advising default retry/backoff delays be defined as module-level constants. 
- Introduce `DEFAULT_RETRY_DELAY_SECONDS` in `src/heart/peripheral/microphone.py` and use it as the default for the `retry_delay` constructor parameter by changing the default to `DEFAULT_RETRY_DELAY_SECONDS`.

### Testing
- Run `make format` to apply repository formatting tools, which completed successfully. 
- Run `make test`, which executed the test suite and resulted in `230 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dfd03295c83218cf22cfc52b90a50)