### PR TITLE
Integrate ConfigurationRegistry with runtime Lagom container and use container in CLI

### DIFF
--- a/docs/research/lagom_runtime_container_cli.md
+++ b/docs/research/lagom_runtime_container_cli.md
@@ -1,0 +1,27 @@
+# Lagom runtime container usage in CLI
+
+## Problem statement
+
+The CLI command responsible for launching the runtime constructed a
+`ConfigurationRegistry` directly, which bypassed the Lagom container used for
+other runtime services. This left the registry outside of the shared dependency
+injection flow and made it harder to override or trace configuration lookup in
+tests.
+
+## Materials
+
+- `lagom` container bindings from `src/heart/runtime/container.py`.
+- CLI entry points in `src/heart/cli/commands/`.
+
+## Change summary
+
+- Register `ConfigurationRegistry` in the runtime container so it can be
+  resolved alongside other runtime services.
+- Build the runtime container before resolving the configuration registry and
+  `GameLoop`, ensuring the CLI uses a single Lagom-backed resolver.
+
+## Affected modules
+
+- `src/heart/runtime/container.py`
+- `src/heart/cli/commands/game_loop.py`
+- `src/heart/cli/commands/run.py`

--- a/src/heart/cli/commands/game_loop.py
+++ b/src/heart/cli/commands/game_loop.py
@@ -1,3 +1,5 @@
+from lagom import Container
+
 from heart.device.selection import select_device
 from heart.runtime.container import build_runtime_container
 from heart.runtime.game_loop import GameLoop
@@ -5,11 +7,15 @@ from heart.runtime.render_pipeline import RendererVariant
 from heart.utilities.env import Configuration
 
 
-def build_game_loop(*, x11_forward: bool) -> GameLoop:
+def build_game_loop_container(*, x11_forward: bool) -> Container:
     render_variant = RendererVariant.parse(Configuration.render_variant())
     device = select_device(x11_forward=x11_forward)
-    resolver = build_runtime_container(
+    return build_runtime_container(
         device=device,
         render_variant=render_variant,
     )
+
+
+def build_game_loop(*, x11_forward: bool) -> GameLoop:
+    resolver = build_game_loop_container(x11_forward=x11_forward)
     return resolver.resolve(GameLoop)

--- a/src/heart/cli/commands/run.py
+++ b/src/heart/cli/commands/run.py
@@ -2,8 +2,9 @@ from typing import Annotated
 
 import typer
 
-from heart.cli.commands.game_loop import build_game_loop
+from heart.cli.commands.game_loop import build_game_loop_container
 from heart.programs.registry import ConfigurationRegistry
+from heart.runtime.game_loop import GameLoop
 from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
@@ -26,12 +27,13 @@ def run_command(
         help="Use X11 forwarding for RGB display",
     ),
 ) -> None:
-    registry = ConfigurationRegistry()
+    resolver = build_game_loop_container(x11_forward=x11_forward)
+    registry = resolver.resolve(ConfigurationRegistry)
     configuration_fn = registry.get(configuration)
     if configuration_fn is None:
         logger.error("Configuration '%s' not found in registry", configuration)
         raise typer.Exit(code=1)
-    loop = build_game_loop(x11_forward=x11_forward)
+    loop = resolver.resolve(GameLoop)
     configuration_fn(loop)
 
     ## ============================= ##

--- a/src/heart/programs/registry.py
+++ b/src/heart/programs/registry.py
@@ -1,14 +1,17 @@
+from __future__ import annotations
+
 from functools import cached_property
 from pathlib import Path
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
-from heart.runtime.game_loop import GameLoop
+if TYPE_CHECKING:
+    from heart.runtime.game_loop import GameLoop
 from heart.utilities.module_registry import discover_registry
 
 
 class ConfigurationRegistry:
     @cached_property
-    def registry(self) -> dict[str, Callable[[GameLoop], None]]:
+    def registry(self) -> dict[str, Callable[["GameLoop"], None]]:
         configurations_dir = Path(__file__).resolve().parent / "configurations"
         return discover_registry(
             configurations_dir,
@@ -17,5 +20,5 @@ class ConfigurationRegistry:
             log_imports=True,
         )
 
-    def get(self, name: str) -> Callable[[GameLoop], None] | None:
+    def get(self, name: str) -> Callable[["GameLoop"], None] | None:
         return self.registry.get(name)

--- a/src/heart/runtime/container.py
+++ b/src/heart/runtime/container.py
@@ -10,6 +10,7 @@ from heart.peripheral.configuration_loader import PeripheralConfigurationLoader
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import apply_provider_registrations
 from heart.peripheral.registry import PeripheralConfigurationRegistry
+from heart.programs.registry import ConfigurationRegistry
 from heart.runtime.display_context import DisplayContext
 from heart.runtime.frame_presenter import FramePresenter
 from heart.runtime.game_loop_components import GameLoopComponents
@@ -109,6 +110,12 @@ def configure_runtime_container(
         overrides,
         AppController,
         Singleton(lambda resolver: AppController(renderer_resolver=resolver)),
+    )
+    _bind(
+        container,
+        overrides,
+        ConfigurationRegistry,
+        Singleton(ConfigurationRegistry),
     )
     _bind(
         container,


### PR DESCRIPTION
### Motivation
- The CLI previously constructed `ConfigurationRegistry` directly, bypassing the shared Lagom container and making overrides/test swaps harder.
- Consolidating runtime services into a single container improves dependency ownership, traceability, and testability.
- Avoid a circular import by deferring runtime `GameLoop` typing and using forward references in the registry.

### Description
- Register `ConfigurationRegistry` in the runtime container by updating `src/heart/runtime/container.py` to bind `ConfigurationRegistry` as a `Singleton`.
- Introduce `build_game_loop_container` in `src/heart/cli/commands/game_loop.py` and have `build_game_loop` resolve `GameLoop` from the returned container so the CLI reuses the same Lagom resolver.
- Update `src/heart/cli/commands/run.py` to build the runtime container and resolve `ConfigurationRegistry` and `GameLoop` from it instead of instantiating the registry directly.
- Break the circular import by changing `src/heart/programs/registry.py` to use `TYPE_CHECKING` and forward-reference `GameLoop`, and add a short doc under `docs/research/lagom_runtime_container_cli.md` describing the change.

### Testing
- Ran `make format` to apply repository formatting rules and the command completed successfully.
- Ran the test suite with `make test` and the full test run completed successfully with `234 passed, 1 skipped`.
- Existing tests that exercise container wiring and composed renderer resolution continue to pass after the changes.
- New runtime wiring was validated by CLI-invoking code paths exercised by the test suite to ensure no regressions in resolution behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e012d2f48832196955935ecba130f)