### PR TITLE
Log unexpected exceptions when reading gamepad state

### DIFF
--- a/src/heart/peripheral/gamepad/gamepad.py
+++ b/src/heart/peripheral/gamepad/gamepad.py
@@ -226,7 +226,7 @@ class Gamepad(Peripheral[Any]):
         except KeyboardInterrupt:
             logger.info("Program terminated")
         except Exception:
-            pass
+            logger.debug("Unexpected error while reading gamepad state", exc_info=True)
 
     def run(self) -> None:
         # Give pygame and USB subsystems time to fully initialize


### PR DESCRIPTION
### Motivation
- The gamepad reader previously swallowed all exceptions with a bare `except Exception: pass`, which hides runtime errors and diverges from the repository error-handling guidance.
- AGENTS.md requires recoverable exceptions to be logged with the shared logger rather than silently discarded.

### Description
- Replace the silent exception handler in `_read_from_gamepad` with a debug log that includes traceback context via `logger.debug(..., exc_info=True)` in `src/heart/peripheral/gamepad/gamepad.py`.
- This change preserves behavior while surfacing unexpected errors for diagnostics.
- Kept the change focused to a single-line replacement to avoid altering control flow or exception semantics.

### Testing
- Ran `make format` to ensure formatting/linting, and it completed successfully.
- No additional automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e975165948321a9903713a34f5d39)