### PR TITLE
tests: use runtime container in navigation resolution

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,10 @@ from typing import Callable
 import pygame
 import pytest
 from hypothesis import HealthCheck, settings
-from lagom import Container
 
 from heart.device import Cube, Device
 from heart.peripheral.core.manager import PeripheralManager
-from heart.runtime.container import build_runtime_container
+from heart.runtime.container import RuntimeContainer, build_runtime_container
 from heart.runtime.game_loop import GameLoop
 from heart.runtime.render_pipeline import RendererVariant
 
@@ -150,7 +149,7 @@ def manager() -> PeripheralManager:
     return PeripheralManager()
 
 @pytest.fixture()
-def resolver(device: Device) -> Container:
+def resolver(device: Device) -> RuntimeContainer:
     return build_runtime_container(
         device=device,
         render_variant=RendererVariant.ITERATIVE,

--- a/tests/navigation/test_composed_renderer_resolution.py
+++ b/tests/navigation/test_composed_renderer_resolution.py
@@ -1,10 +1,12 @@
 """Validate Lagom-backed renderer resolution in composed navigation helpers."""
 
 import pytest
-from lagom import Container
 
+from heart.device import Device
 from heart.navigation import ComposedRenderer
 from heart.renderers import StatefulBaseRenderer
+from heart.runtime.container import build_runtime_container
+from heart.runtime.render_pipeline import RendererVariant
 
 
 class _ContainerRenderer(StatefulBaseRenderer[int]):
@@ -20,18 +22,24 @@ class _ContainerRenderer(StatefulBaseRenderer[int]):
 class TestComposedRendererResolution:
     """Ensure composed renderers can resolve classes via Lagom for consistent dependency wiring."""
 
-    def test_resolves_renderer_types_at_construction(self) -> None:
+    def test_resolves_renderer_types_at_construction(self, device: Device) -> None:
         """Verify renderer classes resolve via Lagom on init so configuration lists stay container-aware."""
-        container = Container()
+        container = build_runtime_container(
+            device=device,
+            render_variant=RendererVariant.ITERATIVE,
+        )
         container[_ContainerRenderer] = _ContainerRenderer
 
         composed = ComposedRenderer([_ContainerRenderer], renderer_resolver=container)
 
         assert isinstance(composed.renderers[0], _ContainerRenderer)
 
-    def test_add_renderer_resolves_types(self) -> None:
+    def test_add_renderer_resolves_types(self, device: Device) -> None:
         """Confirm add_renderer resolves class inputs so dynamic additions still honor container wiring."""
-        container = Container()
+        container = build_runtime_container(
+            device=device,
+            render_variant=RendererVariant.ITERATIVE,
+        )
         container[_ContainerRenderer] = _ContainerRenderer
 
         composed = ComposedRenderer([], renderer_resolver=container)

--- a/tests/navigation/test_multi_scene_resolution.py
+++ b/tests/navigation/test_multi_scene_resolution.py
@@ -1,10 +1,12 @@
 """Validate Lagom-backed renderer resolution in multi-scene navigation helpers."""
 
 import pytest
-from lagom import Container
 
+from heart.device import Device
 from heart.navigation import MultiScene
 from heart.renderers import StatefulBaseRenderer
+from heart.runtime.container import build_runtime_container
+from heart.runtime.render_pipeline import RendererVariant
 
 
 class _ContainerScene(StatefulBaseRenderer[int]):
@@ -20,9 +22,12 @@ class _ContainerScene(StatefulBaseRenderer[int]):
 class TestMultiSceneResolution:
     """Ensure multi-scene navigation resolves class-based scenes via Lagom for consistent wiring."""
 
-    def test_resolves_scene_types_at_construction(self) -> None:
+    def test_resolves_scene_types_at_construction(self, device: Device) -> None:
         """Verify scene classes resolve via Lagom at init so multi-scene compositions stay container-aware."""
-        container = Container()
+        container = build_runtime_container(
+            device=device,
+            render_variant=RendererVariant.ITERATIVE,
+        )
         container[_ContainerScene] = _ContainerScene
 
         multi_scene = MultiScene([_ContainerScene], renderer_resolver=container)


### PR DESCRIPTION
### Motivation
- Tests were importing `lagom.Container` directly which diverges from repository guidance that only `heart.runtime.container` and provider modules should import Lagom types. 
- Align test code with dependency-injection guidance so container usage is centralized and feature modules remain decoupled from Lagom internals.

### Description
- Replace direct `lagom.Container` usage in navigation tests with `build_runtime_container(...)` so tests exercise the same runtime wiring as application code. 
- Type the shared resolver fixture as `RuntimeContainer` in `tests/conftest.py` to follow the documented abstraction. 
- Updated `tests/navigation/test_composed_renderer_resolution.py` and `tests/navigation/test_multi_scene_resolution.py` to build and populate the runtime container instead of instantiating `Container` directly. 
- Kept behavior unchanged; tests still register the test renderer/scene class in the container before resolution.

### Testing
- Ran `make format` and formatting checks which completed successfully. 
- Ran `make test` and the test suite passed with `236 passed, 1 skipped`. 
- No new lint or type errors were introduced according to the repository formatting and type checks. 
- Changed tests were exercised and validated by the CI-local test run above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e9a48a4e8832190888ba1a13ebdea)