### PR TITLE
Refactor PhoneText peripheral structure

### DIFF
--- a/src/heart/peripheral/phone_text.py
+++ b/src/heart/peripheral/phone_text.py
@@ -26,6 +26,7 @@ bz_peripheral = cast(
 # working without any change.
 _SERVICE_UUID = "1235"
 _CHARACTERISTIC_UUID = "5679"
+_LOCAL_NAME = "PhoneText"
 
 
 class PhoneText(Peripheral[str]):
@@ -42,41 +43,16 @@ class PhoneText(Peripheral[str]):
     # Peripheral API
     # ---------------------------------------------------------------------
     def run(self) -> None:  # noqa: D401 – keeping signature of base class
-        if bz_peripheral is None or adapter is None:
-            logger.warning(
-                "bluezero must be installed to run PhoneText as a BLE peripheral."
-            )
+        modules = self._get_bluezero_modules()
+        if modules is None:
             return
+        bluezero_adapter, bluezero_peripheral = modules
 
-        assert adapter is not None
-        assert bz_peripheral is not None
+        hci_addr = self._select_adapter_address(bluezero_adapter)
+        pi_ble = bluezero_peripheral.Peripheral(hci_addr, local_name=_LOCAL_NAME)
+        self._configure_services(pi_ble)
+        self._log_startup(hci_addr)
 
-        # Pick the first Bluetooth adapter available on the host.
-        hci_addr = list(adapter.Adapter.available())[0].address
-
-        # Create and configure the Bluezero peripheral object.
-        pi_ble = bz_peripheral.Peripheral(hci_addr, local_name="PhoneText")
-        pi_ble.add_service(1, _SERVICE_UUID, True)
-
-        # Print clear information about what we're using
-        logger.info("Starting PhoneText peripheral.")
-        logger.info("Service UUID: %s", _SERVICE_UUID)
-        logger.info("Characteristic UUID: %s", _CHARACTERISTIC_UUID)
-        logger.info("Adapter: %s", hci_addr)
-
-        # Characteristic that the iOS application writes its data chunks into.
-        pi_ble.add_characteristic(
-            1,  # srv_id
-            1,  # chr_id
-            _CHARACTERISTIC_UUID,
-            [],  # initial value (empty)
-            False,  # notifying
-            ["write", "write-without-response", "encrypt-write"],
-            write_callback=self._on_write,
-        )
-
-        # Start advertising – this call blocks because Bluezero enters GLib's
-        # main loop internally.
         logger.info("PhoneText peripheral advertising. (Ctrl-C to quit)")
         pi_ble.publish()
 
@@ -105,27 +81,63 @@ class PhoneText(Peripheral[str]):
         """Bluezero callback executed whenever a central writes new data."""
 
         logger.debug("Received value: %r", value)
-        # Accumulate the incoming chunk and process as text only
         self._buffer.extend(value)
+        text_bytes = self._extract_complete_message()
+        if text_bytes is None:
+            return
 
-        # Check if the buffer contains a null terminator which indicates end of message
-        if b"\0" in self._buffer:
-            # Split at the null terminator and take everything before it
-            text_bytes = self._buffer[: self._buffer.index(b"\0")]
-            try:
-                # Convert buffer to string
-                text = text_bytes.decode("utf-8")
-                # Save the received text
-                self._last_text = text
-                self.new_text = True
-                logger.info("Processed text: %r", text)
-            except UnicodeDecodeError as e:
-                logger.warning("Error decoding text: %s", e)
-                logger.debug("Raw bytes: %r", text_bytes)
+        self._handle_message_bytes(text_bytes)
 
-            # Clear the buffer for the next message
-            self._buffer.clear()
+    def _get_bluezero_modules(self) -> tuple[ModuleType, ModuleType] | None:
+        if adapter is None or bz_peripheral is None:
+            logger.warning(
+                "bluezero must be installed to run PhoneText as a BLE peripheral."
+            )
+            return None
+        return adapter, bz_peripheral
 
+    @staticmethod
+    def _select_adapter_address(bluezero_adapter: ModuleType) -> str:
+        return list(bluezero_adapter.Adapter.available())[0].address
+
+    def _configure_services(self, pi_ble: Any) -> None:
+        pi_ble.add_service(1, _SERVICE_UUID, True)
+        pi_ble.add_characteristic(
+            1,  # srv_id
+            1,  # chr_id
+            _CHARACTERISTIC_UUID,
+            [],  # initial value (empty)
+            False,  # notifying
+            ["write", "write-without-response", "encrypt-write"],
+            write_callback=self._on_write,
+        )
+
+    @staticmethod
+    def _log_startup(hci_addr: str) -> None:
+        logger.info("Starting PhoneText peripheral.")
+        logger.info("Service UUID: %s", _SERVICE_UUID)
+        logger.info("Characteristic UUID: %s", _CHARACTERISTIC_UUID)
+        logger.info("Adapter: %s", hci_addr)
+
+    def _extract_complete_message(self) -> bytes | None:
+        terminator_index = self._buffer.find(b"\0")
+        if terminator_index == -1:
+            return None
+        text_bytes = bytes(self._buffer[:terminator_index])
+        self._buffer.clear()
+        return text_bytes
+
+    def _handle_message_bytes(self, text_bytes: bytes) -> None:
+        try:
+            text = text_bytes.decode("utf-8")
+        except UnicodeDecodeError as error:
+            logger.warning("Error decoding text: %s", error)
+            logger.debug("Raw bytes: %r", text_bytes)
+            return
+
+        self._last_text = text
+        self.new_text = True
+        logger.info("Processed text: %r", text)
 
     @classmethod
     def detect(cls) -> Iterator[Self]:


### PR DESCRIPTION
### Motivation
- Improve clarity and maintainability of the BLE `PhoneText` peripheral by reorganizing setup and message handling into focused helpers.
- Reduce complexity in the `run` and `_on_write` paths so responsibilities like adapter selection, service configuration and message parsing are isolated.
- Make message assembly and decoding more explicit and easier to test by extracting buffer handling logic.

### Description
- Add a module-level constant `_LOCAL_NAME` and replace the inline local name string with this constant.
- Split BLE setup and checks into helper methods: `_get_bluezero_modules`, `_select_adapter_address`, `_configure_services`, and `_log_startup`.
- Move message assembly and decoding into `_extract_complete_message` and `_handle_message_bytes`, and simplify `_on_write` to delegate to these helpers.
- Preserve the public `PhoneText` API (`run`, `detect`, `get_last_text`, `pop_text`) while improving internal structure.

### Testing
- Ran `make format` and the repository formatting checks passed.
- Ran `make test` and the test suite completed successfully with `243 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea4872d288321a0996ac049f0df2b)