### PR TITLE
Improve mandelbrot cube render performance

### DIFF
--- a/docs/research/mandelbrot_cube_perf.md
+++ b/docs/research/mandelbrot_cube_perf.md
@@ -1,0 +1,22 @@
+# Mandelbrot Cube Performance Notes
+
+## Problem
+
+The cube renderer recomputes trigonometric rotations and allocates larger-than-needed buffers each frame. This can add CPU cost and memory bandwidth pressure during rendering.
+
+## Observations
+
+- `CubeMandelbrotRenderer` updates azimuths with a per-frame rotation and feeds the results into a Numba kernel for iteration counts.
+- The base cube geometry is static; only rotation changes per frame.
+- The iteration buffer does not need 32-bit storage at the current iteration caps.
+
+## Changes
+
+- Reused computed elevation values across cube faces instead of recomputing the arcsin per face.
+- Shifted scalar constants to `float32` to keep array math in lower precision.
+- Reduced the iteration buffer to `uint16` to lower memory bandwidth during iteration writes.
+
+## Materials
+
+- `src/heart/renderers/mandelbrot/cube_renderer.py`
+- `src/heart/renderers/mandelbrot/scene.py`


### PR DESCRIPTION
### Motivation
- The cube mandelbrot renderer recalculates trigonometric values and uses wider-than-needed numeric types each frame, increasing CPU and memory bandwidth usage.
- The base cube geometry (elevations) is static across faces and can be reused rather than recomputed per face.
- Lower-precision array math and smaller iteration buffers can reduce memory traffic and computation cost when feeding the Numba kernel `get_mandelbrot_converge_time_into`.

### Description
- Converted scalar constants to `float32` (`REAL_CENTER`, `REAL_HALF_RANGE`, `IMAG_HALF_RANGE`, `ROTATION_SPEED`, `PI`, `TWO_PI`, `REAL_SCALE`, `IMAG_SCALE`) to keep array math in lower precision.
- Precomputed `elevation = arcsin(y_base)` once and reused it across faces instead of recomputing inside the face loop, and replaced per-face angle math with an `angle_step` and `np.cos`/`np.sin` for vector-friendly operations.
- Reduced the iteration buffer element type from `int32` to `uint16` to reduce memory bandwidth during iteration writes and downstream array operations.
- Cast per-frame `rotation` to `float32` and switched additions/subtractions using `PI`/`TWO_PI` constants to keep in-pace numeric types, and added a short research note under `docs/research/mandelbrot_cube_perf.md` describing the changes.

### Testing
- Ran `make format` and formatting checks passed.
- Ran the full test suite with `make test` and observed all automated tests pass with `248 passed, 1 skipped` (run time ~34s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eb7b0ef188321a3628fef94fd74bd)