### PR TITLE
Introduce module-level constants for default parameter values

### DIFF
--- a/src/heart/assets/loader.py
+++ b/src/heart/assets/loader.py
@@ -9,6 +9,8 @@ from heart.assets.cache import AssetCache
 from heart.utilities.env import (AssetCacheStrategy, Configuration,
                                  SpritesheetFrameCacheStrategy)
 
+DEFAULT_FONT_SIZE = 10
+
 
 class Loader:
     _image_cache: AssetCache[Path, pygame.Surface] | None = None
@@ -101,7 +103,9 @@ class Loader:
         return Animation(cls._resolve_path(path), 100)
 
     @classmethod
-    def load_font(cls, path: str | PathLike[str], font_size: int = 10) -> pygame.font.Font:
+    def load_font(
+        cls, path: str | PathLike[str], font_size: int = DEFAULT_FONT_SIZE
+    ) -> pygame.font.Font:
         return pygame.font.Font(cls._resolve_path(path), size=font_size)
 
     @classmethod

--- a/src/heart/display/recorder.py
+++ b/src/heart/display/recorder.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:  # pragma: no cover - import cycle guard
     from heart.renderers import StatefulBaseRenderer
     from heart.runtime.game_loop import GameLoop
 
+DEFAULT_RECORDING_FPS = 30
+
 
 class ScreenRecorder:
     """Record frames produced by a :class:`~heart.runtime.game_loop.GameLoop`.
@@ -23,7 +25,7 @@ class ScreenRecorder:
     container that behaves like a video when inspected during development.
     """
 
-    def __init__(self, loop: "GameLoop", *, fps: int = 30) -> None:
+    def __init__(self, loop: "GameLoop", *, fps: int = DEFAULT_RECORDING_FPS) -> None:
         if fps <= 0:
             raise ValueError("fps must be a positive integer")
         self._loop = loop

--- a/src/heart/firmware_io/accel.py
+++ b/src/heart/firmware_io/accel.py
@@ -10,6 +10,8 @@ from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
 
