### PR TITLE
Integrate FrameExporter into runtime container

### DIFF
--- a/docs/research/lagom_frame_exporter_integration.md
+++ b/docs/research/lagom_frame_exporter_integration.md
@@ -1,0 +1,26 @@
+# Lagom Frame Exporter Integration Note
+
+## Problem Statement
+
+`FramePresenter` constructed its own `FrameExporter` instance, which made it
+hard to override export strategies through the Lagom container for tests or
+runtime tuning. That kept frame export behavior outside the shared dependency
+wiring and forced direct constructor access when configuring exporters.
+
+## Materials
+
+- Python 3.11 environment with `uv` for dependency resolution.
+- Lagom dependency (`lagom` in `pyproject.toml`).
+- Source modules: `src/heart/runtime/container.py`,
+  `src/heart/runtime/frame_presenter.py`,
+  `src/heart/runtime/frame_exporter.py`.
+- Tests: `tests/runtime/test_container.py`.
+
+## Notes
+
+- Registered `FrameExporter` as a Lagom singleton in
+  `heart.runtime.container.configure_runtime_container`.
+- `FramePresenter` now accepts the exporter through the container so overrides
+  can swap export strategies without bypassing runtime wiring.
+- Added a container test to confirm that overriding `FrameExporter` updates the
+  `FramePresenter` instance resolved from the container.

--- a/src/heart/runtime/container.py
+++ b/src/heart/runtime/container.py
@@ -12,6 +12,7 @@ from heart.peripheral.core.providers import apply_provider_registrations
 from heart.peripheral.registry import PeripheralConfigurationRegistry
 from heart.programs.registry import ConfigurationRegistry
 from heart.runtime.display_context import DisplayContext
+from heart.runtime.frame_exporter import FrameExporter
 from heart.runtime.frame_presenter import FramePresenter
 from heart.runtime.game_loop_components import GameLoopComponents
 from heart.runtime.peripheral_runtime import PeripheralRuntime
@@ -89,6 +90,7 @@ def configure_runtime_container(
             )
         ),
     )
+    _bind(container, overrides, FrameExporter, Singleton(FrameExporter))
     _bind(
         container,
         overrides,
@@ -98,6 +100,7 @@ def configure_runtime_container(
                 device=resolver[Device],
                 display=resolver[DisplayContext],
                 render_pipeline=resolver[RenderPipeline],
+                frame_exporter=resolver[FrameExporter],
             )
         ),
     )

--- a/src/heart/runtime/frame_presenter.py
+++ b/src/heart/runtime/frame_presenter.py
@@ -14,13 +14,15 @@ from heart.runtime.render_pipeline import RenderPipeline
 if TYPE_CHECKING:
     from heart.renderers import StatefulBaseRenderer
 
+DEFAULT_FRAME_EXPORTER_FACTORY = FrameExporter
+
 
 @dataclass
 class FramePresenter:
     device: Device
     display: DisplayContext
     render_pipeline: RenderPipeline
-    frame_exporter: FrameExporter = field(default_factory=FrameExporter)
+    frame_exporter: FrameExporter = field(default_factory=DEFAULT_FRAME_EXPORTER_FACTORY)
 
     def present(
         self,

--- a/tests/runtime/test_container.py
+++ b/tests/runtime/test_container.py
@@ -3,6 +3,8 @@ from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.registry import PeripheralConfigurationRegistry
 from heart.runtime.container import build_runtime_container
 from heart.runtime.display_context import DisplayContext
+from heart.runtime.frame_exporter import FrameExporter
+from heart.runtime.frame_presenter import FramePresenter
 from heart.runtime.game_loop import GameLoop
 from heart.runtime.game_loop_components import GameLoopComponents
 from heart.runtime.render_pipeline import RendererVariant, RenderPipeline
@@ -55,6 +57,19 @@ class TestRuntimeContainer:
         manager = container.resolve(PeripheralManager)
 
         assert manager.configuration_loader is loader
+
+    def test_container_injects_frame_exporter_overrides(self, device) -> None:
+        """Ensure FramePresenter honors container overrides so frame export strategies remain testable."""
+        exporter = FrameExporter()
+        container = build_runtime_container(
+            device=device,
+            render_variant=RendererVariant.BINARY,
+            overrides={FrameExporter: exporter},
+        )
+
+        presenter = container.resolve(FramePresenter)
+
+        assert presenter.frame_exporter is exporter
 
     def test_game_loop_uses_container_overrides(self, device) -> None:
         """Ensure GameLoop honors container overrides so tests can swap implementations without touching runtime code."""


### PR DESCRIPTION
### Motivation
- Make frame export behavior part of the shared Lagom wiring so export strategies can be overridden via the container for tests and runtime tuning.
- Remove ad-hoc construction of `FrameExporter` inside `FramePresenter` so DI and lifecycle ownership are consistent with other runtime services.
- Improve testability by allowing tests to swap exporter implementations without touching runtime code.

### Description
- Register `FrameExporter` as a singleton in `configure_runtime_container` and resolve it into `FramePresenter` when constructing the presenter in the container.
- Introduce `DEFAULT_FRAME_EXPORTER_FACTORY` and change `FramePresenter` to accept a `frame_exporter` provided by the container as its `field(default_factory=...)` value.
- Add `test_container_injects_frame_exporter_overrides` to `tests/runtime/test_container.py` to verify container overrides propagate to `FramePresenter`.
- Add documentation note `docs/research/lagom_frame_exporter_integration.md` describing the change and rationale.

### Testing
- Ran `make format` to apply repository formatting rules, which completed successfully.
- Ran `make test`, with the test suite completing successfully as `237 passed, 1 skipped`.
- Added a unit test that asserts a container-provided `FrameExporter` instance is used by the resolved `FramePresenter` and it passed.
- Existing container and runtime tests were run and remained green after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e9a6302ac83219ce389e78fc5a272)