### PR TITLE
Please provide the change details (diff or description) so I can write a short, descriptive PR title.

### DIFF
--- a/docs/research/perceptual_hash_e2e_capture.md
+++ b/docs/research/perceptual_hash_e2e_capture.md
@@ -1,0 +1,28 @@
+<!-- markdownlint-disable MD013 -->
+
+# Perceptual hash coverage for ScreenRecorder outputs
+
+## Context
+
+ScreenRecorder writes GIFs that are used to validate end-to-end rendering. The current tests perform exact pixel comparisons, which are brittle when renderer behavior shifts or encoding details change. The request is to introduce perceptual hashing so the suite can tolerate larger visual changes while still detecting meaningful regressions.
+
+## Goal
+
+Add a perceptual-hash based test that verifies ScreenRecorder output stays visually consistent with a known baseline for a small deterministic scene. Use `imagehash` so the comparison is resilient to pixel-level variations while still flagging major departures.
+
+## Materials
+
+- Software: `imagehash`, `Pillow`, `pytest`
+- Code: `src/heart/display/recorder.py`, `tests/display/test_screen_recorder.py`
+
+## Notes
+
+- The test lives in `tests/display/test_screen_recorder.py` alongside the existing ScreenRecorder coverage.
+- A synthetic pattern is drawn via a renderer to avoid dependency on external assets.
+- The expected frame is constructed with `PIL.Image` and hashed with `imagehash.phash` to keep the baseline deterministic.
+- The hash distance threshold is small (`<= 2`) to catch visual drift without making the test overly brittle.
+
+## References
+
+- `src/heart/display/recorder.py`
+- `tests/display/test_screen_recorder.py`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,7 @@ test = [
     "pytest>=8.4.2",
     "pytest-benchmark>=5.2.0",
     "pytest-xdist>=3.8.0",
+    "ImageHash>=4.3.2",
 ]
 lint = [
     "docformatter[tomli]>=1.7.7",

--- a/tests/display/test_screen_recorder.py
+++ b/tests/display/test_screen_recorder.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
 from pathlib import Path
 
+import imagehash
+import pygame
 import pytest
-from PIL import Image, ImageSequence
+from PIL import Image, ImageDraw, ImageSequence
 
 from heart.display.recorder import ScreenRecorder
 from heart.renderers import StatefulBaseRenderer
@@ -18,11 +20,38 @@ class SolidColorRenderer(StatefulBaseRenderer[SolidColorState]):
         super().__init__()
         self._color = color
 
-    def _create_initial_state(self, window, clock, peripheral_manager, orientation) -> SolidColorState:
+    def _create_initial_state(
+        self, window, clock, peripheral_manager, orientation
+    ) -> SolidColorState:
         return SolidColorState(color=self._color)
 
     def real_process(self, window, clock, orientation) -> None:
         window.fill(self.state.color)
+
+
+@dataclass
+class PatternState:
+    background: tuple[int, int, int]
+    accent: tuple[int, int, int]
+
+
+class PatternRenderer(StatefulBaseRenderer[PatternState]):
+    def __init__(
+        self, background: tuple[int, int, int], accent: tuple[int, int, int]
+    ) -> None:
+        super().__init__()
+        self._background = background
+        self._accent = accent
+
+    def _create_initial_state(
+        self, window, clock, peripheral_manager, orientation
+    ) -> PatternState:
+        return PatternState(background=self._background, accent=self._accent)
+
+    def real_process(self, window, clock, orientation) -> None:
+        window.fill(self.state.background)
+        pygame.draw.rect(window, self.state.accent, pygame.Rect(8, 8, 48, 16))
+        pygame.draw.rect(window, self.state.accent, pygame.Rect(16, 40, 32, 16))
 
 
 @pytest.fixture()
@@ -42,9 +71,11 @@ class TestDisplayScreenRecorder:
     )
     def test_screen_recorder_writes_expected_frames(
         self,
-        colors: list[tuple[int, int, int]], screen_recorder: ScreenRecorder, tmp_path: Path
+        colors: list[tuple[int, int, int]],
+        screen_recorder: ScreenRecorder,
+        tmp_path: Path,
     ) -> None:
