### PR TITLE
fix(websocket): add graceful shutdown and background thread/loop cleanup

### DIFF
--- a/docs/research/beats_streaming_io_tuning.md
+++ b/docs/research/beats_streaming_io_tuning.md
@@ -8,6 +8,7 @@ Capture the runtime controls that reduce websocket backpressure when streaming B
 
 - `src/heart/device/beats/websocket.py`
 - `src/heart/device/beats/streaming_config.py`
+- `src/heart/runtime/game_loop/__init__.py`
 
 ## Materials
 
@@ -36,3 +37,4 @@ Beats frames and peripheral updates are serialized into protobuf `StreamEnvelope
 - Frames are enqueued using non-blocking operations from the websocket send path, so the renderer thread does not stall when the queue is saturated.
 - Broadcast fan-out happens concurrently per client, reducing head-of-line blocking when one connection is slow.
 - Overflow behavior is determined by the strategy selection, so operators can prefer freshness (`drop_oldest`) or completeness (`drop_newest`) depending on the audience.
+- Websocket shutdown requests stop the broadcast worker, close the server, and join the background thread so keyboard interrupts unwind without leaving a live event loop.

--- a/src/heart/runtime/game_loop/__init__.py
+++ b/src/heart/runtime/game_loop/__init__.py
@@ -133,6 +133,7 @@ class GameLoop:
             shutdown.on_completed()
             shutdown.dispose()
 
+            self.components.peripheral_runtime.shutdown()
             self.components.render_pipeline.shutdown()
             pygame.quit()
 

--- a/src/heart/runtime/peripheral_runtime.py
+++ b/src/heart/runtime/peripheral_runtime.py
@@ -12,6 +12,7 @@ class PeripheralRuntime:
 
     def __init__(self, peripheral_manager: PeripheralManager) -> None:
         self._peripheral_manager = peripheral_manager
+        self._websocket: WebSocket | None = None
 
     def detect_and_start(self) -> None:
         logger.info("Attempting to detect attached peripherals")
@@ -27,9 +28,15 @@ class PeripheralRuntime:
 
     def configure_streaming(self, websocket: WebSocket | None = None) -> None:
         ws = websocket or WebSocket()
+        self._websocket = ws
         self._peripheral_manager.get_event_bus().subscribe(
             on_next=lambda x: ws.send(kind="peripheral", payload=x),
         )
 
     def tick(self) -> None:
         self._peripheral_manager.game_tick.on_next(True)
+
+    def shutdown(self) -> None:
+        if self._websocket is None:
+            return
+        self._websocket.shutdown()


### PR DESCRIPTION
Branch: feature/fix-websocket-so-that-the-thread-cleanly-20251229-143817
Base: main
Commit: fix(websocket): add graceful shutdown and thread/loop cleanup (34bc261)

Summary
- Add graceful shutdown and cleanup for the Beats websocket server to ensure background thread and asyncio event loop are terminated cleanly on application exit.
- Wire shutdown through the peripheral runtime and game loop so exiting the application cleans up the websocket server.

What changed
- src/heart/device/beats/websocket.py
  - Added DEFAULT_HOST, DEFAULT_PORT, DEFAULT_PING_INTERVAL_SEC, THREAD_JOIN_TIMEOUT_SEC constants.
  - Added _stop_event, _shutdown_lock and _shutdown_requested fields.
  - Replace atexit.register(self._thread.join, timeout=1) with atexit.register(self.shutdown).
  - Implement stop_event to signal broadcast_worker to exit; broadcast worker now races between queue.get() and stop_event.wait().
  - Ensure the server close triggers stop_event and broadcast task is awaited.
  - On thread shutdown, cancel remaining asyncio tasks, gather them, then close the loop.
  - send() is now a no-op after shutdown_requested is set.
  - Implement shutdown() that is thread-safe, idempotent, closes the server via loop.call_soon_threadsafe when called from other threads, sets stop_event, and join()s the websocket thread with a timeout.
- src/heart/runtime/peripheral_runtime.py
  - PeripheralRuntime stores the WebSocket instance and calls ws.shutdown() from new shutdown() method.
  - configure_streaming saves the websocket instance and subscribes peripheral events to it.
- src/heart/runtime/game_loop/__init__.py
  - GameLoop now calls components.peripheral_runtime.shutdown() during shutdown sequence.
- docs/research/beats_streaming_io_tuning.md
  - Document that websocket shutdown stops the broadcast worker, closes the server, and joins the background thread so keyboard interrupts don't leave a live event loop.

Why
- Previously the websocket background thread and its asyncio event loop could remain alive after a KeyboardInterrupt or program exit, causing warnings/errors and preventing a clean shutdown. This change makes shutdown explicit, safe, and idempotent so application exit is clean and deterministic.

How to test
1. Build/run the application (or the component that starts the Beats websocket server) with streaming enabled.
   - Confirm the server starts on localhost:8765 (defaults) or your configured host/port.
   - Example: run the game or integration scenario that triggers PeripheralRuntime.configure_streaming().
2. Connect a client:
   - Install wscat (npm i -g wscat) or use another websocket tool.
   - Connect: wscat -c ws://localhost:8765
   - Verify you receive peripheral frames while the app runs.
3. Trigger shutdown:
   - Method A: Press Ctrl-C in the running app (KeyboardInterrupt).
   - Method B: Let the game loop reach normal shutdown path or call the shutdown sequence programmatically.
4. Observe behavior:
   - The websocket client should be disconnected (server closed).
   - The process should exit promptly (thread join timeout is 1s); you should not see asyncio "Task was destroyed but it is pending!" or "RuntimeError: Event loop is running" warnings.
   - No traceback originating from the websocket server thread should appear in logs.
5. Optional verification:
   - Before and after shutdown, check that no process is listening on the websocket port (e.g., lsof -iTCP:8765 -sTCP:LISTEN or ss/netstat).
   - Reconnect clients and repeat shutdown to ensure idempotency.

Risks / notes
- Shutdown uses a 1s THREAD_JOIN_TIMEOUT_SEC for thread.join(); in extreme cases the thread might not join in that window — the code is idempotent so repeated shutdown calls are safe, but adjust the timeout if you need a longer grace period.
- Tasks are cancelled and gathered during loop shutdown. Exceptions raised by cancelled tasks are suppressed with return_exceptions=True; logging of those exceptions is not preserved by this change.
- send() is a no-op after shutdown_requested is set. Callers that expect send to always succeed should tolerate missing frames after shutdown.
- The shutdown is thread-safe and idempotent; atexit now calls shutdown() rather than joining the thread directly.
- Defaults for host/port/ping interval were introduced as constants; these can be adjusted if you have custom runtime configuration.

Files changed (high level)
- docs/research/beats_streaming_io_tuning.md (doc update)
- src/heart/device/beats/websocket.py (main changes)
- src/heart/runtime/peripheral_runtime.py (lifecycle plumbing)
- src/heart/runtime/game_loop/__init__.py (ensure peripheral shutdown on game exit)

If you want I can add a small integration test that starts the websocket server, connects a dummy client, requests shutdown, and asserts the thread/loop are terminated and the socket is closed.