### PR TITLE
Refactor peripheral manager streams

### DIFF
--- a/src/heart/peripheral/core/manager.py
+++ b/src/heart/peripheral/core/manager.py
@@ -1,27 +1,17 @@
-from functools import cached_property
-from typing import Any, Iterable, TypeVar
+from typing import Any, Iterable
 
 import reactivex
-from reactivex import operators as ops
-from reactivex.abc import SchedulerBase
-from reactivex.subject.behaviorsubject import BehaviorSubject
 
 from heart.peripheral.configuration import PeripheralConfiguration
 from heart.peripheral.configuration_loader import PeripheralConfigurationLoader
-from heart.peripheral.core import Peripheral, PeripheralMessageEnvelope
+from heart.peripheral.core import Peripheral
+from heart.peripheral.core.streams import PeripheralStreams
 from heart.peripheral.gamepad import Gamepad
 from heart.peripheral.registry import PeripheralConfigurationRegistry
-from heart.peripheral.switch import FakeSwitch, SwitchState
-from heart.utilities.env import Configuration, ReactivexEventBusScheduler
+from heart.peripheral.switch import SwitchState
 from heart.utilities.logging import get_logger
-from heart.utilities.reactivex.sharing import share_stream
-from heart.utilities.reactivex_threads import (background_scheduler,
-                                               input_scheduler)
 
 logger = get_logger(__name__)
-
-T = TypeVar("T")
-R = TypeVar("R")
 
 
 class PeripheralManager:
@@ -44,6 +34,7 @@ class PeripheralManager:
             configuration=configuration,
             registry=configuration_registry,
         )
+        self._streams = PeripheralStreams(self._iter_peripherals)
 
     @property
     def peripherals(self) -> tuple[Peripheral[Any], ...]:
@@ -83,6 +74,9 @@ class PeripheralManager:
     def _ensure_configuration(self) -> PeripheralConfiguration:
         return self._configuration_loader.load()
 
+    def _iter_peripherals(self) -> Iterable[Peripheral[Any]]:
+        return tuple(self._peripherals)
+
     def start(self) -> None:
         if self._started:
             raise ValueError("Manager has already been started")
@@ -96,48 +90,19 @@ class PeripheralManager:
         self._peripherals.append(peripheral)
 
     def get_event_bus(self) -> reactivex.Observable[Any]:
-        event_sources = [peripheral.observe for peripheral in self.peripherals]
-        if not event_sources:
-            event_bus = reactivex.empty()
-        else:
-            event_bus = reactivex.merge(*event_sources)
-        scheduler = self._event_bus_scheduler()
-        if scheduler is not None:
-            event_bus = event_bus.pipe(ops.observe_on(scheduler))
-        return share_stream(event_bus, stream_name="PeripheralManager.event_bus")
+        return self._streams.event_bus()
 
     def get_main_switch_subscription(self) -> reactivex.Observable[SwitchState]:
-        main_switches = [
-            peripheral.observe
-            for peripheral in self.peripherals
-            if isinstance(peripheral, FakeSwitch)
-        ]
+        return self._streams.main_switch_subscription()
 
-        if not main_switches:
-            return reactivex.empty()
-
-        merged = reactivex.merge(*main_switches).pipe(
-            ops.map(PeripheralMessageEnvelope[SwitchState].unwrap_peripheral)
-        )
-        return share_stream(merged, stream_name="PeripheralManager.main_switch")
-
-    @cached_property
+    @property
     def game_tick(self) -> reactivex.Subject[Any]:
-        return BehaviorSubject[Any](None)
+        return self._streams.game_tick
 
-    @cached_property
+    @property
     def window(self) -> reactivex.Subject[Any]:
-        return BehaviorSubject[Any](None)
+        return self._streams.window
 
-    @cached_property
+    @property
     def clock(self) -> reactivex.Subject[Any]:
-        return BehaviorSubject[Any](None)
-
-    @staticmethod
-    def _event_bus_scheduler() -> SchedulerBase | None:
-        strategy = Configuration.reactivex_event_bus_scheduler()
-        if strategy is ReactivexEventBusScheduler.BACKGROUND:
-            return background_scheduler()
-        if strategy is ReactivexEventBusScheduler.INPUT:
-            return input_scheduler()
-        return None
+        return self._streams.clock

