### PR TITLE
Please provide the change details (diff or brief summary) so I can write a short, descriptive PR title.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - When reading or writing text files, specify an explicit encoding (prefer `utf-8`) to keep behavior consistent across platforms.
 - Use module-level constants for public constructor or function default values so shared configuration is easy to discover and adjust.
 - When parsing PATH-like environment variables, strip whitespace from each entry and ignore empty values before converting to `Path` objects.
+- Use module-level constants for default argument values and shared string literals in firmware helpers so configuration stays consistent.
 
 ## Dependency Injection (Lagom)
 

--- a/src/heart/firmware_io/identity.py
+++ b/src/heart/firmware_io/identity.py
@@ -18,6 +18,7 @@ else:  # pragma: no cover - supervisor is unavailable on CPython
 
 
 _DEFAULT_COMMIT_CACHE: str | None = None
+DEFAULT_FIRMWARE_COMMIT = "UNKNOWN"
 
 class Identity:
     """Container describing a firmware build."""
@@ -45,7 +46,7 @@ class Identity:
         return payload
 
 
-def default_firmware_commit(default: str = "UNKNOWN") -> str:
+def default_firmware_commit(default: str = DEFAULT_FIRMWARE_COMMIT) -> str:
     """Return a best-effort commit identifier for the running firmware."""
 
     global _DEFAULT_COMMIT_CACHE


### PR DESCRIPTION
Branch: feature/prompts-fix-divergence-20251227-163131
Base: main
Commit: f7a8cdd — refactor(firmware_io): introduce DEFAULT_FIRMWARE_COMMIT constant and use it for default_firmware_commit

Summary of changes
- Introduced a module-level constant DEFAULT_FIRMWARE_COMMIT = "UNKNOWN" in src/heart/firmware_io/identity.py.
- Updated default_firmware_commit() to use the new DEFAULT_FIRMWARE_COMMIT constant as its default parameter instead of a string literal.
- Minor docs: added a line to AGENTS.md recommending use of module-level constants for default argument values and shared string literals in firmware helpers.

Why
- Make the default value for firmware commit discovery a discoverable, module-level constant so shared configuration and literals are easier to find and adjust.
- Follow the repository guideline to prefer module-level constants for defaults and shared strings.

How to test
1. Checkout the branch:
   - git fetch && git checkout feature/prompts-fix-divergence-20251227-163131
2. Run formatting and linting:
   - make format
   - make lint (or run ruff/isort as configured)
3. Run unit tests:
   - pytest -q
   - or run the specific tests that touch firmware_io/identity.py
4. Manual verification:
   - In a Python REPL or small script, import and exercise the function and constant:
     - from heart.firmware_io import identity
     - assert identity.DEFAULT_FIRMWARE_COMMIT == "UNKNOWN"
     - assert identity.default_firmware_commit()  # should return a string (best-effort commit or "UNKNOWN")
   - Confirm behavior is unchanged when callers omit the default argument.
5. CI should pass (run the project CI pipeline).

Risks / Notes
- This is a small refactor only (no behavioral change expected). The function still defaults to "UNKNOWN", now via a constant.
- The module now exposes DEFAULT_FIRMWARE_COMMIT; this is intentional and useful for discoverability. If external code imported by name, it should continue to work.
- If any code relied on the default parameter being an anonymous literal (unlikely), the change could be visible in introspection (default value now refers to a constant), but runtime behavior is unchanged.
- Keep an eye on exports/typing if you rely on strict __all__ or symbol hiding.