### PR TITLE
Fix sensor bus serial newline handling

### DIFF
--- a/drivers/sensor_bus/code.py
+++ b/drivers/sensor_bus/code.py
@@ -195,7 +195,7 @@ def main() -> None:
                 sensors = connect_to_sensors(i2c=i2c)
 
             for sensor_data_payload in sr.read():
-                print(sensor_data_payload)
+                print(sensor_data_payload, end="")
 
             # This also has a `temperature` field but I'm not sure if that's chip temperature or ambient
             time.sleep(wait_between_payloads_seconds)


### PR DESCRIPTION
### Motivation
- Drivers documentation requires serial payloads to use a single trailing newline for framing and REPL consumers.
- `drivers/sensor_bus/code.py` was printing payloads with an extra newline, diverging from the drivers AGENTS.md guidance.
- Keep runtime diagnostic `print` usage in drivers narrowly scoped and compatible with host-side parsers.

### Description
- Change the payload emit call in `drivers/sensor_bus/code.py` from `print(sensor_data_payload)` to `print(sensor_data_payload, end="")` so the driver does not add an extra newline.
- This ensures the driver forwards the pre-formatted JSON payloads verbatim and preserves a single trailing newline produced by the payload creator.
- Ran repository formatter to apply styling rules (`make format`).

### Testing
- Ran `make format`, which completed successfully and reported "All checks passed!".
- No additional automated tests were modified or required for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e013e201c83218bf31de12385338c)