### PR TITLE
Centralize accelerometer min_change default

### DIFF
--- a/src/heart/firmware_io/accel.py
+++ b/src/heart/firmware_io/accel.py
@@ -10,8 +10,6 @@ from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
 
-DEFAULT_MIN_CHANGE_THRESHOLD = 0.1
-
 
 def _form_payload(name: str, data) -> str:
     """Forms a JSON payload string from a dictionary of data.
@@ -58,7 +56,7 @@ class SensorReader:
     """Tracks last values and determines when updates are significant."""
 
     def __init__(
-        self, sensors, min_change: float = DEFAULT_MIN_CHANGE_THRESHOLD
+        self, sensors, min_change: float = constants.ACCEL_MIN_CHANGE_DEFAULT
     ) -> None:
         self.sensors = sensors
         self.min_change = min_change
@@ -88,7 +86,7 @@ class SensorReader:
         return any(abs(n - o) > min_change for n, o in zip(new, old))
 
     @classmethod
-    def connect(cls, i2c, min_change: float = DEFAULT_MIN_CHANGE_THRESHOLD):
+    def connect(cls, i2c, min_change: float = constants.ACCEL_MIN_CHANGE_DEFAULT):
         sensors = cls.connect_to_sensors(i2c=i2c)
         return cls(sensors=sensors, min_change=min_change)
 

--- a/src/heart/firmware_io/constants.py
+++ b/src/heart/firmware_io/constants.py
@@ -7,3 +7,5 @@ GYROSCOPE = "sensor.gyroscope"
 MAGNETIC = "sensor.magnetic"
 DEVICE_IDENTIFY = "device.identify"
 RADIO_PACKET = "peripheral.radio.packet"
+
+ACCEL_MIN_CHANGE_DEFAULT = 0.1


### PR DESCRIPTION
### Motivation
- Make the accelerometer `min_change` threshold discoverable and reusable across callers by centralizing the value.  
- Reduce inline magic numbers in `SensorReader` so tuning and intent are easier to find.  

### Description
- Added a new constant `ACCEL_MIN_CHANGE_DEFAULT` to `src/heart/firmware_io/constants.py`.  
- Updated `SensorReader` in `src/heart/firmware_io/accel.py` to use `constants.ACCEL_MIN_CHANGE_DEFAULT` for its default `min_change` parameter.  
- Removed the local `DEFAULT_MIN_CHANGE_THRESHOLD` literal from `accel.py`.  

### Testing
- Ran `make format` which completed successfully.  
- Ran `make test` which executed the full Pytest suite.  
- Test results: `235` passed, `1` failed, `1` skipped.  
- The failing test is `tests/utilities/test_reactivex_streams.py::TestShareStreamFlowControl::test_share_stream_coalesce_cancels_stale_scheduler_after_fallback`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e9b96c9b48321977769cc0474c18f)