### PR TITLE
Semgrep: flag implicit single-argument text `open()` calls without encoding

### DIFF
--- a/semgrep.yml
+++ b/semgrep.yml
@@ -142,10 +142,13 @@ rules:
     message: Specify an explicit encoding when reading or writing text files.
     severity: ERROR
     patterns:
-      - pattern: open($FILE, $MODE, ...)
+      - pattern-either:
+          - pattern: open($FILE)
+          - pattern: open($FILE, $MODE, ...)
       - metavariable-regex:
           metavariable: $MODE
           regex: ^["']?[rwa]([t+])?["']?$
+      - pattern-not: open($FILE, encoding=$ENCODING, ...)
       - pattern-not: open($FILE, $MODE, ..., encoding=$ENCODING, ...)
     paths:
       include:


### PR DESCRIPTION
### Motivation
- The existing Semgrep rule missed single-argument `open($PATH)` calls so text file opens could omit an explicit `encoding` and evade the check.
- Enforce explicit encodings for text I/O to ensure cross-platform consistency and prefer `utf-8` for readability and portability.
- Preserve existing exemptions for calls that already specify an `encoding` so legitimate uses are not flagged.

### Description
- Updated `semgrep.yml` rule `heart-no-text-open-without-encoding` to use a `pattern-either` that matches both `open($FILE)` and `open($FILE, $MODE, ...)`.
- Added a `pattern-not: open($FILE, encoding=$ENCODING, ...)` exclusion so single-argument opens with `encoding=` are not reported, and retained the existing mode-based exclusion.
- Committed the rule change to the repository configuration so static analysis will catch implicit text opens going forward.

### Testing
- Ran `make format` to apply repository formatting rules and ensure no formatting regressions, and the command completed successfully.
- No unit test changes were introduced as this is a static-analysis rule update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea29b64bc83218d3c430b2195b90b)