### PR TITLE
chore: placeholder PR title — awaiting change details to craft a concise, descriptive title

### DIFF
--- a/docs/research/spook_controller_frame_updates.md
+++ b/docs/research/spook_controller_frame_updates.md
@@ -1,0 +1,20 @@
+# Spook controller frame updates
+
+## Problem
+
+The spook mode animation stalls after initialization because game tick events
+are emitted before the display clock is updated, so spritesheet providers do
+not receive a usable clock delta during the tick-driven state updates.
+
+## Update
+
+- Emit the display clock update before the per-frame game tick so spritesheet
+  providers can compute elapsed time from the latest clock in the same loop.
+- Keep the tick cadence to one event per frame so reactive state updates remain
+  consistent across renderers.
+
+## Materials
+
+- `src/heart/runtime/game_loop/__init__.py`
+- `src/heart/renderers/spritesheet/provider.py`
+- `src/heart/renderers/spritesheet_random/provider.py`

--- a/src/heart/runtime/game_loop/__init__.py
+++ b/src/heart/runtime/game_loop/__init__.py
@@ -226,7 +226,6 @@ class GameLoop:
         if self.components.display.clock is None:
             raise RuntimeError("GameLoop failed to initialize display clock")
         while self.running:
-            self.components.peripheral_runtime.tick()
             self.running = self.components.event_handler.handle_events()
             self._preprocess_setup()
             renderers = self._select_renderers()
@@ -238,6 +237,5 @@ class GameLoop:
             self._render_pacer.pace(render_start, estimated_cost_ms)
 
             self.components.display.clock.tick(self.max_fps)
-            
-            self.components.peripheral_runtime.tick()
             self.components.peripheral_manager.clock.on_next(self.components.display.clock)
+            self.components.peripheral_runtime.tick()


### PR DESCRIPTION
Title: fix(game-loop): emit display clock update before per-frame tick

Branch: feature/fix-the-spook-controller-it-currently-do-20251228-221315
Base: main
Commit: 0a1cc19

What changed
- Added research doc: docs/research/spook_controller_frame_updates.md (explains the problem and reasoning).
- Reordered game loop updates in src/heart/runtime/game_loop/__init__.py:
  - Emit the display clock update (peripheral_manager.clock.on_next) immediately after display.clock.tick(...) and before calling peripheral_runtime.tick().
  - Removed an earlier peripheral_runtime.tick() call that ran before event handling, ensuring one tick per frame and deterministic ordering.
- Minor non-functional edit in src/heart/renderers/three_fractal/renderer.py: a commented debug print was added.

Why
- The spook mode animation could stall because per-frame game tick events were fired before the display clock was updated. Spritesheet providers received tick-driven state updates without a current display clock delta, so they could not compute elapsed time properly.
- Emitting the display clock update before per-frame ticks ensures sprite/spritesheet providers see the latest clock delta during the same frame, preventing the stall while preserving one tick event per frame.

How to test
1. Checkout this branch:
   - git fetch && git checkout feature/fix-the-spook-controller-it-currently-do-20251228-221315
2. Start the app/runtime the same way you normally run it in your environment (the renderer that uses spook mode or spritesheet providers).
3. Reproduce the spook mode animation:
   - Enter the spook mode (the mode that previously exhibited the stall) and observe animations.
   - Expected: spritesheet/frame-based animations advance smoothly each rendered frame (no initial stall after initialization).
4. Verify ordering (optional instrumentation):
   - Add quick logging or temporary prints in:
     - display.clock.tick(...) return or immediately after on_next call,
     - peripheral_runtime.tick()
     to verify the on_next call happens before peripheral_runtime.tick() each frame.
   - Confirm you see one peripheral_runtime.tick() per frame (no extra early tick).
5. Regression check:
   - Walk through other typical input scenarios (gamepad events, user input) to ensure there are no regressions in input handling or event responsiveness.

Risks / Notes
- Behavior change: peripheral_runtime.tick() now runs after the display clock update (instead of once before event handling). Code that relied on tick running before event handling may need review. However, this change intentionally enforces the display-clock-first ordering so sprite time deltas are correct.
- The change preserves one tick per frame; there should be no double-tick side effects.
- The new docs file documents the reasoning for future reference.
- A commented debug print was added to three_fractal/renderer.py — harmless but remove if undesired.

Files touched
- Added: docs/research/spook_controller_frame_updates.md
- Modified: src/heart/runtime/game_loop/__init__.py
- Modified (comment only): src/heart/renderers/three_fractal/renderer.py

If you want, I can add a small test/instrumentation helper to assert ordering (clock update before tick) so this is automatically validated in CI.