### PR TITLE
Refactor asset spritesheet loading modules

### DIFF
--- a/src/heart/assets/animation.py
+++ b/src/heart/assets/animation.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pygame
+
+from heart.assets.spritesheet import Spritesheet
+
+
+class Animation:
+    def __init__(self, spritesheet: Spritesheet, width: int) -> None:
+        self.spritesheet = spritesheet
+
+        image_size = self.spritesheet.sheet.get_size()
+        self.number_of_frames = image_size[0] / width
+
+        self.key_frames = [
+            (width * index, 0, width, image_size[1])
+            for index in range(int(self.number_of_frames))
+        ]
+        self.current_frame = 0
+        self.ms_since_last_update: float | None = None
+        self.ms_per_frame = 25
+
+    def step(self, window: pygame.Surface, clock: pygame.time.Clock) -> pygame.Surface:
+        if (
+            self.ms_since_last_update is None
+            or self.ms_since_last_update > self.ms_per_frame
+        ):
+            if self.current_frame >= self.number_of_frames - 1:
+                self.current_frame = 0
+            else:
+                self.current_frame += 1
+
+            self.ms_since_last_update = 0
+
+        image = self.spritesheet.image_at(self.key_frames[self.current_frame])
+        self.ms_since_last_update += clock.get_time()
+        return image

--- a/src/heart/assets/spritesheet.py
+++ b/src/heart/assets/spritesheet.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import pygame
+
+from heart.utilities.env import Configuration, SpritesheetFrameCacheStrategy
+
+
+class Spritesheet:
+    def __init__(self, filename: str | Path) -> None:
+        path = Path(filename)
+        if not path.exists():
+            raise ValueError(f"'{path}' does not exist.")
+
+        if not path.is_file():
+            raise ValueError(f"'{path}' is not a file.")
+
+        with path.open("rb") as file_handle:
+            self.sheet = pygame.image.load(file_handle).convert_alpha()
+        self._frame_cache: dict[tuple[int, int, int, int], pygame.Surface] = {}
+        self._scaled_cache: dict[tuple[int, int, int, int, int, int], pygame.Surface] = {}
+
+    def get_size(self) -> tuple[int, int]:
+        return self.sheet.get_size()
+
+    def image_at(self, rectangle: tuple[int, int, int, int]) -> pygame.Surface:
+        rect = pygame.Rect(rectangle)
+        cache_key = (rect.x, rect.y, rect.width, rect.height)
+        strategy = Configuration.spritesheet_frame_cache_strategy()
+        if strategy in {
+            SpritesheetFrameCacheStrategy.FRAMES,
+            SpritesheetFrameCacheStrategy.SCALED,
+        }:
+            cached = self._frame_cache.get(cache_key)
+            if cached is not None:
+                return cached
+
+        image = pygame.Surface(rect.size, pygame.SRCALPHA)
+        image.blit(self.sheet, (0, 0), rect)
+        if strategy in {
+            SpritesheetFrameCacheStrategy.FRAMES,
+            SpritesheetFrameCacheStrategy.SCALED,
+        }:
+            self._frame_cache[cache_key] = image
+        return image
+
+    def image_at_scaled(
+        self, rectangle: tuple[int, int, int, int], size: tuple[int, int]
+    ) -> pygame.Surface:
+        rect = pygame.Rect(rectangle)
+        width, height = size
+        cache_key = (rect.x, rect.y, rect.width, rect.height, width, height)
+        strategy = Configuration.spritesheet_frame_cache_strategy()
+        if strategy == SpritesheetFrameCacheStrategy.SCALED:
+            cached = self._scaled_cache.get(cache_key)
+            if cached is not None:
+                return cached
+
+        image = self.image_at(rect)
+        scaled = pygame.transform.scale(image, (width, height))
+        if strategy == SpritesheetFrameCacheStrategy.SCALED:
+            self._scaled_cache[cache_key] = scaled
+        return scaled
+
+    def images_at(
+        self, rects: Iterable[tuple[int, int, int, int]]
+    ) -> list[pygame.Surface]:
+        """Load multiple images by supplying a list of coordinates."""
+
+        return [self.image_at(rect) for rect in rects]
+
+    def load_strip(
+        self, rect: tuple[int, int, int, int], image_count: int
+    ) -> list[pygame.Surface]:
+        """Load a strip of images and return them as a list."""
+
+        rectangles = [
+            (rect[0] + rect[2] * index, rect[1], rect[2], rect[3])
+            for index in range(image_count)
+        ]
+        return self.images_at(rectangles)

--- a/src/heart/renderers/spritesheet_random/state.py
+++ b/src/heart/renderers/spritesheet_random/state.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from enum import StrEnum
 
-from heart.assets.loader import spritesheet as SpritesheetAsset
+from heart.assets.spritesheet import Spritesheet
 from heart.peripheral.switch import SwitchState
 
 
@@ -14,7 +14,7 @@ class LoopPhase(StrEnum):
 @dataclass
 class SpritesheetLoopRandomState:
     switch_state: SwitchState | None
-    spritesheet: SpritesheetAsset | None = None
+    spritesheet: Spritesheet | None = None
     current_frame: int = 0
     loop_count: int = 0
     phase: LoopPhase = LoopPhase.LOOP


### PR DESCRIPTION
### Motivation
- Separate concerns by extracting spritesheet parsing and frame slicing from the generic loader to improve clarity and reuse.
- Move animation frame stepping into a focused module so animation logic is decoupled from I/O and caching.
- Update type annotations so renderers and state modules reference a concrete `Spritesheet` asset type.

### Description
- Add `src/heart/assets/spritesheet.py` implementing a `Spritesheet` class that handles frame extraction and scaled caching.
- Add `src/heart/assets/animation.py` implementing an `Animation` class that accepts a `Spritesheet` instance and advances frames.
- Update `src/heart/assets/loader.py` to import and use `Spritesheet` and `Animation`, adjust cache typing, and keep existing caching behavior via `Loader.load_spirtesheet` and `Loader.load_animation`.
- Update `src/heart/renderers/spritesheet_random/state.py` to reference the new `Spritesheet` type for stronger typing.

### Testing
- Ran `make format` and formatting checks completed successfully (`All checks passed!`).
- Ran the test suite with `make test` and the automated tests completed with `241 passed, 1 skipped`.
- No additional failing automated tests were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea39ef3ac8321b9b7ccbd90e9a095)