### PR TITLE
Need the change details to generate a short, descriptive PR title

### DIFF
--- a/tests/runtime/test_game_loop.py
+++ b/tests/runtime/test_game_loop.py
@@ -1,0 +1,31 @@
+import pytest
+
+from heart.runtime.game_loop import GameLoop
+
+
+class TestGameLoop:
+    """Exercise core GameLoop guardrails so lifecycle assumptions stay reliable for runtime orchestration."""
+
+    def test_singleton_preserves_first_instance(
+        self,
+        device,
+        resolver,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Ensure the first GameLoop remains active so global access stays predictable during runtime setup."""
+        monkeypatch.setattr("heart.runtime.game_loop.ACTIVE_GAME_LOOP", None)
+
+        first_loop = GameLoop(device=device, resolver=resolver)
+        second_loop = GameLoop(device=device, resolver=resolver)
+
+        first_loop._set_singleton()
+        second_loop._set_singleton()
+
+        assert GameLoop.get_game_loop() is first_loop
+
+    def test_one_loop_requires_initialized_screen(self, device, resolver) -> None:
+        """Confirm _one_loop refuses to run without a screen so rendering doesn't fail silently in production."""
+        loop = GameLoop(device=device, resolver=resolver)
+
+        with pytest.raises(RuntimeError, match="GameLoop screen is not initialized"):
+            loop._one_loop([])


### PR DESCRIPTION
PR: Add GameLoop unit tests for singleton and screen initialization
Branch: feature/prompts-write-test-file-src-heart-runtim-20251227-155520
Base: main
Commit: 00f727f — test(runtime): add GameLoop tests for singleton and screen initialization

What changed
- Added tests/runtime/test_game_loop.py (31 lines)
  - test_singleton_preserves_first_instance: verifies the first GameLoop set as singleton remains the active global instance.
  - test_one_loop_requires_initialized_screen: verifies _one_loop raises RuntimeError when run without an initialized screen.

Why
- To exercise and lock down core GameLoop guardrails so lifecycle assumptions used by runtime orchestration remain reliable (singleton behavior and screen initialization checks).

How to test
1. Checkout the branch:
   - git fetch && git checkout feature/prompts-write-test-file-src-heart-runtim-20251227-155520
2. Run the new tests only:
   - pytest tests/runtime/test_game_loop.py -q
3. Or run the full test suite:
   - pytest
4. Expected result:
   - Both tests pass. You should see two successful tests (no failures or errors).

Notes / Risks
- Tests touch private internals (_set_singleton, _one_loop and the ACTIVE_GAME_LOOP global) to validate runtime guardrails. Future refactors that change these internals may break tests even if external behavior is preserved.
- test_singleton_preserves_first_instance uses monkeypatch to reset ACTIVE_GAME_LOOP to None, so test isolation is handled here. If other tests also manipulate the same global without isolation, there could be flakiness—ensure tests modifying ACTIVE_GAME_LOOP use proper setup/teardown.
- This PR only adds tests — no production code changes. Continuous Integration should run the new tests as part of the normal suite.