### PR TITLE
Use game clock for SlideTransition and specify duration in ms

### DIFF
--- a/src/heart/peripheral/core/providers/__init__.py
+++ b/src/heart/peripheral/core/providers/__init__.py
@@ -6,7 +6,6 @@ from reactivex import operators as ops
 
 from heart.peripheral.core import InputDescriptor
 from heart.peripheral.core.providers import registry as providers_registry
-from heart.runtime.display_context import DisplayContext
 from heart.utilities.reactivex_threads import pipe_in_background
 
 apply_provider_registrations = providers_registry.apply_provider_registrations
@@ -26,6 +25,7 @@ class ObservableProvider(Generic[T]):
         """Declare the input streams this provider consumes."""
 
         return ()
+
 
 class StaticStateProvider(ObservableProvider[T]):
     def __init__(self, state: T) -> None:

--- a/src/heart/runtime/game_loop/__init__.py
+++ b/src/heart/runtime/game_loop/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import time
 from typing import TYPE_CHECKING, Any, TypeVar
 
 import numpy as np
@@ -249,7 +248,6 @@ class GameLoop:
             renderers = self._select_renderers()
             self.components.display.configure_window(self._resolve_display_mode(renderers))
 
-            render_start = time.monotonic()
             self._one_loop(renderers=renderers)
             # self._render_pacer.pace(render_start, 20)
 

--- a/tests/renderers/test_slide_transition_provider.py
+++ b/tests/renderers/test_slide_transition_provider.py
@@ -2,127 +2,74 @@
 
 from __future__ import annotations
 
+import math
+
 from hypothesis import given
 from hypothesis import strategies as st
 
 from heart.peripheral.core.manager import PeripheralManager
-from heart.renderers import StatefulBaseRenderer
 from heart.renderers.slide_transition.provider import SlideTransitionProvider
 from heart.renderers.slide_transition.state import SlideTransitionState
 
 
+class _StubClock:
+    def __init__(self, delta_ms: float) -> None:
+        self._delta_ms = delta_ms
+
+    def get_time(self) -> float:
+        return self._delta_ms
+
+
 @st.composite
-def _advance_inputs(draw: st.DrawFn) -> tuple[int, int, int, int]:
-    direction = draw(st.sampled_from([-1, 1]))
-    slide_speed = draw(st.integers(min_value=1, max_value=64))
-    screen_width = draw(st.integers(min_value=1, max_value=256))
-    target_offset = -direction * screen_width
-    x_offset = draw(
-        st.integers(min_value=target_offset - 256, max_value=target_offset + 256)
+def _advance_inputs(draw: st.DrawFn) -> tuple[float, int, float]:
+    fraction_offset = draw(
+        st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False)
     )
-    return direction, slide_speed, screen_width, x_offset
-
-
-@st.composite
-def _steady_inputs(draw: st.DrawFn) -> tuple[int, int, int, int]:
-    direction = draw(st.sampled_from([-1, 1]))
-    slide_speed = draw(st.integers(min_value=1, max_value=64))
-    screen_width = draw(st.integers(min_value=1, max_value=256))
-    x_offset = draw(st.integers(min_value=-512, max_value=512))
-    return direction, slide_speed, screen_width, x_offset
-
-
-@st.composite
-def _screen_refresh_inputs(draw: st.DrawFn) -> tuple[int, int, int]:
-    direction = draw(st.sampled_from([-1, 1]))
-    slide_speed = draw(st.integers(min_value=1, max_value=64))
-    screen_width = draw(st.integers(min_value=1, max_value=256))
-    return direction, slide_speed, screen_width
+    slide_duration_ms = draw(st.integers(min_value=1, max_value=5000))
+    delta_ms = draw(
+        st.floats(min_value=0.0, max_value=5000.0, allow_nan=False, allow_infinity=False)
+    )
+    return fraction_offset, slide_duration_ms, delta_ms
 
 
 class TestSlideTransitionProviderStateTransitions:
     """Property checks for slide transitions so renderer sequencing stays stable under motion."""
 
-    class _StubRenderer(StatefulBaseRenderer[int]):
-        def _create_initial_state(self, window, clock, peripheral_manager, orientation) -> int:
-            return 0
-
-        def real_process(self, window, clock, orientation) -> None:
-            pass
-
     @given(data=_advance_inputs())
-    def test_update_state_moves_toward_target(self, data: tuple[int, int, int, int]) -> None:
-        """Verify slide steps advance toward the target offset so scenes converge deterministically."""
-        direction, slide_speed, screen_width, x_offset = data
-        target_offset = -direction * screen_width
-        provider = SlideTransitionProvider(
-            self._StubRenderer(),
-            self._StubRenderer(),
-            direction=direction,
-            slide_speed=slide_speed,
-        )
+    def test_advance_state_moves_toward_target(self, data: tuple[float, int, float]) -> None:
+        """Verify slide steps advance toward completion so transitions finish predictably."""
+        fraction_offset, slide_duration_ms, delta_ms = data
         state = SlideTransitionState(
             peripheral_manager=PeripheralManager(),
-            x_offset=x_offset,
-            target_offset=target_offset,
+            fraction_offset=fraction_offset,
             sliding=True,
-            screen_w=screen_width,
         )
 
