### PR TITLE
Refactor beats UI imports to use explicit named imports

### DIFF
--- a/experimental/beats/src/components/stream-cube.tsx
+++ b/experimental/beats/src/components/stream-cube.tsx
@@ -1,5 +1,20 @@
 import { useEffect, useRef } from "react";
-import * as THREE from "three";
+import {
+  AmbientLight,
+  BoxGeometry,
+  CanvasTexture,
+  DirectionalLight,
+  GridHelper,
+  Mesh,
+  MeshStandardMaterial,
+  PerspectiveCamera,
+  RepeatWrapping,
+  Scene,
+  SRGBColorSpace,
+  Texture,
+  TextureLoader,
+  WebGLRenderer,
+} from "three";
 
 import { Skeleton } from "./ui/skeleton";
 
@@ -19,15 +34,15 @@ export function StreamCube({ imgURL, onContextError }: StreamCubeProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
-  const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
-  const sceneRef = useRef<THREE.Scene | null>(null);
-  const cameraRef = useRef<THREE.PerspectiveCamera | null>(null);
-  const cubeRef = useRef<THREE.Mesh<THREE.BoxGeometry, THREE.MeshStandardMaterial[]> | null>(
+  const rendererRef = useRef<WebGLRenderer | null>(null);
+  const sceneRef = useRef<Scene | null>(null);
+  const cameraRef = useRef<PerspectiveCamera | null>(null);
+  const cubeRef = useRef<Mesh<BoxGeometry, MeshStandardMaterial[]> | null>(
     null,
   );
-  const gridRef = useRef<THREE.GridHelper | null>(null);
-  const fallbackTextureRef = useRef<THREE.Texture | null>(null);
-  const lastTextureRef = useRef<THREE.Texture | null>(null);
+  const gridRef = useRef<GridHelper | null>(null);
+  const fallbackTextureRef = useRef<Texture | null>(null);
+  const lastTextureRef = useRef<Texture | null>(null);
   const animationRef = useRef<number | null>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
 
@@ -38,27 +53,27 @@ export function StreamCube({ imgURL, onContextError }: StreamCubeProps) {
     if (!container || !canvas) return undefined;
 
     try {
-      const renderer = new THREE.WebGLRenderer({
+      const renderer = new WebGLRenderer({
         antialias: true,
         alpha: true,
         canvas,
       });
       renderer.setPixelRatio(window.devicePixelRatio);
-      renderer.outputColorSpace = THREE.SRGBColorSpace;
+      renderer.outputColorSpace = SRGBColorSpace;
 
-      const scene = new THREE.Scene();
+      const scene = new Scene();
       scene.background = null;
 
       const { clientWidth: width, clientHeight: height } = container;
-      const camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 100);
+      const camera = new PerspectiveCamera(45, width / height, 0.1, 100);
       camera.position.set(0, 0, CAMERA_DISTANCE);
 
-      const ambient = new THREE.AmbientLight(0xffffff, 0.6);
-      const directional = new THREE.DirectionalLight(0xffffff, 0.8);
+      const ambient = new AmbientLight(0xffffff, 0.6);
+      const directional = new DirectionalLight(0xffffff, 0.8);
       directional.position.set(2, 3, 4);
       scene.add(ambient, directional);
 
-      const grid = new THREE.GridHelper(GRID_SIZE, GRID_DIVISIONS, GRID_COLOR, GRID_COLOR);
+      const grid = new GridHelper(GRID_SIZE, GRID_DIVISIONS, GRID_COLOR, GRID_COLOR);
       grid.position.y = -1.2;
       const gridMaterial = grid.material;
       if (Array.isArray(gridMaterial)) {
@@ -72,12 +87,12 @@ export function StreamCube({ imgURL, onContextError }: StreamCubeProps) {
       }
       scene.add(grid);
 
-      const geometry = new THREE.BoxGeometry(2, 2, 2);
+      const geometry = new BoxGeometry(2, 2, 2);
       const fallbackTexture = createFallbackTexture();
       const materials = Array.from({ length: 6 }, () =>
-        new THREE.MeshStandardMaterial({ map: fallbackTexture }),
+        new MeshStandardMaterial({ map: fallbackTexture }),
       );
-      const cube = new THREE.Mesh(geometry, materials);
+      const cube = new Mesh(geometry, materials);
       scene.add(cube);
 
       renderer.setSize(width, height, false);
@@ -163,7 +178,7 @@ export function StreamCube({ imgURL, onContextError }: StreamCubeProps) {
     const applyTexture = async () => {
       if (!cubeRef.current || !fallbackTextureRef.current) return;
 
-      let nextTexture: THREE.Texture | null = null;
+      let nextTexture: Texture | null = null;
       try {
         nextTexture = imgURL ? await loadTexture(imgURL) : fallbackTextureRef.current;
       } catch (error) {
@@ -231,22 +246,22 @@ function createFallbackTexture() {
     }
   }
 
-  const texture = new THREE.CanvasTexture(canvas);
-  texture.colorSpace = THREE.SRGBColorSpace;
-  texture.wrapS = THREE.RepeatWrapping;
-  texture.wrapT = THREE.RepeatWrapping;
+  const texture = new CanvasTexture(canvas);
+  texture.colorSpace = SRGBColorSpace;
+  texture.wrapS = RepeatWrapping;
+  texture.wrapT = RepeatWrapping;
   texture.repeat.set(2, 2);
 
   return texture;
 }
 
 function loadTexture(url: string) {
-  return new Promise<THREE.Texture>((resolve, reject) => {
-    const loader = new THREE.TextureLoader();
+  return new Promise<Texture>((resolve, reject) => {
+    const loader = new TextureLoader();
     loader.load(
       url,
       (texture) => {
-        texture.colorSpace = THREE.SRGBColorSpace;
+        texture.colorSpace = SRGBColorSpace;
         resolve(texture);
       },
       undefined,

--- a/experimental/beats/src/components/stream.tsx
+++ b/experimental/beats/src/components/stream.tsx
@@ -2,6 +2,7 @@ import { useStreamedImage } from "@/actions/ws/providers/ImageProvider";
 import { useWS } from "@/actions/ws/websocket";
 import { Antenna } from "lucide-react";
 import { useCallback, useState } from "react";
+import type { ComponentProps } from "react";
 
 import { StreamCube } from "./stream-cube";
 import { Separator } from "./ui/separator";
@@ -17,7 +18,7 @@ export function StreamStatus(
   {
     streamIsActive,
     ...divProps
-  }: React.ComponentProps<"div"> & {
+  }: ComponentProps<"div"> & {
     streamIsActive: boolean;
   },
 ) {

--- a/experimental/beats/src/components/ui/aspect-ratio.tsx
+++ b/experimental/beats/src/components/ui/aspect-ratio.tsx
@@ -1,5 +1,3 @@
-import * as AspectRatioPrimitive from "@radix-ui/react-aspect-ratio"
-
-const AspectRatio = AspectRatioPrimitive.Root
+import { Root as AspectRatio } from "@radix-ui/react-aspect-ratio"
 
 export { AspectRatio }

--- a/experimental/beats/src/components/ui/breadcrumb.tsx
+++ b/experimental/beats/src/components/ui/breadcrumb.tsx
@@ -1,20 +1,21 @@
-import * as React from "react"
+import { forwardRef } from "react"
+import type { ComponentProps, ComponentPropsWithoutRef, ReactNode } from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { ChevronRight, MoreHorizontal } from "lucide-react"
 
 import { cn } from "@/utils/tailwind"
 
-const Breadcrumb = React.forwardRef<
+const Breadcrumb = forwardRef<
   HTMLElement,
-  React.ComponentPropsWithoutRef<"nav"> & {
-    separator?: React.ReactNode
+  ComponentPropsWithoutRef<"nav"> & {
+    separator?: ReactNode
   }
 >(({ ...props }, ref) => <nav ref={ref} aria-label="breadcrumb" {...props} />)
 Breadcrumb.displayName = "Breadcrumb"
 
-const BreadcrumbList = React.forwardRef<
+const BreadcrumbList = forwardRef<
   HTMLOListElement,
-  React.ComponentPropsWithoutRef<"ol">
+  ComponentPropsWithoutRef<"ol">
 >(({ className, ...props }, ref) => (
   <ol
     ref={ref}
@@ -27,9 +28,9 @@ const BreadcrumbList = React.forwardRef<
 ))
 BreadcrumbList.displayName = "BreadcrumbList"
 
-const BreadcrumbItem = React.forwardRef<
+const BreadcrumbItem = forwardRef<
   HTMLLIElement,
-  React.ComponentPropsWithoutRef<"li">
+  ComponentPropsWithoutRef<"li">
 >(({ className, ...props }, ref) => (
   <li
     ref={ref}
@@ -39,9 +40,9 @@ const BreadcrumbItem = React.forwardRef<
 ))
 BreadcrumbItem.displayName = "BreadcrumbItem"
 
-const BreadcrumbLink = React.forwardRef<
+const BreadcrumbLink = forwardRef<
   HTMLAnchorElement,
-  React.ComponentPropsWithoutRef<"a"> & {
+  ComponentPropsWithoutRef<"a"> & {
     asChild?: boolean
   }
 >(({ asChild, className, ...props }, ref) => {
@@ -57,9 +58,9 @@ const BreadcrumbLink = React.forwardRef<
 })
 BreadcrumbLink.displayName = "BreadcrumbLink"
 
-const BreadcrumbPage = React.forwardRef<
+const BreadcrumbPage = forwardRef<
   HTMLSpanElement,
-  React.ComponentPropsWithoutRef<"span">
+  ComponentPropsWithoutRef<"span">
 >(({ className, ...props }, ref) => (
   <span
     ref={ref}
@@ -76,7 +77,7 @@ const BreadcrumbSeparator = ({
   children,
   className,
   ...props
-}: React.ComponentProps<"li">) => (
+}: ComponentProps<"li">) => (
   <li
     role="presentation"
     aria-hidden="true"
@@ -91,7 +92,7 @@ BreadcrumbSeparator.displayName = "BreadcrumbSeparator"
 const BreadcrumbEllipsis = ({
   className,
   ...props
-}: React.ComponentProps<"span">) => (
+}: ComponentProps<"span">) => (
   <span
     role="presentation"
     aria-hidden="true"

--- a/experimental/beats/src/components/ui/button.tsx
+++ b/experimental/beats/src/components/ui/button.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import type { ComponentProps } from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 
@@ -42,7 +42,7 @@ function Button({
   size,
   asChild = false,
   ...props
-}: React.ComponentProps<"button"> &
+}: ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean
   }) {

--- a/experimental/beats/src/components/ui/collapsible.tsx
+++ b/experimental/beats/src/components/ui/collapsible.tsx
@@ -1,9 +1,7 @@
-import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
-
-const Collapsible = CollapsiblePrimitive.Root
-
-const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger
-
-const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent
+import {
+  Content as CollapsibleContent,
+  Root as Collapsible,
+  Trigger as CollapsibleTrigger,
+} from "@radix-ui/react-collapsible"
 
 export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/experimental/beats/src/components/ui/input.tsx
+++ b/experimental/beats/src/components/ui/input.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
+import type { ComponentProps } from "react"
 
 import { cn } from "@/utils/tailwind"
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+function Input({ className, type, ...props }: ComponentProps<"input">) {
   return (
     <input
       type={type}

--- a/experimental/beats/src/components/ui/navigation-menu.tsx
+++ b/experimental/beats/src/components/ui/navigation-menu.tsx
@@ -1,7 +1,16 @@
-import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
+import {
+  Content as NavigationMenuContentPrimitive,
+  Indicator as NavigationMenuIndicatorPrimitive,
+  Item as NavigationMenuItemPrimitive,
+  Link as NavigationMenuLinkPrimitive,
+  List as NavigationMenuListPrimitive,
+  Root as NavigationMenuRoot,
+  Trigger as NavigationMenuTriggerPrimitive,
+  Viewport as NavigationMenuViewportPrimitive,
+} from "@radix-ui/react-navigation-menu";
 import { cva } from "class-variance-authority";
 import { ChevronDownIcon } from "lucide-react";
-import * as React from "react";
+import type { ComponentProps } from "react";
 
 import { cn } from "@/utils/tailwind";
 
@@ -10,11 +19,11 @@ function NavigationMenu({
   children,
   viewport = true,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Root> & {
+}: ComponentProps<typeof NavigationMenuRoot> & {
   viewport?: boolean;
 }) {
   return (
-    <NavigationMenuPrimitive.Root
+    <NavigationMenuRoot
       data-slot="navigation-menu"
       data-viewport={viewport}
       className={cn(
@@ -25,16 +34,16 @@ function NavigationMenu({
     >
       {children}
       {viewport && <NavigationMenuViewport />}
-    </NavigationMenuPrimitive.Root>
+    </NavigationMenuRoot>
   );
 }
 
 function NavigationMenuList({
   className,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.List>) {
+}: ComponentProps<typeof NavigationMenuListPrimitive>) {
   return (
-    <NavigationMenuPrimitive.List
+    <NavigationMenuListPrimitive
       data-slot="navigation-menu-list"
       className={cn(
         "group flex flex-1 list-none items-center justify-center gap-1",
@@ -48,9 +57,9 @@ function NavigationMenuList({
 function NavigationMenuItem({
   className,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Item>) {
+}: ComponentProps<typeof NavigationMenuItemPrimitive>) {
   return (
-    <NavigationMenuPrimitive.Item
+    <NavigationMenuItemPrimitive
       data-slot="navigation-menu-item"
       className={cn("relative", className)}
       {...props}
@@ -66,9 +75,9 @@ function NavigationMenuTrigger({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Trigger>) {
+}: ComponentProps<typeof NavigationMenuTriggerPrimitive>) {
   return (
-    <NavigationMenuPrimitive.Trigger
+    <NavigationMenuTriggerPrimitive
       data-slot="navigation-menu-trigger"
       className={cn(navigationMenuTriggerStyle(), "group", className)}
       {...props}
@@ -78,16 +87,16 @@ function NavigationMenuTrigger({
         className="relative top-[1px] ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
         aria-hidden="true"
       />
-    </NavigationMenuPrimitive.Trigger>
+    </NavigationMenuTriggerPrimitive>
   );
 }
 
 function NavigationMenuContent({
   className,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Content>) {
+}: ComponentProps<typeof NavigationMenuContentPrimitive>) {
   return (
-    <NavigationMenuPrimitive.Content
+    <NavigationMenuContentPrimitive
       data-slot="navigation-menu-content"
       className={cn(
         "data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 top-0 left-0 w-full p-2 pr-2.5 md:absolute md:w-auto",
@@ -102,14 +111,14 @@ function NavigationMenuContent({
 function NavigationMenuViewport({
   className,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Viewport>) {
+}: ComponentProps<typeof NavigationMenuViewportPrimitive>) {
   return (
     <div
       className={cn(
         "absolute top-full left-0 isolate z-50 flex justify-center",
       )}
     >
-      <NavigationMenuPrimitive.Viewport
+      <NavigationMenuViewportPrimitive
         data-slot="navigation-menu-viewport"
         className={cn(
           "origin-top-center bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border shadow md:w-[var(--radix-navigation-menu-viewport-width)]",
@@ -124,9 +133,9 @@ function NavigationMenuViewport({
 function NavigationMenuLink({
   className,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Link>) {
+}: ComponentProps<typeof NavigationMenuLinkPrimitive>) {
   return (
-    <NavigationMenuPrimitive.Link
+    <NavigationMenuLinkPrimitive
       data-slot="navigation-menu-link"
       className={cn(
         "data-[active=true]:focus:bg-accent data-[active=true]:hover:bg-accent data-[active=true]:bg-accent/50 data-[active=true]:text-accent-foreground hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-ring/50 [&_svg:not([class*='text-'])]:text-muted-foreground flex flex-col gap-1 rounded-sm p-2 text-sm transition-all outline-none focus-visible:ring-[3px] focus-visible:outline-1 [&_svg:not([class*='size-'])]:size-4",
@@ -140,9 +149,9 @@ function NavigationMenuLink({
 function NavigationMenuIndicator({
   className,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Indicator>) {
+}: ComponentProps<typeof NavigationMenuIndicatorPrimitive>) {
   return (
-    <NavigationMenuPrimitive.Indicator
+    <NavigationMenuIndicatorPrimitive
       data-slot="navigation-menu-indicator"
       className={cn(
         "data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden",
@@ -151,7 +160,7 @@ function NavigationMenuIndicator({
       {...props}
     >
       <div className="bg-border relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm shadow-md" />
-    </NavigationMenuPrimitive.Indicator>
+    </NavigationMenuIndicatorPrimitive>
   );
 }
 

--- a/experimental/beats/src/components/ui/separator.tsx
+++ b/experimental/beats/src/components/ui/separator.tsx
@@ -1,5 +1,5 @@
-import * as React from "react"
-import * as SeparatorPrimitive from "@radix-ui/react-separator"
+import type { ComponentProps } from "react"
+import { Root as SeparatorRoot } from "@radix-ui/react-separator"
 
 import { cn } from "@/utils/tailwind"
 
@@ -8,9 +8,9 @@ function Separator({
   orientation = "horizontal",
   decorative = true,
   ...props
-}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+}: ComponentProps<typeof SeparatorRoot>) {
   return (
-    <SeparatorPrimitive.Root
+    <SeparatorRoot
       data-slot="separator"
       decorative={decorative}
       orientation={orientation}

--- a/experimental/beats/src/components/ui/sheet.tsx
+++ b/experimental/beats/src/components/ui/sheet.tsx
@@ -1,39 +1,48 @@
 "use client"
 
-import * as React from "react"
-import * as SheetPrimitive from "@radix-ui/react-dialog"
+import type { ComponentProps } from "react"
+import {
+  Close as SheetClosePrimitive,
+  Content as SheetContentPrimitive,
+  Description as SheetDescriptionPrimitive,
+  Overlay as SheetOverlayPrimitive,
+  Portal as SheetPortalPrimitive,
+  Root as SheetRoot,
+  Title as SheetTitlePrimitive,
+  Trigger as SheetTriggerPrimitive,
+} from "@radix-ui/react-dialog"
 import { XIcon } from "lucide-react"
 
 import { cn } from "@/utils/tailwind"
 
-function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
-  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+function Sheet({ ...props }: ComponentProps<typeof SheetRoot>) {
+  return <SheetRoot data-slot="sheet" {...props} />
 }
 
 function SheetTrigger({
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
-  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}: ComponentProps<typeof SheetTriggerPrimitive>) {
+  return <SheetTriggerPrimitive data-slot="sheet-trigger" {...props} />
 }
 
 function SheetClose({
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Close>) {
-  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}: ComponentProps<typeof SheetClosePrimitive>) {
+  return <SheetClosePrimitive data-slot="sheet-close" {...props} />
 }
 
 function SheetPortal({
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
-  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}: ComponentProps<typeof SheetPortalPrimitive>) {
+  return <SheetPortalPrimitive data-slot="sheet-portal" {...props} />
 }
 
 function SheetOverlay({
   className,
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+}: ComponentProps<typeof SheetOverlayPrimitive>) {
   return (
-    <SheetPrimitive.Overlay
+    <SheetOverlayPrimitive
       data-slot="sheet-overlay"
       className={cn(
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
@@ -49,13 +58,13 @@ function SheetContent({
   children,
   side = "right",
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+}: ComponentProps<typeof SheetContentPrimitive> & {
   side?: "top" | "right" | "bottom" | "left"
 }) {
   return (
     <SheetPortal>
       <SheetOverlay />
-      <SheetPrimitive.Content
+      <SheetContentPrimitive
         data-slot="sheet-content"
         className={cn(
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
@@ -72,16 +81,16 @@ function SheetContent({
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+        <SheetClosePrimitive className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
           <XIcon className="size-4" />
           <span className="sr-only">Close</span>
-        </SheetPrimitive.Close>
-      </SheetPrimitive.Content>
+        </SheetClosePrimitive>
+      </SheetContentPrimitive>
     </SheetPortal>
   )
 }
 
-function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+function SheetHeader({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="sheet-header"
@@ -91,7 +100,7 @@ function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+function SheetFooter({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="sheet-footer"
@@ -104,9 +113,9 @@ function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
 function SheetTitle({
   className,
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+}: ComponentProps<typeof SheetTitlePrimitive>) {
   return (
-    <SheetPrimitive.Title
+    <SheetTitlePrimitive
       data-slot="sheet-title"
       className={cn("text-foreground font-semibold", className)}
       {...props}
@@ -117,9 +126,9 @@ function SheetTitle({
 function SheetDescription({
   className,
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+}: ComponentProps<typeof SheetDescriptionPrimitive>) {
   return (
-    <SheetPrimitive.Description
+    <SheetDescriptionPrimitive
       data-slot="sheet-description"
       className={cn("text-muted-foreground text-sm", className)}
       {...props}

--- a/experimental/beats/src/components/ui/sidebar.tsx
+++ b/experimental/beats/src/components/ui/sidebar.tsx
@@ -2,7 +2,15 @@
 
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
-import * as React from "react"
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
+import type { ComponentProps, CSSProperties } from "react"
 
 import { cn } from "@/components/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -42,10 +50,10 @@ type SidebarContextProps = {
   toggleSidebar: () => void
 }
 
-const SidebarContext = React.createContext<SidebarContextProps | null>(null)
+const SidebarContext = createContext<SidebarContextProps | null>(null)
 
 function useSidebar() {
-  const context = React.useContext(SidebarContext)
+  const context = useContext(SidebarContext)
   if (!context) {
     throw new Error("useSidebar must be used within a SidebarProvider.")
   }
@@ -61,19 +69,19 @@ function SidebarProvider({
   style,
   children,
   ...props
-}: React.ComponentProps<"div"> & {
+}: ComponentProps<"div"> & {
   defaultOpen?: boolean
   open?: boolean
   onOpenChange?: (open: boolean) => void
 }) {
   const isMobile = useIsMobile()
-  const [openMobile, setOpenMobile] = React.useState(false)
+  const [openMobile, setOpenMobile] = useState(false)
 
   // This is the internal state of the sidebar.
   // We use openProp and setOpenProp for control from outside the component.
-  const [_open, _setOpen] = React.useState(defaultOpen)
+  const [_open, _setOpen] = useState(defaultOpen)
   const open = openProp ?? _open
-  const setOpen = React.useCallback(
+  const setOpen = useCallback(
     (value: boolean | ((value: boolean) => boolean)) => {
       const openState = typeof value === "function" ? value(open) : value
       if (setOpenProp) {
@@ -89,12 +97,12 @@ function SidebarProvider({
   )
 
   // Helper to toggle the sidebar.
-  const toggleSidebar = React.useCallback(() => {
+  const toggleSidebar = useCallback(() => {
     return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open)
   }, [isMobile, setOpen, setOpenMobile])
 
   // Adds a keyboard shortcut to toggle the sidebar.
-  React.useEffect(() => {
+  useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
@@ -113,7 +121,7 @@ function SidebarProvider({
   // This makes it easier to style the sidebar with Tailwind classes.
   const state = open ? "expanded" : "collapsed"
 
-  const contextValue = React.useMemo<SidebarContextProps>(
+  const contextValue = useMemo<SidebarContextProps>(
     () => ({
       state,
       open,
@@ -136,7 +144,7 @@ function SidebarProvider({
               "--sidebar-width": SIDEBAR_WIDTH,
               "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
               ...style,
-            } as React.CSSProperties
+            } as CSSProperties
           }
           className={cn(
             "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
@@ -158,7 +166,7 @@ function Sidebar({
   className,
   children,
   ...props
-}: React.ComponentProps<"div"> & {
+}: ComponentProps<"div"> & {
   side?: "left" | "right"
   variant?: "sidebar" | "floating" | "inset"
   collapsible?: "offcanvas" | "icon" | "none"
@@ -191,7 +199,7 @@ function Sidebar({
           style={
             {
               "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
-            } as React.CSSProperties
+            } as CSSProperties
           }
           side={side}
         >
@@ -257,7 +265,7 @@ function SidebarTrigger({
   className,
   onClick,
   ...props
-}: React.ComponentProps<typeof Button>) {
+}: ComponentProps<typeof Button>) {
   const { toggleSidebar } = useSidebar()
 
   return (
@@ -279,7 +287,7 @@ function SidebarTrigger({
   )
 }
 
-function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
+function SidebarRail({ className, ...props }: ComponentProps<"button">) {
   const { toggleSidebar } = useSidebar()
 
   return (
@@ -304,7 +312,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
   )
 }
 
-function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+function SidebarInset({ className, ...props }: ComponentProps<"main">) {
   return (
     <main
       data-slot="sidebar-inset"
@@ -321,7 +329,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
 function SidebarInput({
   className,
   ...props
-}: React.ComponentProps<typeof Input>) {
+}: ComponentProps<typeof Input>) {
   return (
     <Input
       data-slot="sidebar-input"
@@ -332,7 +340,7 @@ function SidebarInput({
   )
 }
 
-function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
+function SidebarHeader({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="sidebar-header"
@@ -343,7 +351,7 @@ function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
+function SidebarFooter({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="sidebar-footer"
@@ -357,7 +365,7 @@ function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
 function SidebarSeparator({
   className,
   ...props
-}: React.ComponentProps<typeof Separator>) {
+}: ComponentProps<typeof Separator>) {
   return (
     <Separator
       data-slot="sidebar-separator"
@@ -368,7 +376,7 @@ function SidebarSeparator({
   )
 }
 
-function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+function SidebarContent({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="sidebar-content"
@@ -382,7 +390,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
+function SidebarGroup({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="sidebar-group"
@@ -397,7 +405,7 @@ function SidebarGroupLabel({
   className,
   asChild = false,
   ...props
-}: React.ComponentProps<"div"> & { asChild?: boolean }) {
+}: ComponentProps<"div"> & { asChild?: boolean }) {
   const Comp = asChild ? Slot : "div"
 
   return (
@@ -418,7 +426,7 @@ function SidebarGroupAction({
   className,
   asChild = false,
   ...props
-}: React.ComponentProps<"button"> & { asChild?: boolean }) {
+}: ComponentProps<"button"> & { asChild?: boolean }) {
   const Comp = asChild ? Slot : "button"
 
   return (
@@ -440,7 +448,7 @@ function SidebarGroupAction({
 function SidebarGroupContent({
   className,
   ...props
-}: React.ComponentProps<"div">) {
+}: ComponentProps<"div">) {
   return (
     <div
       data-slot="sidebar-group-content"
@@ -451,7 +459,7 @@ function SidebarGroupContent({
   )
 }
 
-function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
+function SidebarMenu({ className, ...props }: ComponentProps<"ul">) {
   return (
     <ul
       data-slot="sidebar-menu"
@@ -462,7 +470,7 @@ function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
   )
 }
 
-function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
+function SidebarMenuItem({ className, ...props }: ComponentProps<"li">) {
   return (
     <li
       data-slot="sidebar-menu-item"
@@ -503,10 +511,10 @@ function SidebarMenuButton({
   tooltip,
   className,
   ...props
-}: React.ComponentProps<"button"> & {
+}: ComponentProps<"button"> & {
   asChild?: boolean
   isActive?: boolean
-  tooltip?: string | React.ComponentProps<typeof TooltipContent>
+  tooltip?: string | ComponentProps<typeof TooltipContent>
 } & VariantProps<typeof sidebarMenuButtonVariants>) {
   const Comp = asChild ? Slot : "button"
   const { isMobile, state } = useSidebar()
@@ -550,7 +558,7 @@ function SidebarMenuAction({
   asChild = false,
   showOnHover = false,
   ...props
-}: React.ComponentProps<"button"> & {
+}: ComponentProps<"button"> & {
   asChild?: boolean
   showOnHover?: boolean
 }) {
@@ -580,7 +588,7 @@ function SidebarMenuAction({
 function SidebarMenuBadge({
   className,
   ...props
-}: React.ComponentProps<"div">) {
+}: ComponentProps<"div">) {
   return (
     <div
       data-slot="sidebar-menu-badge"
@@ -603,11 +611,11 @@ function SidebarMenuSkeleton({
   className,
   showIcon = false,
   ...props
-}: React.ComponentProps<"div"> & {
+}: ComponentProps<"div"> & {
   showIcon?: boolean
 }) {
   // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
+  const width = useMemo(() => {
     return `${Math.floor(Math.random() * 40) + 50}%`
   }, [])
 
@@ -630,14 +638,14 @@ function SidebarMenuSkeleton({
         style={
           {
             "--skeleton-width": width,
-          } as React.CSSProperties
+          } as CSSProperties
         }
       />
     </div>
   )
 }
 
-function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
+function SidebarMenuSub({ className, ...props }: ComponentProps<"ul">) {
   return (
     <ul
       data-slot="sidebar-menu-sub"
@@ -655,7 +663,7 @@ function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
 function SidebarMenuSubItem({
   className,
   ...props
-}: React.ComponentProps<"li">) {
+}: ComponentProps<"li">) {
   return (
     <li
       data-slot="sidebar-menu-sub-item"
@@ -672,7 +680,7 @@ function SidebarMenuSubButton({
   isActive = false,
   className,
   ...props
-}: React.ComponentProps<"a"> & {
+}: ComponentProps<"a"> & {
   asChild?: boolean
   size?: "sm" | "md"
   isActive?: boolean

--- a/experimental/beats/src/components/ui/skeleton.tsx
+++ b/experimental/beats/src/components/ui/skeleton.tsx
@@ -1,6 +1,8 @@
+import type { ComponentProps } from "react"
+
 import { cn } from "@/utils/tailwind"
 
-function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+function Skeleton({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"

--- a/experimental/beats/src/components/ui/spinner.tsx
+++ b/experimental/beats/src/components/ui/spinner.tsx
@@ -1,8 +1,9 @@
+import type { ComponentProps } from "react"
 import { Loader2Icon } from "lucide-react"
 
 import { cn } from "@/utils/tailwind"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({ className, ...props }: ComponentProps<"svg">) {
   return (
     <Loader2Icon
       role="status"

--- a/experimental/beats/src/components/ui/toggle-group.tsx
+++ b/experimental/beats/src/components/ui/toggle-group.tsx
@@ -1,13 +1,17 @@
 "use client";
 
-import * as React from "react";
-import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
+import { createContext, useContext } from "react";
+import type { ComponentProps } from "react";
+import {
+  Item as ToggleGroupItemPrimitive,
+  Root as ToggleGroupRoot,
+} from "@radix-ui/react-toggle-group";
 import { type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/utils/tailwind";
 import { toggleVariants } from "@/components/ui/toggle";
 
-const ToggleGroupContext = React.createContext<
+const ToggleGroupContext = createContext<
   VariantProps<typeof toggleVariants>
 >({
   size: "default",
@@ -20,10 +24,10 @@ function ToggleGroup({
   size,
   children,
   ...props
-}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+}: ComponentProps<typeof ToggleGroupRoot> &
   VariantProps<typeof toggleVariants>) {
   return (
-    <ToggleGroupPrimitive.Root
+    <ToggleGroupRoot
       data-slot="toggle-group"
       data-variant={variant}
       data-size={size}
@@ -36,7 +40,7 @@ function ToggleGroup({
       <ToggleGroupContext.Provider value={{ variant, size }}>
         {children}
       </ToggleGroupContext.Provider>
-    </ToggleGroupPrimitive.Root>
+    </ToggleGroupRoot>
   );
 }
 
@@ -46,12 +50,12 @@ function ToggleGroupItem({
   variant,
   size,
   ...props
-}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
+}: ComponentProps<typeof ToggleGroupItemPrimitive> &
   VariantProps<typeof toggleVariants>) {
-  const context = React.useContext(ToggleGroupContext);
+  const context = useContext(ToggleGroupContext);
 
   return (
-    <ToggleGroupPrimitive.Item
+    <ToggleGroupItemPrimitive
       data-slot="toggle-group-item"
       data-variant={context.variant || variant}
       data-size={context.size || size}
@@ -66,7 +70,7 @@ function ToggleGroupItem({
       {...props}
     >
       {children}
-    </ToggleGroupPrimitive.Item>
+    </ToggleGroupItemPrimitive>
   );
 }
 

--- a/experimental/beats/src/components/ui/toggle.tsx
+++ b/experimental/beats/src/components/ui/toggle.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as TogglePrimitive from "@radix-ui/react-toggle";
+import type { ComponentProps } from "react";
+import { Root as ToggleRoot } from "@radix-ui/react-toggle";
 import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/utils/tailwind";
@@ -31,10 +31,10 @@ function Toggle({
   variant,
   size,
   ...props
-}: React.ComponentProps<typeof TogglePrimitive.Root> &
+}: ComponentProps<typeof ToggleRoot> &
   VariantProps<typeof toggleVariants>) {
   return (
-    <TogglePrimitive.Root
+    <ToggleRoot
       data-slot="toggle"
       className={cn(toggleVariants({ variant, size, className }))}
       {...props}

--- a/experimental/beats/src/components/ui/tooltip.tsx
+++ b/experimental/beats/src/components/ui/tooltip.tsx
@@ -1,14 +1,21 @@
-import * as React from "react"
-import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+import type { ComponentProps } from "react"
+import {
+  Arrow as TooltipArrow,
+  Content as TooltipContentPrimitive,
+  Portal as TooltipPortal,
+  Provider as TooltipProviderPrimitive,
+  Root as TooltipRoot,
+  Trigger as TooltipTriggerPrimitive,
+} from "@radix-ui/react-tooltip"
 
 import { cn } from "@/utils/tailwind"
 
 function TooltipProvider({
   delayDuration = 0,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+}: ComponentProps<typeof TooltipProviderPrimitive>) {
   return (
-    <TooltipPrimitive.Provider
+    <TooltipProviderPrimitive
       data-slot="tooltip-provider"
       delayDuration={delayDuration}
       {...props}
@@ -18,18 +25,18 @@ function TooltipProvider({
 
 function Tooltip({
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+}: ComponentProps<typeof TooltipRoot>) {
   return (
     <TooltipProvider>
-      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+      <TooltipRoot data-slot="tooltip" {...props} />
     </TooltipProvider>
   )
 }
 
 function TooltipTrigger({
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
-  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}: ComponentProps<typeof TooltipTriggerPrimitive>) {
+  return <TooltipTriggerPrimitive data-slot="tooltip-trigger" {...props} />
 }
 
 function TooltipContent({
@@ -37,10 +44,10 @@ function TooltipContent({
   sideOffset = 0,
   children,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+}: ComponentProps<typeof TooltipContentPrimitive>) {
   return (
-    <TooltipPrimitive.Portal>
-      <TooltipPrimitive.Content
+    <TooltipPortal>
+      <TooltipContentPrimitive
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
@@ -50,9 +57,9 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
-      </TooltipPrimitive.Content>
-    </TooltipPrimitive.Portal>
+        <TooltipArrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      </TooltipContentPrimitive>
+    </TooltipPortal>
   )
 }
 

--- a/experimental/beats/src/hooks/use-mobile.ts
+++ b/experimental/beats/src/hooks/use-mobile.ts
@@ -1,11 +1,11 @@
-import * as React from "react"
+import { useEffect, useState } from "react"
 
 const MOBILE_BREAKPOINT = 768
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+  const [isMobile, setIsMobile] = useState<boolean | undefined>(undefined)
 
-  React.useEffect(() => {
+  useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)

--- a/experimental/beats/vite.renderer.config.mts
+++ b/experimental/beats/vite.renderer.config.mts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import { resolve } from "path";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
@@ -20,7 +20,7 @@ export default defineConfig({
   resolve: {
     preserveSymlinks: true,
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": resolve(__dirname, "./src"),
     },
   },
 });

--- a/experimental/beats/vitest.config.ts
+++ b/experimental/beats/vitest.config.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import { resolve } from "path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": resolve(__dirname, "./src"),
     },
   },
   test: {


### PR DESCRIPTION
### Motivation
- Bring the experimental beats frontend into compliance with repository style rules that discourage namespace/wildcard imports and favor explicit imports and precise typing.  
- Reduce runtime / typing ambiguity by replacing `React.*` usage with direct hooks/type helpers and switching Three.js to named imports.  
- Make build tooling clearer by using named `path` helpers in Vite/Vitest configs instead of namespace `path` usage.  
- Improve maintainability of UI components by preferring `ComponentProps` and `forwardRef` helpers for clearer component typings.

### Description
- Replaced many namespace imports (e.g. `import * as React from ...`, `import * as THREE from ...`, `import * as FooPrimitive from ...`) with explicit named imports and React type helpers across `experimental/beats/src/components` and hooks.  
- Converted Three.js usage in `stream-cube.tsx` to named imports and updated related type annotations to use concrete Three.js types.  
- Replaced `React.ComponentProps<...>` and other `React.*` usages with `ComponentProps`, `forwardRef`, direct `useState`/`useEffect` imports, and similar refinements to component signatures and types.  
- Updated Vite and Vitest configs to use `resolve` from `path` instead of the `path` namespace helper to match the style convention.

### Testing
- Ran `make format` and the formatter/linting checks completed successfully.  
- Ran `make test`; the suite executed with 234 tests passing, 2 tests failing.  
- The failing tests are `tests/utilities/test_reactivex_streams.py::TestShareStreamFlowControl::test_share_stream_coalesces_latest_when_configured` and `tests/utilities/test_reactivex_streams.py::TestShareStreamFlowControl::test_share_stream_coalesce_cancels_stale_scheduler_after_fallback`.  
- All other automated tests completed successfully before these two failures were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e9755af9883219ba18cdbaca35cd8)