### PR TITLE
Improve mandelbrot cube render performance

### DIFF
--- a/docs/research/mandelbrot_cube_performance.md
+++ b/docs/research/mandelbrot_cube_performance.md
@@ -1,0 +1,17 @@
+# Mandelbrot Cube Rendering Performance Notes
+
+## Problem statement
+
+The Mandelbrot cube renderer in `src/heart/renderers/mandelbrot/cube_renderer.py` was allocating multiple large arrays every frame (azimuths, real/imag coordinates, palette lookups, and a transposed color buffer). Those allocations added CPU overhead and created extra GC pressure while the scene was animating.
+
+## Approach
+
+- Preallocate per-frame buffers (azimuths, real coordinates, color buffer) inside the renderer state to reuse them across frames.
+- Precompute the static imaginary coordinates for the cube faces so they are not recomputed every frame.
+- Use NumPy in-place math (`np.add`, `np.multiply`, `np.remainder`, `np.clip`) and `np.take(..., out=...)` to avoid intermediate arrays during rotation, coordinate conversion, and palette lookup.
+- Keep a swapped-axis view of the color buffer so `pygame.surfarray.blit_array` can consume it without creating a new transposed array each frame.
+
+## Materials
+
+- `src/heart/renderers/mandelbrot/cube_renderer.py`
+- `src/heart/renderers/mandelbrot/scene.py`


### PR DESCRIPTION
### Motivation

- Reduce per-frame memory allocations and GC pressure in the cube-mapped Mandelbrot renderer to improve frame smoothness and CPU usage.
- Avoid repeated coordinate and color-array reallocations by reusing buffers and precomputing static data.
- Use in-place NumPy arithmetic to eliminate intermediate arrays during the per-frame rotation and coordinate conversion.

### Description

- Add numeric constants (`TWO_PI`, `REAL_SCALE`, `IMAG_SCALE`) and extend `CubeMandelbrotState` with reusable buffers: `azimuths`, `real_coords`, `imag_coords`, `color_buffer`, and `surface_view` in `src/heart/renderers/mandelbrot/cube_renderer.py`.
- Precompute the static imaginary coordinate grid and allocate a single color buffer whose transposed view (`surface_view`) is passed to `pygame.surfarray.blit_array` to avoid per-frame `transpose` allocations.
- Replace ephemeral array math with in-place NumPy operations (`np.add`, `np.remainder`, `np.multiply`, `np.clip`) and use `np.take(..., out=...)` for palette lookups to minimize temporaries.
- Add a research note `docs/research/mandelbrot_cube_performance.md` documenting the approach and rationale.

### Testing

- Ran code formatting with `make format`, which passed.
- Ran the test suite with `make test`, which executed all tests; 245+ tests passed but one unrelated test failed: `TestShareStreamFlowControl.test_share_stream_coalesces_latest_when_configured`.
- Verified the renderer module imports and local execution flow during warm-up compilation paths exercised in existing renderer tests.
- Modified files: `src/heart/renderers/mandelbrot/cube_renderer.py` and `docs/research/mandelbrot_cube_performance.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eac02cd4c832193fcb1347cc41e74)