### PR TITLE
Register RenderLoopPacer in runtime container and resolve it from GameLoop

### DIFF
--- a/docs/code_flow.md
+++ b/docs/code_flow.md
@@ -40,6 +40,7 @@ flowchart LR
     subgraph Runtime["GameLoop Orchestration"]
         direction TB
         Loop["GameLoop Service\n(heart.runtime.game_loop.GameLoop)"]
+        RenderPacer["Render Loop Pacer\n(heart.runtime.render_pacing.RenderLoopPacer)"]
         AppRouter["AppController / Mode Router"]
         ModeServices["Mode Services & Renderers"]
         RenderPipeline["Render Pipeline"]
@@ -71,6 +72,7 @@ flowchart LR
     end
 
     CLI --> Registry --> ContainerBuilder --> RuntimeContainer --> Loop
+    RuntimeContainer --> RenderPacer --> Loop
     Loop --> Configurer --> AppRouter
     Loop --> AppRouter
     RuntimeContainer --> AppRouter
@@ -91,7 +93,7 @@ flowchart LR
     RxScheduler --> PhoneText --> AppRouter
 
     class CLI,Registry,Configurer,ContainerBuilder,RuntimeContainer,ModeServices,RenderPipeline,RendererProcessor,SurfaceProvider,CompositionManager service;
