### PR TITLE
Expand Lagom resolution in navigation compositions

### DIFF
--- a/docs/research/lagom_configuration_helpers.md
+++ b/docs/research/lagom_configuration_helpers.md
@@ -25,3 +25,9 @@ custom container is supplied, keeping renderer provider bindings consistent even
 outside the default builder. Configuration modules now call these helpers
 instead of reaching into the container directly, keeping Lagom usage centralized
 in the runtime layer.
+
+`ComposedRenderer` now resolves renderer classes passed at construction or via
+`add_renderer` when a resolver is available. `AppController` accepts renderer
+classes or lists of renderer classes for titles, allowing configuration code to
+lean on Lagom for renderer instantiation without reaching into container
+internals.

--- a/src/heart/navigation/app_controller.py
+++ b/src/heart/navigation/app_controller.py
@@ -72,7 +72,11 @@ class AppController(StatefulBaseRenderer[AppControllerState]):
 
     def add_mode(
         self,
-        title: str | list[StatefulBaseRenderer] | StatefulBaseRenderer | None = None,
+        title: str
+        | list[StatefulBaseRenderer | type[StatefulBaseRenderer]]
+        | type[StatefulBaseRenderer]
+        | StatefulBaseRenderer
+        | None = None,
     ) -> ComposedRenderer:
         # TODO: Add a navigation page back in
         result = ComposedRenderer([], renderer_resolver=self._renderer_resolver)
@@ -95,7 +99,11 @@ class AppController(StatefulBaseRenderer[AppControllerState]):
         self.modes.real_process(window=window, clock=clock, orientation=orientation)
 
     def _build_title_renderer(
-        self, title: str | list[StatefulBaseRenderer] | StatefulBaseRenderer
+        self,
+        title: str
+        | list[StatefulBaseRenderer | type[StatefulBaseRenderer]]
+        | type[StatefulBaseRenderer]
+        | StatefulBaseRenderer,
     ) -> StatefulBaseRenderer:
         if isinstance(title, str):
             return TextRendering(
@@ -104,8 +112,12 @@ class AppController(StatefulBaseRenderer[AppControllerState]):
                 font_size=14,
                 color=Color(255, 105, 180),
             )
-        if isinstance(title, StatefulBaseRenderer):
-            return title
         if isinstance(title, list):
             return ComposedRenderer(title, renderer_resolver=self._renderer_resolver)
+        if isinstance(title, type) and issubclass(title, StatefulBaseRenderer):
+            if self._renderer_resolver is None:
+                raise ValueError("AppController requires a renderer resolver")
+            return self._renderer_resolver.resolve(title)
+        if isinstance(title, StatefulBaseRenderer):
+            return title
         raise ValueError(f"Title must be a string or StatefulBaseRenderer, got: {title}")

--- a/src/heart/navigation/composed_renderer.py
+++ b/src/heart/navigation/composed_renderer.py
@@ -10,6 +10,7 @@ from heart.peripheral.core.manager import PeripheralManager
 from heart.renderers import StatefulBaseRenderer
 
 RendererT = TypeVar("RendererT", bound=StatefulBaseRenderer)
+RendererSpec = StatefulBaseRenderer | type[StatefulBaseRenderer]
 
 
 class RendererResolver(Protocol):
@@ -28,12 +29,12 @@ class ComposedRendererState:
 class ComposedRenderer(StatefulBaseRenderer[ComposedRendererState]):
     def __init__(
         self,
-        renderers: list[StatefulBaseRenderer],
+        renderers: list[RendererSpec],
         renderer_resolver: RendererResolver | None = None,
     ) -> None:
         super().__init__()
-        self.renderers: list[StatefulBaseRenderer] = renderers
         self._renderer_resolver = renderer_resolver
+        self.renderers = [self._resolve_renderer_spec(renderer) for renderer in renderers]
 
     def _real_get_renderers(self) -> list[StatefulBaseRenderer]:
         result: list[StatefulBaseRenderer] = []
@@ -62,10 +63,13 @@ class ComposedRenderer(StatefulBaseRenderer[ComposedRendererState]):
             orientation=orientation,
         )
 
-    def add_renderer(self, *renderers: StatefulBaseRenderer) -> None:
-        self.renderers.extend(renderers)
+    def add_renderer(self, *renderers: RendererSpec) -> None:
+        resolved_renderers = [
+            self._resolve_renderer_spec(renderer) for renderer in renderers
+        ]
+        self.renderers.extend(resolved_renderers)
         if self.is_initialized():
