### PR TITLE
Add sliding image marble tests

### DIFF
--- a/tests/display/test_sliding_image_marbles.py
+++ b/tests/display/test_sliding_image_marbles.py
@@ -1,0 +1,104 @@
+"""Exercise SlidingImage reactive outputs with marble diagrams."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pygame
+import pytest
+import reactivex
+from reactivex import operators as ops
+from reactivex.testing.marbles import marbles_testing
+
+from heart.renderers.sliding_image.provider import SlidingImageStateProvider
+from heart.renderers.sliding_image.state import SlidingImageState
+from heart.runtime.frame_exporter import FrameExporter
+from heart.utilities.env import FrameExportStrategy
+
+
+@dataclass(frozen=True)
+class _StubManager:
+    window: reactivex.Observable[pygame.Surface | None]
+    game_tick: reactivex.Observable[object]
+
+
+def _render_sliding_frame(
+    state: SlidingImageState,
+    base_image: pygame.Surface,
+) -> pygame.Surface:
+    if state.width <= 0:
+        raise ValueError("State width must be positive for rendering")
+
+    height = base_image.get_height()
+    scaled_image = pygame.transform.scale(base_image, (state.width, height))
+    frame = pygame.Surface((state.width, height), pygame.SRCALPHA)
+    frame.fill((0, 0, 0, 0))
+
+    offset = state.offset
+    width = state.width
+
+    frame.blit(scaled_image, (-offset, 0))
+    if offset:
+        frame.blit(scaled_image, (width - offset, 0))
+    return frame
+
+
+class TestSlidingImageMarbleOutputs:
+    """Validate marble-timed SlidingImage states produce accurate output frames."""
+
+    @pytest.mark.parametrize(
+        ("speed", "tick_pattern", "expected_offsets"),
+        [
+            (1, "-a-b-c-d-|", [0, 1, 2, 3, 0]),
+            (2, "-a-b-c-|", [0, 2, 0, 2]),
+        ],
+        ids=["speed-1-wrap", "speed-2-steps"],
+    )
+    def test_marble_stream_renders_expected_offsets(
+        self,
+        speed: int,
+        tick_pattern: str,
+        expected_offsets: list[int],
+    ) -> None:
+        """Ensure marbled game ticks advance slide offsets so image wraps stay correct."""
+
+        pygame.display.set_mode((1, 1))
+        base_surface = pygame.Surface((4, 1), pygame.SRCALPHA)
+        colors = [(255, 0, 0), (0, 255, 0), (0, 0, 255), (255, 255, 0)]
+        for index, color in enumerate(colors):
+            base_surface.set_at((index, 0), (*color, 255))
+
+        window_surface = pygame.Surface((4, 1), pygame.SRCALPHA)
+        initial_state = SlidingImageState(speed=speed, width=4)
+        provider = SlidingImageStateProvider(initial_state=initial_state)
+        exporter = FrameExporter(strategy_provider=lambda: FrameExportStrategy.ARRAY)
+
+        tick_values = {label: True for label in tick_pattern if label.isalpha()}
+
+        with marbles_testing() as (start, cold, _hot, _exp):
+            window_stream = cold("a------|", {"a": window_surface})
+            tick_stream = cold(tick_pattern, tick_values)
+            manager = _StubManager(window=window_stream, game_tick=tick_stream)
+            image_stream = provider.observable(manager).pipe(
+                ops.filter(lambda state: state.width > 0),
+                ops.map(lambda state: _render_sliding_frame(state, base_surface)),
+                ops.map(exporter.export),
+                ops.map(
+                    lambda image: [
+                        image.getpixel((x, 0)) for x in range(image.size[0])
+                    ]
+                ),
+            )
+            records = start(image_stream)
+
+        images = [
+            record.value.value
+            for record in records
+            if record.value.kind == "N"
+        ]
+
+        expected = [
+            colors[offset:] + colors[:offset] for offset in expected_offsets
+        ]
+
+        assert images == expected


### PR DESCRIPTION
### Motivation

- Provide deterministic, marble-driven tests that validate image outputs produced by sliding-image render streams.
- Ensure slide offsets wrap correctly and exported frame images remain consistent across tick patterns and export strategies.
- Exercise the existing reactive stream helpers and `FrameExporter` to catch regressions in rendering/packing logic.

### Description

- Add `tests/display/test_sliding_image_marbles.py` which uses `reactivex.testing.marbles.marbles_testing` to drive window and tick streams and assert pixel outputs. 
- Introduce a small rendering helper `_render_sliding_frame` and use `SlidingImageStateProvider` plus `FrameExporter` with `FrameExportStrategy.ARRAY` to produce testable image frames.
- Use marble `cold` streams to keep timing deterministic in the tests and map marble emissions to expected color rotations.
- Run repository formatting via `make format` as part of the change.

### Testing

- Ran `make format` and the formatting checks passed.
- Ran the test suite with `make test` and observed `243 passed, 1 skipped`.
- The new marble tests pass under the shared test environment and integrate with existing reactivex test helpers.
- No additional automated test failures were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea1f829e083218d39dd4852ac98c5)