### PR TITLE
Refine Lagom container usage guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,9 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 
 - Prefer using `heart.runtime.container.build_runtime_container` and the provider registration helpers in
   `heart.peripheral.core.providers` rather than instantiating new Lagom `Container` objects in feature modules.
+- Only `heart.runtime.container` and `heart.peripheral.core.providers` should import Lagom types directly. Other
+  modules should depend on `heart.runtime.container.RuntimeContainer` when they need to reference the container
+  type so dependency wiring stays centralized.
 
 ## Error Handling
 

--- a/src/heart/runtime/container.py
+++ b/src/heart/runtime/container.py
@@ -17,12 +17,14 @@ from heart.runtime.peripheral_runtime import PeripheralRuntime
 from heart.runtime.pygame_event_handler import PygameEventHandler
 from heart.runtime.render_pipeline import RendererVariant, RenderPipeline
 
+RuntimeContainer = Container
+
 
 def build_runtime_container(
     device: Device,
     render_variant: RendererVariant,
     overrides: Mapping[type[Any], object] | None = None,
-) -> Container:
+) -> RuntimeContainer:
     container = Container()
     configure_runtime_container(
         container=container,
@@ -35,7 +37,7 @@ def build_runtime_container(
 
 def configure_runtime_container(
     *,
-    container: Container,
+    container: RuntimeContainer,
     device: Device,
     render_variant: RendererVariant,
     overrides: Mapping[type[Any], object] | None = None,
@@ -145,7 +147,7 @@ def configure_runtime_container(
 
 
 def _bind(
-    container: Container,
+    container: RuntimeContainer,
     overrides: Mapping[type[Any], object] | None,
     key: type[Any],
     value: object,

--- a/src/heart/runtime/game_loop.py
+++ b/src/heart/runtime/game_loop.py
@@ -4,11 +4,10 @@ from typing import TYPE_CHECKING, Any, TypeVar
 
 import numpy as np
 import pygame
-from lagom import Container
 
 from heart.device import Device
 from heart.navigation import ComposedRenderer, MultiScene
-from heart.runtime.container import (build_runtime_container,
+from heart.runtime.container import (RuntimeContainer, build_runtime_container,
                                      configure_runtime_container)
 from heart.runtime.game_loop_components import GameLoopComponents
 from heart.runtime.render_pipeline import RendererVariant
@@ -27,7 +26,7 @@ class GameLoop:
     def __init__(
         self,
         device: Device,
-        resolver: Container | None = None,
+        resolver: RuntimeContainer | None = None,
         max_fps: int = 500,
         render_variant: RendererVariant = RendererVariant.ITERATIVE,
     ) -> None:


### PR DESCRIPTION
### Motivation
- Centralize Lagom usage so dependency-injection wiring and imports are consistent across the codebase.
- Prevent feature modules from directly importing Lagom types to keep DI concerns in one place.
- Improve type clarity when referring to the application container by introducing a project-level alias. 

### Description
- Added a guidance rule to `AGENTS.md` requiring only `heart.runtime.container` and `heart.peripheral.core.providers` to import Lagom types directly. 
- Introduced `RuntimeContainer = Container` alias in `src/heart/runtime/container.py` and updated `build_runtime_container`, `configure_runtime_container`, and `_bind` signatures to use `RuntimeContainer`.
- Updated `src/heart/runtime/game_loop.py` to import and use `RuntimeContainer` instead of referencing `lagom.Container` directly and removed the direct Lagom import from that module.
- Ran formatting fixes (`make format`) to keep code style consistent.

### Testing
- Ran `make format`, which completed and fixed formatting issues in the modified files.
- Ran `make test`, which completed successfully with `234 passed, 1 skipped`.
- All automated tests passed locally after the changes.
- No additional automated test failures were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e015115208321a92535d4f6404597)