### PR TITLE
Use default color constant for YoListen renderer

### DIFF
--- a/src/heart/renderers/yolisten/renderer.py
+++ b/src/heart/renderers/yolisten/renderer.py
@@ -17,12 +17,18 @@ from heart.utilities.logging import get_logger
 PHYPOX_URL = "http://192.168.1.50/get?accY&accX&accZ&dB"
 PHYPOX_POLL_INTERVAL_SECONDS = 0.05
 PHYPOX_LOG_POLL_INTERVAL_SECONDS = 0.1
+DEFAULT_BASE_COLOR = Color(255, 0, 0)
 logger = get_logger(__name__)
 
 
 class YoListenRenderer(StatefulBaseRenderer[YoListenState]):
-    def __init__(self, color: Color = Color(255, 0, 0), provider: YoListenStateProvider | None = None) -> None:
-        self.base_color = color
+    def __init__(
+        self,
+        color: Color | None = None,
+        provider: YoListenStateProvider | None = None,
+    ) -> None:
+        resolved_color = color or DEFAULT_BASE_COLOR
+        self.base_color = resolved_color
         self.words = ["YO", "LISTEN", "Y'HEAR", "THAT"]
         self.screen_count = 4
         self.flicker_intensity = 0.4
@@ -65,7 +71,7 @@ class YoListenRenderer(StatefulBaseRenderer[YoListenState]):
         self.test_mode = False
         self.phyphox_db = 50.0
         self.provider = provider or YoListenStateProvider(
-            color,
+            resolved_color,
             base_scroll_speed=self._base_scroll_speed,
             flicker_speed=self.flicker_speed,
             flicker_intensity=self.flicker_intensity,


### PR DESCRIPTION
### Motivation
- Align YoListen renderer with repository guidelines that prefer module-level constants for public constructor defaults.
- Reduce duplicate literal usage by extracting the default color into a named constant for discoverability.
- Ensure provider initialization uses the same resolved default to avoid mismatched defaults between components.

### Description
- Add `DEFAULT_BASE_COLOR = Color(255, 0, 0)` at module scope in `src/heart/renderers/yolisten/renderer.py`.
- Change `YoListenRenderer.__init__` to accept `color: Color | None = None` and resolve it with `resolved_color = color or DEFAULT_BASE_COLOR`.
- Use `resolved_color` when assigning `self.base_color` and when constructing the `YoListenStateProvider` so both use the same default.

### Testing
- Ran `make format`, which completed successfully.
- Executed the test suite with `make test`, which resulted in `234 passed, 1 skipped` and exited successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e013b31c4832195f61e99eeeb54d1)