### PR TITLE
Fix axis clustering span limits

### DIFF
--- a/src/heart/derive/layout.py
+++ b/src/heart/derive/layout.py
@@ -129,7 +129,7 @@ def _cluster_positions(values: Iterable[float], tolerance: float) -> list[float]
 
     clusters: list[list[float]] = [[sorted_values[0]]]
     for value in sorted_values[1:]:
-        if abs(value - clusters[-1][-1]) <= tolerance:
+        if value - clusters[-1][0] <= tolerance:
             clusters[-1].append(value)
         else:
             clusters.append([value])

--- a/tests/derive/test_layout.py
+++ b/tests/derive/test_layout.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from heart.derive import layout
+
+
+class TestClusterPositions:
+    """Validate cluster grouping behaviour that keeps axis buckets distinct."""
+
+    @pytest.mark.parametrize(
+        ("values", "tolerance", "expected"),
+        [
+            pytest.param(
+                [0.0, 0.5, 1.0],
+                0.6,
+                [0.25, 1.0],
+                id="blocks_transitive_merge",
+            ),
+            pytest.param(
+                [0.0, 0.2, 0.4],
+                0.5,
+                [0.2],
+                id="single_cluster_within_span",
+            ),
+        ],
+    )
+    def test_cluster_positions_respects_span_limit(
+        self,
+        values: list[float],
+        tolerance: float,
+        expected: list[float],
+    ) -> None:
+        """Ensure clusters cap their span to avoid collapsing distinct rows/columns."""
+        clustered = layout._cluster_positions(values, tolerance)
+
+        assert clustered == pytest.approx(expected)


### PR DESCRIPTION
### Motivation

- Prevent transitive merging of axis positions that can collapse distinct rows/columns when gaps are non-uniform.
- The previous clustering compared candidates against the last member of a cluster which allowed long spans to be formed transitively.
- Incorrect clustering can undercount rows/columns and mis-order LEDs when box spacing has jitter or variable gaps.

### Description

- Change `_cluster_positions` to compare a candidate value against the cluster's first element (`clusters[-1][0]`) so a cluster enforces a maximum span instead of chaining via the last value.  
- Add unit tests in `tests/derive/test_layout.py` that validate clustering blocks transitive merges and still groups tight spans.  
- Run formatting to apply repository style rules via `make format` before committing changes.

### Testing

- Ran `make format` successfully to apply formatting rules.  
- Ran `make test` which executed the full pytest suite and completed with `250 passed, 1 skipped`.  
- The newly added tests in `tests/derive/test_layout.py` executed as part of the suite and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eb82b822883219e9004ba78a567cc)