### PR TITLE
Fix 3D glasses renderer catalog path

### DIFF
--- a/docs/renderers/renderer_catalog.md
+++ b/docs/renderers/renderer_catalog.md
@@ -141,7 +141,7 @@ The loop registers the renderer in
 
 ## 3D glasses renderer
 
-**Module:** `src/heart/renderers/three_d_glasses.py`
+**Module:** `src/heart/renderers/three_d_glasses/renderer.py`
 
 `ThreeDGlassesRenderer` remaps static imagery into a red/cyan anaglyph so the
 left and right lenses see offset channel data. Frames advance on a configurable


### PR DESCRIPTION
### Motivation

- The renderer catalog referenced a non-existent module path which could mislead readers integrating the renderer.
- The actual renderer implementation lives under the `three_d_glasses` package rather than a single `three_d_glasses.py` module.

### Description

- Update the renderer catalog entry in `docs/renderers/renderer_catalog.md` to point to `src/heart/renderers/three_d_glasses/renderer.py`.
- This clarifies where `ThreeDGlassesRenderer` is exported and avoids confusion when following docs or importing the renderer.

### Testing

- Ran `make format` to ensure formatting checks passed. 
- Ran `make test` and the test suite completed successfully with all tests passing (248 passed, 1 skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eb81ad5ec83218503abb67fda4c8f)