### PR TITLE
Avoid hardware device selection in mandelbrot main

### DIFF
--- a/src/heart/renderers/mandelbrot/scene.py
+++ b/src/heart/renderers/mandelbrot/scene.py
@@ -593,7 +593,7 @@ def get_julia_converge_time(re, im, c_real, c_imag, max_iter):
 def main() -> None:
     import pygame
 
-    from heart.device.selection import select_device
+    from heart.device.local import LocalScreen
     from heart.runtime.container import build_runtime_container
     from heart.runtime.render_pipeline import RendererVariant
     from heart.utilities.env import Configuration
@@ -605,8 +605,8 @@ def main() -> None:
     pygame.init()
 
     # Set up the display
-    WIDTH, HEIGHT = 512, 256
-    screen = pygame.display.set_mode((WIDTH, HEIGHT))
+    width, height = 512, 256
+    screen = pygame.display.set_mode((width, height))
     pygame.display.set_caption("Mandelbrot Explorer")
 
     # Create the mandelbrot renderer
@@ -623,7 +623,8 @@ def main() -> None:
     frame_count = 0
 
     render_variant = RendererVariant.parse(Configuration.render_variant())
-    device = select_device(x11_forward=False)
+    orientation = Rectangle.with_layout(1, 1)
+    device = LocalScreen(width=width, height=height, orientation=orientation)
     container = build_runtime_container(
         device=device,
         render_variant=render_variant,
@@ -642,9 +643,7 @@ def main() -> None:
             screen.fill((0, 0, 0))
 
             # Process and render
-            mandelbrot._internal_process(
-                screen, clock, manager, Rectangle.with_layout(1, 1)
-            )
+            mandelbrot._internal_process(screen, clock, manager, orientation)
 
             # Update the display
             pygame.display.flip()


### PR DESCRIPTION
### Motivation
- Prevent the mandelbrot example from importing and initializing RGB-matrix hardware when the script only needs a `PeripheralManager` on desktop environments.
- Avoid crashes on workstations where `Configuration.use_isolated_renderer()` or `Configuration.is_pi()` cause `select_device` to instantiate `LEDMatrix` and import `rgbmatrix`.
- Keep the mandelbrot entrypoint lightweight so it can run without platform-specific display drivers.

### Description
- Replace `select_device(...)` with a local `LocalScreen` constructed using the example window `width`/`height` and a shared `orientation` for container setup. 
- Pass the created `orientation` into `mandelbrot._internal_process` instead of recreating a `Rectangle` inline. 
- Simplify display size variable names from `WIDTH, HEIGHT` to `width, height` to match the `LocalScreen` constructor.
- Change is confined to `src/heart/renderers/mandelbrot/scene.py` and preserves `PeripheralManager` initialization via the runtime container.

### Testing
- Ran `make format` and formatting checks passed. 
- Ran the test suite with `make test` and observed `241 passed, 1 skipped`.
- Confirmed the mandelbrot main no longer imports device selection code path at startup on desktop. 
- All automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea260868483219b0cf8710a761d94)