-            for item in renderers:
+            for item in resolved_renderers:
                 item.initialize(
                     self.state.window,
                     self.state.clock,
@@ -89,9 +93,18 @@ class ComposedRenderer(StatefulBaseRenderer[ComposedRendererState]):
     def resolve_renderer_from_container(
         self, renderer: type[StatefulBaseRenderer]
     ) -> None:
-        if self._renderer_resolver is None:
-            raise ValueError("ComposedRenderer requires a renderer resolver")
-        self.resolve_renderer(self._renderer_resolver, renderer)
+        self.add_renderer(renderer)
+
+    def _resolve_renderer_spec(self, renderer: RendererSpec) -> StatefulBaseRenderer:
+        if isinstance(renderer, type):
+            if not issubclass(renderer, StatefulBaseRenderer):
+                raise TypeError(
+                    "ComposedRenderer requires StatefulBaseRenderer subclasses"
+                )
+            if self._renderer_resolver is None:
+                raise ValueError("ComposedRenderer requires a renderer resolver")
+            return self._renderer_resolver.resolve(renderer)
+        return renderer
 
     def real_process(
         self,

--- a/src/heart/runtime/game_loop.py
+++ b/src/heart/runtime/game_loop.py
@@ -66,14 +66,16 @@ class GameLoop:
         return self.context_container.resolve(dependency)
 
     def compose(
-        self, renderers: list["StatefulBaseRenderer[Any]"]
+        self,
+        renderers: list["StatefulBaseRenderer[Any]" | type["StatefulBaseRenderer[Any]"]],
     ) -> ComposedRenderer:
         return ComposedRenderer(renderers, renderer_resolver=self.context_container)
 
     def add_mode(
         self,
         title: str
-        | list["StatefulBaseRenderer[Any]"]
+        | list["StatefulBaseRenderer[Any]" | type["StatefulBaseRenderer[Any]"]]
+        | type["StatefulBaseRenderer[Any]"]
         | "StatefulBaseRenderer[Any]"
         | None = None,
     ) -> ComposedRenderer:

--- a/tests/navigation/test_composed_renderer_resolution.py
+++ b/tests/navigation/test_composed_renderer_resolution.py
@@ -1,0 +1,45 @@
+"""Validate Lagom-backed renderer resolution in composed navigation helpers."""
+
+import pytest
+from lagom import Container
+
+from heart.navigation import ComposedRenderer
+from heart.renderers import StatefulBaseRenderer
+
+
+class _ContainerRenderer(StatefulBaseRenderer[int]):
+    """Renderer used to confirm container-backed resolution paths."""
+
+    def _create_initial_state(self, *_args, **_kwargs) -> int:
+        return 0
+
+    def real_process(self, *_args, **_kwargs) -> None:
+        return None
+
+
+class TestComposedRendererResolution:
+    """Ensure composed renderers can resolve classes via Lagom for consistent dependency wiring."""
+
+    def test_resolves_renderer_types_at_construction(self) -> None:
+        """Verify renderer classes resolve via Lagom on init so configuration lists stay container-aware."""
+        container = Container()
+        container[_ContainerRenderer] = _ContainerRenderer
+
+        composed = ComposedRenderer([_ContainerRenderer], renderer_resolver=container)
+
+        assert isinstance(composed.renderers[0], _ContainerRenderer)
+
+    def test_add_renderer_resolves_types(self) -> None:
+        """Confirm add_renderer resolves class inputs so dynamic additions still honor container wiring."""
+        container = Container()
+        container[_ContainerRenderer] = _ContainerRenderer
+
+        composed = ComposedRenderer([], renderer_resolver=container)
+        composed.add_renderer(_ContainerRenderer)
+
+        assert isinstance(composed.renderers[0], _ContainerRenderer)
+
+    def test_requires_resolver_for_renderer_types(self) -> None:
+        """Assert renderer classes require a resolver so misconfigured compositions fail fast."""
+        with pytest.raises(ValueError, match="renderer resolver"):
+            ComposedRenderer([_ContainerRenderer])


### PR DESCRIPTION
### Motivation

- Reduce ad-hoc container access by letting navigation helpers rely on a shared Lagom resolver so renderer wiring is consistent across runtime and configuration code.
- Allow configuration lists to contain renderer classes (not only instances) so composition code can defer instantiation to the runtime container and support test overrides.

### Description

- Update `ComposedRenderer` to accept `StatefulBaseRenderer` instances or subclasses and resolve classes via a provided `renderer_resolver` using `_resolve_renderer_spec`.
- Extend `AppController` so title builders may be renderer classes or lists of renderer classes and resolve them via the controller's `renderer_resolver` when present.
- Broaden `GameLoop.compose`/`add_mode` typing to accept renderer classes and ensure the loop exposes `resolve`/`compose` helpers wired to the runtime container.
- Add documentation note to `docs/research/lagom_configuration_helpers.md` describing the new resolver-backed composition behavior.

### Testing

- Added `tests/navigation/test_composed_renderer_resolution.py` to validate class-based resolution at construction and via `add_renderer` and to ensure resolver-required errors are raised.
- Ran code formatting (`make format`) and the full test suite (`make test`), which completed with all tests passing: `233 passed, 1 skipped`.
- Existing container and runtime tests (`tests/runtime/test_container.py`) continue to validate that overrides propagate through `GameLoop` and container-built components.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dfd1a39788321945affc91f79d9da)