### PR TITLE
Extract RenderPlanSelector and delegate render plan selection

### DIFF
--- a/src/heart/runtime/render_plan_selector.py
+++ b/src/heart/runtime/render_plan_selector.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
+
+from heart.runtime.render_plan_cache import RenderPlanCache
+from heart.runtime.render_planner import RenderPlan, RenderPlanner
+from heart.runtime.rendering.variants import RendererVariant, RenderMethod
+from heart.utilities.env import Configuration
+
+if TYPE_CHECKING:
+    from heart.renderers import StatefulBaseRenderer
+
+
+class RenderPlanSelector:
+    def __init__(
+        self,
+        planner: RenderPlanner,
+        render_dispatch: dict[RendererVariant, RenderMethod],
+    ) -> None:
+        self._planner = planner
+        self._render_dispatch = render_dispatch
+        self._active_plan: RenderPlan | None = None
+        self._plan_cache = RenderPlanCache(
+            planner,
+            Configuration.render_plan_refresh_ms(),
+            Configuration.render_plan_signature_strategy(),
+        )
+
+    def get_plan(
+        self,
+        renderers: list["StatefulBaseRenderer[Any]"],
+        render_variant: RendererVariant,
+        override_renderer_variant: RendererVariant | None = None,
+    ) -> RenderPlan:
+        return self._plan_cache.get_plan(
+            renderers,
+            render_variant,
+            override_renderer_variant,
+        )
+
+    def get_active_plan(
+        self,
+        renderers: list["StatefulBaseRenderer[Any]"],
+        render_variant: RendererVariant,
+        override_renderer_variant: RendererVariant | None = None,
+    ) -> RenderPlan:
+        if self._active_plan is not None:
+            return self._active_plan
+        return self.get_plan(renderers, render_variant, override_renderer_variant)
+
+    def resolve_render_method(self, plan: RenderPlan) -> RenderMethod:
+        return self._render_dispatch.get(
+            plan.variant,
+            self._render_dispatch[RendererVariant.ITERATIVE],
+        )
+
+    @contextmanager
+    def activate_plan(self, plan: RenderPlan) -> Generator[None, None, None]:
+        self._active_plan = plan
+        try:
+            yield
+        finally:
+            self._active_plan = None


### PR DESCRIPTION
### Motivation

- Separate render plan caching and method dispatch from the main `RenderPipeline` to improve clarity and reduce surface area of the pipeline class.
- Encapsulate the `RenderPlanCache` usage and active-plan handling in a focused helper so future changes to planning strategies are easier to reason about.
- Make the render pipeline responsible only for orchestration (collecting surfaces and composing) and delegate plan lookup/resolution to a single responsibility component.

### Description

- Add `src/heart/runtime/render_plan_selector.py` which implements `RenderPlanSelector` and contains the `RenderPlanCache` and active-plan context manager via `activate_plan`.
- Update `RenderPipeline` to construct and use `RenderPlanSelector` for plan lookup and render-method resolution, and remove its previous plan cache/active-plan state.
- Modify `_get_plan`, `_get_active_plan`, `_resolve_render_method`, and `render_with_plan` in `src/heart/runtime/render_pipeline.py` to call into `RenderPlanSelector` and use its `activate_plan` context manager.
- Adjust imports and type signatures where necessary so the new selector receives the configured `renderer_variant` and the existing runtime behavior is preserved.

### Testing

- Ran `make format` successfully to apply code formatting.
- Ran `make test` and the full test suite completed with `248 passed, 1 skipped`.
- No new unit tests were added; existing tests validate the refactor did not change runtime behavior.
- All checks and formatting/linting passed prior to commit."}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eadba7b60832185473e5d6f024031)