### PR TITLE
Derive Layout/Orientation and perimeter from colored 3D bounding boxes

### DIFF
--- a/docs/research/layout_derivation_from_bounding_boxes.md
+++ b/docs/research/layout_derivation_from_bounding_boxes.md
@@ -1,0 +1,25 @@
+# Layout derivation from colored bounding boxes
+
+## Problem
+
+We need a way to derive display orientation and layout directly from colored
+bounding boxes so the runtime can describe LED positions in 3D space without
+hard-coding grid assumptions. The immediate goal is a flat rectangular matrix
+representation that can later be replaced with a more flexible projection model.
+
+## Current approach
+
+- Use `ColoredBoundingBox` inputs with 3D bounds and derive axis positions from
+  bounding-box centers.
+- Compute rows and columns by clustering the centers along each axis.
+- Build a perimeter polygon from the min/max XY extents at a reference Z plane.
+- Order LED positions by row/column while keeping the underlying 3D centers so
+  future projections can ignore the flat-matrix ordering.
+
+Source files:
+
+- `src/heart/derive/layout.py`
+
+## Materials
+
+- None (software-only derivation).

--- a/src/heart/derive/__init__.py
+++ b/src/heart/derive/__init__.py
@@ -1,0 +1,9 @@
+from heart.derive.layout import BoundingBox3D as BoundingBox3D
+from heart.derive.layout import ColoredBoundingBox as ColoredBoundingBox
+from heart.derive.layout import Layout as Layout
+from heart.derive.layout import Orientation as Orientation
+from heart.derive.layout import Point3D as Point3D
+from heart.derive.layout import \
+    derive_layout_from_boxes as derive_layout_from_boxes
+from heart.derive.layout import \
+    derive_orientation_from_boxes as derive_orientation_from_boxes

