### PR TITLE
Add RenderSurfaceCollector and integrate into RenderPipeline

### DIFF
--- a/src/heart/runtime/rendering/surface_collection.py
+++ b/src/heart/runtime/rendering/surface_collection.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING, Any, Callable, Sequence
+
+import pygame
+
+if TYPE_CHECKING:
+    from heart.renderers import StatefulBaseRenderer
+
+RenderSurfaceCallback = Callable[["StatefulBaseRenderer[Any]"], pygame.Surface | None]
+
+
+class RenderSurfaceCollector:
+    def __init__(
+        self,
+        process_renderer: RenderSurfaceCallback,
+        executor_factory: Callable[[], ThreadPoolExecutor],
+    ) -> None:
+        self._process_renderer = process_renderer
+        self._executor_factory = executor_factory
+
+    def collect(
+        self,
+        renderers: Sequence["StatefulBaseRenderer[Any]"],
+        *,
+        parallel: bool,
+    ) -> list[pygame.Surface]:
+        if parallel:
+            return self._collect_parallel(renderers)
+        return self._collect_serial(renderers)
+
+    def _collect_serial(
+        self,
+        renderers: Sequence["StatefulBaseRenderer[Any]"],
+    ) -> list[pygame.Surface]:
+        if not renderers:
+            return []
+        surfaces: list[pygame.Surface] = []
+        for renderer in renderers:
+            surface = self._process_renderer(renderer)
+            if surface is not None:
+                surfaces.append(surface)
+        return surfaces
+
+    def _collect_parallel(
+        self,
+        renderers: Sequence["StatefulBaseRenderer[Any]"],
+    ) -> list[pygame.Surface]:
+        if not renderers:
+            return []
+        executor = self._executor_factory()
+        return [
+            surface
+            for surface in executor.map(self._process_renderer, renderers)
+            if surface is not None
+        ]


### PR DESCRIPTION
### Motivation
- Centralize serial and parallel renderer surface gathering to make the render pipeline flow clearer.
- Reduce duplication of surface-collection logic and provide a single place to manage executor usage.
- Preserve existing renderer override/monkeypatch behaviour used by tests to ensure testability.

### Description
- Add `src/heart/runtime/rendering/surface_collection.py` which implements `RenderSurfaceCollector` and a `collect` API for serial or parallel collection.
- Wire `RenderPipeline` to use `RenderSurfaceCollector.collect` instead of inline `_collect_surfaces_serial`/`_collect_surfaces_parallel` logic.
- Add a small delegate method ` _process_renderer_delegate` and pass it to the collector so `process_renderer` overrides (e.g., in tests) continue to work.
- Keep existing composition and merge behaviour by continuing to use `SurfaceCompositionManager` and `merge_surfaces` as before.

### Testing
- Ran code formatting with `make format` and it completed successfully.
- Ran the full test suite with `make test` (Pytest) and the suite passed with `246 passed, 1 skipped`.
- The render-pipeline related tests (including binary/iterative collection scenarios) were validated as part of the full test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eac6c73e0832199aa652a71d70f47)