### PR TITLE
Measure adaptive pacing from render start

### DIFF
--- a/src/heart/runtime/game_loop.py
+++ b/src/heart/runtime/game_loop.py
@@ -229,12 +229,12 @@ class GameLoop:
             raise RuntimeError("GameLoop failed to initialize display clock")
         clock = self.display.clock
         while self.running:
-            frame_start = time.monotonic()
             self.peripheral_runtime.tick()
             self.running = self.event_handler.handle_events()
             self._preprocess_setup()
             renderers = self._select_renderers()
+            render_start = time.monotonic()
             plan = self._one_loop(renderers)
             estimated_cost_ms = plan.estimated_cost_ms if plan.has_samples else None
-            self._render_pacer.pace(frame_start, estimated_cost_ms)
+            self._render_pacer.pace(render_start, estimated_cost_ms)
             clock.tick(self.max_fps)


### PR DESCRIPTION
### Motivation
- The adaptive pacing logic computes a target interval as `estimated_cost_ms / utilization`, but it was compared to elapsed time measured after rendering completed, causing the render time to be double-counted against the target.  
- This resulted in sleeping for the full target interval in addition to the render cost, producing a lower-than-intended FPS.  
- Measuring from render start ensures the pacing target caps the total frame time as intended.  

### Description
- Record a `render_start = time.monotonic()` immediately before rendering begins in `GameLoop._run_main_loop`.  
- Pass `render_start` into `RenderLoopPacer.pace()` instead of the previous `frame_start` timestamp.  
- This change aligns the pacing measurement with the renderer start time without altering `RenderLoopPacer` itself.  

### Testing
- Ran `make format` to apply code formatting and it completed successfully.  
- No automated unit test suite (`make test`) was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eb7d1241c8321b5b3afe28a2f62ad)