### PR TITLE
Standardize driver serial output

### DIFF
--- a/drivers/AGENTS.md
+++ b/drivers/AGENTS.md
@@ -8,6 +8,7 @@
 
 ## Debugging guidance
 - When adding diagnostic output, use `print` statements guarded behind a module-level `DEBUG` flag rather than logging frameworks that CircuitPython does not ship with by default.
+- When emitting serial payloads, route writes through a dedicated helper function so serial output behavior stays consistent and testable.
 - Keep exception handling minimal; allow errors to propagate so they can be inspected over the serial REPL. Only catch exceptions when you can recover or to add chip-specific hints.
 - Include docstrings that describe how to reproduce hardware issues via the REPL so that future debugging does not require the full game runtime.
 - Keep serial payload framing to a single trailing newline to avoid redundant whitespace on constrained links.

--- a/drivers/sensor_bus/code.py
+++ b/drivers/sensor_bus/code.py
@@ -29,6 +29,12 @@ def _debug(message: str) -> None:
     if DEBUG:
         print(message)
 
+
+def _write_serial_bus(message: str) -> None:
+    """Emit the event payload over the serial bus."""
+
+    print(message, end="")
+
 IDENTITY = identity.Identity(
     device_name=DEVICE_NAME,
     firmware_commit=identity.default_firmware_commit(),
@@ -195,7 +201,7 @@ def main() -> None:
                 sensors = connect_to_sensors(i2c=i2c)
 
             for sensor_data_payload in sr.read():
-                print(sensor_data_payload, end="")
+                _write_serial_bus(sensor_data_payload)
 
             # This also has a `temperature` field but I'm not sure if that's chip temperature or ambient
             time.sleep(wait_between_payloads_seconds)


### PR DESCRIPTION
### Motivation
- Drivers currently write serial payloads directly with `print`, which makes behavior harder to test and standardize across drivers. 
- Add a higher-level guideline to the drivers agent to encourage consistent serial I/O handling. 

### Description
- Add a new debugging guidance rule in `drivers/AGENTS.md` advising that serial payloads be routed through a dedicated helper. 
- Implement `_write_serial_bus` in `drivers/sensor_bus/code.py` and replace the direct `print(..., end="")` call with `_write_serial_bus(...)`. 

### Testing
- Ran `make format` and the repository formatting checks completed successfully. 
- Ran `make test` and the test suite completed with `246 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea5c7abc48321adb84036df3acecd)