-        """Verify that ScreenRecorder emits a GIF whose frames match the provided renderer colours. This demonstrates capture fidelity so visual regressions are caught when renderers change."""
+        """Verify ScreenRecorder emits a GIF whose frames match renderer colours. This keeps capture fidelity high so visual regressions are caught when renderers change."""
         inputs = [[SolidColorRenderer(color)] for color in colors]
 
         output_path = tmp_path / "capture.gif"
@@ -60,13 +91,33 @@ class TestDisplayScreenRecorder:
 
         assert observed == colors
 
+    def test_screen_recorder_matches_expected_perceptual_hash(
+        self, screen_recorder: ScreenRecorder, tmp_path: Path
+    ) -> None:
+        """Verify ScreenRecorder output aligns with a perceptual hash baseline. This guards end-to-end capture against large rendering changes without brittle pixel-by-pixel comparisons."""
+        background = (5, 10, 20)
+        accent = (220, 40, 60)
+        inputs = [[PatternRenderer(background, accent)]]
 
+        result_path = screen_recorder.record(inputs, tmp_path / "hash.gif")
+
+        with Image.open(result_path) as image:
+            first_frame = next(ImageSequence.Iterator(image)).convert("RGB")
+            observed_hash = imagehash.phash(first_frame)
+
+        expected = Image.new("RGB", (64, 64), background)
+        draw = ImageDraw.Draw(expected)
+        draw.rectangle([8, 8, 55, 23], fill=accent)
+        draw.rectangle([16, 40, 47, 55], fill=accent)
+        expected_hash = imagehash.phash(expected)
+
+        distance = observed_hash - expected_hash
+        assert distance <= 2, f"perceptual hash distance too high: {distance}"
 
     def test_screen_recorder_sets_frame_duration(
-        self,
-        screen_recorder: ScreenRecorder, tmp_path: Path
+        self, screen_recorder: ScreenRecorder, tmp_path: Path
     ) -> None:
