### PR TITLE
Optimize mandelbrot rendering with interior checks and caching

### DIFF
--- a/docs/research/mandelbrot_interior_checks.md
+++ b/docs/research/mandelbrot_interior_checks.md
@@ -1,0 +1,37 @@
+______________________________________________________________________
+
+## title: Mandelbrot interior checks for faster convergence
+
+## Problem statement
+
+Rendering the Mandelbrot view in `src/heart/renderers/mandelbrot/scene.py` spends most
+of its time iterating points that are mathematically guaranteed to be inside the set.
+Skipping those points reduces total iteration work without changing the visible output
+for interior regions.
+
+## Observations
+
+The main cardioid and the period-2 bulb are common interior regions that can be tested
+analytically before running the escape-time loop. As a reference, Wikipedia describes
+the cardioid test as: “A point c is in the main cardioid if it satisfies q(q + (x − 1/4))
+≤ 1/4 y², where q = (x − 1/4)² + y².” It also notes: “The period-2 bulb has the equation
+(x + 1)² + y² ≤ 1/16.” (Source: <https://en.wikipedia.org/wiki/Mandelbrot_set>).
+
+These checks are directly applicable to `get_mandelbrot_converge_time` and can be
+gated behind a configuration flag so the renderer can fall back to the original
+algorithm if needed.
+
+## Implementation notes
+
+- Added `MandelbrotInteriorStrategy` and `MandelbrotConfiguration` to make the check
+  selectable via `HEART_MANDELBROT_INTERIOR_STRATEGY` (`none` or `cardioid`).
+- Implemented `_is_in_mandelbrot_interior` in
+  `src/heart/renderers/mandelbrot/scene.py` and used it inside the numba kernel when
+  the strategy is enabled.
+- Cached Julia render results and palette arrays in the same module to avoid redundant
+  allocations on frames with unchanged parameters.
+
+## Materials
+
+- Wikipedia: Mandelbrot set interior tests.
+  <https://en.wikipedia.org/wiki/Mandelbrot_set>

--- a/src/heart/utilities/env/config.py
+++ b/src/heart/utilities/env/config.py
@@ -1,6 +1,7 @@
 from heart.utilities.env.assets import AssetsConfiguration
 from heart.utilities.env.color import ColorConfiguration
 from heart.utilities.env.device_layout import DeviceLayoutConfiguration
+from heart.utilities.env.mandelbrot import MandelbrotConfiguration
 from heart.utilities.env.peripheral import PeripheralConfiguration
 from heart.utilities.env.reactivex import ReactivexConfiguration
 from heart.utilities.env.rendering import RenderingConfiguration
@@ -15,5 +16,6 @@ class Configuration(
     RenderingConfiguration,
     ColorConfiguration,
     AssetsConfiguration,
+    MandelbrotConfiguration,
 ):
     """Aggregate environment configuration helpers."""

--- a/src/heart/utilities/env/enums.py
+++ b/src/heart/utilities/env/enums.py
@@ -64,6 +64,11 @@ class LifeRuleStrategy(StrEnum):
     TABLE = "table"
 
 
+class MandelbrotInteriorStrategy(StrEnum):
+    NONE = "none"
+    CARDIOID = "cardioid"
+
+
 class DeviceLayoutMode(StrEnum):
     CUBE = "cube"
     RECTANGLE = "rectangle"

--- a/src/heart/utilities/env/mandelbrot.py
+++ b/src/heart/utilities/env/mandelbrot.py
@@ -1,0 +1,20 @@
+import os
+
+from heart.utilities.env.enums import MandelbrotInteriorStrategy
+
+DEFAULT_MANDELBROT_INTERIOR_STRATEGY = MandelbrotInteriorStrategy.CARDIOID
+
+
+class MandelbrotConfiguration:
+    @classmethod
+    def mandelbrot_interior_strategy(cls) -> MandelbrotInteriorStrategy:
+        strategy = os.environ.get(
+            "HEART_MANDELBROT_INTERIOR_STRATEGY",
+            DEFAULT_MANDELBROT_INTERIOR_STRATEGY.value,
+        ).strip()
+        try:
+            return MandelbrotInteriorStrategy(strategy.lower())
+        except ValueError as exc:
+            raise ValueError(
+                "HEART_MANDELBROT_INTERIOR_STRATEGY must be 'none' or 'cardioid'"
+            ) from exc


### PR DESCRIPTION
### Motivation

- Reduce CPU work in the Mandelbrot renderer by skipping points that are provably inside the set (main cardioid / period-2 bulb) so escape-time loops spend less time on interior pixels. (Reference: Wikipedia — Mandelbrot set interior tests: `https://en.wikipedia.org/wiki/Mandelbrot_set`.)
- Make the interior-check behaviour selectable so the renderer can fall back to the original algorithm when desired.
- Avoid per-frame allocations for palettes and Julia convergence results to reduce GC pressure and improve steady-state performance.
- Keep heavy work inside jitted kernels where possible to maximize benefit from vectorization / numba.

### Description

- Added `MandelbrotInteriorStrategy` enum and a `MandelbrotConfiguration` with `HEART_MANDELBROT_INTERIOR_STRATEGY` to control the strategy (values: `none`, `cardioid`).
- Implemented `_is_in_mandelbrot_interior` and wired an interior-check fast path into the jitted `get_mandelbrot_converge_time` kernel so interior points can be skipped when the strategy is enabled.
- Introduced caching for Julia convergence results and precomputed palette arrays in `src/heart/renderers/mandelbrot/scene.py` to avoid repeated `np.array` and mesh allocations across frames when parameters are unchanged.
- Added a research note at `docs/research/mandelbrot_interior_checks.md` documenting the rationale and source for the analytic checks.

### Testing

- Ran `make format` which completed successfully (formatting/linting checks passed).
- Ran the test suite via `make test` (Pytest); observed `246 passed, 1 skipped` with no failures.
- Verified that formatting and tests report no regressions after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea5bf3c7083219abb3f614a0c4613)