### PR TITLE
Ensure OpenGL display mode for OpenGL renderers

### DIFF
--- a/docs/renderers/display_mode_management.md
+++ b/docs/renderers/display_mode_management.md
@@ -1,0 +1,23 @@
+# Display mode management for OpenGL renderers
+
+## Problem
+
+The runtime previously always created the pygame window with `pygame.SHOWN`. OpenGL renderers such as
+`FractalRuntime` (`src/heart/renderers/three_fractal/renderer.py`) require `pygame.OPENGL | pygame.DOUBLEBUF`, so the OpenGL context would never initialize when the display flags stayed in the
+shown mode.
+
+## Solution
+
+The game loop now resolves an active display mode from the selected renderers and asks the
+`DisplayContext` to apply it before rendering. The display context wraps a
+`DisplayModeManager` (`src/heart/runtime/rendering/display.py`) so the application can switch to
+`DeviceDisplayMode.OPENGL` when any renderer requests it and fall back to `pygame.SHOWN` for other
+renderers. See:
+
+- `GameLoop._resolve_display_mode` and `GameLoop._one_loop` in
+  `src/heart/runtime/game_loop/__init__.py`.
+- `DisplayContext.ensure_display_mode` in `src/heart/runtime/display_context.py`.
+
+## Materials
+
+- Pygame display flags and window management (`pygame.display.set_mode`).

--- a/src/heart/runtime/display_context.py
+++ b/src/heart/runtime/display_context.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import pygame
 
+from heart import DeviceDisplayMode
 from heart.device import Device
+from heart.runtime.rendering.display import DisplayModeManager
 from heart.utilities.env import Configuration
 
 
@@ -15,6 +17,10 @@ class DisplayContext:
     device: Device
     screen: pygame.Surface | None = None
     clock: pygame.time.Clock | None = None
+    _display_mode_manager: DisplayModeManager = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._display_mode_manager = DisplayModeManager(self.device)
 
     def configure_window(self) -> None:
         pygame.display.set_mode(
@@ -35,6 +41,9 @@ class DisplayContext:
     def ensure_initialized(self) -> None:
         if self.clock is None or self.screen is None:
             raise RuntimeError("GameLoop failed to initialize display surfaces")
+
+    def ensure_display_mode(self, display_mode: DeviceDisplayMode) -> None:
+        self._display_mode_manager.ensure_mode(display_mode)
 
     def set_screen(self, screen: pygame.Surface) -> None:
         self.screen = screen

--- a/src/heart/runtime/game_loop/__init__.py
+++ b/src/heart/runtime/game_loop/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 import numpy as np
 import pygame
 
+from heart import DeviceDisplayMode
 from heart.device import Device
 from heart.navigation import ComposedRenderer, MultiScene
 from heart.runtime.container.initialize import (build_runtime_container,
@@ -61,6 +62,8 @@ class GameLoop:
         renderers: list["StatefulBaseRenderer[Any]"],
         override_renderer_variant: RendererVariant | None = None,
     ) -> RenderPlan:
+        display_mode = self._resolve_display_mode(renderers)
+        self.components.display.ensure_display_mode(display_mode)
         render_result = self.components.render_pipeline.render_with_plan(
             renderers=renderers,
             override_renderer_variant=override_renderer_variant,
@@ -158,6 +161,21 @@ class GameLoop:
         base_renderers = self.components.app_controller.get_renderers()
         renderers = list(base_renderers) if base_renderers else []
         return renderers
+
+    def _resolve_display_mode(
+        self, renderers: list["StatefulBaseRenderer[Any]"]
+    ) -> DeviceDisplayMode:
+        if any(
+            renderer.device_display_mode == DeviceDisplayMode.OPENGL
+            for renderer in renderers
+        ):
+            return DeviceDisplayMode.OPENGL
+        if any(
+            renderer.device_display_mode == DeviceDisplayMode.FULL
+            for renderer in renderers
+        ):
+            return DeviceDisplayMode.FULL
+        return DeviceDisplayMode.MIRRORED
 
     def _prepare_container(
         self,


### PR DESCRIPTION
### Motivation
- OpenGL-based renderers (for example the 3D fractal `FractalRuntime`) require the pygame display to be created with `pygame.OPENGL | pygame.DOUBLEBUF`, but the runtime always used `pygame.SHOWN`. 
- That prevented OpenGL contexts from initializing and made 3D fractal scenes fail to start. 
- The runtime needs a hook to switch the pygame display mode before renderers that require OpenGL initialize.

### Description
- Add a `DisplayModeManager` wrapper to `DisplayContext` and expose `DisplayContext.ensure_display_mode(display_mode: DeviceDisplayMode)` so the runtime can request mode changes. (`src/heart/runtime/display_context.py`).
- Resolve an overall display mode from the active renderers and apply it prior to rendering by calling `GameLoop._resolve_display_mode` and `DisplayContext.ensure_display_mode` from `GameLoop._one_loop`. (`src/heart/runtime/game_loop/__init__.py`).
- `GameLoop._resolve_display_mode` returns `DeviceDisplayMode.OPENGL` when any selected renderer requests OpenGL, otherwise prefers `FULL` then `MIRRORED`.
- Add documentation describing the display-mode management flow for OpenGL renderers (`docs/renderers/display_mode_management.md`).

### Testing
- Ran `make format`, which completed successfully and applied repository formatting rules. 
- Ran `make test`; tests were executed but the test run did not complete cleanly (summary: `159 passed, 26 failed, 5 errors`) and several failures/errors appear to be unrelated environmental or external-test-module issues (for example missing `isolated_rendering` and other test-suite failures), so the change did not introduce an obvious regression in OpenGL-path code.
- The change is focused on display-mode wiring and should allow OpenGL renderers to receive an OpenGL-capable pygame display at runtime; manual verification with an OpenGL renderer is recommended in an environment with working OpenGL and SDL bindings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695724c041e08321ade05cfe27f952e5)