### PR TITLE
Add universal post-processing renderers

### DIFF
--- a/src/heart/navigation/app_controller.py
+++ b/src/heart/navigation/app_controller.py
@@ -48,6 +48,9 @@ class AppController(StatefulBaseRenderer[AppControllerState]):
     def get_renderers(self) -> list[StatefulBaseRenderer]:
         return self.modes.get_renderers()
 
+    def get_post_processors(self) -> list[StatefulBaseRenderer]:
+        return self.modes.get_post_processors()
+
     def add_sleep_mode(self) -> None:
         sleep_title = [
             SpritesheetLoop(

--- a/src/heart/navigation/composed_renderer.py
+++ b/src/heart/navigation/composed_renderer.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import pygame
-
 from heart import DeviceDisplayMode
 from heart.device import Orientation
 from heart.peripheral.core.manager import PeripheralManager

--- a/src/heart/navigation/multi_scene.py
+++ b/src/heart/navigation/multi_scene.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import pygame
-
 from heart.device import Orientation
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.switch import SwitchState

--- a/src/heart/peripheral/core/manager.py
+++ b/src/heart/peripheral/core/manager.py
@@ -7,7 +7,7 @@ from heart.peripheral.configuration_loader import PeripheralConfigurationLoader
 from heart.peripheral.core import Peripheral
 from heart.peripheral.core.streams import PeripheralStreams
 from heart.peripheral.registry import PeripheralConfigurationRegistry
-from heart.peripheral.switch import SwitchState
+from heart.peripheral.switch import BluetoothSwitch, SwitchState
 from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
@@ -85,6 +85,12 @@ class PeripheralManager:
 
     def get_main_switch_subscription(self) -> reactivex.Observable[SwitchState]:
         return self._streams.main_switch_subscription()
+
+    def bluetooth_switch(self) -> BluetoothSwitch | None:
+        for peripheral in self._peripherals:
+            if isinstance(peripheral, BluetoothSwitch):
+                return peripheral
+        return None
 
     @property
     def game_tick(self) -> reactivex.Subject[Any]:

--- a/src/heart/peripheral/core/providers/__init__.py
+++ b/src/heart/peripheral/core/providers/__init__.py
@@ -6,7 +6,6 @@ from reactivex import operators as ops
 
 from heart.peripheral.core import InputDescriptor
 from heart.peripheral.core.providers import registry as providers_registry
-from heart.runtime.display_context import DisplayContext
 from heart.utilities.reactivex_threads import pipe_in_background
 
 apply_provider_registrations = providers_registry.apply_provider_registrations

--- a/src/heart/peripheral/switch.py
+++ b/src/heart/peripheral/switch.py
@@ -74,6 +74,9 @@ class BaseSwitch(Peripheral[SwitchState]):
         )
         return result
 
+    def get_rotation_since_last_long_button_press(self) -> int:
+        return self.rotational_value - self.rotation_value_at_last_long_button_press
+
 class FakeSwitch(BaseSwitch):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)

--- a/src/heart/renderers/atomic.py
+++ b/src/heart/renderers/atomic.py
@@ -4,8 +4,6 @@ import time
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, final
 
-import pygame
-
 from heart import DeviceDisplayMode
 from heart.device import Orientation
 from heart.peripheral.core.manager import PeripheralManager

--- a/src/heart/renderers/base.py
+++ b/src/heart/renderers/base.py
@@ -1,7 +1,5 @@
 import time
 
-import pygame
-
 from heart import DeviceDisplayMode
 from heart.device import Orientation
 from heart.peripheral.core.manager import PeripheralManager

--- a/src/heart/renderers/combined_bpm_screen/renderer.py
+++ b/src/heart/renderers/combined_bpm_screen/renderer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pygame
 import reactivex
 from pygame import Surface
 from pygame import time as pygame_time

--- a/src/heart/renderers/doppler/renderer.py
+++ b/src/heart/renderers/doppler/renderer.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import numpy as np
 import pygame
 from pygame import Surface