--- a/src/heart/derive/layout.py
+++ b/src/heart/derive/layout.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import median
+from typing import Iterable, Sequence
+
+DEFAULT_AXIS_TOLERANCE_RATIO = 0.6
+DEFAULT_PERIMETER_VERTEX_COUNT = 4
+
+
+@dataclass(frozen=True)
+class Point3D:
+    x: float
+    y: float
+    z: float
+
+
+@dataclass(frozen=True)
+class BoundingBox3D:
+    min_point: Point3D
+    max_point: Point3D
+
+    def center(self) -> Point3D:
+        return Point3D(
+            x=(self.min_point.x + self.max_point.x) / 2,
+            y=(self.min_point.y + self.max_point.y) / 2,
+            z=(self.min_point.z + self.max_point.z) / 2,
+        )
+
+    def size(self) -> Point3D:
+        return Point3D(
+            x=self.max_point.x - self.min_point.x,
+            y=self.max_point.y - self.min_point.y,
+            z=self.max_point.z - self.min_point.z,
+        )
+
+
+@dataclass(frozen=True)
+class ColoredBoundingBox:
+    color: tuple[int, int, int]
+    bounds: BoundingBox3D
+
+
+@dataclass(frozen=True)
+class Layout:
+    columns: int
+    rows: int
+    perimeter: tuple[Point3D, ...]
+
+
+@dataclass(frozen=True)
+class Orientation:
+    layout: Layout
+    led_positions: tuple[Point3D, ...]
+
+
+def derive_layout_from_boxes(
+    boxes: Sequence[ColoredBoundingBox],
+    *,
+    axis_tolerance_ratio: float = DEFAULT_AXIS_TOLERANCE_RATIO,
+) -> Layout:
+    axis_positions = _derive_axis_positions(boxes, axis_tolerance_ratio)
+    perimeter = _derive_perimeter(boxes)
+    return Layout(
+        columns=len(axis_positions.x_positions),
+        rows=len(axis_positions.y_positions),
+        perimeter=perimeter,
+    )
+
+
+def derive_orientation_from_boxes(
+    boxes: Sequence[ColoredBoundingBox],
+    *,
+    axis_tolerance_ratio: float = DEFAULT_AXIS_TOLERANCE_RATIO,
+) -> Orientation:
+    axis_positions = _derive_axis_positions(boxes, axis_tolerance_ratio)
+    perimeter = _derive_perimeter(boxes)
+    layout = Layout(
+        columns=len(axis_positions.x_positions),
+        rows=len(axis_positions.y_positions),
+        perimeter=perimeter,
+    )
+    ordered_positions = _order_led_positions(boxes, axis_positions)
+    return Orientation(layout=layout, led_positions=ordered_positions)
+
+
+@dataclass(frozen=True)
+class _AxisPositions:
+    x_positions: tuple[float, ...]
+    y_positions: tuple[float, ...]
+    z_reference: float
+
+
+def _derive_axis_positions(
+    boxes: Sequence[ColoredBoundingBox],
+    axis_tolerance_ratio: float,
+) -> _AxisPositions:
+    if not boxes:
+        raise ValueError("Expected at least one bounding box to derive layout.")
+
+    centers = [box.bounds.center() for box in boxes]
+    sizes = [box.bounds.size() for box in boxes]
+    tolerance = _calculate_axis_tolerance(sizes, axis_tolerance_ratio)
+
+    x_positions = _cluster_positions([center.x for center in centers], tolerance)
+    y_positions = _cluster_positions([center.y for center in centers], tolerance)
+    z_reference = median(center.z for center in centers)
+    return _AxisPositions(
+        x_positions=tuple(x_positions),
+        y_positions=tuple(y_positions),
+        z_reference=z_reference,
+    )
+
+
+def _calculate_axis_tolerance(
+    sizes: Iterable[Point3D],
+    axis_tolerance_ratio: float,
+) -> float:
+    dimensions = [min(size.x, size.y) for size in sizes]
+    if not dimensions:
+        return 0.0
+    return median(dimensions) * axis_tolerance_ratio
+
+
+def _cluster_positions(values: Iterable[float], tolerance: float) -> list[float]:
+    sorted_values = sorted(values)
+    if not sorted_values:
+        return []
+
+    clusters: list[list[float]] = [[sorted_values[0]]]
+    for value in sorted_values[1:]:
+        if abs(value - clusters[-1][-1]) <= tolerance:
+            clusters[-1].append(value)
+        else:
+            clusters.append([value])
+
+    return [sum(cluster) / len(cluster) for cluster in clusters]
+
+
+def _derive_perimeter(boxes: Sequence[ColoredBoundingBox]) -> tuple[Point3D, ...]:
+    if not boxes:
+        raise ValueError("Expected bounding boxes to derive a perimeter polygon.")
+
+    min_x = min(box.bounds.min_point.x for box in boxes)
+    max_x = max(box.bounds.max_point.x for box in boxes)
+    min_y = min(box.bounds.min_point.y for box in boxes)
+    max_y = max(box.bounds.max_point.y for box in boxes)
+    z_reference = median(box.bounds.center().z for box in boxes)
+
+    perimeter = (
+        Point3D(min_x, min_y, z_reference),
+        Point3D(max_x, min_y, z_reference),
+        Point3D(max_x, max_y, z_reference),
+        Point3D(min_x, max_y, z_reference),
+    )
+    if len(perimeter) != DEFAULT_PERIMETER_VERTEX_COUNT:
+        raise ValueError("Unexpected perimeter vertex count.")
+    return perimeter
+
+
+def _order_led_positions(
+    boxes: Sequence[ColoredBoundingBox],
+    axis_positions: _AxisPositions,
+) -> tuple[Point3D, ...]:
+    placements: list[tuple[int, int, Point3D]] = []
+    for box in boxes:
+        center = box.bounds.center()
+        row = _closest_axis_index(center.y, axis_positions.y_positions)
+        column = _closest_axis_index(center.x, axis_positions.x_positions)
+        placements.append((row, column, center))
+
+    placements.sort(key=lambda placement: (placement[0], placement[1]))
+    return tuple(position for _, _, position in placements)
+
+
+def _closest_axis_index(value: float, positions: Sequence[float]) -> int:
+    if not positions:
+        raise ValueError("No axis positions available for layout derivation.")
+    distances = [abs(value - position) for position in positions]
+    return distances.index(min(distances))


### PR DESCRIPTION
### Motivation

- Provide a way to compute `Orientation` and `Layout` from colored 3D bounding boxes so display geometry (including LED positions) is derived from detection data instead of hard-coded grids.
- Expose a bounding perimeter polygon that articulates the display perimeter in 3D space for future projection algorithms.
- Keep a simple flat rectangular matrix representation as the immediate consumer while preserving underlying 3D points for later removal of that assumption.

### Description

- Add `src/heart/derive/layout.py` implementing `Point3D`, `BoundingBox3D`, `ColoredBoundingBox`, `Layout`, and `Orientation` dataclasses and derivation helpers such as `derive_layout_from_boxes` and `derive_orientation_from_boxes`.
- Implement axis clustering to infer `columns`/`rows` from bounding-box centers and compute a perimeter polygon from min/max XY extents at a reference Z plane using `_derive_perimeter`.
- Provide ordered LED positions by mapping each bounding-box center to the closest clustered row/column in `_order_led_positions` and return the positions as 3D points.
- Add `src/heart/derive/__init__.py` to re-export the new API and a research note `docs/research/layout_derivation_from_bounding_boxes.md` documenting the approach and rationale.

### Testing

- Ran formatting via `make format` and fixed/verified style issues; the formatting step completed successfully.
- No unit tests or runtime integration tests were executed as part of this change.
- Developers should run `make test` and add unit tests that validate clustering, perimeter construction, and LED ordering against synthetic bounding-box inputs in follow-up work.
- `make format` ensured the new files conform to project style rules and lint expectations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eae738494832187471744b6f76268)