### PR TITLE
Refactor driver update modules for clarity

### DIFF
--- a/src/heart/manage/driver_update/filesystem.py
+++ b/src/heart/manage/driver_update/filesystem.py
@@ -1,28 +1,12 @@
 """Filesystem helpers for driver updates."""
 
 import shutil
-import subprocess
 from pathlib import Path
 
-from heart import firmware_io
-from heart.manage.driver_update.downloads import download_file
 from heart.manage.driver_update.exceptions import UpdateError
 from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
-
-CIRCUIT_PY_COMMON_LIBS_UNZIPPED_NAME = (
-    "adafruit-circuitpython-bundle-9.x-mpy-20250412"
-)
-CIRCUIT_PY_COMMON_LIBS = (
-    "https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/download/"
-    f"20250412/{CIRCUIT_PY_COMMON_LIBS_UNZIPPED_NAME}.zip"
-)
-CIRCUIT_PY_COMMON_LIBS_CHECKSUM = (
-    "6d49c73c352da31d5292508ff9b3eca2803372c1d2acca7175b64be2ff2bc450"
-)
-DRIVER_SETTINGS_FILENAME = "settings.toml"
-DRIVER_FILES = ("boot.py", "code.py", DRIVER_SETTINGS_FILENAME)
 
 
 def copy_file(source: Path, destination: Path) -> None:
@@ -39,6 +23,8 @@ def copy_file(source: Path, destination: Path) -> None:
 
 
 def ensure_driver_files(driver_path: Path) -> None:
+    from heart.manage.driver_update.layout import DRIVER_FILES
+
     missing = [
         name for name in DRIVER_FILES if not (driver_path / name).exists()
     ]
@@ -46,42 +32,3 @@ def ensure_driver_files(driver_path: Path) -> None:
         message = f"Missing driver files in {driver_path}: {', '.join(missing)}"
         logger.error(message)
         raise UpdateError(message)
-
-
-def load_driver_libs(libs: list[str], destination: Path) -> None:
-    shutil.rmtree(destination, ignore_errors=True)
-    destination.mkdir(parents=True, exist_ok=True)
-    copy_file(
-        Path(firmware_io.__file__).parent,
-        destination.joinpath(*firmware_io.__package__.split(".")),
-    )
-
-    if not libs:
-        logger.info("Skipping loading driver libs as no libs were requested.")
-        return
-
-    logger.info("Loading the following libs: %s", libs)
-    zip_location = download_file(
-        CIRCUIT_PY_COMMON_LIBS, CIRCUIT_PY_COMMON_LIBS_CHECKSUM
-    )
-    unzipped_location = zip_location.with_suffix("")
-    lib_path = unzipped_location / "lib"
-
-    if not lib_path.exists():
-        subprocess.run(
-            ["unzip", str(zip_location)],
-            check=True,
-            cwd=str(unzipped_location.parent),
-        )
-    else:
-        logger.info(
-            "Skipping unzipping %s because %s exists", zip_location, lib_path
-        )
-
-    for lib in libs:
-        copy_file(lib_path / lib, destination / lib)
-        mpy_source = lib_path / f"{lib}.mpy"
-        if mpy_source.exists():
-            copy_file(mpy_source, destination / f"{lib}.mpy")
-        else:
-            logger.warning("Skipping missing %s", mpy_source)

--- a/src/heart/manage/driver_update/layout.py
+++ b/src/heart/manage/driver_update/layout.py
@@ -1,0 +1,4 @@
+"""Driver file layout constants."""
+
+DRIVER_SETTINGS_FILENAME = "settings.toml"
+DRIVER_FILES = ("boot.py", "code.py", DRIVER_SETTINGS_FILENAME)