-from pygame.time import Clock
 
 from heart import DeviceDisplayMode
 from heart.device import Orientation

--- a/src/heart/renderers/heart_title_screen/renderer.py
+++ b/src/heart/renderers/heart_title_screen/renderer.py
@@ -1,4 +1,4 @@
-from pygame import Surface, time
+from pygame import Surface
 
 from heart import DeviceDisplayMode
 from heart.assets.loader import Loader

--- a/src/heart/renderers/l_system/renderer.py
+++ b/src/heart/renderers/l_system/renderer.py
@@ -6,7 +6,6 @@ from collections import deque
 import numpy as np
 import pygame
 from pygame import Surface
-from pygame.time import Clock
 
 from heart import DeviceDisplayMode
 from heart.device import Orientation

--- a/src/heart/renderers/led_wave_boat/renderer.py
+++ b/src/heart/renderers/led_wave_boat/renderer.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pygame
 from pygame import Surface
-from pygame.time import Clock
 
 from heart import DeviceDisplayMode
 from heart.device import Orientation

--- a/src/heart/renderers/life/renderer.py
+++ b/src/heart/renderers/life/renderer.py
@@ -2,7 +2,6 @@
 import numpy as np
 import pygame
 from pygame import Surface
-from pygame.time import Clock
 
 from heart import DeviceDisplayMode
 from heart.device import Orientation

--- a/src/heart/renderers/mandelbrot/cube_renderer.py
+++ b/src/heart/renderers/mandelbrot/cube_renderer.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 import numpy as np
 import pygame
 from pygame import Surface
-from pygame.time import Clock
 
 from heart import DeviceDisplayMode
 from heart.device import Orientation

--- a/src/heart/renderers/mario/renderer.py
+++ b/src/heart/renderers/mario/renderer.py
@@ -1,5 +1,4 @@
 
-import pygame
 
 from heart import DeviceDisplayMode
 from heart.device import Orientation

