### PR TITLE
Clarify Lagom test import criteria

### DIFF
--- a/docs/planning/lagom_deeper_integration.md
+++ b/docs/planning/lagom_deeper_integration.md
@@ -25,8 +25,8 @@ This plan proposes consolidating runtime dependency wiring into a single Lagom c
 | Peripheral provider registry uses container-scoped bindings | Container module exposes registration for `PeripheralManager` and providers | Peripheral owner |
 | Renderers can be resolved through container with explicit scopes | `ComposedRenderer.resolve_renderer` uses shared container API and tests cover container binding | Rendering owner |
 | Container configuration is centralized | New module (e.g., `src/heart/runtime/container.py`) defines container construction and registration | Runtime owner |
-| Tests can swap implementations via container overrides | Unit tests use Lagom `Container` overrides without changing runtime modules | Test owner |
-| Lagom imports stay centralized | Lagom types are only imported in `src/heart/runtime/container.py` and `src/heart/peripheral/core/providers/` | Runtime owner |
+| Tests can swap implementations via container overrides | Unit tests use Lagom `Container` overrides or `RuntimeContainer` helper APIs without changing runtime modules | Test owner |
+| Lagom imports stay centralized in production modules | Lagom types are only imported in `src/heart/runtime/container.py` and `src/heart/peripheral/core/providers/`; test modules may import Lagom for overrides | Runtime owner |
 
 ## Task Breakdown Checklists
 


### PR DESCRIPTION
### Motivation
- Remove ambiguity between the plan's requirement to centralize Lagom imports and the need for tests to override container bindings. 
- Make it explicit that production modules should avoid importing Lagom types directly while allowing test code to use overrides. 
- Ensure the success criteria in the Lagom integration plan are actionable and reflect realistic testing practices. 

### Description
- Updated `docs/planning/lagom_deeper_integration.md` success criteria to allow unit tests to use Lagom `Container` overrides or `RuntimeContainer` helper APIs. 
- Clarified that Lagom import centralization applies to production modules and that test modules may import Lagom for overrides. 
- Small, focused documentation-only change to make validation signals consistent with testing needs. 

### Testing
- Ran `make format` and the formatting checks completed successfully. 
- Ran `make test` and the test suite executed but reported one failing test. 
- Test summary: `247 passed`, `1 failed`, `1 skipped` across the suite. 
- The failing test was `tests/utilities/test_reactivex_streams.py::TestShareStreamFlowControl::test_share_stream_coalesces_latest_when_configured` (assertion mismatch).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eb7e474d48321aed69797c9d614ec)