-    class Loop,AppRouter orchestrator;
+    class Loop,AppRouter,RenderPacer orchestrator;
     class PeripheralMgr,RxScheduler,Switch,Gamepad,Sensors,HeartRate,PhoneText input;
     class DisplaySvc,LocalScreen,Capture,DeviceBridge,LedMatrix,AverageMirror,SingleLED output;
 ```

--- a/docs/research/lagom_render_loop_pacer_integration.md
+++ b/docs/research/lagom_render_loop_pacer_integration.md
@@ -1,0 +1,26 @@
+# Lagom Render Loop Pacer Integration Note
+
+## Problem Statement
+
+The render loop pacing configuration was constructed directly inside
+`heart.runtime.game_loop.GameLoop`, which bypassed the runtime container and left pacing
+behaviour outside the Lagom wiring path. That made it harder to override pacing defaults
+for tests or alternative runtime setups, and it fractured the dependency injection story
+for the runtime loop.
+
+## Materials
+
+- Python 3.11 environment with `uv` for dependency resolution.
+- Lagom dependency (`lagom` in `pyproject.toml`).
+- Source modules: `src/heart/runtime/container.py`,
+  `src/heart/runtime/game_loop.py`,
+  `src/heart/runtime/render_pacing.py`.
+
+## Notes
+
+The runtime container now registers a singleton provider for
+`heart.runtime.render_pacing.RenderLoopPacer` using configuration values from
+`heart.utilities.env.Configuration`. `GameLoop` resolves the pacer from the shared
+container instead of building it inline, keeping pacing behaviour consistent with the
+rest of the runtime dependencies and allowing container overrides to customize the loop
+for tests or alternative runtime entry points.

--- a/src/heart/runtime/container.py
+++ b/src/heart/runtime/container.py
@@ -17,7 +17,9 @@ from heart.runtime.frame_presenter import FramePresenter
 from heart.runtime.game_loop_components import GameLoopComponents
 from heart.runtime.peripheral_runtime import PeripheralRuntime
 from heart.runtime.pygame_event_handler import PygameEventHandler
+from heart.runtime.render_pacing import RenderLoopPacer
 from heart.runtime.render_pipeline import RendererVariant, RenderPipeline
+from heart.utilities.env import Configuration
 from heart.utilities.logging import get_logger
 
 RuntimeContainer = Container
@@ -71,6 +73,14 @@ def _build_peripheral_runtime(resolver: RuntimeContainer) -> PeripheralRuntime:
 
 def _build_app_controller(resolver: RuntimeContainer) -> AppController:
     return AppController(renderer_resolver=resolver)
+
+
+def _build_render_loop_pacer(_: RuntimeContainer) -> RenderLoopPacer:
+    return RenderLoopPacer(
+        strategy=Configuration.render_loop_pacing_strategy(),
+        min_interval_ms=Configuration.render_loop_pacing_min_interval_ms(),
+        utilization_target=Configuration.render_loop_pacing_utilization(),
+    )
 
 
 def _build_game_loop_components(
@@ -221,6 +231,12 @@ def _configure_runtime_bindings(
         overrides,
         AppController,
         Singleton(_build_app_controller),
+    )
+    _bind(
+        container,
+        overrides,
+        RenderLoopPacer,
+        Singleton(_build_render_loop_pacer),
     )
     _bind(
         container,

--- a/src/heart/runtime/game_loop.py
+++ b/src/heart/runtime/game_loop.py
@@ -14,7 +14,6 @@ from heart.runtime.game_loop_components import GameLoopComponents
 from heart.runtime.render_pacing import RenderLoopPacer
 from heart.runtime.render_pipeline import RendererVariant
 from heart.runtime.render_planner import RenderPlan
-from heart.utilities.env import Configuration
 from heart.utilities.logging import get_logger
 
 if TYPE_CHECKING:
@@ -54,11 +53,7 @@ class GameLoop:
         self.event_handler = components.event_handler
         self.peripheral_manager = components.peripheral_manager
         self.peripheral_runtime = components.peripheral_runtime
-        self._render_pacer = RenderLoopPacer(
-            strategy=Configuration.render_loop_pacing_strategy(),
-            min_interval_ms=Configuration.render_loop_pacing_min_interval_ms(),
-            utilization_target=Configuration.render_loop_pacing_utilization(),
-        )
+        self._render_pacer = self.context_container.resolve(RenderLoopPacer)
 
         # Lampe controller
         self.feedback_buffer: np.ndarray | None = None

--- a/tests/runtime/test_container.py
+++ b/tests/runtime/test_container.py
@@ -7,6 +7,7 @@ from heart.runtime.frame_exporter import FrameExporter
 from heart.runtime.frame_presenter import FramePresenter
 from heart.runtime.game_loop import GameLoop
 from heart.runtime.game_loop_components import GameLoopComponents
+from heart.runtime.render_pacing import RenderLoopPacer
 from heart.runtime.render_pipeline import RendererVariant, RenderPipeline
 
 
@@ -28,6 +29,7 @@ class TestRuntimeContainer:
         assert container.resolve(DisplayContext) is container.resolve(DisplayContext)
         assert render_pipeline is container.resolve(RenderPipeline)
         assert render_pipeline.renderer_variant is RendererVariant.BINARY
+        assert container.resolve(RenderLoopPacer) is container.resolve(RenderLoopPacer)
 
     def test_container_injects_configuration_registry(self, device) -> None:
         """Confirm the container shares a registry instance so configuration overrides stay consistent at runtime."""


### PR DESCRIPTION
### Motivation
- Centralize runtime pacing configuration in the shared Lagom container so pacing behaviour can be overridden and tested consistently.
- Remove ad-hoc construction of the render loop pacer inside `GameLoop` to keep dependency wiring uniform across the runtime.
- Keep Lagom usage confined to the container/provider layers so feature modules depend on `RuntimeContainer` instead of Lagom internals.

### Description
- Added `_build_render_loop_pacer` and registered a `RenderLoopPacer` singleton in `src/heart/runtime/container.py` using `Configuration` values.
- Changed `GameLoop` to resolve the pacer from the container (`self._render_pacer = self.context_container.resolve(RenderLoopPacer)`) instead of constructing it inline.
- Updated `tests/runtime/test_container.py` to assert that `RenderLoopPacer` is provided as a singleton by the container and refreshed runtime wiring docs in `docs/code_flow.md` and added a research note `docs/research/lagom_render_loop_pacer_integration.md`.

### Testing
- Ran `make format` and formatting fixes were applied successfully.
- Ran `make test` and the full Pytest suite completed successfully.
- Test summary: `248 passed, 1 skipped` (including updated `tests/runtime/test_container.py`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eadc1a6a88321aa606b6c181c542a)