--- a/src/heart/renderers/post_processing.py
+++ b/src/heart/renderers/post_processing.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pygame
+
+from heart import DeviceDisplayMode
+from heart.device import Orientation
+from heart.peripheral.core.manager import PeripheralManager
+from heart.renderers import StatefulBaseRenderer
+from heart.runtime.display_context import DisplayContext
+from heart.utilities.color_conversion import (convert_hsv_to_rgb,
+                                              convert_rgb_to_hsv)
+
+SATURATION_STEP = 0.05
+SATURATION_MIN = 0.0
+SATURATION_MAX = 5.0
+HUE_STEP = 0.03
+EDGE_THRESHOLD_DEFAULT = 1
+EDGE_THRESHOLD_STEP = 0.10
+EDGE_BACKGROUND_DIM = 0.75
+EDGE_GAMMA = 0.5
+
+
+@dataclass
+class PostProcessorState:
+    peripheral_manager: PeripheralManager
+
+
+def _get_image_view(surface: pygame.Surface) -> tuple[np.ndarray, np.ndarray]:
+    pixels = pygame.surfarray.pixels3d(surface)
+    image = pixels.swapaxes(0, 1)
+    return image, pixels
+
+
+class BasePostProcessor(StatefulBaseRenderer[PostProcessorState]):
+    def __init__(self) -> None:
+        super().__init__()
+        self.device_display_mode = DeviceDisplayMode.FULL
+
+    def _create_initial_state(
+        self,
+        window: DisplayContext,
+        peripheral_manager: PeripheralManager,
+        orientation: Orientation,
+    ) -> PostProcessorState:
+        return PostProcessorState(peripheral_manager=peripheral_manager)
+
+
+class SaturationPostProcessor(BasePostProcessor):
+    def real_process(
+        self,
+        window: DisplayContext,
+        orientation: Orientation,
+    ) -> None:
+        bluetooth = self.state.peripheral_manager.bluetooth_switch()
+        if bluetooth is None:
+            return
+        if (switch_one := bluetooth.switch_one()) is None:
+            return
+        rotation_delta = switch_one.get_rotation_since_last_long_button_press()
+        if rotation_delta == 0:
+            return
+
+        factor = 1.0 + SATURATION_STEP * rotation_delta
+        factor = max(SATURATION_MIN, min(SATURATION_MAX, factor))
+
+        image, pixels = _get_image_view(window.screen)
+        img = image.astype(np.float32)
+        lum = (
+            0.299 * img[..., 0] + 0.587 * img[..., 1] + 0.114 * img[..., 2]
+        )[..., None]
+        img_sat = lum + factor * (img - lum)
+        image[:] = np.clip(img_sat, 0, 255).astype(np.uint8)
+        del pixels
+
+
+class HueShiftPostProcessor(BasePostProcessor):
+    def __init__(self) -> None:
+        super().__init__()
+        self._tmp_float: np.ndarray | None = None
+
+    def real_process(
+        self,
+        window: DisplayContext,
+        orientation: Orientation,
+    ) -> None:
+        bluetooth = self.state.peripheral_manager.bluetooth_switch()
+        if bluetooth is None:
+            return
+        hue_switch = bluetooth.switch_two()
+        if hue_switch is None:
+            return
+        delta = hue_switch.get_rotation_since_last_long_button_press()
+        if delta == 0:
+            return
+
+        image, pixels = _get_image_view(window.screen)
+        if self._tmp_float is None or self._tmp_float.shape != image.shape:
+            self._tmp_float = np.empty_like(image, dtype=np.float32)
+
+        hue_delta = (delta * HUE_STEP) % 1.0
+        hsv = convert_rgb_to_hsv(image)
+        self._tmp_float[:] = hsv
+        self._tmp_float[..., 0] = (
+            (self._tmp_float[..., 0] / 179.0 + hue_delta) % 1.0 * 179.0
+        )
+        image[:] = convert_hsv_to_rgb(self._tmp_float.astype(np.uint8))
+        del pixels
+
+
+class EdgePostProcessor(BasePostProcessor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.edge_thresh = EDGE_THRESHOLD_DEFAULT
+
+    def real_process(
+        self,
+        window: DisplayContext,
+        orientation: Orientation,
+    ) -> None:
+        bluetooth = self.state.peripheral_manager.bluetooth_switch()
+        if bluetooth is None:
+            return
+        edge_switch = bluetooth.switch_three()
+        if edge_switch is None:
+            return
+        delta = edge_switch.get_rotation_since_last_long_button_press()
+        if delta == 0:
+            return
+
+        self.edge_thresh = int(
+            np.clip(
+                self.edge_thresh * (1.0 + EDGE_THRESHOLD_STEP * delta),
+                1,
+                255,
+            )
+        )
+
+        image, pixels = _get_image_view(window.screen)
+        lum = (
+            0.299 * image[..., 0]
+            + 0.587 * image[..., 1]
+            + 0.114 * image[..., 2]
+        ).astype(np.int16)
+
+        gx = np.abs(np.roll(lum, -1, 1) - np.roll(lum, 1, 1))
+        gy = np.abs(np.roll(lum, -1, 0) - np.roll(lum, 1, 0))
+        edge_mag = gx + gy
+
+        denom = max(1, 255 - self.edge_thresh)
+        alpha = np.clip(
+            (edge_mag.astype(np.float32) - self.edge_thresh) / denom,
+            0.0,
+            1.0,
+        )
+        alpha **= EDGE_GAMMA
+        alpha = alpha[..., None]
+
+        base = image.astype(np.float32) * EDGE_BACKGROUND_DIM
+        edges = alpha * 255.0
+        out = np.clip(base + edges, 0, 255)
+        image[:] = out.astype(np.uint8)
+        del pixels
+
+
+class NullPostProcessor(BasePostProcessor):
+    def real_process(
+        self,
+        window: DisplayContext,
+        orientation: Orientation,
+    ) -> None:
+        return

--- a/src/heart/renderers/random_pixel/renderer.py
+++ b/src/heart/renderers/random_pixel/renderer.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Callable
 
-import pygame
-
 from heart import DeviceDisplayMode
 from heart.device import Orientation
 from heart.display.color import Color

--- a/src/heart/renderers/slide_transition/provider.py
+++ b/src/heart/renderers/slide_transition/provider.py
@@ -2,16 +2,13 @@ from __future__ import annotations
 
 from dataclasses import replace
 
-import pygame
 import reactivex
 from reactivex import operators as ops
 
-from heart.device import Orientation
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import ObservableProvider
 from heart.renderers import StatefulBaseRenderer
 from heart.renderers.slide_transition.state import SlideTransitionState
-from heart.runtime.display_context import DisplayContext
 from heart.utilities.reactivex_threads import pipe_in_background
 
 

--- a/src/heart/renderers/slide_transition/renderer.py
+++ b/src/heart/renderers/slide_transition/renderer.py
@@ -1,7 +1,6 @@
 import logging
 import time
 
-import pygame
 import reactivex
 
 from heart import DeviceDisplayMode
@@ -11,7 +10,6 @@ from heart.renderers import StatefulBaseRenderer
 from heart.renderers.slide_transition.provider import SlideTransitionProvider
 from heart.renderers.slide_transition.state import SlideTransitionState
 from heart.runtime.display_context import DisplayContext
-from heart.runtime.rendering.surface.provider import RendererSurfaceProvider
 from heart.utilities.logging import get_logger
 from heart.utilities.logging_control import get_logging_controller
 
@@ -86,7 +84,7 @@ class SlideTransitionRenderer(StatefulBaseRenderer[SlideTransitionState]):
             key=f"render.loop.{slide_label}",
             logger=logger,
             level=logging.INFO,
-            msg=f"renderer=%s duration_ms=%.2f",
+            msg="renderer=%s duration_ms=%.2f",
             args=(renderer.name, duration_ms),
         )
 

