### PR TITLE
Add logging for Lagom container bindings

### DIFF
--- a/src/heart/peripheral/core/providers/registry.py
+++ b/src/heart/peripheral/core/providers/registry.py
@@ -4,20 +4,28 @@ from typing import Any
 
 from lagom import Container
 
+from heart.utilities.logging import get_logger
+
 ProviderKey = type[Any]
 ProviderValue = Any
 
 _registry: dict[ProviderKey, ProviderValue] = {}
 _containers: list[Container] = []
+logger = get_logger(__name__)
 
 
 def register_provider(key: ProviderKey, provider: ProviderValue) -> None:
     _registry[key] = provider
+    logger.debug("Registered Lagom provider for %s.", key)
     for container in _containers:
         _register_container_provider(container, key, provider)
 
 
 def apply_provider_registrations(container: Container) -> None:
+    logger.debug(
+        "Applying Lagom provider registrations to container with %d entries.",
+        len(_registry),
+    )
     for key, provider in _registry.items():
         _register_container_provider(container, key, provider)
     if container not in _containers:
@@ -34,5 +42,7 @@ def _register_container_provider(
     provider: ProviderValue,
 ) -> None:
     if key in container.defined_types:
+        logger.debug("Lagom container already defines %s; skipping.", key)
         return
     container[key] = provider
+    logger.debug("Lagom container bound provider for %s.", key)

--- a/src/heart/runtime/container.py
+++ b/src/heart/runtime/container.py
@@ -17,8 +17,11 @@ from heart.runtime.game_loop_components import GameLoopComponents
 from heart.runtime.peripheral_runtime import PeripheralRuntime
 from heart.runtime.pygame_event_handler import PygameEventHandler
 from heart.runtime.render_pipeline import RendererVariant, RenderPipeline
+from heart.utilities.logging import get_logger
 
 RuntimeContainer = Container
+
+logger = get_logger(__name__)
 
 
 def build_runtime_container(
@@ -27,6 +30,7 @@ def build_runtime_container(
     overrides: Mapping[type[Any], object] | None = None,
 ) -> RuntimeContainer:
     container = Container()
+    logger.debug("Created Lagom container for runtime configuration.")
     configure_runtime_container(
         container=container,
         device=device,
@@ -43,6 +47,10 @@ def configure_runtime_container(
     render_variant: RendererVariant,
     overrides: Mapping[type[Any], object] | None = None,
 ) -> None:
+    logger.debug(
+        "Configuring Lagom runtime container with overrides=%s.",
+        set(overrides.keys()) if overrides else set(),
+    )
     _bind(container, overrides, Device, device)
     _bind(container, overrides, RendererVariant, render_variant)
     _bind(
@@ -161,7 +169,10 @@ def _bind(
 ) -> None:
     if overrides and key in overrides:
         container[key] = overrides[key]
+        logger.debug("Applied Lagom override for %s.", key)
         return
     if key in container.defined_types:
+        logger.debug("Lagom already defined %s; skipping registration.", key)
         return
     container[key] = value
+    logger.debug("Registered Lagom provider for %s.", key)


### PR DESCRIPTION
### Motivation
- Improve visibility into Lagom container wiring to aid debugging and troubleshooting of runtime configuration.
- Make peripheral provider registration and application observable so provider lifecycle events can be diagnosed.
- Surface when overrides are applied or when provider registrations are skipped to help detect configuration conflicts.
- Conform to the repository logging conventions by using `heart.utilities.logging.get_logger` for module-level loggers.

### Description
- Import and instantiate a module logger in `src/heart/runtime/container.py` and add debug logs in `build_runtime_container`, `configure_runtime_container`, and `_bind` to report container creation, overrides, and binding events.
- Import and instantiate a module logger in `src/heart/peripheral/core/providers/registry.py` and add debug logs in `register_provider`, `apply_provider_registrations`, and `_register_container_provider` to report provider registration and application activity.
- Debug messages include the set of override keys, the number of registered providers, and events for applied overrides, skipped registrations, and bound providers.
- No functional changes to provider binding logic were made; only non-intrusive debug logging was added.

### Testing
- Ran `make format` to apply repository formatting rules and checks, which completed successfully.
- No new automated unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e998587588321b499b407604455f3)