### PR TITLE
Use monotonic time for renderer timing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - Prefer module-level constants for retry thresholds in reconnect or recovery loops instead of inline numeric literals.
 - Prefer `pathlib.Path.read_text`/`write_text` helpers for straightforward text file I/O.
 - When reading or writing text files, specify an explicit encoding (prefer `utf-8`) to keep behavior consistent across platforms.
+- For renderer or animation timing, use `time.monotonic()` to avoid wall-clock jumps; reserve `time.time()` for timestamps that need to be shared outside the process.
 
 ## Error Handling
 

--- a/src/heart/renderers/hilbert_curve/provider.py
+++ b/src/heart/renderers/hilbert_curve/provider.py
@@ -165,7 +165,7 @@ class HilbertCurveProvider(ObservableProvider[HilbertCurveState]):
             next_order, width, height, self.xmargin, self.ymargin
         )
         target_curve = resample_curve_numba(next_points, self.resample_count)
-        now = time.time()
+        now = time.monotonic()
         return HilbertCurveState(
             width=width,
             height=height,
@@ -274,7 +274,7 @@ class HilbertCurveProvider(ObservableProvider[HilbertCurveState]):
             initial_state = self.initial_state(width=size[0], height=size[1])
             return peripheral_manager.game_tick.pipe(
                 ops.filter(lambda tick: tick is not None),
-                ops.map(lambda _: time.time()),
+                ops.map(lambda _: time.monotonic()),
                 ops.scan(
                     lambda state, now: self.advance(state, now=now),
                     seed=initial_state,

--- a/src/heart/renderers/mandelbrot/scene.py
+++ b/src/heart/renderers/mandelbrot/scene.py
@@ -70,7 +70,7 @@ class MandelbrotMode(StatefulBaseRenderer[AppState]):
         orientation: Orientation,
     ) -> AppState:
         pygame.font.init()
-        self.time_initialized = time.time()
+        self.time_initialized = time.monotonic()
         self.font = pygame.font.SysFont("monospace", 8)
         self.clock = clock
         self.height = window.get_height()
@@ -132,7 +132,7 @@ class MandelbrotMode(StatefulBaseRenderer[AppState]):
 
     def process_input(self) -> bool:
         # when we first enter the scene, ignore input for a bit
-        if time.time() - self.time_initialized < 0.5:
+        if time.monotonic() - self.time_initialized < 0.5:
             return False
 
         self.keyboard_controls.update()

--- a/src/heart/renderers/three_fractal/renderer.py
+++ b/src/heart/renderers/three_fractal/renderer.py
@@ -187,7 +187,7 @@ class FractalRuntime(StatefulBaseRenderer[FractalRuntimeState]):
             ),
         )
 
-        self.time_initialized = time.time()
+        self.time_initialized = time.monotonic()
         self.target_surface = window
         window_size = window.get_size()
         tiled_mode = isinstance(orientation, Cube)
@@ -223,10 +223,10 @@ class FractalRuntime(StatefulBaseRenderer[FractalRuntimeState]):
         self.mat = np.identity(4, np.float32)
         self.mat[3, :3] = np.array(start_pos)
         self.prevMat = np.copy(self.mat)
-        self.last_update_time = time.time()
+        self.last_update_time = time.monotonic()
 
         self.shader.set(self.sphere_radius_var, self.BASE_RADIUS)
-        self.last_frame_time = time.time()
+        self.last_frame_time = time.monotonic()
         return FractalRuntimeState(peripheral_manager=peripheral_manager)
 
         self.mode = "auto"
@@ -473,7 +473,7 @@ class FractalRuntime(StatefulBaseRenderer[FractalRuntimeState]):
     def _check_break_auto(self, peripheral_manager: PeripheralManager):
         # ignore break auto check at first to avoid inut overlap from scene
         # select mode
-        if time.time() - self.time_initialized < 0.3:
+        if time.monotonic() - self.time_initialized < 0.3:
             return
 
         gamepad = peripheral_manager.get_gamepad()
@@ -725,7 +725,7 @@ class FractalRuntime(StatefulBaseRenderer[FractalRuntimeState]):
         if window is not self.target_surface:
             self.target_surface = window
 
-        now = time.time()
+        now = time.monotonic()
         self.delta_real_time = now - (self.last_frame_time or 0.0)
         self.last_frame_time = now
 

--- a/src/heart/renderers/yolisten/provider.py
+++ b/src/heart/renderers/yolisten/provider.py
@@ -110,7 +110,7 @@ class YoListenStateProvider(ObservableProvider[YoListenState]):
 
             state = self.update_flicker(
                 state,
-                time.time(),
+                time.monotonic(),
                 flicker_speed=self.flicker_speed,
                 flicker_intensity=self.flicker_intensity,
             )


### PR DESCRIPTION
### Motivation
- Renderer and animation code relied on `time.time()` for elapsed-time comparisons which can jump with wall-clock updates and break timing-sensitive logic.  
- The repository guidance should explicitly recommend monotonic clocks for internal timing to avoid regressions.  
- Several renderers used `time.time()` for initialization and delta calculations which diverged from the peripheral guidance to use monotonic time for elapsed comparisons.  

### Description
- Add an AGENTS rule recommending `time.monotonic()` for renderer/animation timing in `AGENTS.md`.  
- Replace `time.time()` with `time.monotonic()` in `src/heart/renderers/hilbert_curve/provider.py`, `src/heart/renderers/mandelbrot/scene.py`, `src/heart/renderers/three_fractal/renderer.py`, and `src/heart/renderers/yolisten/provider.py`.  
- Update elapsed-time comparisons and timestamp initializations to use `time.monotonic()` so runtime timing is robust to wall-clock adjustments.  
- Run project formatting to keep style consistent (`make format`).  

### Testing
- Ran `make format` and it completed successfully with "All checks passed!".  
- Ran a lightweight test that verified test functions and classes include required docstrings and it reported no missing docstrings.  
- No unit test suite was executed as part of this change (no `make test` run was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dfcf08c78832199e860df74598dee)