--- a/src/heart/renderers/spritesheet/renderer.py
+++ b/src/heart/renderers/spritesheet/renderer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pygame
 import reactivex
 
 from heart import DeviceDisplayMode

--- a/src/heart/renderers/spritesheet_random/renderer.py
+++ b/src/heart/renderers/spritesheet_random/renderer.py
@@ -1,4 +1,3 @@
-import pygame
 import reactivex
 
 from heart import DeviceDisplayMode

--- a/src/heart/renderers/stateful.py
+++ b/src/heart/renderers/stateful.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 from typing import Generic
 
-import pygame
 from reactivex import Observable
 from reactivex.disposable import Disposable
 
-from heart import DeviceDisplayMode
 from heart.device import Orientation
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import (ObservableProvider,

--- a/src/heart/renderers/three_fractal/provider.py
+++ b/src/heart/renderers/three_fractal/provider.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import pygame
 import reactivex
-from pygame.time import Clock
 
 from heart.device import Device, Orientation
 from heart.peripheral.core.manager import PeripheralManager

--- a/src/heart/renderers/water_cube/provider.py
+++ b/src/heart/renderers/water_cube/provider.py
@@ -2,13 +2,11 @@
 import reactivex
 from reactivex import operators as ops
 
-from heart import DeviceDisplayMode
 from heart.device import Device
 from heart.peripheral.core.providers import ObservableProvider
 from heart.peripheral.providers.acceleration import AllAccelerometersProvider
 from heart.peripheral.sensor import Acceleration
 from heart.renderers.water_cube.state import WaterCubeState
-from heart.runtime.display_context import DisplayContext
 from heart.utilities.reactivex_threads import pipe_in_background
 
 

--- a/src/heart/renderers/water_cube/renderer.py
+++ b/src/heart/renderers/water_cube/renderer.py
@@ -14,8 +14,6 @@ from typing import Tuple
 
 import numpy as np
 import pygame
-from pygame import Surface
-from pygame.time import Clock
 
 from heart import DeviceDisplayMode
 from heart.device import Orientation

--- a/src/heart/renderers/water_title_screen/renderer.py
+++ b/src/heart/renderers/water_title_screen/renderer.py
@@ -1,8 +1,6 @@
 import math
 
 import pygame
-from pygame import Surface
-from pygame.time import Clock
 
 from heart import DeviceDisplayMode
 from heart.device import Orientation

--- a/src/heart/runtime/display_context.py
+++ b/src/heart/runtime/display_context.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 import pygame
 

--- a/src/heart/runtime/game_loop/__init__.py
+++ b/src/heart/runtime/game_loop/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import time
 from typing import TYPE_CHECKING, Any, TypeVar
 
 import numpy as np
@@ -11,6 +10,7 @@ from heart.device import Device
 from heart.navigation import ComposedRenderer, MultiScene
 from heart.runtime.container.initialize import (build_runtime_container,
                                                 configure_runtime_container)
+from heart.runtime.display_context import DisplayContext
 from heart.runtime.game_loop.components import GameLoopComponents
 from heart.runtime.rendering.pacing import RenderLoopPacer
 from heart.runtime.rendering.pipeline import RendererVariant
@@ -64,8 +64,32 @@ class GameLoop:
         )
         render_surface = render_result.surface
         if render_surface is not None:
