### PR TITLE
Add marble export tests for image rendering

### DIFF
--- a/tests/display/test_render_image_marbles.py
+++ b/tests/display/test_render_image_marbles.py
@@ -75,3 +75,73 @@ class TestRenderImageMarbleOutputs:
         ]
 
         assert images == [(size, (10, 20, 30)) for size in expected_sizes]
+
+    @pytest.mark.parametrize(
+        ("sizes", "expected_sizes"),
+        [
+            ([(1, 1), (3, 2), (3, 2)], [(1, 1), (3, 2)]),
+            ([(4, 1), (4, 1), (2, 4)], [(4, 1), (2, 4)]),
+        ],
+        ids=["array-buffer-match-rect", "array-buffer-match-flip"],
+    )
+    def test_marble_stream_exports_consistent_images_across_strategies(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        sizes: list[tuple[int, int]],
+        expected_sizes: list[tuple[int, int]],
+    ) -> None:
+        """Check marbled exports align across array/buffer strategies to keep outputs stable."""
+
+        base_surface = pygame.Surface((1, 1), pygame.SRCALPHA)
+        base_surface.fill((100, 150, 200, 255))
+        monkeypatch.setattr(Loader, "load", lambda _: base_surface)
+        pygame.display.set_mode((1, 1))
+
+        marble_labels = ["a", "b", "c"]
+        window_values = {
+            label: pygame.Surface(size, pygame.SRCALPHA)
+            for label, size in zip(marble_labels, sizes, strict=True)
+        }
+        provider = RenderImageStateProvider(image_file="fixture.png")
+        array_exporter = FrameExporter(
+            strategy_provider=lambda: FrameExportStrategy.ARRAY
+        )
+        buffer_exporter = FrameExporter(
+            strategy_provider=lambda: FrameExportStrategy.BUFFER
+        )
+
+        with marbles_testing() as (start, _cold, hot, _exp):
+            window_stream = hot("-a-b-c-|", window_values)
+            manager = _StubManager(window=window_stream)
+            image_stream = provider.observable(manager).pipe(
+                ops.map(
+                    lambda state: pygame.transform.scale(
+                        state.base_image, state.window_size
+                    )
+                ),
+                ops.map(
+                    lambda surface: (
+                        array_exporter.export(surface),
+                        buffer_exporter.export(surface),
+                    )
+                ),
+            )
+            records = start(image_stream)
+
+        images = [
+            (
+                record.value.value[0].size,
+                record.value.value[0].convert("RGBA").getpixel((0, 0)),
+                record.value.value[1].size,
+                record.value.value[1].convert("RGBA").getpixel((0, 0)),
+            )
+            for record in records
+            if record.value.kind == "N"
+        ]
+
+        expected = [
+            (size, (100, 150, 200, 255), size, (100, 150, 200, 255))
+            for size in expected_sizes
+        ]
+
+        assert images == expected


### PR DESCRIPTION
### Motivation

- Add deterministic tests that exercise reactive rendering outputs using marble diagrams so image exports remain stable.
- Verify `FrameExporter` produces equivalent results across `FrameExportStrategy.ARRAY` and `FrameExportStrategy.BUFFER` to avoid regressions in export code paths.
- Exercise additional window size sequences to validate scaling and deduplication behaviour in the render provider.

### Description

- Added a new parameterized test `test_marble_stream_exports_consistent_images_across_strategies` in `tests/display/test_render_image_marbles.py` that compares array and buffer exports.
- The test uses `marbles_testing` to drive a `peripheral_manager.window` observable and maps provider outputs to scaled `pygame.Surface` objects.
- It creates two `FrameExporter` instances with strategy providers for `FrameExportStrategy.ARRAY` and `FrameExportStrategy.BUFFER`, exports both, and asserts exported PIL image sizes and RGBA pixels match expected values.
- The change is confined to the test suite and reuses existing test scaffolding and the `RenderImageStateProvider` fixture.

### Testing

- Ran `make format` to apply repository formatting rules and it completed successfully.
- Ran `make test` to execute the full test suite which completed successfully.
- Test run summary: `241 passed, 1 skipped` (includes the new marble tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea07c40ac8321b2a6becf8960afe3)