### PR TITLE
Deepen Lagom provider integration for renderers

### DIFF
--- a/docs/research/lagom_renderer_provider_integration.md
+++ b/docs/research/lagom_renderer_provider_integration.md
@@ -15,6 +15,8 @@ DI concerns.
   `src/heart/renderers/cloth_sail/`,
   `src/heart/renderers/three_fractal/`,
   `src/heart/renderers/mario/`,
+  `src/heart/renderers/channel_diffusion/`,
+  `src/heart/renderers/three_d_glasses/`,
   `src/heart/programs/configurations/lib_2025.py`,
   `src/heart/programs/configurations/l_system.py`,
   `src/heart/programs/configurations/porthole_window.py`,
@@ -34,3 +36,9 @@ leaking device plumbing into configuration modules.
 `ComposedRenderer.resolve_renderer_from_container` so Lagom supplies the registered state
 providers. This reduces direct provider construction in configuration modules while keeping the
 runtime container responsible for provider wiring.
+
+`ChannelDiffusionStateProvider` and `ThreeDGlassesStateProvider` are now registered with the
+provider registry. The channel diffusion configuration resolves its renderer through the Lagom
+container, and the 3D glasses demo resolves a container-managed provider before instantiating the
+renderer. This keeps provider construction centralized and makes it easier to override providers in
+tests.

--- a/src/heart/programs/configurations/channel_diffusion.py
+++ b/src/heart/programs/configurations/channel_diffusion.py
@@ -4,4 +4,4 @@ from heart.runtime.game_loop import GameLoop
 
 def configure(loop: GameLoop) -> None:
     mode = loop.add_mode()
-    mode.add_renderer(ChannelDiffusionRenderer())
+    mode.resolve_renderer_from_container(ChannelDiffusionRenderer)