+            self._apply_post_processors(render_surface)
             self.components.display.blit(render_surface, (0, 0))
             pygame.display.flip()
+
+    def _apply_post_processors(self, surface: pygame.Surface) -> None:
+        post_processors = self.components.app_controller.get_post_processors()
+        if not post_processors:
+            return
+        post_context = DisplayContext(
+            device=self.device,
+            screen=surface,
+            clock=self.components.display.clock,
+            last_render_mode=self.components.display.last_render_mode,
+        )
+        for renderer in post_processors:
+            if not renderer.initialized:
+                renderer.initialize(
+                    window=post_context,
+                    peripheral_manager=self.components.peripheral_manager,
+                    orientation=self.device.orientation,
+                )
+            renderer._internal_process(
+                window=post_context,
+                peripheral_manager=self.components.peripheral_manager,
+                orientation=self.device.orientation,
+            )
 
     def resolve(self, dependency: type[DependencyT]) -> DependencyT:
         return self.context_container.resolve(dependency)
@@ -249,7 +273,6 @@ class GameLoop:
             renderers = self._select_renderers()
             self.components.display.configure_window(self._resolve_display_mode(renderers))
 
-            render_start = time.monotonic()
             self._one_loop(renderers=renderers)
             # self._render_pacer.pace(render_start, 20)
 

--- a/src/heart/runtime/rendering/pipeline.py
+++ b/src/heart/runtime/rendering/pipeline.py
@@ -6,13 +6,12 @@ from typing import TYPE_CHECKING, Any
 
 import pygame
 
-from heart.device import Device
 from heart.peripheral.core.manager import PeripheralManager
 from heart.runtime.display_context import DisplayContext
 from heart.runtime.rendering.renderer_processor import RendererProcessor
 from heart.runtime.rendering.surface.collection import RenderSurfaceCollector
 from heart.runtime.rendering.surface.merge import SurfaceCompositionManager
-from heart.runtime.rendering.variants import RendererVariant, RenderMethod
+from heart.runtime.rendering.variants import RendererVariant
 from heart.utilities.env import Configuration
 
 if TYPE_CHECKING:

--- a/src/heart/runtime/rendering/renderer_processor.py
+++ b/src/heart/runtime/rendering/renderer_processor.py
@@ -15,7 +15,6 @@ from heart.utilities.logging import get_logger
 from heart.utilities.logging_control import get_logging_controller
 
 if TYPE_CHECKING:
