### PR TITLE
Refine Lagom provider registration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,9 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - Only `heart.runtime.container` and `heart.peripheral.core.providers` should import Lagom types directly. Other
   modules should depend on `heart.runtime.container.RuntimeContainer` when they need to reference the container
   type so dependency wiring stays centralized.
+- Feature modules should register singleton bindings with provider helpers (for example,
+  `register_singleton_provider`) instead of reaching for Lagom bindings directly, so container usage remains
+  encapsulated.
 
 ## Error Handling
 

--- a/src/heart/cli/commands/game_loop.py
+++ b/src/heart/cli/commands/game_loop.py
@@ -1,13 +1,11 @@
-from lagom import Container
-
 from heart.device.selection import select_device
-from heart.runtime.container import build_runtime_container
+from heart.runtime.container import RuntimeContainer, build_runtime_container
 from heart.runtime.game_loop import GameLoop
 from heart.runtime.render_pipeline import RendererVariant
 from heart.utilities.env import Configuration
 
 
-def build_game_loop_container(*, x11_forward: bool) -> Container:
+def build_game_loop_container(*, x11_forward: bool) -> RuntimeContainer:
     render_variant = RendererVariant.parse(Configuration.render_variant())
     device = select_device(x11_forward=x11_forward)
     return build_runtime_container(

--- a/src/heart/peripheral/core/providers/__init__.py
+++ b/src/heart/peripheral/core/providers/__init__.py
@@ -9,6 +9,7 @@ from heart.peripheral.core.providers import registry as providers_registry
 
 apply_provider_registrations = providers_registry.apply_provider_registrations
 register_provider = providers_registry.register_provider
+register_singleton_provider = providers_registry.register_singleton_provider
 registered_providers = providers_registry.registered_providers
 
 T = TypeVar("T")

--- a/src/heart/peripheral/core/providers/registry.py
+++ b/src/heart/peripheral/core/providers/registry.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from lagom import Container
+from lagom import Container, Singleton
 
 ProviderKey = type[Any]
 ProviderValue = Any
@@ -15,6 +15,12 @@ def register_provider(key: ProviderKey, provider: ProviderValue) -> None:
     _registry[key] = provider
     for container in _containers:
         _register_container_provider(container, key, provider)
+
+
+def register_singleton_provider(
+    key: ProviderKey, provider: ProviderValue
+) -> None:
+    register_provider(key, Singleton(provider))
 
 
 def apply_provider_registrations(container: Container) -> None:

--- a/src/heart/renderers/mario/__init__.py
+++ b/src/heart/renderers/mario/__init__.py
@@ -1,6 +1,4 @@
-from lagom import Singleton
-
-from heart.peripheral.core.providers import register_provider
+from heart.peripheral.core.providers import register_singleton_provider
 from heart.peripheral.providers.acceleration import AllAccelerometersProvider
 from heart.renderers.mario.provider import MarioRendererProvider
 from heart.renderers.mario.renderer import MarioRenderer  # noqa: F401
@@ -9,13 +7,11 @@ from heart.renderers.mario.state import MarioRendererState  # noqa: F401
 MARIO_METADATA_FILE_PATH = "mario_64.json"
 MARIO_SHEET_FILE_PATH = "mario_64.png"
 
-register_provider(
+register_singleton_provider(
     MarioRendererProvider,
-    Singleton(
-        lambda builder: MarioRendererProvider(
-            accel_stream=builder[AllAccelerometersProvider],
-            sheet_file_path=MARIO_SHEET_FILE_PATH,
-            metadata_file_path=MARIO_METADATA_FILE_PATH,
-        )
+    lambda builder: MarioRendererProvider(
+        accel_stream=builder[AllAccelerometersProvider],
+        sheet_file_path=MARIO_SHEET_FILE_PATH,
+        metadata_file_path=MARIO_METADATA_FILE_PATH,
     ),
 )

--- a/src/heart/renderers/tixyland/__init__.py
+++ b/src/heart/renderers/tixyland/__init__.py
@@ -1,12 +1,11 @@
-from lagom import Singleton
-
-from heart.peripheral.core.providers import register_provider
+from heart.peripheral.core.providers import (register_provider,
+                                             register_singleton_provider)
 from heart.renderers.tixyland.factory import TixylandFactory  # noqa: F401
 from heart.renderers.tixyland.provider import TixylandStateProvider
 from heart.renderers.tixyland.renderer import Tixyland  # noqa: F401
 
 register_provider(TixylandStateProvider, TixylandStateProvider)
-register_provider(
+register_singleton_provider(
     TixylandFactory,
-    Singleton(lambda builder: TixylandFactory(lambda: builder[TixylandStateProvider])),
+    lambda builder: TixylandFactory(lambda: builder[TixylandStateProvider]),
 )


### PR DESCRIPTION
### Motivation

- Prevent feature modules from importing Lagom types directly and centralize container usage behind provider helpers.
- Provide a small, higher-level API for registering singleton provider bindings so modules do not construct `lagom.Singleton` themselves.
- Ensure code and type annotations use the repository-wide `RuntimeContainer` alias instead of `lagom.Container` where appropriate.

### Description

- Add `register_singleton_provider` to `src/heart/peripheral/core/providers/registry.py` and export it via `src/heart/peripheral/core/providers/__init__.py`.
- Migrate renderer modules to use `register_singleton_provider` and remove direct `from lagom import Singleton` imports in `src/heart/renderers/mario/__init__.py` and `src/heart/renderers/tixyland/__init__.py`.
- Update the CLI to annotate `build_game_loop_container` as returning `RuntimeContainer` and import `RuntimeContainer` from `heart.runtime.container` in `src/heart/cli/commands/game_loop.py`.
- Add a new guidance rule to `AGENTS.md` recommending feature modules register singleton bindings with provider helpers like `register_singleton_provider` instead of creating Lagom bindings directly.

### Testing

- Ran `make format` and the repository formatting checks passed successfully.
- No Pytest test suite runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e971b2d408321b589f52727bf6fa0)