--- a/src/heart/programs/configurations/three_d_glasses_demo.py
+++ b/src/heart/programs/configurations/three_d_glasses_demo.py
@@ -1,4 +1,5 @@
-from heart.renderers.three_d_glasses import ThreeDGlassesRenderer
+from heart.renderers.three_d_glasses import (ThreeDGlassesRenderer,
+                                             ThreeDGlassesStateProvider)
 from heart.runtime.game_loop import GameLoop
 
 IMAGE_SEQUENCE = [
@@ -10,10 +11,12 @@ IMAGE_SEQUENCE = [
 def configure(loop: GameLoop) -> None:
     """Attach the ThreeDGlassesRenderer for manual testing."""
 
+    provider = loop.resolve(ThreeDGlassesStateProvider)
     mode = loop.add_mode("3D Glasses Demo")
     mode.add_renderer(
         ThreeDGlassesRenderer(
             list(IMAGE_SEQUENCE),
             frame_duration_ms=650,
+            provider=provider,
         )
     )

--- a/src/heart/renderers/channel_diffusion/__init__.py
+++ b/src/heart/renderers/channel_diffusion/__init__.py
@@ -1,6 +1,9 @@
+from heart.peripheral.core.providers import register_provider
 from heart.renderers.channel_diffusion.provider import \
-    ChannelDiffusionStateProvider  # noqa: F401
+    ChannelDiffusionStateProvider as ChannelDiffusionStateProvider
 from heart.renderers.channel_diffusion.renderer import \
-    ChannelDiffusionRenderer  # noqa: F401
+    ChannelDiffusionRenderer as ChannelDiffusionRenderer
 from heart.renderers.channel_diffusion.state import \
-    ChannelDiffusionState  # noqa: F401
+    ChannelDiffusionState as ChannelDiffusionState
+
+register_provider(ChannelDiffusionStateProvider, ChannelDiffusionStateProvider)

--- a/src/heart/renderers/channel_diffusion/renderer.py
+++ b/src/heart/renderers/channel_diffusion/renderer.py
@@ -13,8 +13,8 @@ from heart.renderers.channel_diffusion.state import ChannelDiffusionState
 
 
 class ChannelDiffusionRenderer(StatefulBaseRenderer[ChannelDiffusionState]):
-    def __init__(self, provider: ChannelDiffusionStateProvider | None = None) -> None:
-        self._provider = provider or ChannelDiffusionStateProvider()
+    def __init__(self, provider: ChannelDiffusionStateProvider) -> None:
+        self._provider = provider
         self._initial_state: ChannelDiffusionState | None = None
         super().__init__(builder=self._provider)
         self.device_display_mode = DeviceDisplayMode.FULL

--- a/src/heart/renderers/three_d_glasses/__init__.py
+++ b/src/heart/renderers/three_d_glasses/__init__.py
@@ -1,6 +1,9 @@
+from heart.peripheral.core.providers import register_provider
 from heart.renderers.three_d_glasses.provider import \
-    ThreeDGlassesStateProvider  # noqa: F401
+    ThreeDGlassesStateProvider as ThreeDGlassesStateProvider
 from heart.renderers.three_d_glasses.renderer import \
-    ThreeDGlassesRenderer  # noqa: F401
+    ThreeDGlassesRenderer as ThreeDGlassesRenderer
 from heart.renderers.three_d_glasses.state import \
-    ThreeDGlassesState  # noqa: F401
+    ThreeDGlassesState as ThreeDGlassesState
+
+register_provider(ThreeDGlassesStateProvider, ThreeDGlassesStateProvider)

--- a/tests/display/test_channel_diffusion_renderer.py
+++ b/tests/display/test_channel_diffusion_renderer.py
@@ -5,7 +5,8 @@ import pygame
 
 from heart.device import Rectangle
 from heart.peripheral.core.manager import PeripheralManager
-from heart.renderers.channel_diffusion import ChannelDiffusionRenderer
+from heart.renderers.channel_diffusion import (ChannelDiffusionRenderer,
+                                               ChannelDiffusionStateProvider)
 
 
 class TestChannelDiffusionRenderer:
@@ -14,7 +15,7 @@ class TestChannelDiffusionRenderer:
     def test_single_white_pixel_spreads_channels(self, stub_clock_factory) -> None:
         """Ensure a lone white pixel fans out by channel while dimming in place to keep the seed deterministic."""
 
-        renderer = ChannelDiffusionRenderer()
+        renderer = ChannelDiffusionRenderer(ChannelDiffusionStateProvider())
         manager = PeripheralManager()
         clock = stub_clock_factory(0)
         orientation = Rectangle.with_layout(1, 1)


### PR DESCRIPTION
### Motivation
- Reduce ad-hoc construction and centralize dependency wiring by using the shared Lagom container for renderer state providers.
- Avoid duplicated `PeripheralManager` and `Device` plumbing in configuration modules by resolving providers from the runtime container.
- Make renderers easier to override in tests and to swap implementations via container overrides.

### Description
- Register `ChannelDiffusionStateProvider` and `ThreeDGlassesStateProvider` with the provider registry via `register_provider` so they are applied to runtime containers.
- Change `ChannelDiffusionRenderer` to accept an injected `ChannelDiffusionStateProvider` in its constructor instead of constructing the provider internally.
- Update configuration modules to resolve renderers/providers from the container by using `mode.resolve_renderer_from_container(ChannelDiffusionRenderer)` and `loop.resolve(ThreeDGlassesStateProvider)` where appropriate.
- Update the channel diffusion unit test to construct the renderer with a `ChannelDiffusionStateProvider` and add a brief note to the Lagom renderer provider integration research doc.

### Testing
- Ran `make format` and formatting checks completed successfully.
- Ran `make test` and the test suite passed with `239 passed, 1 skipped`.
- Existing renderer and integration tests covering provider-backed renderers were exercised and succeeded.
- No new failing tests were introduced after the refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea05af59083219008926d64b503c2)