### PR TITLE
Resolve GameLoop via Lagom container

### DIFF
--- a/docs/research/lagom_game_loop_container_resolution.md
+++ b/docs/research/lagom_game_loop_container_resolution.md
@@ -1,0 +1,26 @@
+# Lagom GameLoop container resolution note
+
+## Problem Statement
+
+Runtime entrypoints still instantiated `GameLoop` directly, which bypassed the Lagom
+container even though the container already wired core runtime services. This left the
+entrypoint responsible for choosing constructor parameters instead of letting the
+container own the wiring, and it made it harder to keep `GameLoop` construction aligned
+with container overrides in tests.
+
+## Materials
+
+- Python 3.11 environment with `uv` for dependency resolution.
+- Lagom dependency (`lagom` in `pyproject.toml`).
+- Source modules: `src/heart/runtime/container.py`,
+  `src/heart/runtime/game_loop.py`,
+  `src/heart/cli/commands/game_loop.py`,
+  `tests/runtime/test_container.py`.
+
+## Notes
+
+`build_runtime_container` now registers `GameLoop` as a singleton resolved through Lagom,
+so entrypoints can request `GameLoop` from the container instead of wiring it manually.
+The CLI game loop builder uses `resolver.resolve(GameLoop)` to keep runtime creation
+aligned with container overrides, and the container tests assert that `GameLoop` is
+resolved from the same container instance.

--- a/src/heart/cli/commands/game_loop.py
+++ b/src/heart/cli/commands/game_loop.py
@@ -12,8 +12,4 @@ def build_game_loop(*, x11_forward: bool) -> GameLoop:
         device=device,
         render_variant=render_variant,
     )
-    return GameLoop(
-        device=device,
-        resolver=resolver,
-        render_variant=render_variant,
-    )
+    return resolver.resolve(GameLoop)

--- a/src/heart/runtime/container.py
+++ b/src/heart/runtime/container.py
@@ -111,6 +111,20 @@ def build_runtime_container(
         ),
     )
     _bind(container, overrides, PygameEventHandler, Singleton(PygameEventHandler))
+    from heart.runtime.game_loop import GameLoop
+
+    _bind(
+        container,
+        overrides,
+        GameLoop,
+        Singleton(
+            lambda resolver: GameLoop(
+                device=resolver[Device],
+                resolver=resolver,
+                render_variant=resolver[RendererVariant],
+            )
+        ),
+    )
     apply_provider_registrations(container)
     return container
 

--- a/tests/runtime/test_container.py
+++ b/tests/runtime/test_container.py
@@ -93,3 +93,15 @@ class TestRuntimeContainer:
         loop = GameLoop(device=device, resolver=container)
 
         assert loop.device is alternate_device
+
+    def test_container_resolves_game_loop(self, device) -> None:
+        """Confirm the container can resolve GameLoop so entrypoints reuse the shared DI wiring."""
+        container = build_runtime_container(
+            device=device,
+            render_variant=RendererVariant.ITERATIVE,
+        )
+
+        loop = container.resolve(GameLoop)
+
+        assert loop.context_container is container
+        assert loop.device is device


### PR DESCRIPTION
### Motivation

- Centralize runtime dependency wiring so the container owns construction and lifecycle of core services instead of ad-hoc instantiation.  
- Ensure `GameLoop` construction respects container overrides used in tests and provider registrations.  
- Keep renderer and peripheral resolution consistent by routing entrypoints through the same Lagom container.  

### Description

- Register `GameLoop` as a `Singleton` in `build_runtime_container` so it is resolved via the Lagom `Container`.  
- Update the CLI entrypoint to return `resolver.resolve(GameLoop)` from `src/heart/cli/commands/game_loop.py` instead of constructing `GameLoop` directly.  
- Add a unit test `test_container_resolves_game_loop` in `tests/runtime/test_container.py` that asserts the container resolves `GameLoop` and that it uses the container-provided `Device`.  
- Add a research note `docs/research/lagom_game_loop_container_resolution.md` documenting the rationale and usage pattern.  

### Testing

- Ran `make format` and it completed successfully.  
- Ran `make test` which executed the full Pytest suite against the change.  
- Test run result: `230` passed, `1` failed, `1` skipped, with the failing test `tests/utilities/test_reactivex_streams.py::TestShareStreamFlowControl::test_share_stream_coalesces_latest_when_configured`.  
- The failing test appears unrelated to the `GameLoop` registration change and is left outstanding for follow-up investigation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dfd1d5fbc83218927762d856dcfdd)