### PR TITLE
Refactor Lagom provider factories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
   encapsulated.
 - When tracking runtime containers for provider registration updates, use weak references (for example,
   `weakref.WeakSet`) so stale containers do not stay alive after shutdown.
+- Define Lagom provider factories as named module-level callables instead of inline lambdas so the dependency
+  graph stays discoverable and traceable in logs and stack traces.
 
 ## Error Handling
 


### PR DESCRIPTION
### Motivation

- Improve traceability and debuggability of Lagom provider bindings by replacing inline lambdas with named factory callables.
- Enforce a repository guideline that encourages module-level provider factories so dependency construction is discoverable in logs and stack traces.

### Description

- Add a new Lagom guideline to `AGENTS.md` recommending named module-level provider factories instead of inline lambdas.
- Introduce `_build_*` factory functions in `src/heart/runtime/container.py` for peripheral loader, peripheral manager, display context, render pipeline, frame presenter, peripheral runtime, app controller, and game loop components.
- Replace inline `lambda resolver: ...` Singletons with `Singleton(_build_...)` calls while preserving the existing binding logic.
- Run repository formatting to normalize code style after the change.

### Testing

- Ran `make format` to apply formatting and linting fixes, and it completed successfully.
- No other automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea0662d98832191aa6816f8436942)