### PR TITLE
Integrate Lagom resolution into MultiScene

### DIFF
--- a/docs/research/lagom_multi_scene_resolution.md
+++ b/docs/research/lagom_multi_scene_resolution.md
@@ -1,0 +1,23 @@
+# Lagom Multi-Scene Resolution Note
+
+## Problem Statement
+
+Multi-scene navigation accepted only pre-built renderer instances, which meant container-managed
+renderers could not be resolved when composing scenes dynamically. This kept Lagom usage isolated
+from the multi-scene workflow and pushed dependency wiring into configuration modules.
+
+## Materials
+
+- Python 3.11 runtime with `uv` for dependency management.
+- Lagom dependency (`lagom` in `pyproject.toml`).
+- Source files: `src/heart/navigation/multi_scene.py`,
+  `src/heart/navigation/app_controller.py`,
+  `tests/navigation/test_multi_scene_resolution.py`.
+
+## Notes
+
+`MultiScene` now accepts renderer classes in addition to instances and resolves them through the
+shared Lagom container when a `renderer_resolver` is provided. `AppController.add_scene` passes its
+resolver into new `MultiScene` instances so scenes created through the game loop can opt into
+container-backed dependency wiring. The navigation tests verify that class-based scenes resolve
+through Lagom and that missing resolvers raise a clear error.

--- a/src/heart/navigation/app_controller.py
+++ b/src/heart/navigation/app_controller.py
@@ -65,7 +65,10 @@ class AppController(StatefulBaseRenderer[AppControllerState]):
         mode.add_renderer(RenderColor(Color(0, 0, 0)))
 
     def add_scene(self) -> MultiScene:
-        new_scene = MultiScene(scenes=[])
+        new_scene = MultiScene(
+            scenes=[],
+            renderer_resolver=self._renderer_resolver,
+        )
         title_renderer = self._build_title_renderer("Untitled")
         self.modes.add_new_pages(title_renderer, new_scene)
         return new_scene

--- a/tests/navigation/test_multi_scene_resolution.py
+++ b/tests/navigation/test_multi_scene_resolution.py
@@ -1,0 +1,35 @@
+"""Validate Lagom-backed renderer resolution in multi-scene navigation helpers."""
+
+import pytest
+from lagom import Container
+
+from heart.navigation import MultiScene
+from heart.renderers import StatefulBaseRenderer
+
+
+class _ContainerScene(StatefulBaseRenderer[int]):
+    """Renderer used to confirm container-backed resolution paths."""
+
+    def _create_initial_state(self, *_args, **_kwargs) -> int:
+        return 0
+
+    def real_process(self, *_args, **_kwargs) -> None:
+        return None
+
+
+class TestMultiSceneResolution:
+    """Ensure multi-scene navigation resolves class-based scenes via Lagom for consistent wiring."""
+
+    def test_resolves_scene_types_at_construction(self) -> None:
+        """Verify scene classes resolve via Lagom at init so multi-scene compositions stay container-aware."""
+        container = Container()
+        container[_ContainerScene] = _ContainerScene
+
+        multi_scene = MultiScene([_ContainerScene], renderer_resolver=container)
+
+        assert isinstance(multi_scene.scenes[0], _ContainerScene)
+
+    def test_requires_resolver_for_scene_types(self) -> None:
+        """Assert scene classes require a resolver so misconfigured compositions fail fast."""
+        with pytest.raises(ValueError, match="renderer resolver"):
+            MultiScene([_ContainerScene])


### PR DESCRIPTION
### Motivation

- Move renderer construction for multi-scene navigation onto the shared Lagom container so dependency wiring stays centralized and testable.
- Allow `MultiScene` compositions to accept renderer classes (not only instances) so container-backed renderers can be resolved lazily.
- Propagate the existing `renderer_resolver` from `AppController` to scenes created via the game loop to keep resolution consistent.

### Description

- Change `MultiScene` constructor to accept `scenes: list[RendererSpec]` and an optional `renderer_resolver: RendererResolver | None` and resolve class specs via a new `_resolve_renderer_spec` helper.
- Add a check to raise a clear `ValueError` when a class-based scene is provided without a `renderer_resolver` and a `TypeError` for invalid types.
- Wire `AppController.add_scene` to pass `self._renderer_resolver` into new `MultiScene` instances so scenes created through the loop inherit resolver behavior.
- Add `tests/navigation/test_multi_scene_resolution.py` to validate Lagom-backed resolution and create `docs/research/lagom_multi_scene_resolution.md` documenting the change.

### Testing

- Ran `make format` and the repository formatting checks completed successfully.
- Ran `make test` and the full suite completed with all tests passing.
- Test summary: `236 passed, 1 skipped`.
- New navigation tests for `MultiScene` passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e012aeb34832183946ba7cafc28e3)