### PR TITLE
Centralize Lagom runtime container wiring

### DIFF
--- a/docs/research/lagom_runtime_container_bootstrap.md
+++ b/docs/research/lagom_runtime_container_bootstrap.md
@@ -1,0 +1,26 @@
+# Lagom runtime container bootstrap note
+
+## Problem Statement
+
+Custom Lagom containers passed into `GameLoop` needed ad-hoc wiring to register
+core runtime dependencies and provider registrations. That left container
+configuration logic split between `GameLoop` and `build_runtime_container`,
+which made it easy for callers to miss bindings when they supplied their own
+container instance.
+
+## Materials
+
+- Python 3.11 environment with `uv` for dependency management.
+- Lagom dependency (`lagom` in `pyproject.toml`).
+- Source modules: `src/heart/runtime/container.py`,
+  `src/heart/runtime/game_loop.py`,
+  `src/heart/peripheral/core/providers/registry.py`.
+
+## Notes
+
+`configure_runtime_container` now centralizes runtime bindings and provider
+registrations for any Lagom container. `build_runtime_container` uses this helper
+when it creates a new container, and `GameLoop` calls the same helper when a
+custom container is supplied. The shared configuration flow keeps dependency
+wiring consistent across default and custom containers while preserving existing
+bindings for overrides.

--- a/src/heart/runtime/container.py
+++ b/src/heart/runtime/container.py
@@ -24,6 +24,22 @@ def build_runtime_container(
     overrides: Mapping[type[Any], object] | None = None,
 ) -> Container:
     container = Container()
+    configure_runtime_container(
+        container=container,
+        device=device,
+        render_variant=render_variant,
+        overrides=overrides,
+    )
+    return container
+
+
+def configure_runtime_container(
+    *,
+    container: Container,
+    device: Device,
+    render_variant: RendererVariant,
+    overrides: Mapping[type[Any], object] | None = None,
+) -> None:
     _bind(container, overrides, Device, device)
     _bind(container, overrides, RendererVariant, render_variant)
     _bind(
@@ -112,7 +128,6 @@ def build_runtime_container(
     )
     _bind(container, overrides, PygameEventHandler, Singleton(PygameEventHandler))
     apply_provider_registrations(container)
-    return container
 
 
 def _bind(
@@ -123,5 +138,7 @@ def _bind(
 ) -> None:
     if overrides and key in overrides:
         container[key] = overrides[key]
+        return
+    if key in container.defined_types:
         return
     container[key] = value

--- a/src/heart/runtime/game_loop.py
+++ b/src/heart/runtime/game_loop.py
@@ -8,8 +8,8 @@ from lagom import Container
 
 from heart.device import Device
 from heart.navigation import ComposedRenderer, MultiScene
-from heart.peripheral.core.providers import apply_provider_registrations
-from heart.runtime.container import build_runtime_container
+from heart.runtime.container import (build_runtime_container,
+                                     configure_runtime_container)
 from heart.runtime.game_loop_components import GameLoopComponents
 from heart.runtime.render_pipeline import RendererVariant
 from heart.utilities.logging import get_logger
@@ -38,11 +38,11 @@ class GameLoop:
             )
         else:
             self.context_container = resolver
-            apply_provider_registrations(self.context_container)
-            if Device not in self.context_container.defined_types:
-                self.context_container[Device] = device
-            if RendererVariant not in self.context_container.defined_types:
-                self.context_container[RendererVariant] = render_variant
+            configure_runtime_container(
+                container=self.context_container,
+                device=device,
+                render_variant=render_variant,
+            )
         self.initialized = False
         self.device = self.context_container.resolve(Device)
 


### PR DESCRIPTION
### Motivation
- Prevent ad-hoc wiring and duplicated setup when callers supply a custom Lagom `Container` to the runtime. 
- Make dependency bindings and provider registrations consistent between the default container and user-provided containers. 
- Reduce the chance that callers accidentally omit important registrations (e.g., `Device`, `RendererVariant`, providers). 

### Description
- Add a shared `configure_runtime_container(*, container, device, render_variant, overrides)` helper that applies standard Lagom bindings and provider registrations. 
- Update `build_runtime_container()` to call `configure_runtime_container` when creating the default container. 
- Change `GameLoop.__init__` to call `configure_runtime_container` for custom `resolver` containers instead of performing ad-hoc registrations. 
- Make `_bind` respect existing container definitions by returning early when `key in container.defined_types`, and add a documentation note at `docs/research/lagom_runtime_container_bootstrap.md`. 

### Testing
- Ran formatting with `make format` and the formatter reported success. 
- Ran the full test suite with `make test`, which completed successfully with `230 passed, 1 skipped`. 
- No additional automated tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dfd13c6c08321bb9a5a9aeec02d64)