### PR TITLE
Fix PhoneText adapter address typing

### DIFF
--- a/src/heart/peripheral/phone_text.py
+++ b/src/heart/peripheral/phone_text.py
@@ -98,7 +98,8 @@ class PhoneText(Peripheral[str]):
 
     @staticmethod
     def _select_adapter_address(bluezero_adapter: ModuleType) -> str:
-        return list(bluezero_adapter.Adapter.available())[0].address
+        address = list(bluezero_adapter.Adapter.available())[0].address
+        return cast(str, address)
 
     def _configure_services(self, pi_ble: Any) -> None:
         pi_ble.add_service(1, _SERVICE_UUID, True)


### PR DESCRIPTION
### Motivation
- Mypy reported `Returning Any from function declared to return "str"` in `PhoneText._select_adapter_address` because the Bluezero adapter address had an untyped value.
- Ensure the public API of `PhoneText` returns the expected `str` type to satisfy static type checking and avoid surprise runtime types.

### Description
- Cast the Bluezero adapter address to `str` in `PhoneText._select_adapter_address` by assigning the value to `address` and returning `cast(str, address)`.
- No behavioral changes to runtime logic or BLE interactions are introduced; this is a typing-only fix.
- Kept changes minimal and localized to `src/heart/peripheral/phone_text.py`.

### Testing
- Ran `make format` and formatting checks completed successfully.
- Ran the test suite with `make test` and observed `246 passed, 1 skipped`.
- No new tests were added for this typing change and existing tests all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea9111bb88321bd8a24e5d8de02de)