### PR TITLE
Use weak refs for Lagom container tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,8 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - Feature modules should register singleton bindings with provider helpers (for example,
   `register_singleton_provider`) instead of reaching for Lagom bindings directly, so container usage remains
   encapsulated.
+- When tracking runtime containers for provider registration updates, use weak references (for example,
+  `weakref.WeakSet`) so stale containers do not stay alive after shutdown.
 
 ## Error Handling
 

--- a/src/heart/peripheral/core/providers/registry.py
+++ b/src/heart/peripheral/core/providers/registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import weakref
 from typing import Any
 
 from lagom import Container, Singleton
@@ -10,7 +11,7 @@ ProviderKey = type[Any]
 ProviderValue = Any
 
 _registry: dict[ProviderKey, ProviderValue] = {}
-_containers: list[Container] = []
+_containers: weakref.WeakSet[Container] = weakref.WeakSet()
 logger = get_logger(__name__)
 
 
@@ -34,8 +35,7 @@ def apply_provider_registrations(container: Container) -> None:
     )
     for key, provider in _registry.items():
         _register_container_provider(container, key, provider)
-    if container not in _containers:
-        _containers.append(container)
+    _containers.add(container)
 
 
 def registered_providers() -> dict[ProviderKey, ProviderValue]:


### PR DESCRIPTION
### Motivation
- Ensure the provider registry does not retain runtime `Container` instances after shutdown to avoid memory leaks.
- Align implementation with repository guidance to track runtime containers via weak references.
- Make provider registration lifecycle safer by preventing stale containers from being kept alive by strong references.

### Description
- Added a guidance bullet to `AGENTS.md` recommending `weakref.WeakSet` for tracking runtime containers.
- Updated `src/heart/peripheral/core/providers/registry.py` to `import weakref` and use `_containers: weakref.WeakSet[Container] = weakref.WeakSet()` with `_containers.add(container)`.
- Ran repository formatting (`make format`) to apply code style changes.

### Testing
- Executed `make format`, which completed successfully.
- Ran `make test`; the test suite executed but had one failing test: `tests/utilities/test_reactivex_streams.py::TestShareStreamFlowControl::test_share_stream_coalesce_cancels_stale_scheduler_after_fallback`.
- Test summary: 235 passed, 1 skipped, 1 failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e9c1109a8832193b94dee1b9bc213)