### PR TITLE
Need change details — please provide the diff or a brief description to generate a PR title

### DIFF
--- a/src/heart/renderers/three_fractal/renderer.py
+++ b/src/heart/renderers/three_fractal/renderer.py
@@ -462,7 +462,6 @@ class FractalRuntime(StatefulBaseRenderer[FractalRuntimeState]):
     # def _check_enter_auto(self, peripheral_manager: PeripheralManager):
     #     gamepad = peripheral_manager.get_gamepad()
     #     mapping = BitDoLite2Bluetooth() if Configuration.is_pi() else BitDoLite2()
-    #     print(f"Gamepad: {gamepad}")
     #     if gamepad.is_connected():
     #         if gamepad.was_tapped(mapping.BUTTON_Y):
     #             self.mode = "auto"


### PR DESCRIPTION
Title: chore: remove stray commented debug print in three_fractal renderer

Branch: feature/prompts-fix-divergence-20251228-214036
Base: main
Commit: 9fc2208

What changed
- Removed a single stray commented debug print line from:
  - src/heart/renderers/three_fractal/renderer.py
- Net diff: 1 deletion, no functional code changes.

Why
- Clean up leftover commented debug code to keep the renderer source tidy and avoid confusion for future readers.
- No behavior change intended.

How to test
1. Checkout the branch
   - git fetch && git checkout feature/prompts-fix-divergence-20251228-214036
2. Confirm the change is present
   - git show 9fc2208
   - or grep the file to ensure the commented print is gone:
     - git grep "print(f\"Gamepad: " || true
3. Run unit tests and linters (project-specific commands)
   - e.g. pytest or make test
   - e.g. flake8/ruff/black checks used by the repo
4. Run the three_fractal renderer (manual smoke test)
   - Start the application/demo that exercises the three_fractal renderer and verify normal behavior. There should be no change in runtime behavior or output.
5. CI should pass (automated checks / test suite)

Risks / Notes
- Low risk: only a commented debug line was removed, so no runtime effect.
- If that debug line was intentionally left for quick local troubleshooting, prefer using structured logging (logger.debug) or a documented temporary comment instead of ad-hoc prints.