--- a/src/heart/peripheral/core/streams.py
+++ b/src/heart/peripheral/core/streams.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from functools import cached_property
+from typing import Any, Callable, Iterable
+
+import reactivex
+from reactivex import operators as ops
+from reactivex.abc import SchedulerBase
+from reactivex.subject.behaviorsubject import BehaviorSubject
+
+from heart.peripheral.core import Peripheral, PeripheralMessageEnvelope
+from heart.peripheral.switch import FakeSwitch, SwitchState
+from heart.utilities.env import Configuration, ReactivexEventBusScheduler
+from heart.utilities.reactivex.sharing import share_stream
+from heart.utilities.reactivex_threads import (background_scheduler,
+                                               input_scheduler)
+
+PeripheralSource = Callable[[], Iterable[Peripheral[Any]]]
+
+
+class PeripheralStreams:
+    """Build shared reactive streams for detected peripherals."""
+
+    def __init__(self, peripheral_source: PeripheralSource) -> None:
+        self._peripheral_source = peripheral_source
+
+    def event_bus(self) -> reactivex.Observable[Any]:
+        event_sources = [peripheral.observe for peripheral in self._peripheral_source()]
+        if not event_sources:
+            event_bus = reactivex.empty()
+        else:
+            event_bus = reactivex.merge(*event_sources)
+        scheduler = self._event_bus_scheduler()
+        if scheduler is not None:
+            event_bus = event_bus.pipe(ops.observe_on(scheduler))
+        return share_stream(event_bus, stream_name="PeripheralManager.event_bus")
+
+    def main_switch_subscription(self) -> reactivex.Observable[SwitchState]:
+        main_switches = [
+            peripheral.observe
+            for peripheral in self._peripheral_source()
+            if isinstance(peripheral, FakeSwitch)
+        ]
+
+        if not main_switches:
+            return reactivex.empty()
+
+        merged = reactivex.merge(*main_switches).pipe(
+            ops.map(PeripheralMessageEnvelope[SwitchState].unwrap_peripheral)
+        )
+        return share_stream(merged, stream_name="PeripheralManager.main_switch")
+
+    @cached_property
+    def game_tick(self) -> reactivex.Subject[Any]:
+        return BehaviorSubject[Any](None)
+
+    @cached_property
+    def window(self) -> reactivex.Subject[Any]:
+        return BehaviorSubject[Any](None)
+
+    @cached_property
+    def clock(self) -> reactivex.Subject[Any]:
+        return BehaviorSubject[Any](None)
+
+    @staticmethod
+    def _event_bus_scheduler() -> SchedulerBase | None:
+        strategy = Configuration.reactivex_event_bus_scheduler()
+        if strategy is ReactivexEventBusScheduler.BACKGROUND:
+            return background_scheduler()
+        if strategy is ReactivexEventBusScheduler.INPUT:
+            return input_scheduler()
+        return None


### PR DESCRIPTION
### Motivation

- Improve clarity by separating reactive stream assembly from peripheral management responsibilities.
- Encapsulate event bus and subject creation to make `PeripheralManager` easier to understand and test.
- Reduce duplicated Rx scheduling and stream-sharing logic in the manager implementation.

### Description

- Add `src/heart/peripheral/core/streams.py` implementing `PeripheralStreams` which builds shared reactivex streams and subjects such as `event_bus`, `main_switch_subscription`, `game_tick`, `window`, and `clock`.
- Update `PeripheralManager` to instantiate `PeripheralStreams` and delegate `get_event_bus()`, `get_main_switch_subscription()`, and the `game_tick`/`window`/`clock` properties to the new helper, and add `_iter_peripherals()` as the source for the streams.
- Remove inline stream composition, scheduler selection, and subject creation from `manager.py` and adjust imports accordingly.
- Run code formatting (`make format`) to apply project style rules.

### Testing

- Ran `make format`, which completed successfully.
- Ran the full test suite with `make test`; the run completed with the majority of tests passing but reported `2 failed, 239 passed, 1 skipped`.
- The two failing tests are `tests/renderers/test_sliding_state_provider.py::TestSlidingStateProviderTransitions::test_advance_state_uses_expected_width[spec0]` and `tests/renderers/test_pixels_state_provider.py::TestPixelStateProviderTransitions::test_next_state_advances_without_reset[RainStateProvider-RainState]` and failures originate from Hypothesis health checks flagging slow input generation.
- No changes were made to the failing renderer tests in this PR and the failures appear related to test input generation timing rather than the new stream refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea22979a883219495e79e2a936db5)