### PR TITLE
Update fixture docstring to include setup cost

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def default_render_merge_strategy(monkeypatch: pytest.MonkeyPatch) -> None:
 def default_reactivex_stream_coalesce_window(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Disable stream coalescing by default so reactive tests remain deterministic."""
+    """Disable stream coalescing for deterministic reactive tests; mutates env vars per test."""
 
     monkeypatch.setenv("HEART_RX_STREAM_COALESCE_WINDOW_MS", "0")
     yield


### PR DESCRIPTION
### Motivation

- The autouse fixture `default_reactivex_stream_coalesce_window` in `tests/conftest.py` lacked a statement about setup cost required by `tests/AGENTS.md`.
- Without the setup-cost note, readers cannot quickly assess fixture overhead or side effects such as environment mutation.

### Description

- Edit the docstring for `default_reactivex_stream_coalesce_window` in `tests/conftest.py` to include the setup cost note that it mutates environment variables per test.
- Keep the docstring concise while clarifying both the primary use case (disabling stream coalescing for deterministic reactive tests) and the cost (per-test env var mutation).

### Testing

- Ran `make format` to apply repository formatting tools and the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea2756a7c8321a117848265b1e982)