### PR TITLE
Refactor runtime game loop bootstrap helpers

### DIFF
--- a/src/heart/cli/commands/run.py
+++ b/src/heart/cli/commands/run.py
@@ -2,9 +2,9 @@ from typing import Annotated
 
 import typer
 
-from heart.cli.commands.game_loop import build_game_loop_container
 from heart.programs.registry import ConfigurationRegistry
 from heart.runtime.game_loop import GameLoop
+from heart.runtime.launcher import build_game_loop_container
 from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)

--- a/src/heart/runtime/launcher.py
+++ b/src/heart/runtime/launcher.py
@@ -1,13 +1,13 @@
-from lagom import Container
+"""Runtime bootstrap helpers for building the game loop."""
 
 from heart.device.selection import select_device
-from heart.runtime.container import build_runtime_container
+from heart.runtime.container import RuntimeContainer, build_runtime_container
 from heart.runtime.game_loop import GameLoop
 from heart.runtime.render_pipeline import RendererVariant
 from heart.utilities.env import Configuration
 
 
-def build_game_loop_container(*, x11_forward: bool) -> Container:
+def build_game_loop_container(*, x11_forward: bool) -> RuntimeContainer:
     render_variant = RendererVariant.parse(Configuration.render_variant())
     device = select_device(x11_forward=x11_forward)
     return build_runtime_container(


### PR DESCRIPTION
### Motivation
- Centralize game-loop bootstrap logic under the runtime package to make runtime ownership explicit.
- Reduce coupling between the CLI and runtime by moving resolver construction out of the CLI commands.
- Improve discoverability for runtime-related helpers and make future runtime changes easier to locate.

### Description
- Add `src/heart/runtime/launcher.py` containing `build_game_loop_container` and `build_game_loop` runtime bootstrap helpers.
- Remove the former `src/heart/cli/commands/game_loop.py` helper (moved into `heart.runtime.launcher`).
- Update `src/heart/cli/commands/run.py` to import `build_game_loop_container` from `heart.runtime.launcher` instead of the CLI module.

### Testing
- Ran `make format` and the repository formatting checks passed.
- Ran `make test` and the full Pytest suite completed successfully with `236 passed, 1 skipped`.
- No additional automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e97b57db88321bc8bc01b194d9e2f)