+DEFAULT_MIN_CHANGE_THRESHOLD = 0.1
+
 
 def _form_payload(name: str, data) -> str:
     """Forms a JSON payload string from a dictionary of data.
@@ -55,7 +57,9 @@ def form_tuple_payload(name: str, data: tuple) -> str:
 class SensorReader:
     """Tracks last values and determines when updates are significant."""
 
-    def __init__(self, sensors, min_change: float = 0.1) -> None:
+    def __init__(
+        self, sensors, min_change: float = DEFAULT_MIN_CHANGE_THRESHOLD
+    ) -> None:
         self.sensors = sensors
         self.min_change = min_change
 
@@ -84,7 +88,7 @@ class SensorReader:
         return any(abs(n - o) > min_change for n, o in zip(new, old))
 
     @classmethod
-    def connect(cls, i2c, min_change: float = 0.1):
+    def connect(cls, i2c, min_change: float = DEFAULT_MIN_CHANGE_THRESHOLD):
         sensors = cls.connect_to_sensors(i2c=i2c)
         return cls(sensors=sensors, min_change=min_change)
 

--- a/src/heart/peripheral/gamepad/gamepad.py
+++ b/src/heart/peripheral/gamepad/gamepad.py
@@ -17,6 +17,9 @@ from heart.utilities.reactivex_threads import input_scheduler
 
 logger = get_logger(__name__)
 INITIALIZATION_DELAY_SECONDS = 1.5
+DEFAULT_JOYSTICK_ID = 0
+DEFAULT_AXIS_DEAD_ZONE = 0.0
+DEFAULT_AXIS_THRESHOLD = 0.0
 
 
 class GamepadIdentifier(StrEnum):
@@ -33,7 +36,9 @@ class Gamepad(Peripheral[Any]):
     EVENT_LIFECYCLE = "gamepad.lifecycle"
 
     def __init__(
-        self, joystick_id: int = 0, joystick: pygame.joystick.JoystickType | None = None
+        self,
+        joystick_id: int = DEFAULT_JOYSTICK_ID,
+        joystick: pygame.joystick.JoystickType | None = None,
     ) -> None:
         super().__init__()
         self.joystick_id = joystick_id
@@ -64,16 +69,22 @@ class Gamepad(Peripheral[Any]):
         self._tap_flag[button_id] = False
         return tapped
 
-    def axis_value(self, axis_id: int, dead_zone: float = 0) -> float:
+    def axis_value(
+        self, axis_id: int, dead_zone: float = DEFAULT_AXIS_DEAD_ZONE
+    ) -> float:
         axis_value = self._axis_curr_frame[self.axis_key(axis_id)]
         if abs(axis_value) < dead_zone:
             return 0
         return axis_value
 
-    def axis_passed_threshold(self, axis_id: int, threshold: float = 0) -> bool:
+    def axis_passed_threshold(
+        self, axis_id: int, threshold: float = DEFAULT_AXIS_THRESHOLD
+    ) -> bool:
         return self._axis_curr_frame[self.axis_key(axis_id)] > threshold
 
-    def axis_tapped(self, axis_id: int, threshold: float = 0) -> bool:
+    def axis_tapped(
+        self, axis_id: int, threshold: float = DEFAULT_AXIS_THRESHOLD
+    ) -> bool:
         tapped = self._axis_curr_frame[self.axis_key(axis_id)] > threshold
         tapped_last_frame = self._axis_tapped_prev_frame[self.axis_key(axis_id)]
         self._axis_tapped_prev_frame[self.axis_key(axis_id)] = tapped

--- a/src/heart/peripheral/ir_sensor_array.py
+++ b/src/heart/peripheral/ir_sensor_array.py
@@ -34,6 +34,8 @@ else:
     least_squares = _least_squares
 
 SPEED_OF_LIGHT = 299_792_458.0  # metres per second
+DEFAULT_DMA_BUFFER_SIZE = 64
+DEFAULT_RADIAL_LAYOUT_RADIUS = 0.12
 
 
 @dataclass(slots=True)
@@ -73,7 +75,7 @@ class IRDMAPacket:
 class IRArrayDMAQueue:
     """Double-buffered queue that simulates a DMA capture pipeline."""
 
-    def __init__(self, *, buffer_size: int = 64) -> None:
+    def __init__(self, *, buffer_size: int = DEFAULT_DMA_BUFFER_SIZE) -> None:
         if buffer_size <= 0:
             msg = "buffer_size must be positive"
             raise ValueError(msg)
@@ -346,7 +348,7 @@ class IRSensorArray(Peripheral[Input]):
         )
 
 
-def radial_layout(radius: float = 0.12) -> list[list[float]]:
+def radial_layout(radius: float = DEFAULT_RADIAL_LAYOUT_RADIUS) -> list[list[float]]:
     """Return sensor positions for a square radial layout."""
 
     half = radius / math.sqrt(2)

--- a/src/heart/renderers/doppler/renderer.py
+++ b/src/heart/renderers/doppler/renderer.py
@@ -11,11 +11,15 @@ from heart.renderers import StatefulBaseRenderer
 from heart.renderers.doppler.provider import DopplerStateProvider
 from heart.renderers.doppler.state import DopplerState
 
+DEFAULT_HUE_EXTENT = 2.0 / 3.0
+
 
 class DopplerRenderer(StatefulBaseRenderer[DopplerState]):
     """Render a Doppler-style 3D particle effect credited to Sri."""
 
-    def __init__(self, builder: DopplerStateProvider, hue_extent: float = 2.0 / 3.0):
+    def __init__(
+        self, builder: DopplerStateProvider, hue_extent: float = DEFAULT_HUE_EXTENT
+    ):
         super().__init__(builder=builder)
         self.device_display_mode = DeviceDisplayMode.FULL
         self._hue_extent = hue_extent

--- a/src/heart/renderers/flame/renderer.py
+++ b/src/heart/renderers/flame/renderer.py
@@ -14,6 +14,9 @@ from heart.renderers import StatefulBaseRenderer
 from heart.renderers.flame.provider import FlameStateProvider
 from heart.renderers.flame.state import FlameState
 
+DEFAULT_FLAME_WIDTH = 64
+DEFAULT_FLAME_HEIGHT = 16
+DEFAULT_FLAME_SIDE = "bottom"
 
 # ------------------------------------------------------------------------------------
 #  Utility helpers
@@ -159,7 +162,11 @@ class FlameGenerator:
         ((1.000, 0.900, 0.600), 0.990),
     ]
 
-    def __init__(self, width: int = 64, height: int = 16):
+    def __init__(
+        self,
+        width: int = DEFAULT_FLAME_WIDTH,
+        height: int = DEFAULT_FLAME_HEIGHT,
+    ):
         self.w, self.h = width, height
 
         # Static UV grids (pixelated to 1/64 like the shader)
@@ -180,7 +187,7 @@ class FlameGenerator:
     # -------------------------------------------------------------------------
     #  Public API
     # -------------------------------------------------------------------------
-    def surface(self, t: float, side: str = "bottom") -> pygame.Surface:
+    def surface(self, t: float, side: str = DEFAULT_FLAME_SIDE) -> pygame.Surface:
         """Generate the flame strip for the given time `t`.
 
         side ∈ {"bottom","top","left","right"} – controls orientation.

