### PR TITLE
Add utility to generate concise GitHub PR titles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,3 +85,7 @@ Keep files narrowly scoped. If a module starts handling multiple concerns (e.g.,
 ## Environment Cleanup
 
 If a single file or module starts accumulating setup, orchestration, configuration, and cleanup logic, move those responsibilities into smaller, focused modules or helpers so each file handles fewer concerns and is easier to reason about.
+
+## Configuration Defaults
+
+Define CLI default values as module-level constants so they stay consistent across commands and are easy to review.

--- a/scripts/generate_protobuf.py
+++ b/scripts/generate_protobuf.py
@@ -14,6 +14,7 @@ logger = get_logger(__name__)
 
 DEFAULT_PROTO_PATH = Path("src")
 DEFAULT_PYTHON_OUT = Path("src")
+DEFAULT_PROTO_PATHS = [DEFAULT_PROTO_PATH]
 
 app = typer.Typer(add_completion=False)
 
@@ -29,7 +30,7 @@ def generate(
         resolve_path=True,
     ),
     proto_path: list[Path] = typer.Option(
-        [DEFAULT_PROTO_PATH],
+        DEFAULT_PROTO_PATHS,
         "--proto-path",
         help="Root directory for protobuf imports. Repeat to add more.",
     ),

--- a/scripts/ir_calibrate.py
+++ b/scripts/ir_calibrate.py
@@ -15,6 +15,12 @@ from heart.peripheral.ir_sensor_array import SPEED_OF_LIGHT, radial_layout
 
 app = typer.Typer(help="Calibrate IR sensor arrays from captured sweep data.")
 
+DEFAULT_OUTPUT_PATH = Path("ir_array_offsets.json")
+DEFAULT_LAYOUT = "radial"
+DEFAULT_LAYOUT_FILE = None
+DEFAULT_PROPAGATION_SPEED = SPEED_OF_LIGHT
+DEFAULT_TELEMETRY_URL = None
+
 
 @dataclass(slots=True)
 class CaptureRecord:
@@ -137,22 +143,22 @@ def _compute_offsets(
 def calibrate(
     data: Path = typer.Argument(..., help="Path to captured sweep data (JSON)."),
     output: Path = typer.Option(
-        Path("ir_array_offsets.json"),
+        DEFAULT_OUTPUT_PATH,
         "--output",
         "-o",
         help="Destination for calibration offsets (JSON).",
     ),
-    layout: str = typer.Option("radial", help="Built-in sensor layout to use."),
+    layout: str = typer.Option(DEFAULT_LAYOUT, help="Built-in sensor layout to use."),
     layout_file: Path | None = typer.Option(
-        None,
+        DEFAULT_LAYOUT_FILE,
         help="Optional path to custom sensor layout JSON overriding --layout.",
     ),
     propagation_speed: float = typer.Option(
-        SPEED_OF_LIGHT,
+        DEFAULT_PROPAGATION_SPEED,
         help="Propagation speed for the burst medium (m/s).",
     ),
     telemetry_url: str | None = typer.Option(
-        None,
+        DEFAULT_TELEMETRY_URL,
         help="Optional HTTP endpoint that receives the calibration payload.",
     ),
 ) -> None:


### PR DESCRIPTION
Branch: feature/prompts-fix-divergence-20251228-221645
Base: main
Commit: refactor: centralize CLI default values as module-level constants

What changed
- Centralized CLI default values into module-level constants:
  - scripts/generate_protobuf.py
    - Added DEFAULT_PROTO_PATHS and used it as the default for --proto-path.
  - scripts/ir_calibrate.py
    - Added DEFAULT_OUTPUT_PATH, DEFAULT_LAYOUT, DEFAULT_LAYOUT_FILE, DEFAULT_PROPAGATION_SPEED, DEFAULT_TELEMETRY_URL and used them for the corresponding typer.Options.
- Documentation
  - AGENTS.md: added guidance to define CLI default values as module-level constants.

Why
- Make CLI defaults easier to review and keep consistent across commands.
- Reduce duplication of literal defaults inline in option declarations and make the defaults obvious at the top of each module.

How to test
1. Inspect help output for both scripts (ensures defaults are wired into typer options)
   - generate_protobuf:
     - Run: python scripts/generate_protobuf.py --help
     - Expect: the --proto-path option exists and shows the default (src).
   - ir_calibrate:
     - Run: python scripts/ir_calibrate.py --help
     - Expect: options --output, --layout, --layout-file, --propagation-speed, --telemetry-url show defaults:
       - --output default: ir_array_offsets.json
       - --layout default: radial
       - --layout-file default: None (or no default listed)
       - --propagation-speed default: the numeric SPEED_OF_LIGHT value from heart.peripheral.ir_sensor_array
       - --telemetry-url default: None (or no default listed)

2. Verify runtime behavior is unchanged
   - generate_protobuf default behavior:
     - Run without specifying --proto-path:
       - python scripts/generate_protobuf.py generate path/to/file.proto
       - Confirm imports/resolution uses src as proto path.
     - Run with multiple proto paths:
       - python scripts/generate_protobuf.py generate --proto-path src --proto-path third_party path/to/file.proto
       - Confirm both proto-paths are accepted and used.
   - ir_calibrate defaults:
     - Create a small valid capture JSON (or use an existing capture file) and run:
       - python scripts/ir_calibrate.py path/to/capture.json
       - Confirm output is written to ir_array_offsets.json and layout 'radial' is used.
     - Override options to confirm they still work:
       - python scripts/ir_calibrate.py path/to/capture.json --output custom.json --layout linear --propagation-speed 300000000

3. (Optional) Run test suite
   - If the repo has tests, run: pytest -q
   - Confirm no regressions related to these scripts.

Risks / notes
- The new DEFAULT_PROTO_PATHS is a module-level list (mutable). If code mutates this list at runtime and the same Python process reuses the module, the default could change between invocations. In typical CLI use (single process per invocation) this is unlikely to be an issue, but consider using an immutable tuple or a factory (None -> new list) if persistent mutation is a concern.
- This is a refactor-only change to how defaults are declared; behavior should remain backward compatible. Still verify CLI behavior (help text and default usage) as described above.
- Changes assume imports (Path, SPEED_OF_LIGHT) remain available in the modules — no import changes were required.

If you want, I can update DEFAULT_PROTO_PATHS to an immutable tuple (DEFAULT_PROTO_PATHS = (DEFAULT_PROTO_PATH,)) to avoid the mutable-default risk.