### PR TITLE
Use runtime container for mandelbrot peripheral manager

### DIFF
--- a/docs/planning/lagom_deeper_integration.md
+++ b/docs/planning/lagom_deeper_integration.md
@@ -43,6 +43,7 @@ This plan proposes consolidating runtime dependency wiring into a single Lagom c
 - [ ] Update `GameLoop` to accept a container created by the builder module and remove ad-hoc instantiation.
 - [ ] Align `ComposedRenderer.resolve_renderer` with the shared container instance so renderers can share registered services.
 - [ ] Move the global container from `src/heart/peripheral/core/providers/__init__.py` into the container builder module or a dedicated peripheral container module to avoid multiple container instances.
+- [ ] Update standalone renderer scripts (for example, `src/heart/renderers/mandelbrot/scene.py`) to resolve `PeripheralManager` through the runtime container instead of direct instantiation.
 - [ ] Ensure configuration and overrides for tests are documented and demonstrate the pattern in a new test module.
 
 ### Validation

--- a/src/heart/renderers/mandelbrot/scene.py
+++ b/src/heart/renderers/mandelbrot/scene.py
@@ -590,8 +590,13 @@ def get_julia_converge_time(re, im, c_real, c_imag, max_iter):
     return result
 
 
-def main():
+def main() -> None:
     import pygame
+
+    from heart.device.selection import select_device
+    from heart.runtime.container import build_runtime_container
+    from heart.runtime.render_pipeline import RendererVariant
+    from heart.utilities.env import Configuration
 
     profiling = os.environ.get("PROFILING", "False").lower() == "true"
     check_frames = int(os.environ.get("CHECK_FRAMES", "100"))
@@ -617,7 +622,13 @@ def main():
 
     frame_count = 0
 
-    manager = PeripheralManager()
+    render_variant = RendererVariant.parse(Configuration.render_variant())
+    device = select_device(x11_forward=False)
+    container = build_runtime_container(
+        device=device,
+        render_variant=render_variant,
+    )
+    manager = container.resolve(PeripheralManager)
     manager.detect()
     manager.start()
     try:


### PR DESCRIPTION
### Motivation

- Ensure standalone renderer scripts obtain runtime services from the same Lagom container used by the application to keep dependency wiring consistent.
- Reduce ad-hoc construction of `PeripheralManager` so components can be overridden in tests and share lifecycle guarantees with other runtime singletons.

### Description

- Replace direct `PeripheralManager()` construction in `src/heart/renderers/mandelbrot/scene.py` with a container-backed resolution via `build_runtime_container` and `container.resolve(PeripheralManager)`.
- Add necessary imports (`select_device`, `build_runtime_container`, `RendererVariant`, `Configuration`) and parse the configured `RendererVariant` when building the container.
- Update the Lagom deep integration plan at `docs/planning/lagom_deeper_integration.md` to call out updating standalone renderer scripts to use the runtime container.

### Testing

- Ran `make format` and formatting checks passed.
- Ran `make test`; the test suite executed but one test failed: `tests/utilities/test_reactivex_streams.py::TestShareStreamFlowControl::test_share_stream_coalesces_latest_when_configured`.
- All other tests passed (236 passed, 1 skipped, 1 failed) when the suite was run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e9c6a94c08321ba72af903214ca96)