--- a/src/heart/renderers/mandelbrot/control_mappings.py
+++ b/src/heart/renderers/mandelbrot/control_mappings.py
@@ -13,6 +13,8 @@ from heart.peripheral.gamepad.peripheral_mappings import (BitDoLite2,
 from heart.renderers.mandelbrot.controls import SceneControls
 from heart.utilities.env import Configuration
 
+DEFAULT_STICK_MULTIPLIER = 1.0
+
 
 class SceneControlsMapping(ABC):
     def update(self):
@@ -210,7 +212,7 @@ class SwitchLikeControls(SceneControlsMapping, ABC):
         if self.gamepad.was_tapped(self.mapping.BUTTON_X):
             self.scene_controls.cycle_palette(forward=False)
 
-    def _handle_stick(self, multiplier: float = 1.0):
+    def _handle_stick(self, multiplier: float = DEFAULT_STICK_MULTIPLIER):
         x_mov = self.gamepad.axis_value(self.mapping.AXIS_LEFT_X, self.dead_zone)
         y_mov = self.gamepad.axis_value(self.mapping.AXIS_LEFT_Y, self.dead_zone)
 

--- a/src/heart/renderers/mandelbrot/controls.py
+++ b/src/heart/renderers/mandelbrot/controls.py
@@ -5,6 +5,14 @@ import numpy as np
 
 from heart.renderers.mandelbrot.state import AppState, ViewMode
 
+DEFAULT_PAN_ZOOM: float | None = None
+DEFAULT_CURSOR_DELTA = 0
+DEFAULT_CURSOR_MODE = "julia"
+DEFAULT_PALETTE_FORWARD = True
+DEFAULT_SHOW_FPS: bool | None = None
+DEFAULT_EXPLICIT_MODE: str | None = None
+DEFAULT_MOVE_MULTIPLIER = 1.0
+
 
 class SceneControls:
     def __init__(self, state: AppState):
@@ -19,7 +27,7 @@ class SceneControls:
     def disable_auto(self):
         self.state.mode = "free"
 
-    def get_pan_amount(self, zoom: float = None):
+    def get_pan_amount(self, zoom: float | None = DEFAULT_PAN_ZOOM):
         pan_scaling = 0.05
         return pan_scaling / zoom
 
@@ -32,7 +40,12 @@ class SceneControls:
         # self._reset_mandelbrot()
         self.state.reset()
 
-    def update_cursor_pos(self, delta_x: int = 0, delta_y: int = 0, cursor="julia"):
+    def update_cursor_pos(
+        self,
+        delta_x: int = DEFAULT_CURSOR_DELTA,
+        delta_y: int = DEFAULT_CURSOR_DELTA,
+        cursor: str = DEFAULT_CURSOR_MODE,
+    ):
         padding = 3
         y_lo_bound = -(self.state.msurface_height // 2) + padding  # - 2
         y_hi_bound = (self.state.msurface_height // 2) - padding  # - padding + 1
@@ -62,7 +75,7 @@ class SceneControls:
         elif target_y > y_hi_bound:
             self._move_down("panning")
 
-    def cycle_palette(self, forward: bool = True):
+    def cycle_palette(self, forward: bool = DEFAULT_PALETTE_FORWARD):
         step = 1 if forward else -1
         self.state.palette_index = (
             self.state.palette_index + step
@@ -112,7 +125,7 @@ class SceneControls:
         self.state.movement_mode = "cursor" if self.state.julia_mode else "panning"
         self.state.show_left_cursor = self.state.julia_mode
 
-    def _toggle_fps(self, show: bool = None):
+    def _toggle_fps(self, show: bool | None = DEFAULT_SHOW_FPS):
         if show is None:
             self.state.show_fps = not self.state.show_fps
         else:
@@ -232,7 +245,13 @@ class SceneControls:
             "notes": None,  # No clear cycle detected
         }
 
-    def _move(self, x: int, y: int, explicit_mode: str = None, multiplier: float = 1.0):
+    def _move(
+        self,
+        x: int,
+        y: int,
+        explicit_mode: str | None = DEFAULT_EXPLICIT_MODE,
+        multiplier: float = DEFAULT_MOVE_MULTIPLIER,
+    ):
         cursor_mode = explicit_mode or "cursor"
         self.disable_auto()
         x = x * multiplier
@@ -297,7 +316,7 @@ class SceneControls:
         #     self.state.jmovement.y += y * self.get_pan_amount(self.state.jzoom)
 
     # Movement handlers
-    def _move_up(self, explicit_mode: str = None):
+    def _move_up(self, explicit_mode: str | None = DEFAULT_EXPLICIT_MODE):
         self._move(0, -1, explicit_mode=explicit_mode)
         # mode = explicit_mode or self.state.movement_mode
         # if mode == "cursor":
@@ -306,7 +325,7 @@ class SceneControls:
         # else:
         #     self.state.movement.y -= self.get_pan_amount()
 
-    def _move_down(self, explicit_mode: str = None):
+    def _move_down(self, explicit_mode: str | None = DEFAULT_EXPLICIT_MODE):
         self._move(0, 1, explicit_mode=explicit_mode)
         # mode = explicit_mode or self.state.movement_mode
         # if mode == "cursor":
@@ -315,7 +334,7 @@ class SceneControls:
         # else:
         #     self.state.movement.y += self.get_pan_amount()
 
-    def _move_left(self, explicit_mode: str = None):
+    def _move_left(self, explicit_mode: str | None = DEFAULT_EXPLICIT_MODE):
         self._move(-1, 0, explicit_mode=explicit_mode)
         # mode = explicit_mode or self.state.movement_mode
         # if mode == "cursor":
@@ -327,7 +346,7 @@ class SceneControls:
         #     elif self.state.selected_surface == "julia":
         #         self.state.jmovement.x -= self.get_pan_amount()
 
-    def _move_right(self, explicit_mode: str = None):
+    def _move_right(self, explicit_mode: str | None = DEFAULT_EXPLICIT_MODE):
         self._move(1, 0, explicit_mode=explicit_mode)
         # mode = explicit_mode or self.state.movement_mode
         # if mode == "cursor":

--- a/src/heart/renderers/three_d_glasses/provider.py
+++ b/src/heart/renderers/three_d_glasses/provider.py
@@ -7,9 +7,16 @@ from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import ObservableProvider
 from heart.renderers.three_d_glasses.state import ThreeDGlassesState
 
+DEFAULT_FRAME_DURATION_MS = 650
+DEFAULT_FRAME_COUNT = 0
+
 
 class ThreeDGlassesStateProvider(ObservableProvider[ThreeDGlassesState]):
-    def __init__(self, frame_duration_ms: int = 650, frame_count: int = 0) -> None:
+    def __init__(
+        self,
+        frame_duration_ms: int = DEFAULT_FRAME_DURATION_MS,
+        frame_count: int = DEFAULT_FRAME_COUNT,
+    ) -> None:
         if frame_duration_ms <= 0:
             raise ValueError("frame_duration_ms must be positive")
         self._frame_duration_ms = frame_duration_ms

--- a/src/heart/renderers/water_title_screen/provider.py
+++ b/src/heart/renderers/water_title_screen/provider.py
@@ -8,9 +8,15 @@ from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import ObservableProvider
 from heart.renderers.water_title_screen.state import WaterTitleScreenState
 
+DEFAULT_WAVE_SPEED = 0.5
+
 
 class WaterTitleScreenStateProvider(ObservableProvider[WaterTitleScreenState]):
-    def __init__(self, peripheral_manager: PeripheralManager, wave_speed: float = 0.5):
+    def __init__(
+        self,
+        peripheral_manager: PeripheralManager,
+        wave_speed: float = DEFAULT_WAVE_SPEED,
+    ):
         self._peripheral_manager = peripheral_manager
         self._wave_speed = wave_speed
 

--- a/src/heart/utilities/reactivex/types.py
+++ b/src/heart/utilities/reactivex/types.py
@@ -6,6 +6,7 @@ import reactivex
 from reactivex.disposable import Disposable
 
 T_co = TypeVar("T_co", covariant=True)
+DEFAULT_SUBSCRIBER_COUNT = 1
 
 
 class ConnectableStream(Protocol[T_co]):
@@ -15,4 +16,6 @@ class ConnectableStream(Protocol[T_co]):
 
     def pipe(self, *operators: Any) -> reactivex.Observable[T_co]: ...
 
-    def auto_connect(self, subscriber_count: int = 1) -> reactivex.Observable[T_co]: ...
+    def auto_connect(
+        self, subscriber_count: int = DEFAULT_SUBSCRIBER_COUNT
+    ) -> reactivex.Observable[T_co]: ...


### PR DESCRIPTION
### Motivation

- Bring code into alignment with the repository guideline to use module-level constants for public constructor and function default values.
- Make default tunables discoverable and easier to adjust by centralizing literal defaults into named constants.
- Reduce scattered magic literals across renderers, peripherals, and utilities to improve readability and maintainability.

### Description

- Added module-level default constants and switched function/constructor defaults to reference them across multiple modules (notably `src/heart/assets/loader.py`, `src/heart/display/recorder.py`, `src/heart/firmware_io/accel.py`, `src/heart/peripheral/gamepad/gamepad.py`, `src/heart/peripheral/ir_sensor_array.py`, `src/heart/renderers/*`, and `src/heart/utilities/reactivex/types.py`).
- Updated signatures to use the new constants (for example `DEFAULT_FONT_SIZE`, `DEFAULT_RECORDING_FPS`, `DEFAULT_MIN_CHANGE_THRESHOLD`, `DEFAULT_JOYSTICK_ID`, `DEFAULT_DMA_BUFFER_SIZE`, `DEFAULT_HUE_EXTENT`, `DEFAULT_FLAME_WIDTH/HEIGHT/SIDE`, and other `DEFAULT_*` values).
- Kept behaviour unchanged apart from replacing inline literal defaults with named constants, and applied repository formatting rules with `make format`.

### Testing

- Ran `make format` and the formatter completed with no remaining issues.
- Ran the full test suite with `make test`; the run completed successfully with `236 passed, 1 skipped`.
- All modified files were linted/formatted as part of the workflow and no test regressions were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e97598e0083218b57970e8dcaac38)