### PR TITLE
Prefer f-strings and normalize string assembly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - Avoid using `print` for runtime diagnostics in peripheral modules; use the shared logger.
 - Avoid leaving commented debug print statements in production modules; remove them once they are no longer needed.
 - Avoid wildcard imports; use explicit imports so dependencies stay clear and tooling can track usage.
+- Prefer f-strings over string concatenation when assembling Python strings so formatting stays readable.
 - Prefer mixins or composition over direct inheritance.
 - Prefer `StrEnum` values over raw strings for strategy/configuration mode selections.
 - Use `heart.utilities.logging.get_logger` for internal logging so handlers and log levels stay consistent across modules.

--- a/drivers/radio_bridge/code.py
+++ b/drivers/radio_bridge/code.py
@@ -54,7 +54,7 @@ class RadioBridgeRuntime:
 
     def _encode_payload(self, payload: Mapping[str, object]) -> str:
         frame = {"event_type": RADIO_PACKET, "data": dict(payload)}
-        return json.dumps(frame) + "\n"
+        return f"{json.dumps(frame)}\n"
 
     def run_once(self) -> None:
         respond_to_identify_query()

--- a/experimental/scripts/render_code_flow.py
+++ b/experimental/scripts/render_code_flow.py
@@ -26,7 +26,7 @@ def extract_mermaid_blocks(markdown: str) -> Iterable[str]:
         if line.strip().startswith("```"):
             in_block = False
             if block_lines:
-                yield "\n".join(block_lines).strip() + "\n"
+                yield f"{'\n'.join(block_lines).strip()}\n"
             block_lines = []
         else:
             block_lines.append(line)

--- a/src/heart/display/shaders/shader.py
+++ b/src/heart/display/shaders/shader.py
@@ -55,7 +55,7 @@ class Shader:
 
         program = self.compile_program(vert_shader, frag_shader)
         for k in _UNIFORMS:
-            self.keys[k] = glGetUniformLocation(program, "_" + k)
+            self.keys[k] = glGetUniformLocation(program, f"_{k}")
 
         # Return the program
         return program

--- a/src/heart/firmware_io/accel.py
+++ b/src/heart/firmware_io/accel.py
@@ -28,7 +28,7 @@ def _form_payload(name: str, data) -> str:
             "value": data,
         },
     }
-    return "\n" + json.dumps(payload) + "\n"
+    return f"\n{json.dumps(payload)}\n"
 
 
 def form_tuple_payload(name: str, data: tuple) -> str:

--- a/src/heart/firmware_io/rotary_encoder.py
+++ b/src/heart/firmware_io/rotary_encoder.py
@@ -12,13 +12,8 @@ DEFAULT_ROTARY_ENCODER_INDEX = 0
 # We don't use `json` here because the Trinkey doesn't support it by default
 def form_json(name: str, data: int, producer_id: int):
     return (
-        '{"event_type": "'
-        + name
-        + '", "data": '
-        + str(data)
-        + ', "producer_id": '
-        + str(producer_id)
-        + "}"
+        f'{{"event_type": "{name}", "data": {data}, '
+        f'"producer_id": {producer_id}}}'
     )
 
 

--- a/src/heart/renderers/pacman/renderer.py
+++ b/src/heart/renderers/pacman/renderer.py
@@ -46,11 +46,17 @@ class PacmanGhostRenderer(StatefulBaseRenderer[PacmanGhostState]):
         ghost_red = "redghost.png"
 
         if state.reverse:
-            self.ghost1 = pygame.transform.flip(load("scaredghost1.png" if state.blood else ghost_prefix + ".png"), True, False)
+            self.ghost1 = pygame.transform.flip(
+                load("scaredghost1.png" if state.blood else f"{ghost_prefix}.png"),
+                True,
+                False,
+            )
             self.ghost2 = pygame.transform.flip(load(ghost_blue if not state.blood else "scaredghost2.png"), True, False)
             self.ghost3 = pygame.transform.flip(load("scaredghost1.png" if state.blood else ghost_red), True, False)
         else:
-            self.ghost1 = load("scaredghost1.png" if state.blood else ghost_prefix + ".png")
+            self.ghost1 = load(
+                "scaredghost1.png" if state.blood else f"{ghost_prefix}.png"
+            )
             self.ghost2 = load("scaredghost2.png" if state.blood else ghost_blue)
             self.ghost3 = load("scaredghost1.png" if state.blood else ghost_red)
 


### PR DESCRIPTION
### Motivation

- Reduce instances of string concatenation and improve readability by preferring formatted string literals.
- Align repository coding style with the guidance in `AGENTS.md` and prevent future divergences in string assembly.
- Make string construction consistently safer and easier to maintain across firmware and host modules.

### Description

- Add a new guidance rule to `AGENTS.md`: prefer f-strings over string concatenation when assembling Python strings.
- Replace manual concatenation/`+` assembly with f-strings in several places, including `src/heart/firmware_io/accel.py`, `src/heart/firmware_io/rotary_encoder.py`, `src/heart/display/shaders/shader.py`, `src/heart/renderers/pacman/renderer.py`, `drivers/radio_bridge/code.py`, and `experimental/scripts/render_code_flow.py`.
- Kept behavior identical while modernizing formatting and preserving on-device string output shapes (including newline framing where present).

### Testing

- Ran `make format`, which completed successfully.
- Ran `make test`, resulting in `239 passed, 1 skipped` across the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea1c5fae483219237560b22ff4b44)