### PR TITLE
Switch Roboto text rendering to pixel font

### DIFF
--- a/docs/renderers/renderer_catalog.md
+++ b/docs/renderers/renderer_catalog.md
@@ -201,7 +201,11 @@ totem run --configuration dual_output_demo
 **Package:** `src/heart/renderers/text/`
 
 The text renderer is split into focused modules so state, wiring, and rendering
-remain isolated:
+remain isolated. The free text pipeline renders with the pixel font and disables
+anti-aliasing to preserve crisp glyph edges on low-resolution displays.
+The text renderer defaults to the same pixel font; font names that end in
+`.ttf` load from assets while other names resolve through the system font
+registry.
 
 - `provider.py` builds `TextRenderingState` and wires the main switch
   subscription that updates state on rotations.

--- a/src/heart/navigation/app_controller.py
+++ b/src/heart/navigation/app_controller.py
@@ -56,7 +56,7 @@ class AppController(StatefulBaseRenderer[AppControllerState]):
             ),
             TextRendering(
                 text=["sleep"],
-                font="Roboto",
+                font="Grand9K Pixel.ttf",
                 font_size=16,
                 color=Color.kirby(),
                 y_location=0.55,
@@ -112,7 +112,7 @@ class AppController(StatefulBaseRenderer[AppControllerState]):
         if isinstance(title, str):
             return TextRendering(
                 text=[title],
-                font="Roboto",
+                font="Grand9K Pixel.ttf",
                 font_size=12,
                 color=Color(255, 105, 180),
                 y_location=0.5,

--- a/src/heart/programs/configurations/lib_2024.py
+++ b/src/heart/programs/configurations/lib_2024.py
@@ -18,7 +18,7 @@ def configure(loop: GameLoop) -> None:
                 MandelbrotTitle(),
                 TextRendering(
                     text=["mandelbrot"],
-                    font="Roboto",
+                    font="Grand9K Pixel.ttf",
                     font_size=14,
                     color=Color(255, 255, 255),
                     y_location=0.55,

--- a/src/heart/programs/configurations/lib_2025.py
+++ b/src/heart/programs/configurations/lib_2025.py
@@ -41,7 +41,7 @@ def configure(loop: GameLoop) -> None:
                 MandelbrotTitle(),
                 TextRendering(
                     text=["mandelbrot"],
-                    font="Roboto",
+                    font="Grand9K Pixel.ttf",
                     font_size=14,
                     color=Color(255, 255, 255),
                     y_location=0.55,
@@ -63,7 +63,7 @@ def configure(loop: GameLoop) -> None:
                 RenderImage(image_file="mario_still.png"),
                 TextRendering(
                     text=["mario"],
-                    font="Roboto",
+                    font="Grand9K Pixel.ttf",
                     font_size=14,
                     color=Color(255, 0, 0),
                     y_location=0.05,
@@ -82,7 +82,7 @@ def configure(loop: GameLoop) -> None:
                 multicolor_renderer(),
                 TextRendering(
                     text=["shroomed"],
-                    font="Roboto",
+                    font="Grand9K Pixel.ttf",
                     font_size=14,
                     color=Color(0, 0, 0),
                     y_location=0.5,
@@ -105,7 +105,7 @@ def configure(loop: GameLoop) -> None:
                 loop.resolve(HeartTitleScreen),
                 TextRendering(
                     text=["heart rate"],
-                    font="Roboto",
+                    font="Grand9K Pixel.ttf",
                     font_size=14,
                     color=Color(255, 105, 180),
                     y_location=0.5,
@@ -121,7 +121,7 @@ def configure(loop: GameLoop) -> None:
                 loop.resolve(WaterTitleScreen),
                 TextRendering(
                     text=["water"],
-                    font="Roboto",
+                    font="Grand9K Pixel.ttf",
                     font_size=14,
                     color=Color(255, 105, 180),
                     y_location=0.5,

--- a/src/heart/renderers/artist/renderer.py
+++ b/src/heart/renderers/artist/renderer.py
@@ -17,7 +17,7 @@ class ArtistScene(MultiScene):
             RenderImage(image_file="artist/imaginal_disk.png"),
             TextRendering(
                 text=["artist"],
-                font="Roboto",
+                font="Grand9K Pixel.ttf",
                 font_size=14,
                 color=Color(255, 105, 180),
                 y_location=0.5,

--- a/src/heart/renderers/free_text/provider.py
+++ b/src/heart/renderers/free_text/provider.py
@@ -14,14 +14,19 @@ from heart.peripheral.core.providers import ObservableProvider
 from heart.renderers.free_text.state import FreeTextRendererState
 from heart.utilities.reactivex_threads import pipe_in_background
 
+PIXEL_FONT_PATH = "Grand9K Pixel.ttf"
+FONT_SIZE_MAX = 12
+FONT_SIZE_MIN = 6
+INITIAL_FONT_SIZE = 10
+
 
 class FreeTextStateProvider(ObservableProvider[FreeTextRendererState]):
     def __init__(self) -> None:
         self._text = BehaviorSubject("Waiting for text...")
         self._font_cache: dict[int, pygame.font.Font] = {}
-        self._font_size_max: int = 12
-        self._font_size_min: int = 6
-        self._initial_font_size: int = 10
+        self._font_size_max: int = FONT_SIZE_MAX
+        self._font_size_min: int = FONT_SIZE_MIN
+        self._initial_font_size: int = INITIAL_FONT_SIZE
 
     def observable(
         self, peripheral_manager: PeripheralManager
@@ -73,7 +78,7 @@ class FreeTextStateProvider(ObservableProvider[FreeTextRendererState]):
 
     def get_font(self, size: int) -> pygame.font.Font:
         if size not in self._font_cache:
-            self._font_cache[size] = Loader.load_font("Grand9K Pixel.ttf", font_size=size)
+            self._font_cache[size] = Loader.load_font(PIXEL_FONT_PATH, font_size=size)
         return self._font_cache[size]
 
     def _fit_font_and_wrap(

--- a/src/heart/renderers/free_text/renderer.py
+++ b/src/heart/renderers/free_text/renderer.py
@@ -10,6 +10,9 @@ from heart.renderers import StatefulBaseRenderer
 from heart.renderers.free_text.provider import FreeTextStateProvider
 from heart.renderers.free_text.state import FreeTextRendererState
 
+TEXT_COLOR = (255, 105, 180)
+TEXT_ANTIALIAS = False
+
 
 class FreeTextRenderer(StatefulBaseRenderer[FreeTextRendererState]):
     """Render the most recent text message that arrived via *PhoneText*."""
@@ -55,7 +58,7 @@ class FreeTextRenderer(StatefulBaseRenderer[FreeTextRendererState]):
         y = (window_height - total_height) // 2
 
         for line in visible_lines:
-            rendered = font.render(line, True, (255, 105, 180))
+            rendered = font.render(line, TEXT_ANTIALIAS, TEXT_COLOR)
             text_width, _ = rendered.get_size()
             x = (window_width - text_width) // 2
             window.blit(rendered, (x, y))

--- a/src/heart/renderers/kirby/renderer.py
+++ b/src/heart/renderers/kirby/renderer.py
@@ -23,7 +23,7 @@ class KirbyScene(MultiScene):
             ),
             TextRendering(
                 text=["kirby mode"],
-                font="Roboto",
+                font="Grand9K Pixel.ttf",
                 font_size=12,
                 color=Color.kirby(),
                 y_location=0.65,

--- a/src/heart/renderers/text/provider.py
+++ b/src/heart/renderers/text/provider.py
@@ -60,7 +60,7 @@ class TextRenderingProvider(ObservableProvider[TextRenderingState]):
     def default(cls, text: str) -> "TextRenderingProvider":
         return cls(
             text=[text],
-            font_name="Roboto",
+            font_name="Grand9K Pixel.ttf",
             font_size=14,
             color=Color(255, 105, 180),
             x_location=None,

--- a/src/heart/renderers/text/renderer.py
+++ b/src/heart/renderers/text/renderer.py
@@ -2,12 +2,16 @@ import pygame
 import pygame.ftfont
 import reactivex
 
+from heart.assets.loader import Loader
 from heart.device import Orientation
 from heart.display.color import Color
 from heart.peripheral.core.manager import PeripheralManager
 from heart.renderers import StatefulBaseRenderer
 from heart.renderers.text.provider import TextRenderingProvider
 from heart.renderers.text.state import TextRenderingState
+
+PIXEL_FONT_PATH = "Grand9K Pixel.ttf"
+PIXEL_FONT_ANTIALIAS = False
 
 
 class TextRendering(StatefulBaseRenderer[TextRenderingState]):
@@ -42,7 +46,7 @@ class TextRendering(StatefulBaseRenderer[TextRenderingState]):
     def default(cls, text: str) -> "TextRendering":
         return cls(
             text=[text],
-            font="Roboto",
+            font=PIXEL_FONT_PATH,
             font_size=14,
             color=Color(255, 105, 180),
             x_location=0.5,
@@ -71,10 +75,15 @@ class TextRendering(StatefulBaseRenderer[TextRenderingState]):
         lines = current_text.split("\n")
         font_key = (self.state.font_name, self.state.font_size)
         if self._font is None or self._font_key != font_key:
-            self._font = pygame.ftfont.SysFont(
-                self.state.font_name,
-                self.state.font_size,
-            )
+            if self.state.font_name.endswith(".ttf"):
+                self._font = Loader.load_font(
+                    self.state.font_name, font_size=self.state.font_size
+                )
+            else:
+                self._font = pygame.ftfont.SysFont(
+                    self.state.font_name,
+                    self.state.font_size,
+                )
             self._font_key = font_key
 
         font = self._font
@@ -89,10 +98,15 @@ class TextRendering(StatefulBaseRenderer[TextRenderingState]):
         else:
             y_offset = 0
 
+        antialias = (
+            PIXEL_FONT_ANTIALIAS
+            if self.state.font_name.endswith(".ttf")
+            else True
+        )
         for line in lines:
             text_surface = font.render(
                 line,
-                True,
+                antialias,
                 self.state.color._as_tuple(),
             )
             text_width, _ = text_surface.get_size()


### PR DESCRIPTION
### Motivation
- Use a pixel-style font for on-screen text so glyphs render crisply on low-resolution displays.
- Ensure .ttf font assets are loaded from the project assets while preserving system font resolution for named fonts.
- Make the pixel font behavior explicit and documented for renderer users.

### Description
- Default TextRendering now uses a pixel font (`Grand9K Pixel.ttf`) and `TextRenderingProvider.default` was updated accordingly.
- `TextRendering` was changed to load `.ttf` fonts via `Loader.load_font` and to choose anti-aliasing according to font type, with a `PIXEL_FONT_ANTIALIAS` constant set to disable AA for pixel fonts.
- Free-text pipeline was updated with `PIXEL_FONT_PATH`, font-size bounds, and caching in `FreeTextStateProvider`, and the free-text renderer now renders using the pixel font with anti-aliasing disabled via `TEXT_ANTIALIAS`.
- Replaced occurrences of the `Roboto` font with `Grand9K Pixel.ttf` in scenes/configurations and updated `docs/renderers/renderer_catalog.md` to describe the change.

### Testing
- Ran `make format`, which completed successfully and applied formatting changes where necessary.
- Ran `make test`, which executed the test suite but resulted in multiple failures and errors (26 failed, 5 errors); failures appear across unrelated modules and are not isolated to the text renderer changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957214784b483219584122a6882e182)