### PR TITLE
Define default accelerometer change threshold constant

### DIFF
--- a/src/heart/firmware_io/accel.py
+++ b/src/heart/firmware_io/accel.py
@@ -10,6 +10,8 @@ from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
 
+DEFAULT_MIN_CHANGE = 0.1
+
 
 def _form_payload(name: str, data) -> str:
     """Forms a JSON payload string from a dictionary of data.
@@ -55,7 +57,7 @@ def form_tuple_payload(name: str, data: tuple) -> str:
 class SensorReader:
     """Tracks last values and determines when updates are significant."""
 
-    def __init__(self, sensors, min_change: float = 0.1) -> None:
+    def __init__(self, sensors, min_change: float = DEFAULT_MIN_CHANGE) -> None:
         self.sensors = sensors
         self.min_change = min_change
 
@@ -84,7 +86,7 @@ class SensorReader:
         return any(abs(n - o) > min_change for n, o in zip(new, old))
 
     @classmethod
-    def connect(cls, i2c, min_change: float = 0.1):
+    def connect(cls, i2c, min_change: float = DEFAULT_MIN_CHANGE):
         sensors = cls.connect_to_sensors(i2c=i2c)
         return cls(sensors=sensors, min_change=min_change)
 


### PR DESCRIPTION
### Motivation
- Align with the repository guideline to use module-level constants for public constructor default values by removing inline literals.
- Make the accelerometer `min_change` default discoverable and reusable across callers by centralizing the value.
- Reduce magic-number usage in `SensorReader` to make intent and tuning easier to find.

### Description
- Add a module-level `DEFAULT_MIN_CHANGE = 0.1` constant in `src/heart/firmware_io/accel.py`.
- Use `DEFAULT_MIN_CHANGE` as the default for `SensorReader.__init__` and `SensorReader.connect` instead of inline `0.1` literals.
- No other behavioral changes were made beyond replacing the literal defaults with the new constant.

### Testing
- Ran `make format`, which completed successfully.
- No Pytest suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e975d122c832197c9cc5a1cf6633e)