### PR TITLE
WIP: provide change details to generate a descriptive PR title

### DIFF
--- a/drivers/rotary_encoder/code.py
+++ b/drivers/rotary_encoder/code.py
@@ -14,6 +14,7 @@ import rotaryio
 from digitalio import DigitalInOut, Direction, Pull
 
 from heart.firmware_io import device_id, identity, rotary_encoder
+from heart.utilities.logging import get_logger
 
 DEVICE_NAME = "rotary-encoder"
 IDENTITY = identity.Identity(
@@ -22,11 +23,12 @@ IDENTITY = identity.Identity(
     device_id=device_id.persistent_device_id(),
 )
 DEBUG = False
+logger = get_logger(__name__)
 
 
 def _debug(message: str) -> None:
     if DEBUG:
-        print(message)
+        logger.debug(message)
 
 
 def _write_serial_bus(message: str) -> None:

--- a/drivers/sensor_bus/code.py
+++ b/drivers/sensor_bus/code.py
@@ -17,17 +17,19 @@ from adafruit_lsm6ds.ism330dhcx import ISM330DHCX
 from adafruit_lsm303_accel import LSM303_Accel
 
 from heart.firmware_io import constants, device_id, identity
+from heart.utilities.logging import get_logger
 
 WAIT_BEFORE_TRYING_TO_CONNECT_TO_SENSOR_SECONDS: float = 1.0
 DEFAULT_WAIT_BETWEEN_PAYLOADS_SECONDS: float = 0.1
 DEFAULT_MIN_CHANGE_THRESHOLD: float = 0.1
 DEBUG = False
 DEVICE_NAME = "sensor-bus"
+logger = get_logger(__name__)
 
 
 def _debug(message: str) -> None:
     if DEBUG:
-        print(message)
+        logger.debug(message)
 
 
 def _write_serial_bus(message: str) -> None:


### PR DESCRIPTION
Title: refactor(drivers): replace debug print with logger in rotary_encoder and sensor_bus

Branch: feature/prompts-fix-divergence-20251228-221111  
Base: main  
Commit: 5942f25

What changed
- Replaced debug print calls with logger.debug in:
  - drivers/rotary_encoder/code.py
  - drivers/sensor_bus/code.py
- Added import and local logger instance: from heart.utilities.logging import get_logger; logger = get_logger(__name__)
- Total diff: 2 files changed, 6 insertions(+), 2 deletions(-)

Why
- Move from ad-hoc print debugging to the centralized logging utility for consistent, configurable, and leveled debug output across drivers.

How to test
1. Checkout branch and build/flash (or run) firmware as you normally would:
   - git fetch && git checkout feature/prompts-fix-divergence-20251228-221111
   - follow your repository's build/flash steps (e.g., build/flash firmware to device)
2. Verify imports/resolution:
   - Run static checks (optional): flake8 / mypy / unit tests used in this repo to ensure no import or typing regressions.
3. Verify runtime behavior (device):
   - Ensure logging backend is initialized early in the firmware (same as on main).
   - Enable debug in each driver to exercise debug paths:
     - In drivers/rotary_encoder/code.py set DEBUG = True (or toggle via existing config if available).
     - In drivers/sensor_bus/code.py set DEBUG = True.
   - Reboot firmware and attach to serial/console where logs are emitted.
   - Interact with the rotary encoder and sensor bus (rotate encoder, trigger sensor reads).
   - Expected: debug messages emitted through the logger (logger.debug) appear in the configured log sink instead of raw print output.
4. Smoke test normal operation:
   - Set DEBUG = False (default) and confirm no debug output and that drivers function normally (no regressions in behavior).
   - Run integration/functional tests verifying rotary encoder and sensor readings still work as before.

Risks / Notes
- Low risk change: behavior is identical when DEBUG=False. When DEBUG=True, output goes through the logging system instead of print.
- Logging requires the central logging utility to be initialized and configured to route messages to the desired sink (serial/console). If logging isn't configured, debug messages may not appear.
- Slight increase in binary size due to logger usage is possible but expected to be negligible.
- No public API changes; internal refactor only.

Files touched
- drivers/rotary_encoder/code.py
- drivers/sensor_bus/code.py

If you want, I can also add a quick smoke-test script or instructions to enable logging configuration in firmware startup so debug messages are visible by default.