### PR TITLE
Refactor Lagom GameLoop provider

### DIFF
--- a/docs/research/lagom_runtime_container_integration.md
+++ b/docs/research/lagom_runtime_container_integration.md
@@ -21,3 +21,4 @@ Runtime services were wired manually in `GameLoop`, and provider registrations r
 ## Integration Notes
 
 The container builder registers `Device`, `RendererVariant`, and runtime singletons so they can be resolved wherever needed. `GameLoopComponents` is registered as a container singleton, so `GameLoop` resolves a single bundle of runtime services through Lagom instead of manually wiring each service. Provider registration is centralized in a registry that can apply to any runtime container, allowing late imports (such as renderer modules) to update active containers without a global `Container` instance. This keeps Lagom integration consistent across runtime components while still allowing tests to override dependencies in a single place.
+`GameLoop` itself is now constructed through the named `_build_game_loop` provider so container wiring remains traceable in logs and stack traces.

--- a/src/heart/runtime/container.py
+++ b/src/heart/runtime/container.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Mapping
+from typing import TYPE_CHECKING, Any, Mapping
 
 from lagom import Container, Singleton
 
@@ -23,6 +23,9 @@ from heart.utilities.logging import get_logger
 RuntimeContainer = Container
 
 logger = get_logger(__name__)
+
+if TYPE_CHECKING:
+    from heart.runtime.game_loop import GameLoop
 
 
 def _build_peripheral_configuration_loader(
@@ -81,6 +84,16 @@ def _build_game_loop_components(
         event_handler=resolver[PygameEventHandler],
         peripheral_manager=resolver[PeripheralManager],
         peripheral_runtime=resolver[PeripheralRuntime],
+    )
+
+
+def _build_game_loop(resolver: RuntimeContainer) -> GameLoop:
+    from heart.runtime.game_loop import GameLoop
+
+    return GameLoop(
+        device=resolver[Device],
+        resolver=resolver,
+        render_variant=resolver[RendererVariant],
     )
 
 
@@ -234,11 +247,5 @@ def _configure_game_loop_bindings(
         container,
         overrides,
         GameLoop,
-        Singleton(
-            lambda resolver: GameLoop(
-                device=resolver[Device],
-                resolver=resolver,
-                render_variant=resolver[RendererVariant],
-            )
-        ),
+        Singleton(_build_game_loop),
     )


### PR DESCRIPTION
### Motivation

- Make Lagom container wiring for the runtime more traceable by replacing an inline lambda provider with a named factory.
- Align provider registration with repository DI guidelines that prefer named module-level provider callables for discoverability.
- Reduce anonymous construction logic so `GameLoop` resolution appears clearly in stack traces and logs.

### Description

- Introduce a named provider function ` _build_game_loop` in `src/heart/runtime/container.py` that constructs `GameLoop` from the container. 
- Replace the previous inline `Singleton(lambda resolver: ...)` registration with `Singleton(_build_game_loop)` for `GameLoop` bindings. 
- Add a `TYPE_CHECKING` import for `GameLoop` to satisfy type checking without importing at module import time. 
- Update `docs/research/lagom_runtime_container_integration.md` to note that `GameLoop` is now constructed via the named provider.

### Testing

- Ran `make format` and the formatter check passed. 
- Ran `make test` and the full test suite completed successfully with `243 passed, 1 skipped`.
- Verified the repository lints/formatters and tests after the change (no failures observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea4fb4b388321a00ac011d839ca36)