### PR TITLE
Add default rotary encoder index constant

### DIFF
--- a/src/heart/firmware_io/rotary_encoder.py
+++ b/src/heart/firmware_io/rotary_encoder.py
@@ -6,6 +6,7 @@ from digitalio import Pull
 from heart.firmware_io import constants
 
 LONG_PRESS_DURATION_SECONDS = 0.5
+DEFAULT_ROTARY_ENCODER_INDEX = 0
 
 
 # We don't use `json` here because the Trinkey doesn't support it by default
@@ -26,7 +27,7 @@ class RotaryEncoderHandler:
         self,
         encoder,
         switch,
-        index=0,
+        index=DEFAULT_ROTARY_ENCODER_INDEX,
         *,
         clock: Callable[[], float] | None = None,
     ):


### PR DESCRIPTION
### Motivation
- Align with repository guidance to use module-level constants for public constructor default values.
- Replace an inline literal default with a named constant to improve discoverability and maintainability.
- Keep firmware I/O modules consistent with coding conventions in `AGENTS.md`.
- Make future changes to the default index easier and centralized.

### Description
- Add `DEFAULT_ROTARY_ENCODER_INDEX = 0` to `src/heart/firmware_io/rotary_encoder.py` as a module-level constant.
- Use the new `DEFAULT_ROTARY_ENCODER_INDEX` in the `RotaryEncoderHandler` constructor default instead of the literal `0`.
- Preserve existing runtime behaviour while improving code clarity.
- Run formatting to apply repository style rules with `make format`.

### Testing
- Ran `make format`, which completed successfully.
- No unit tests were added or modified as part of this change.
- The single-file change is non-behavioural and does not affect existing test expectations.
- Formatting checks passed after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea0754be08321895105ea2eecba55)