### PR TITLE
Add marble-driven tests for RenderImage output scaling

### DIFF
--- a/tests/display/test_render_image_marbles.py
+++ b/tests/display/test_render_image_marbles.py
@@ -1,0 +1,77 @@
+"""Exercise RenderImage reactive outputs with marble diagrams."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pygame
+import pytest
+import reactivex
+from reactivex import operators as ops
+from reactivex.testing.marbles import marbles_testing
+
+from heart.assets.loader import Loader
+from heart.renderers.image.provider import RenderImageStateProvider
+from heart.runtime.frame_exporter import FrameExporter
+from heart.utilities.env import FrameExportStrategy
+
+
+@dataclass(frozen=True)
+class _StubManager:
+    window: reactivex.Observable[pygame.Surface | None]
+
+
+class TestRenderImageMarbleOutputs:
+    """Validate marbled window updates produce correct output images for reactive rendering."""
+
+    @pytest.mark.parametrize(
+        ("sizes", "expected_sizes"),
+        [
+            ([(2, 2), (4, 4), (4, 4)], [(2, 2), (4, 4)]),
+            ([(1, 3), (1, 3), (5, 2)], [(1, 3), (5, 2)]),
+        ],
+        ids=["dedupe-repeated-size", "dedupe-non-square"],
+    )
+    def test_marble_stream_scales_images_to_window_sizes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        sizes: list[tuple[int, int]],
+        expected_sizes: list[tuple[int, int]],
+    ) -> None:
+        """Confirm marble-timed window sizes emit scaled images so render streams stay deterministic."""
+
+        base_surface = pygame.Surface((2, 2), pygame.SRCALPHA)
+        base_surface.fill((10, 20, 30, 255))
+        monkeypatch.setattr(Loader, "load", lambda _: base_surface)
+        pygame.display.set_mode((1, 1))
+
+        marble_labels = ["a", "b", "c"]
+        window_values = {
+            label: pygame.Surface(size, pygame.SRCALPHA)
+            for label, size in zip(marble_labels, sizes, strict=True)
+        }
+        provider = RenderImageStateProvider(image_file="fixture.png")
+        exporter = FrameExporter(
+            strategy_provider=lambda: FrameExportStrategy.ARRAY
+        )
+
+        with marbles_testing() as (start, _cold, hot, _exp):
+            window_stream = hot("-a-b-c-|", window_values)
+            manager = _StubManager(window=window_stream)
+            image_stream = provider.observable(manager).pipe(
+                ops.map(
+                    lambda state: pygame.transform.scale(
+                        state.base_image, state.window_size
+                    )
+                ),
+                ops.map(exporter.export),
+            )
+            records = start(image_stream)
+
+        images = [
+            (record.value.value.size, record.value.value.getpixel((0, 0)))
+            for record in records
+            if record.value.kind == "N"
+        ]
+
+        assert images == [(size, (10, 20, 30)) for size in expected_sizes]


### PR DESCRIPTION
### Motivation

- Provide deterministic, time-controlled tests for reactive render pipelines using marble diagrams so image output correctness can be validated under simulated timing.
- Validate that `RenderImage` state updates scale the base image to emitted window sizes and that repeated sizes are de-duplicated by the observable pipeline.

### Description

- Add `tests/display/test_render_image_marbles.py` which defines marble-based scenarios for window size updates and subscribes to the `RenderImageStateProvider` output.
- Use `reactivex.testing.marbles_testing` to create hot observables and `FrameExporter` (with `FrameExportStrategy.ARRAY`) to convert produced surfaces to `PIL.Image` for pixel assertions.
- Initialize a minimal SDL video mode via `pygame.display.set_mode((1, 1))` in the test to avoid `pygame.error: No video mode has been set` when converting surfaces.

### Testing

- Formatted code with `make format` and ran the full test suite with `make test`.
- Test run result: all tests passed locally (`238 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e9c23f22483218df24a3a5855d5a5)