### PR TITLE
Refactor navigation renderer spec handling

### DIFF
--- a/src/heart/navigation/app_controller.py
+++ b/src/heart/navigation/app_controller.py
@@ -13,9 +13,10 @@ from heart.renderers.color import RenderColor
 from heart.renderers.spritesheet import SpritesheetLoop
 from heart.renderers.text import TextRendering
 
-from .composed_renderer import ComposedRenderer, RendererResolver
+from .composed_renderer import ComposedRenderer
 from .game_modes import GameModes
 from .multi_scene import MultiScene
+from .renderer_specs import RendererResolver
 
 
 @dataclass

--- a/src/heart/navigation/multi_scene.py
+++ b/src/heart/navigation/multi_scene.py
@@ -9,7 +9,8 @@ from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.switch import SwitchState
 from heart.renderers import StatefulBaseRenderer
 
-from .composed_renderer import RendererResolver, RendererSpec
+from .renderer_specs import (RendererResolver, RendererSpec,
+                             resolve_renderer_spec)
 
 
 @dataclass
@@ -26,7 +27,10 @@ class MultiScene(StatefulBaseRenderer[MultiSceneState]):
     ) -> None:
         super().__init__()
         self._renderer_resolver = renderer_resolver
-        self.scenes = [self._resolve_renderer_spec(scene) for scene in scenes]
+        self.scenes = [
+            resolve_renderer_spec(scene, renderer_resolver, "MultiScene")
+            for scene in scenes
+        ]
 
     def get_renderers(self) -> list[StatefulBaseRenderer]:
         index = self._active_scene_index()
@@ -65,12 +69,3 @@ class MultiScene(StatefulBaseRenderer[MultiSceneState]):
     def _active_scene_index(self) -> int:
         offset = self.state.offset_of_button_value or 0
         return (self.state.current_button_value - offset) % len(self.scenes)
-
-    def _resolve_renderer_spec(self, renderer: RendererSpec) -> StatefulBaseRenderer:
-        if isinstance(renderer, type):
-            if not issubclass(renderer, StatefulBaseRenderer):
-                raise TypeError("MultiScene requires StatefulBaseRenderer subclasses")
-            if self._renderer_resolver is None:
-                raise ValueError("MultiScene requires a renderer resolver")
-            return self._renderer_resolver.resolve(renderer)
-        return renderer

--- a/src/heart/navigation/renderer_specs.py
+++ b/src/heart/navigation/renderer_specs.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Protocol, TypeVar
+
+from heart.renderers import StatefulBaseRenderer
+
+RendererT = TypeVar("RendererT", bound=StatefulBaseRenderer)
+RendererSpec = StatefulBaseRenderer | type[StatefulBaseRenderer]
+
+
+class RendererResolver(Protocol):
+    def resolve(self, dependency: type[RendererT]) -> RendererT:
+        """Resolve renderer instances from the shared container."""
+
+
+def resolve_renderer_spec(
+    renderer: RendererSpec,
+    renderer_resolver: RendererResolver | None,
+    owner: str,
+) -> StatefulBaseRenderer:
+    if isinstance(renderer, type):
+        if not issubclass(renderer, StatefulBaseRenderer):
+            raise TypeError(f"{owner} requires StatefulBaseRenderer subclasses")
+        if renderer_resolver is None:
+            raise ValueError(f"{owner} requires a renderer resolver")
+        return renderer_resolver.resolve(renderer)
+    return renderer


### PR DESCRIPTION
### Motivation
- Reduce duplication by centralizing renderer-spec parsing and resolution logic shared across navigation components.
- Improve clarity of navigation module responsibilities by extracting a small, focused helper for resolving renderer dependencies.
- Make it easier to reason about dependency resolution for renderers and to reuse the same validation/error messages.

### Description
- Add `src/heart/navigation/renderer_specs.py` which defines `RendererResolver`, `RendererSpec`, and the `resolve_renderer_spec` helper.
- Update `ComposedRenderer` in `src/heart/navigation/composed_renderer.py` to use `resolve_renderer_spec` instead of its inline `_resolve_renderer_spec` logic.
- Update `MultiScene` in `src/heart/navigation/multi_scene.py` to use `resolve_renderer_spec` and remove duplicate resolution code.
- Change `AppController` import to reference the centralized `RendererResolver` type from `renderer_specs.py` and run formatting changes.

### Testing
- Ran `make format` to apply formatting and lint fixes, and the command completed successfully.
- No automated unit test suite (`make test`) was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eb7bd77088321ae582d209c6472a3)