### PR TITLE
Refactor navigation renderer resolution

### DIFF
--- a/docs/navigation_renderer_resolution.md
+++ b/docs/navigation_renderer_resolution.md
@@ -1,0 +1,22 @@
+# Navigation renderer resolution
+
+## Overview
+
+Renderer composition in the navigation layer accepts either renderer instances or
+renderer classes. The class forms require a container-backed resolver so that
+construction stays centralized. The logic for validating and resolving those
+renderer specifications now lives in `src/heart/navigation/renderer_resolution.py`
+so that `ComposedRenderer`, `MultiScene`, and `AppController` share consistent
+validation and error handling.
+
+## Module responsibilities
+
+- `src/heart/navigation/renderer_resolution.py` defines the `RendererSpec` type,
+  the `RendererResolver` protocol, and helper functions for resolving renderer
+  specifications with clear context messages.
+- `src/heart/navigation/composed_renderer.py` uses the shared helpers to resolve
+  its renderer list and to add additional renderers after initialization.
+- `src/heart/navigation/multi_scene.py` uses the shared helpers to resolve its
+  scene list consistently.
+- `src/heart/navigation/app_controller.py` uses the shared helpers when a title
+  renderer is provided as a class type.

--- a/src/heart/navigation/app_controller.py
+++ b/src/heart/navigation/app_controller.py
@@ -13,9 +13,11 @@ from heart.renderers.color import RenderColor
 from heart.renderers.spritesheet import SpritesheetLoop
 from heart.renderers.text import TextRendering
 
-from .composed_renderer import ComposedRenderer, RendererResolver
+from .composed_renderer import ComposedRenderer
 from .game_modes import GameModes
 from .multi_scene import MultiScene
+from .renderer_resolution import (RendererResolver, RendererSpec,
+                                  resolve_renderer_spec)
 
 
 @dataclass
@@ -76,7 +78,7 @@ class AppController(StatefulBaseRenderer[AppControllerState]):
     def add_mode(
         self,
         title: str
-        | list[StatefulBaseRenderer | type[StatefulBaseRenderer]]
+        | list[RendererSpec]
         | type[StatefulBaseRenderer]
         | StatefulBaseRenderer
         | None = None,
@@ -104,7 +106,7 @@ class AppController(StatefulBaseRenderer[AppControllerState]):
     def _build_title_renderer(
         self,
         title: str
-        | list[StatefulBaseRenderer | type[StatefulBaseRenderer]]
+        | list[RendererSpec]
         | type[StatefulBaseRenderer]
         | StatefulBaseRenderer,
     ) -> StatefulBaseRenderer:
@@ -118,9 +120,9 @@ class AppController(StatefulBaseRenderer[AppControllerState]):
         if isinstance(title, list):
             return ComposedRenderer(title, renderer_resolver=self._renderer_resolver)
         if isinstance(title, type) and issubclass(title, StatefulBaseRenderer):
-            if self._renderer_resolver is None:
-                raise ValueError("AppController requires a renderer resolver")
-            return self._renderer_resolver.resolve(title)
+            return resolve_renderer_spec(
+                title, self._renderer_resolver, context="AppController title"
+            )
         if isinstance(title, StatefulBaseRenderer):
             return title
         raise ValueError(f"Title must be a string or StatefulBaseRenderer, got: {title}")

--- a/src/heart/navigation/renderer_resolution.py
+++ b/src/heart/navigation/renderer_resolution.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Protocol, TypeVar
+
+from heart.renderers import StatefulBaseRenderer
+
+RendererT = TypeVar("RendererT", bound=StatefulBaseRenderer)
+RendererSpec = StatefulBaseRenderer | type[StatefulBaseRenderer]
+
+
+class RendererResolver(Protocol):
+    def resolve(self, dependency: type[RendererT]) -> RendererT:
+        """Resolve renderer instances from the shared container."""
+
+
+def resolve_renderer_spec(
+    renderer: RendererSpec,
+    resolver: RendererResolver | None,
+    *,
+    context: str,
+) -> StatefulBaseRenderer:
+    if isinstance(renderer, type):
+        if not issubclass(renderer, StatefulBaseRenderer):
+            raise TypeError(f"{context} requires StatefulBaseRenderer subclasses")
+        if resolver is None:
+            raise ValueError(f"{context} requires a renderer resolver")
+        return resolver.resolve(renderer)
+    return renderer
+
+
+def resolve_renderer_specs(
+    renderers: Iterable[RendererSpec],
+    resolver: RendererResolver | None,
+    *,
+    context: str,
+) -> list[StatefulBaseRenderer]:
+    return [
+        resolve_renderer_spec(renderer, resolver, context=context)
+        for renderer in renderers
+    ]


### PR DESCRIPTION
### Motivation

- Reduce duplication and improve clarity around how navigation-layer renderer specifications are validated and resolved.  
- Centralize the logic so class-based renderer specs use a single container-backed resolution path with consistent error messages.  
- Make the navigation components easier to maintain and reason about by extracting resolution helpers.  

### Description

- Add `src/heart/navigation/renderer_resolution.py` which defines `RendererSpec`, the `RendererResolver` protocol, and `resolve_renderer_spec(s)` helper functions.  
- Update `src/heart/navigation/composed_renderer.py` and `src/heart/navigation/multi_scene.py` to use the shared `resolve_renderer_specs` helpers and remove the duplicated resolution code.  
- Update `src/heart/navigation/app_controller.py` to use `resolve_renderer_spec` for title renderer resolution and adjust type annotations to `RendererSpec`.  
- Add documentation `docs/navigation_renderer_resolution.md` describing the new module responsibilities and usage.  

### Testing

- Ran `make format` and automatic formatting completed successfully.  
- Ran the test suite with `make test` and all automated tests passed: `248 passed, 1 skipped`.  
- No new failing tests were introduced by the refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eb7a0ae5c8321b6add902a5e47573)