-        """Verify that ScreenRecorder records frames using the expected millisecond duration. This keeps playback timing accurate so exported recordings feel consistent."""
+        """Verify ScreenRecorder records frames using the expected millisecond duration. This keeps playback timing accurate so exported recordings feel consistent."""
         inputs = [
             [SolidColorRenderer((10, 20, 30))],
             [SolidColorRenderer((30, 40, 50))],
@@ -75,8 +126,7 @@ class TestDisplayScreenRecorder:
 
         with Image.open(result_path) as image:
             durations = [
-                frame.info.get("duration")
-                for frame in ImageSequence.Iterator(image)
+                frame.info.get("duration") for frame in ImageSequence.Iterator(image)
             ]
 
         expected_duration = max(
@@ -85,9 +135,9 @@ class TestDisplayScreenRecorder:
         )
         assert durations == [expected_duration] * len(inputs)
 
-
-
-    def test_screen_recorder_requires_inputs(self, screen_recorder: ScreenRecorder, tmp_path: Path) -> None:
-        """Verify that ScreenRecorder raises an error when recording with no renderer frames. This prevents silent failures when capture pipelines are misconfigured."""
+    def test_screen_recorder_requires_inputs(
+        self, screen_recorder: ScreenRecorder, tmp_path: Path
+    ) -> None:
+        """Verify ScreenRecorder raises an error when recording with no renderer frames. This prevents silent failures when capture pipelines are misconfigured."""
         with pytest.raises(ValueError):
             screen_recorder.record([], tmp_path / "empty.gif")

--- a/uv.lock
+++ b/uv.lock
@@ -539,6 +539,7 @@ dev = [
 dev = [
     { name = "docformatter" },
     { name = "hypothesis" },
+    { name = "imagehash" },
     { name = "isort" },
     { name = "mdformat" },
     { name = "mypy" },
@@ -560,6 +561,7 @@ lint = [
 ]
 test = [
     { name = "hypothesis" },
+    { name = "imagehash" },
     { name = "pytest" },
     { name = "pytest-benchmark" },
     { name = "pytest-xdist" },
@@ -602,6 +604,7 @@ provides-extras = ["dev"]
 dev = [
     { name = "docformatter", extras = ["tomli"], specifier = ">=1.7.7" },
     { name = "hypothesis", specifier = ">=6.120.0" },
+    { name = "imagehash", specifier = ">=4.3.2" },
     { name = "isort", specifier = ">=7.0.0" },
     { name = "mdformat", specifier = ">=1.0.0" },
     { name = "mypy", specifier = ">=1.13.0" },
@@ -623,6 +626,7 @@ lint = [
 ]
 test = [
     { name = "hypothesis", specifier = ">=6.120.0" },
+    { name = "imagehash", specifier = ">=4.3.2" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-benchmark", specifier = ">=5.2.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
@@ -693,6 +697,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "imagehash"
+version = "4.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "pywavelets" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/de/5c0189b0582e21583c2a213081c35a2501c0f9e51f21f6a52f55fbb9a4ff/ImageHash-4.3.2.tar.gz", hash = "sha256:e54a79805afb82a34acde4746a16540503a9636fd1ffb31d8e099b29bbbf8156", size = 303190, upload-time = "2025-02-01T08:45:39.328Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/2c/5f0903a53a62029875aaa3884c38070cc388248a2c1b9aa935632669e5a7/ImageHash-4.3.2-py2.py3-none-any.whl", hash = "sha256:02b0f965f8c77cd813f61d7d39031ea27d4780e7ebcad56c6cd6a709acc06e5f", size = 296657, upload-time = "2025-02-01T08:45:36.102Z" },
 ]
 
 [[package]]
@@ -1722,6 +1741,65 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/6b/ce3727395e52b7b76dfcf0c665e37d223b680b9becc60710d4bc08b7b7cb/pyusb-1.3.1.tar.gz", hash = "sha256:3af070b607467c1c164f49d5b0caabe8ac78dbed9298d703a8dbf9df4052d17e", size = 77281, upload-time = "2025-01-08T23:45:01.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/28/b8/27e6312e86408a44fe16bd28ee12dd98608b39f7e7e57884a24e8f29b573/pyusb-1.3.1-py3-none-any.whl", hash = "sha256:bf9b754557af4717fe80c2b07cc2b923a9151f5c08d17bdb5345dac09d6a0430", size = 58465, upload-time = "2025-01-08T23:45:00.029Z" },
+]
+
+[[package]]
+name = "pywavelets"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/75/50581633d199812205ea8cdd0f6d52f12a624886b74bf1486335b67f01ff/pywavelets-1.9.0.tar.gz", hash = "sha256:148d12203377772bea452a59211d98649c8ee4a05eff019a9021853a36babdc8", size = 3938340, upload-time = "2025-08-04T16:20:04.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/8b/ca700d0c174c3a4eec1fbb603f04374d1fed84255c2a9f487cfaa749c865/pywavelets-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:54662cce4d56f0d6beaa6ebd34b2960f3aa4a43c83c9098a24729e9dc20a4be2", size = 4323640, upload-time = "2025-08-04T16:18:51.683Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f3/0fa57b6407ea9c4452b0bc182141256b9481b479ffbfc9d7fdb73afe193b/pywavelets-1.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0d8ed4b4d1eab9347e8fe0c5b45008ce5a67225ce5b05766b8b1fa923a5f8b34", size = 4294938, upload-time = "2025-08-04T16:18:53.818Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/95/a998313c8459a57e488ff2b18e24be9e836aedda3aa3a1673197deeaa59a/pywavelets-1.9.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:862be65481fdfecfd84c6b0ca132ba571c12697a082068921bca5b5e039f1371", size = 4472829, upload-time = "2025-08-04T16:18:55.508Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/8c/f316a153f7f89d2753df8a7371d15d0faab87e709fe02715dbc297c79385/pywavelets-1.9.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d76b7fa8fc500b09201d689b4f15bf5887e30ffbe2e1f338eb8470590eb4521a", size = 4524936, upload-time = "2025-08-04T16:18:57.146Z" },
+    { url = "https://files.pythonhosted.org/packages/24/f7/89fdc1caef4b384a341a8e149253e23f36c1702bbb986a26123348624854/pywavelets-1.9.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:aa859d0b686a697c87a47e29319aebe44125f114a4f8c7e444832b921f52de5a", size = 4481475, upload-time = "2025-08-04T16:18:58.725Z" },
+    { url = "https://files.pythonhosted.org/packages/82/53/b733fbfb71853e4a5c430da56e325a763562d65241dd785f0fadb67aed6a/pywavelets-1.9.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:20e97b84a263003e2c7348bcf72beba96edda1a6169f072dc4e4d4ee3a6c7368", size = 4527994, upload-time = "2025-08-04T16:18:59.917Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/15/5f6a6e9fdad8341e42642ed622a5f3033da4ea9d426cc3e574ae418b4726/pywavelets-1.9.0-cp311-cp311-win32.whl", hash = "sha256:f8330cdbfa506000e63e79525716df888998a76414c5cd6ecd9a7e371191fb05", size = 4136109, upload-time = "2025-08-04T16:19:01.511Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/33/62dbb4aea86ec9d79b283127c42cc896f4d4ff265a9aeb1337a7836dd550/pywavelets-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:ed10959a17df294ef55948dcc76367d59ec7b6aad67e38dd4e313d2fe3ad47b2", size = 4228321, upload-time = "2025-08-04T16:19:03.164Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/37/3fda13fb2518fdd306528382d6b18c116ceafefff0a7dccd28f1034f4dd2/pywavelets-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30baa0788317d3c938560c83fe4fc43817342d06e6c9662a440f73ba3fb25c9b", size = 4320835, upload-time = "2025-08-04T16:19:04.855Z" },
+    { url = "https://files.pythonhosted.org/packages/36/65/a5549325daafc3eae4b52de076798839eaf529a07218f8fb18cccefe76a1/pywavelets-1.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:df7436a728339696a7aa955c020ae65c85b0d9d2b5ff5b4cf4551f5d4c50f2c7", size = 4290469, upload-time = "2025-08-04T16:19:06.178Z" },
+    { url = "https://files.pythonhosted.org/packages/05/85/901bb756d37dfa56baa26ef4a3577aecfe9c55f50f51366fede322f8c91d/pywavelets-1.9.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:07b26526db2476974581274c43a9c2447c917418c6bd03c8d305ad2a5cd9fac3", size = 4437717, upload-time = "2025-08-04T16:19:07.514Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/34/0f54dd9c288941294898877008bcb5c07012340cc9c5db9cff1bd185d449/pywavelets-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:573b650805d2f3c981a0e5ae95191c781a722022c37a0f6eba3fa7eae8e0ee17", size = 4483843, upload-time = "2025-08-04T16:19:08.857Z" },
+    { url = "https://files.pythonhosted.org/packages/48/1f/cff6bb4ea64ff508d8cac3fe113c0aa95310a7446d9efa6829027cc2afdf/pywavelets-1.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3747ec804492436de6e99a7b6130480e53406d047e87dc7095ab40078a515a23", size = 4442236, upload-time = "2025-08-04T16:19:11.061Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/53/a3846eeefe0fb7ca63ae045f038457aa274989a15af793c1b824138caf98/pywavelets-1.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5163665686219c3f43fd5bbfef2391e87146813961dad0f86c62d4aed561f547", size = 4488077, upload-time = "2025-08-04T16:19:12.333Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/98/44852d2fe94455b72dece2db23562145179d63186a1c971125279a1c381f/pywavelets-1.9.0-cp312-cp312-win32.whl", hash = "sha256:80b8ab99f5326a3e724f71f23ba8b0a5b03e333fa79f66e965ea7bed21d42a2f", size = 4134094, upload-time = "2025-08-04T16:19:13.564Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a7/0d9ee3fe454d606e0f5c8e3aebf99d2ecddbfb681826a29397729538c8f1/pywavelets-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:92bfb8a117b8c8d3b72f2757a85395346fcbf37f50598880879ae72bd8e1c4b9", size = 4213900, upload-time = "2025-08-04T16:19:14.939Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a7/dec4e450675d62946ad975f5b4d924437df42d2fae46e91dfddda2de0f5a/pywavelets-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:74f8455c143818e4b026fc67b27fd82f38e522701b94b8a6d1aaf3a45fcc1a25", size = 4316201, upload-time = "2025-08-04T16:19:16.259Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0c/b54b86596c0df68027e48c09210e907e628435003e77048384a2dd6767e3/pywavelets-1.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c50320fe0a4a23ddd8835b3dc9b53b09ee05c7cc6c56b81d0916f04fc1649070", size = 4286838, upload-time = "2025-08-04T16:19:17.92Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/9c/333969c3baad8af2e7999e83addcb7bb1d1fd48e2d812fb27e2e89582cb1/pywavelets-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d6e059265223ed659e5214ab52a84883c88ddf3decbf08d7ec6abb8e4c5ed7be", size = 4430753, upload-time = "2025-08-04T16:19:19.529Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1b/a24c6ff03b026b826ad7b9267bd63cd34ce026795a0302f8a5403840b8e7/pywavelets-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ae10ed46c139c7ddb8b1249cfe0989f8ccb610d93f2899507b1b1573a0e424b5", size = 4491315, upload-time = "2025-08-04T16:19:20.717Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c7/e3fbb502fca3469e51ced4f1e1326364c338be91edc5db5a8ddd26b303fa/pywavelets-1.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c8f8b1cc2df012401cb837ee6fa2f59607c7b4fe0ff409d9a4f6906daf40dc86", size = 4437654, upload-time = "2025-08-04T16:19:22.359Z" },
+    { url = "https://files.pythonhosted.org/packages/92/44/c9b25084048d9324881a19b88e0969a4141bcfdc1d218f1b4b680b7af1c1/pywavelets-1.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:db43969c7a8fbb17693ecfd14f21616edc3b29f0e47a49b32fa4127c01312a67", size = 4496435, upload-time = "2025-08-04T16:19:23.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b6/b27ec18c72b1dee3314e297af39c5f8136d43cc130dd93cb6c178ca820e5/pywavelets-1.9.0-cp313-cp313-win32.whl", hash = "sha256:9e7d60819d87dcd6c68a2d1bc1d37deb1f4d96607799ab6a25633ea484dcda41", size = 4132709, upload-time = "2025-08-04T16:19:25.415Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/87/78ef3f9fb36cdb16ee82371d22c3a7c89eeb79ec8c9daef6222060da6c79/pywavelets-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:0d70da9d7858c869e24dc254f16a61dc09d8a224cad85a10c393b2eccddeb126", size = 4213377, upload-time = "2025-08-04T16:19:26.875Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cd/ca0d9db0ff29e3843f6af60c2f5eb588794e05ca8eeb872a595867b1f3f5/pywavelets-1.9.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4dc85f44c38d76a184a1aa2cb038f802c3740428c9bb877525f4be83a223b134", size = 4354336, upload-time = "2025-08-04T16:19:28.745Z" },
+    { url = "https://files.pythonhosted.org/packages/82/d6/70afefcc1139f37d02018a3b1dba3b8fc87601bb7707d9616b7f7a76e269/pywavelets-1.9.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7acf6f950c6deaecd210fbff44421f234a8ca81eb6f4da945228e498361afa9d", size = 4335721, upload-time = "2025-08-04T16:19:30.371Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/3a/713f731b9ed6df0c36269c8fb62be8bb28eb343b9e26b13d6abda37bce38/pywavelets-1.9.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:144d4fc15c98da56654d0dca2d391b812b8d04127b194a37ad4a497f8e887141", size = 4418702, upload-time = "2025-08-04T16:19:31.743Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e8/f801eb4b5f7a316ba20054948c5d6b27b879c77fab2674942e779974bd86/pywavelets-1.9.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1aa3729585408a979d655736f74b995b511c86b9be1544f95d4a3142f8f4b8b5", size = 4470023, upload-time = "2025-08-04T16:19:32.963Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/cc/44b002cb16f2a392f2082308dd470b3f033fa4925d3efa7c46f790ce895a/pywavelets-1.9.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e0e24ad6b8eb399c49606dd1fcdcbf9749ad7f6d638be3fe6f59c1f3098821e2", size = 4426498, upload-time = "2025-08-04T16:19:34.151Z" },
+    { url = "https://files.pythonhosted.org/packages/91/fe/2b70276ede7878c5fe8356ca07574db5da63e222ce39a463e84bfad135e8/pywavelets-1.9.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3830e6657236b53a3aae20c735cccead942bb97c54bbca9e7d07bae01645fe9c", size = 4477528, upload-time = "2025-08-04T16:19:35.932Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ed/d58b540c15e36508cfeded7b0d39493e811b0dce18d9d4e6787fb2e89685/pywavelets-1.9.0-cp313-cp313t-win32.whl", hash = "sha256:81bb65facfbd7b50dec50450516e72cdc51376ecfdd46f2e945bb89d39bfb783", size = 4186493, upload-time = "2025-08-04T16:19:37.198Z" },
+    { url = "https://files.pythonhosted.org/packages/84/b2/12a849650d618a86bbe4d8876c7e20a7afe59a8cad6f49c57eca9af26dfa/pywavelets-1.9.0-cp313-cp313t-win_amd64.whl", hash = "sha256:47d52cf35e2afded8cfe1133663f6f67106a3220b77645476ae660ad34922cb4", size = 4274821, upload-time = "2025-08-04T16:19:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/1f/18c82122547c9eec2232d800b02ada1fbd30ce2136137b5738acca9d653e/pywavelets-1.9.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:53043d2f3f4e55a576f51ac594fe33181e1d096d958e01524db5070eb3825306", size = 4314440, upload-time = "2025-08-04T16:19:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e1/1c92ac6b538ef5388caf1a74af61cf6af16ea6d14115bb53357469cb38d6/pywavelets-1.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:56bc36b42b1b125fd9cb56e7956b22f8d0f83c1093f49c77fc042135e588c799", size = 4290162, upload-time = "2025-08-04T16:19:41.322Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d3/d856a2cac8069c20144598fa30a43ca40b5df2e633230848a9a942faf04a/pywavelets-1.9.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:08076eb9a182ddc6054ac86868fb71df6267c341635036dc63d20bdbacd9ad7e", size = 4437162, upload-time = "2025-08-04T16:19:42.556Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/54/777e0495acd4fb008791e84889be33d6e7fc8af095b441d939390b7d2491/pywavelets-1.9.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4ee1ee7d80f88c64b8ec3b5021dd1e94545cc97f0cd479fb51aa7b10f6def08e", size = 4498169, upload-time = "2025-08-04T16:19:43.791Z" },
+    { url = "https://files.pythonhosted.org/packages/76/68/81b97f4d18491a18fbe17e06e2eee80a591ce445942f7b6f522de07813c5/pywavelets-1.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3226b6f62838a6ccd7782cb7449ee5d8b9d61999506c1d9b03b2baf41b01b6fd", size = 4443318, upload-time = "2025-08-04T16:19:45.368Z" },
+    { url = "https://files.pythonhosted.org/packages/92/74/5147f2f0436f7aa131cb1bc13dba32ef5f3862748ae1c7366b4cde380362/pywavelets-1.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9fb7f4b11d18e2db6dd8deee7b3ce8343d45f195f3f278c2af6e3724b1b93a24", size = 4503294, upload-time = "2025-08-04T16:19:46.632Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/d4/af998cc71e869919e0ab45471bd43e91d055ac7bc3ce6f56cc792c9b6bc8/pywavelets-1.9.0-cp314-cp314-win32.whl", hash = "sha256:9902d9fc9812588ab2dce359a1307d8e7f002b53a835640e2c9388fe62a82fd4", size = 4144478, upload-time = "2025-08-04T16:19:47.974Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/66/1d071eae5cc3e3ad0e45334462f8ce526a79767ccb759eb851aa5b78a73a/pywavelets-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:7e57792bde40e331d6cc65458e5970fd814dba18cfc4e9add9d051e901a7b7c7", size = 4227186, upload-time = "2025-08-04T16:19:49.57Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/1f/da0c03ac99bd9d20409c0acf6417806d4cf333d70621da9f535dd0cf27fa/pywavelets-1.9.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b47c72fb4b76d665c4c598a5b621b505944e5b761bf03df9d169029aafcb652f", size = 4354391, upload-time = "2025-08-04T16:19:51.221Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b6/de9e225d8cc307fbb4fda88aefa79442775d5e27c58ee4d3c8a8580ceba6/pywavelets-1.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:969e369899e7eab546ea5d77074e4125082e6f9dad71966499bf5dee3758be55", size = 4335810, upload-time = "2025-08-04T16:19:52.813Z" },
+    { url = "https://files.pythonhosted.org/packages/33/3b/336761359d07cd44a4233ca854704ff2a9e78d285879ccc82d254b9daa57/pywavelets-1.9.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8aeffd4f35036c1fade972a61454de5709a7a8fc9a7d177eefe3ac34d76962e5", size = 4422220, upload-time = "2025-08-04T16:19:54.068Z" },
+    { url = "https://files.pythonhosted.org/packages/98/61/76ccc7ada127f14f65eda40e37407b344fd3713acfca7a94d7f0f67fe57d/pywavelets-1.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f63f400fcd4e7007529bd06a5886009760da35cd7e76bb6adb5a5fbee4ffeb8c", size = 4470156, upload-time = "2025-08-04T16:19:55.379Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/de/142ca27ee729cf64113c2560748fcf2bd45b899ff282d6f6f3c0e7f177bb/pywavelets-1.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a63bcb6b5759a7eb187aeb5e8cd316b7adab7de1f4b5a0446c9a6bcebdfc22fb", size = 4430167, upload-time = "2025-08-04T16:19:56.566Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/5e/90b39adff710d698c00ba9c3125e2bec99dad7c5f1a3ba37c73a78a6689f/pywavelets-1.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9950eb7c8b942e9bfa53d87c7e45a420dcddbd835c4c5f1aca045a3f775c6113", size = 4477378, upload-time = "2025-08-04T16:19:58.162Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/1a/89f5f4ebcb9d34d9b7b2ac0a868c8b6d8c78d699a36f54407a060cea0566/pywavelets-1.9.0-cp314-cp314t-win32.whl", hash = "sha256:097f157e07858a1eb370e0d9c1bd11185acdece5cca10756d6c3c7b35b52771a", size = 4209132, upload-time = "2025-08-04T16:20:00.371Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d2/a8065103f5e2e613b916489e6c85af6402a1ec64f346d1429e2d32cb8d03/pywavelets-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3b6ff6ba4f625d8c955f68c2c39b0a913776d406ab31ee4057f34ad4019fb33b", size = 4306793, upload-time = "2025-08-04T16:20:02.934Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Title: test: add perceptual-hash coverage for ScreenRecorder outputs

Branch: feature/update-test-suite-to-include-a-tests-tha-20251228-211816
Base: main
Commit: 66505ed — test: add perceptual-hash coverage for ScreenRecorder outputs

What changed
- Added docs/research/perceptual_hash_e2e_capture.md describing motivation, goal and approach for perceptual-hash based testing.
- Added ImageHash to test dependencies (pyproject.toml) and updated lockfile (uv.lock) to include imagehash and transitive deps (pywavelets, scipy, etc.).
- Extended tests/display/test_screen_recorder.py:
  - Introduced PatternRenderer and a new test test_screen_recorder_matches_expected_perceptual_hash that:
    - Records a small deterministic scene using ScreenRecorder.
    - Computes perceptual (pHash) of the recorded first frame using imagehash.phash.
    - Computes expected pHash from a PIL-generated baseline image and asserts Hamming distance <= 2.
  - Minor docstring/formatting and small refactors in existing tests.

Why
- Pixel-perfect GIF/frame comparisons are brittle (encoders/renderer variations). Perceptual hashing makes the end-to-end capture tests tolerant to minor encoding/renderer differences while still catching meaningful visual regressions.

How to test (manual / CI)
1. Checkout the branch:
   - git fetch && git checkout feature/update-test-suite-to-include-a-tests-tha-20251228-211816
2. Install dependencies (choose your environment tool):
   - Poetry: poetry install --with test
   - Or pip: pip install -e ".[test]" (or otherwise ensure test extras are installed)
   Note: imagehash (>=4.3.2) and its native/compiled transitive deps (numpy, pywavelets, scipy) are required.
3. Run the new test (recommended single test first):
   - pytest tests/display/test_screen_recorder.py::TestDisplayScreenRecorder::test_screen_recorder_matches_expected_perceptual_hash -q
4. Optionally run the full test file or test suite:
   - pytest tests/display/test_screen_recorder.py -q
   - pytest -q
5. Inspect failures:
   - The assertion reports the perceptual hash distance when the recorded frame drifts beyond the threshold.

Risks / Notes
- New test dependency: imagehash and its dependencies (pywavelets, scipy, numpy, pillow) increase CI runtime and may require platform-specific wheels; CI images without prebuilt wheels could lead to longer installs or build failures. Verify CI images include compatible wheels or allow building wheels.
- Threshold (Hamming distance <= 2) was chosen to balance tolerance and sensitivity; if false positives/negatives occur, we may need to tune it.
- The test uses a synthetic deterministic pattern to avoid external assets; ensure ScreenRecorder rendering surface size and timing remain deterministic in CI environments (headless/display settings).
- Lockfile updated (uv.lock) — ensure the pipeline uses the updated lockfile to keep installs reproducible.
- This test reduces brittleness but is not a replacement for pixel-perfect checks where exact fidelity is required.

If you want, I can:
- Add CI changes to ensure required binary wheels are available, or
- Lower/raise the pHash threshold and re-run locally to calibrate.