--- a/src/heart/manage/driver_update/libraries.py
+++ b/src/heart/manage/driver_update/libraries.py
@@ -1,0 +1,62 @@
+"""Library bundle handling for driver updates."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from heart import firmware_io
+from heart.manage.driver_update.downloads import download_file
+from heart.manage.driver_update.filesystem import copy_file
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+CIRCUIT_PY_COMMON_LIBS_UNZIPPED_NAME = (
+    "adafruit-circuitpython-bundle-9.x-mpy-20250412"
+)
+CIRCUIT_PY_COMMON_LIBS = (
+    "https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/download/"
+    f"20250412/{CIRCUIT_PY_COMMON_LIBS_UNZIPPED_NAME}.zip"
+)
+CIRCUIT_PY_COMMON_LIBS_CHECKSUM = (
+    "6d49c73c352da31d5292508ff9b3eca2803372c1d2acca7175b64be2ff2bc450"
+)
+
+
+def load_driver_libs(libs: list[str], destination: Path) -> None:
+    shutil.rmtree(destination, ignore_errors=True)
+    destination.mkdir(parents=True, exist_ok=True)
+    copy_file(
+        Path(firmware_io.__file__).parent,
+        destination.joinpath(*firmware_io.__package__.split(".")),
+    )
+
+    if not libs:
+        logger.info("Skipping loading driver libs as no libs were requested.")
+        return
+
+    logger.info("Loading the following libs: %s", libs)
+    zip_location = download_file(
+        CIRCUIT_PY_COMMON_LIBS, CIRCUIT_PY_COMMON_LIBS_CHECKSUM
+    )
+    unzipped_location = zip_location.with_suffix("")
+    lib_path = unzipped_location / "lib"
+
+    if not lib_path.exists():
+        subprocess.run(
+            ["unzip", str(zip_location)],
+            check=True,
+            cwd=str(unzipped_location.parent),
+        )
+    else:
+        logger.info(
+            "Skipping unzipping %s because %s exists", zip_location, lib_path
+        )
+
+    for lib in libs:
+        copy_file(lib_path / lib, destination / lib)
+        mpy_source = lib_path / f"{lib}.mpy"
+        if mpy_source.exists():
+            copy_file(mpy_source, destination / f"{lib}.mpy")
+        else:
+            logger.warning("Skipping missing %s", mpy_source)

--- a/src/heart/manage/driver_update/mounts.py
+++ b/src/heart/manage/driver_update/mounts.py
@@ -6,8 +6,9 @@ from pathlib import Path
 from heart.manage.driver_update.configuration import DriverConfig
 from heart.manage.driver_update.downloads import download_file
 from heart.manage.driver_update.exceptions import UpdateError
-from heart.manage.driver_update.filesystem import (DRIVER_FILES, copy_file,
-                                                   load_driver_libs)
+from heart.manage.driver_update.filesystem import copy_file
+from heart.manage.driver_update.layout import DRIVER_FILES
+from heart.manage.driver_update.libraries import load_driver_libs
 from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)

--- a/src/heart/manage/update.py
+++ b/src/heart/manage/update.py
@@ -2,8 +2,8 @@ import sys
 
 from heart.manage.driver_update.configuration import load_driver_config
 from heart.manage.driver_update.exceptions import UpdateError
-from heart.manage.driver_update.filesystem import (DRIVER_SETTINGS_FILENAME,
-                                                   ensure_driver_files)
+from heart.manage.driver_update.filesystem import ensure_driver_files
+from heart.manage.driver_update.layout import DRIVER_SETTINGS_FILENAME
 from heart.manage.driver_update.mounts import (circuitpy_mounts,
                                                install_uf2_if_available,
                                                mount_points,


### PR DESCRIPTION
### Motivation
- Separate responsibilities in the driver update feature so file layout, filesystem helpers, and library bundle handling are easier to understand and maintain.
- Reduce module size and implicit coupling by extracting constants and heavy I/O logic into focused modules.
- Make the driver update codepath easier to reuse and test by moving layout and library handling out of the generic filesystem helpers.

### Description
- Extracted driver layout constants `DRIVER_SETTINGS_FILENAME` and `DRIVER_FILES` into a new `heart.manage.driver_update.layout` module.
- Moved library bundle download/unzip/copy logic and related constants into a new `heart.manage.driver_update.libraries` module and implemented `load_driver_libs` there.
- Removed library-specific constants and `load_driver_libs` from `filesystem.py`, and updated `ensure_driver_files` to import layout constants at runtime.
- Updated imports in `mounts.py` and `update.py` to use the new `layout` and `libraries` modules and kept `filesystem.copy_file` for copying operations.

### Testing
- Ran `make format` and the repository formatting check completed successfully.
- Ran `make test`; the test suite mostly passed but one test failed: `tests/utilities/test_reactivex_streams.py::TestShareStreamFlowControl::test_share_stream_coalesces_latest_when_configured` (expected `[2, 3]` but received `[2]`).
- All other automated tests completed as part of the `make test` run (245 passed, 1 skipped, 1 failed).
- No additional manual testing was performed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea5d4f4b483218f5f05e1080b37ba)