### PR TITLE
Normalize Rust renderer env paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - Prefer `pathlib.Path.read_text`/`write_text` helpers for straightforward text file I/O.
 - When reading or writing text files, specify an explicit encoding (prefer `utf-8`) to keep behavior consistent across platforms.
 - Use module-level constants for public constructor or function default values so shared configuration is easy to discover and adjust.
+- When parsing PATH-like environment variables, strip whitespace from each entry and ignore empty values before converting to `Path` objects.
 
 ## Dependency Injection (Lagom)
 

--- a/src/heart/renderers/rust.py
+++ b/src/heart/renderers/rust.py
@@ -58,7 +58,8 @@ def _resolve_search_paths(search_paths: Sequence[Path] | None) -> list[Path]:
 def _parse_env_paths(raw_paths: str) -> list[Path]:
     if not raw_paths:
         return []
-    return [Path(entry) for entry in raw_paths.split(os.pathsep) if entry]
+    entries = (entry.strip() for entry in raw_paths.split(os.pathsep))
+    return [Path(entry) for entry in entries if entry]
 
 
 def _load_spec(module_name: str, spec: importlib.machinery.ModuleSpec) -> ModuleType:


### PR DESCRIPTION
### Motivation
- PATH-like environment variables such as `HEART_RUST_RENDERERS_PATH` can contain whitespace or empty entries that lead to spurious or invalid `Path` objects when parsed.
- Repository documentation should explicitly recommend robust parsing for PATH-like values so code and contributors follow the same expectation.

### Description
- Add a new guidance rule to `AGENTS.md` to strip whitespace and ignore empty entries when parsing PATH-like environment variables. 
- Update the `_parse_env_paths` helper in `src/heart/renderers/rust.py` to strip each entry (`entry.strip()`) and filter out empty entries before converting to `Path` objects. 

### Testing
- Ran `make format` and the formatting checks completed successfully. 
- Ran `make test` and the test suite completed with `241 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea3dadacc8321996a25796dad647d)