-        result = provider.update_state(state=state, screen_width=screen_width)
+        result = SlideTransitionProvider._advance(
+            state=state,
+            clock=_StubClock(delta_ms=delta_ms),
+            slide_duration_ms=slide_duration_ms,
+        )
 
-        assert abs(result.x_offset - target_offset) <= abs(x_offset - target_offset)
-        assert result.target_offset == target_offset
-        assert result.screen_w == screen_width
-        if result.x_offset == target_offset:
+        expected = min(1.0, fraction_offset + (delta_ms / slide_duration_ms))
+        assert math.isclose(result.fraction_offset, expected, rel_tol=0.0, abs_tol=1e-6)
+        if expected >= 1.0:
             assert result.sliding is False
         else:
-            assert abs(result.x_offset - x_offset) <= slide_speed
             assert result.sliding is True
 
-    @given(data=_steady_inputs())
-    def test_update_state_keeps_idle_state(self, data: tuple[int, int, int, int]) -> None:
+    def test_advance_state_keeps_idle_state(self) -> None:
         """Verify idle transitions stay unchanged so halted slides do not jitter."""
-        direction, slide_speed, screen_width, x_offset = data
-        provider = SlideTransitionProvider(
-            self._StubRenderer(),
-            self._StubRenderer(),
-            direction=direction,
-            slide_speed=slide_speed,
-        )
         state = SlideTransitionState(
             peripheral_manager=PeripheralManager(),
-            x_offset=x_offset,
-            target_offset=-direction * screen_width,
+            fraction_offset=0.25,
             sliding=False,
-            screen_w=screen_width,
         )
 
-        result = provider.update_state(state=state, screen_width=screen_width)
+        result = SlideTransitionProvider._advance(
+            state=state,
+            clock=_StubClock(delta_ms=16.0),
+            slide_duration_ms=1000,
+        )
 
         assert result == state
-
-    @given(data=_screen_refresh_inputs())
-    def test_update_state_refreshes_missing_target(self, data: tuple[int, int, int]) -> None:
-        """Verify missing targets refresh to screen width so transitions restart coherently."""
-        direction, slide_speed, screen_width = data
-        provider = SlideTransitionProvider(
-            self._StubRenderer(),
-            self._StubRenderer(),
-            direction=direction,
-            slide_speed=slide_speed,
-        )
-        state = SlideTransitionState(
-            peripheral_manager=PeripheralManager(),
-            x_offset=0,
-            target_offset=None,
-            sliding=False,
-            screen_w=screen_width,
-        )
-
-        result = provider.update_state(state=state, screen_width=screen_width)
-
-        assert result.target_offset == -direction * screen_width
-        assert result.screen_w == screen_width
-        assert result.x_offset == 0
-        assert result.sliding is False


### PR DESCRIPTION
### Motivation

- Replace the previous game-tick based slide advancement with clock-driven timing for smoother and frame-rate-independent transitions.
- Express transition speed as a millisecond duration to make it easier to reason about end-to-end timing instead of per-tick increments.
- Improve determinism for slide completion by accumulating real elapsed milliseconds rather than counting ticks.
- Remove a couple of stale/unnecessary imports and unused variables discovered while changing timing code.

### Description

- Introduce `DEFAULT_SLIDE_DURATION_MS` and `MIN_SLIDE_DURATION_MS` and replace the `slide_speed` parameter with `slide_duration_ms` on `SlideTransitionProvider`.
- Switch the provider observable to consume `peripheral_manager.clock` and compute the fraction offset using `clock.get_time()` (ms) divided by the configured duration.
- Update the `_advance` implementation to accept a `pygame.time.Clock` and `slide_duration_ms`, advance `fraction_offset` by `delta_ms / slide_duration_ms`, and stop when the fraction reaches `1.0`.
- Refresh `tests/renderers/test_slide_transition_provider.py` to exercise the clock-driven `_advance` logic with a stubbed clock, and remove an unused import in `peripheral` providers plus an unused timing variable in the game loop.

### Testing

- Ran `make format`, which completed successfully.
- Ran `make test`; the updated slide transition provider unit tests (`tests/renderers/test_slide_transition_provider.py`) passed.
- The full test run reported remaining unrelated regressions and environment configuration issues (test run summary: approximately `21 failed, 133 passed, 7 warnings, 28 errors`).
- Manual lint/format adjustments were applied to address import/unused-variable warnings discovered during the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964059d20808321bcfe5198067e6962)