### PR TITLE
Use StrEnum for string enums and note Lagom DI guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,11 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - Prefer `pathlib.Path.read_text`/`write_text` helpers for straightforward text file I/O.
 - When reading or writing text files, specify an explicit encoding (prefer `utf-8`) to keep behavior consistent across platforms.
 
+## Dependency Injection (Lagom)
+
+- Prefer using `heart.runtime.container.build_runtime_container` and the provider registration helpers in
+  `heart.peripheral.core.providers` rather than instantiating new Lagom `Container` objects in feature modules.
+
 ## Error Handling
 
 - Avoid catching `BaseException`; catch `Exception` or more specific error types so system-exiting signals propagate.

--- a/src/heart/__init__.py
+++ b/src/heart/__init__.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from enum import StrEnum
 
 
-class DeviceDisplayMode(Enum):
+class DeviceDisplayMode(StrEnum):
     MIRRORED = "mirrored"
     FULL = "full"
     OPENGL = "opengl"

--- a/src/heart/peripheral/gamepad/gamepad.py
+++ b/src/heart/peripheral/gamepad/gamepad.py
@@ -2,7 +2,7 @@ import subprocess
 import time
 from collections import defaultdict
 from datetime import timedelta
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Iterator, Self
 
 import pygame.joystick
@@ -19,11 +19,12 @@ logger = get_logger(__name__)
 INITIALIZATION_DELAY_SECONDS = 1.5
 
 
-class GamepadIdentifier(Enum):
+class GamepadIdentifier(StrEnum):
     # string values need to exactly match what's reported from joystick.get_name()
     # so check that first when adding a controller type
     BIT_DO_LITE_2 = "8BitDo Lite 2"
     SWITCH_PRO = "Nintendo Switch Pro Controller"
+
 
 class Gamepad(Peripheral[Any]):
     EVENT_BUTTON = "gamepad.button"

--- a/src/heart/renderers/spritesheet/state.py
+++ b/src/heart/renderers/spritesheet/state.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from heart.peripheral.gamepad.gamepad import Gamepad
@@ -54,7 +54,7 @@ class FrameDescription:
         )
 
 
-class LoopPhase(Enum):
+class LoopPhase(StrEnum):
     START = "start"
     LOOP = "loop"
     END = "end"


### PR DESCRIPTION
### Motivation

- Align code with repository guidance to prefer `StrEnum` over raw strings for configuration and mode selections.
- Reduce accidental misuse of the Lagom `Container` by documenting preferred DI helpers and a single container construction path.
- Centralize runtime behaviour choices (display mode, spritesheet phases, gamepad identifiers) as typed string enums for clearer intent and safer comparisons.

### Description

- Replace `Enum` with `StrEnum` for `DeviceDisplayMode` in `src/heart/__init__.py`, `LoopPhase` in `src/heart/renderers/spritesheet/state.py`, and `GamepadIdentifier` in `src/heart/peripheral/gamepad/gamepad.py` so string-valued enums are strong-typed.
- Add a new section to `AGENTS.md` titled "Dependency Injection (Lagom)" recommending `build_runtime_container` and the provider registration helpers in `heart.peripheral.core.providers` instead of ad-hoc `lagom.Container` instantiation.
- Run repository-wide formatting via `make format` to ensure style consistency.

### Testing

- Ran `make format` and formatting checks completed successfully.
- Ran the test suite with `make test` and observed `230 passed, 1 skipped`.
- No automated tests failed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dfc6648408321971a668e799a07a1)