-    from heart.device import Device
     from heart.peripheral.core.manager import PeripheralManager
     from heart.renderers import StatefulBaseRenderer
 

--- a/src/heart/runtime/rendering/surface/cache.py
+++ b/src/heart/runtime/rendering/surface/cache.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any
 
 import pygame
 
-from heart.device import Device
 from heart.runtime.display_context import DisplayContext
 
 if TYPE_CHECKING:

--- a/src/heart/runtime/rendering/surface/merge.py
+++ b/src/heart/runtime/rendering/surface/merge.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor
-from functools import partial
 from typing import assert_never
 
 import pygame

--- a/src/heart/runtime/rendering/surface/provider.py
+++ b/src/heart/runtime/rendering/surface/provider.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pygame
 
 from heart import DeviceDisplayMode
-from heart.device import Device, Layout, Orientation
+from heart.device import Layout, Orientation
 from heart.runtime.display_context import DisplayContext
 from heart.runtime.rendering.surface.cache import RendererSurfaceCache
 from heart.utilities.env import Configuration, RenderTileStrategy
+
 
 class RendererSurfaceProvider:
     def __init__(

--- a/src/heart/utilities/color_conversion.py
+++ b/src/heart/utilities/color_conversion.py
@@ -287,3 +287,13 @@ def _convert_hsv_to_bgr(image: np.ndarray) -> np.ndarray:
             HSV_TO_BGR_CACHE.move_to_end(key)
 
     return result
+
+
+def convert_rgb_to_hsv(image: np.ndarray) -> np.ndarray:
+    bgr = np.ascontiguousarray(image[..., ::-1])
+    return _convert_bgr_to_hsv(bgr)
+
+
+def convert_hsv_to_rgb(image: np.ndarray) -> np.ndarray:
+    bgr = _convert_hsv_to_bgr(image)
+    return bgr[..., ::-1]

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -3,7 +3,7 @@ import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
 
 from heart.renderers.random_pixel import RandomPixel
-from heart.runtime.game_loop import GameLoop, RendererVariant
+from heart.runtime.game_loop import GameLoop
 
 
 class TestEnvironment:


### PR DESCRIPTION
### Motivation

- Provide a place to apply device-agnostic post-processing on composed frames so simple image effects (saturation, hue shift, edge detect) can be reused across modes.  
- Expose the Bluetooth switch controls to renderers so physical rotary/button input can drive post-processing parameters.  
- Reuse existing RGB/HSV conversion utilities to implement hue adjustments without adding an OpenCV runtime dependency.  
- Apply post-processing after the render pipeline composition so effects operate on the final composed frame.

### Description

- Add `src/heart/renderers/post_processing.py` with four post-processors: `SaturationPostProcessor`, `HueShiftPostProcessor`, `EdgePostProcessor`, and `NullPostProcessor`, all deriving from `StatefulBaseRenderer`.  
- Wire post-processors into navigation by adding a `post_processors` list to `GameModeState`, defaulting to the four processors via `GameModes._default_post_processors`, and expose them through `AppController.get_post_processors()`.  
- Apply post-processors in the main loop by calling `GameLoop._apply_post_processors` on the composed `pygame.Surface` before blitting to the display.  
- Add supporting helpers: `PeripheralManager.bluetooth_switch()` to locate a `BluetoothSwitch`, `BaseSwitch.get_rotation_since_last_long_button_press()` for rotation queries, and RGB↔HSV wrappers `convert_rgb_to_hsv`/`convert_hsv_to_rgb` in `heart.utilities.color_conversion`.

### Testing

- Ran `make format` and the repository formatting fixes completed successfully.  
- Ran `make test`: the test run executed but did not fully pass (131 passed, 24 failed, 28 errors).  
- The test failures include an environment/configuration-related error: `ValueError: HEART_RENDER_MERGE_STRATEGY must be 'in_place', found: batched`.  
- Additional unrelated tests in the suite also failed/errored during this run (see test output for details).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964064c5da0832198a53dc99957c405)