### PR TITLE
ir_calibrate: explicit UTF-8 I/O and ensure output directory exists

### DIFF
--- a/scripts/ir_calibrate.py
+++ b/scripts/ir_calibrate.py
@@ -25,7 +25,7 @@ class CaptureRecord:
 
 
 def _load_records(path: Path) -> list[CaptureRecord]:
-    text = path.read_text().strip()
+    text = path.read_text(encoding="utf-8").strip()
     if not text:
         return []
 
@@ -68,7 +68,7 @@ def _load_records(path: Path) -> list[CaptureRecord]:
 
 def _resolve_layout(layout: str, layout_file: Path | None) -> np.ndarray:
     if layout_file is not None:
-        data = json.loads(layout_file.read_text())
+        data = json.loads(layout_file.read_text(encoding="utf-8"))
         if not isinstance(data, (list, tuple)):
             raise typer.BadParameter("Layout file must contain a list of positions")
         return np.asarray(data, dtype=float)
@@ -169,7 +169,8 @@ def calibrate(
     )
 
     payload = {"offsets": offsets, "metrics": metrics}
-    output.write_text(json.dumps(payload, indent=2))
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     typer.echo(f"Wrote calibration to {output}")
 
     if telemetry_url:
@@ -183,4 +184,3 @@ def calibrate(
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point
     app()
-


### PR DESCRIPTION
### Motivation

- Align the IR calibration CLI with repository I/O guidance by specifying explicit encodings for text file reads and writes.
- Avoid platform-dependent behavior when reading/writing JSON files by always using `utf-8` encoding.
- Prevent runtime errors when writing output files by ensuring the destination directory exists before writing.
- Keep the script consistent with the `Path.read_text`/`Path.write_text` and file-encoding recommendations in `AGENTS.md`.

### Description

- Added `encoding="utf-8"` to `Path.read_text()` in `_load_records` to parse capture JSON files with an explicit encoding.
- Added `encoding="utf-8"` to `Path.read_text()` when resolving a custom layout file in `_resolve_layout`.
- Ensured the output directory exists by calling `output.parent.mkdir(parents=True, exist_ok=True)` before writing offsets.
- Wrote the calibration payload with `output.write_text(..., encoding="utf-8")` to ensure deterministic file encoding.

### Testing

- Ran `make format` (Ruff/isort/Black/docformatter/mdformat) and it completed successfully with all checks passed.
- No new unit tests were added for this change.
- No `pytest` suite was executed as part of this change.
- The change is limited to file I/O and preserves existing calibration logic and telemetry behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e0137ac8c832188c15a436ce7c7bf)