### PR TITLE
Refactor render plan caching for clarity

### DIFF
--- a/src/heart/runtime/render_plan_cache.py
+++ b/src/heart/runtime/render_plan_cache.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any, cast
+
+from heart.runtime.render_planner import RenderPlan, RenderPlanner
+from heart.runtime.rendering.variants import RendererVariant
+
+if TYPE_CHECKING:
+    from heart.renderers import StatefulBaseRenderer
+
+
+class RenderPlanCache:
+    def __init__(self, planner: RenderPlanner, refresh_ms: int) -> None:
+        self._planner = planner
+        self._refresh_ms = refresh_ms
+        self._signature: tuple[int, ...] | None = None
+        self._override: RendererVariant | None = None
+        self._default_variant: RendererVariant | None = None
+        self._plan_time = 0.0
+        self._plan: RenderPlan | None = None
+
+    def get_plan(
+        self,
+        renderers: list["StatefulBaseRenderer[Any]"],
+        default_variant: RendererVariant,
+        override_renderer_variant: RendererVariant | None = None,
+    ) -> RenderPlan:
+        signature = self._renderers_signature(renderers)
+        if self._is_cache_valid(
+            signature,
+            override_renderer_variant,
+            default_variant,
+        ):
+            return cast(RenderPlan, self._plan)
+        self._planner.set_default_variant(default_variant)
+        plan = self._planner.plan(renderers, override_renderer_variant)
+        self._signature = signature
+        self._override = override_renderer_variant
+        self._default_variant = default_variant
+        self._plan_time = time.monotonic()
+        self._plan = plan
+        return plan
+
+    def _is_cache_valid(
+        self,
+        signature: tuple[int, ...],
+        override_renderer_variant: RendererVariant | None,
+        default_variant: RendererVariant,
+    ) -> bool:
+        if self._refresh_ms <= 0 or self._plan is None:
+            return False
+        if signature != self._signature or override_renderer_variant != self._override:
+            return False
+        if default_variant != self._default_variant:
+            return False
+        age_ms = (time.monotonic() - self._plan_time) * 1000.0
+        return age_ms < self._refresh_ms
+
+    @staticmethod
+    def _renderers_signature(
+        renderers: list["StatefulBaseRenderer[Any]"],
+    ) -> tuple[int, ...]:
+        return tuple(id(renderer) for renderer in renderers)


### PR DESCRIPTION
### Motivation
- Separate render plan caching into its own helper to keep `RenderPipeline` focused on orchestration.
- Prevent stale cached plans when the default renderer variant changes by tracking the variant in the cache.
- Reduce complexity and duplicated timing/signature state inside `RenderPipeline`.

### Description
- Add `RenderPlanCache` in `src/heart/runtime/render_plan_cache.py` which encapsulates plan creation, signature tracking, age validation, and default-variant invalidation.
- Update `RenderPipeline` to use the new `RenderPlanCache` instead of maintaining inline cache state and timing fields.
- Ensure the cache invalidates when the renderer default variant, renderer list signature, or override variant changes.
- Clean up imports and simplify `_ensure_plan`/`render` to call `RenderPlanCache.get_plan`.

### Testing
- Ran `make format` and formatting checks completed successfully.
- Ran `make test` and the full test suite completed with `236 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e9bdb5e1083219b7faeda225e1a4e)