### PR TITLE
Refactor runtime container bindings for clarity

### DIFF
--- a/src/heart/runtime/container.py
+++ b/src/heart/runtime/container.py
@@ -53,6 +53,35 @@ def configure_runtime_container(
     )
     _bind(container, overrides, Device, device)
     _bind(container, overrides, RendererVariant, render_variant)
+    _configure_peripheral_bindings(container, overrides)
+    _configure_display_bindings(container, overrides)
+    _configure_render_bindings(container, overrides)
+    _configure_runtime_bindings(container, overrides)
+    _configure_game_loop_bindings(container, overrides)
+    apply_provider_registrations(container)
+
+
+def _bind(
+    container: RuntimeContainer,
+    overrides: Mapping[type[Any], object] | None,
+    key: type[Any],
+    value: object,
+) -> None:
+    if overrides and key in overrides:
+        container[key] = overrides[key]
+        logger.debug("Applied Lagom override for %s.", key)
+        return
+    if key in container.defined_types:
+        logger.debug("Lagom already defined %s; skipping registration.", key)
+        return
+    container[key] = value
+    logger.debug("Registered Lagom provider for %s.", key)
+
+
+def _configure_peripheral_bindings(
+    container: RuntimeContainer,
+    overrides: Mapping[type[Any], object] | None,
+) -> None:
     _bind(
         container,
         overrides,
@@ -79,12 +108,24 @@ def configure_runtime_container(
             )
         ),
     )
+
+
+def _configure_display_bindings(
+    container: RuntimeContainer,
+    overrides: Mapping[type[Any], object] | None,
+) -> None:
     _bind(
         container,
         overrides,
         DisplayContext,
         Singleton(lambda resolver: DisplayContext(device=resolver[Device])),
     )
+
+
+def _configure_render_bindings(
+    container: RuntimeContainer,
+    overrides: Mapping[type[Any], object] | None,
+) -> None:
     _bind(
         container,
         overrides,
@@ -109,6 +150,12 @@ def configure_runtime_container(
             )
         ),
     )
+
+
+def _configure_runtime_bindings(
+    container: RuntimeContainer,
+    overrides: Mapping[type[Any], object] | None,
+) -> None:
     _bind(
         container,
         overrides,
@@ -127,6 +174,13 @@ def configure_runtime_container(
         ConfigurationRegistry,
         Singleton(ConfigurationRegistry),
     )
+    _bind(container, overrides, PygameEventHandler, Singleton(PygameEventHandler))
+
+
+def _configure_game_loop_bindings(
+    container: RuntimeContainer,
+    overrides: Mapping[type[Any], object] | None,
+) -> None:
     _bind(
         container,
         overrides,
@@ -143,7 +197,6 @@ def configure_runtime_container(
             )
         ),
     )
-    _bind(container, overrides, PygameEventHandler, Singleton(PygameEventHandler))
     from heart.runtime.game_loop import GameLoop
 
     _bind(
@@ -158,21 +211,3 @@ def configure_runtime_container(
             )
         ),
     )
-    apply_provider_registrations(container)
-
-
-def _bind(
-    container: RuntimeContainer,
-    overrides: Mapping[type[Any], object] | None,
-    key: type[Any],
-    value: object,
-) -> None:
-    if overrides and key in overrides:
-        container[key] = overrides[key]
-        logger.debug("Applied Lagom override for %s.", key)
-        return
-    if key in container.defined_types:
-        logger.debug("Lagom already defined %s; skipping registration.", key)
-        return
-    container[key] = value
-    logger.debug("Registered Lagom provider for %s.", key)


### PR DESCRIPTION
### Motivation
- Improve readability of `configure_runtime_container` by decomposing a large registration function into focused helpers.
- Group Lagom provider registrations by concern (peripheral, display, render, runtime, game loop) to make lifecycle and dependencies clearer.
- Make future changes and overrides easier to reason about and maintain by localizing related bindings.

### Description
- Introduce `_bind` helper and new helper functions `
_configure_peripheral_bindings`, `
_configure_display_bindings`, `
_configure_render_bindings`, `
_configure_runtime_bindings`, and `
_configure_game_loop_bindings` in `src/heart/runtime/container.py`.
- Move existing provider registrations into the appropriate helper functions and streamline `configure_runtime_container` to call these helpers.
- Defer importing and binding of `GameLoop` into the dedicated game loop configuration helper to keep related bindings colocated.
- Keep existing override behavior and registration guards intact so functionality is unchanged.

### Testing
- Ran `make format` and it completed without errors.
- Ran `make test` and the full Pytest suite completed successfully with `236 passed, 1 skipped`.
- Unit tests that exercise the runtime container (e.g., `tests/runtime/test_container.py`) passed as part of the suite.
- No regressions were observed in the automated test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e9bd23f9483219a7373da8a0f9d7e)