### PR TITLE
Fix slide transition type checking import

### DIFF
--- a/src/heart/renderers/slide_transition/provider.py
+++ b/src/heart/renderers/slide_transition/provider.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from typing import TYPE_CHECKING
 
 import reactivex
 from reactivex import operators as ops
@@ -10,6 +11,9 @@ from heart.peripheral.core.providers import ObservableProvider
 from heart.renderers import StatefulBaseRenderer
 from heart.renderers.slide_transition.state import SlideTransitionState
 from heart.utilities.reactivex_threads import pipe_in_background
+
+if TYPE_CHECKING:
+    import pygame
 
 DEFAULT_SLIDE_DURATION_MS = 333
 MIN_SLIDE_DURATION_MS = 1


### PR DESCRIPTION
### Motivation

- A linter error flagged an undefined name `pygame` in the slide transition provider type annotations, causing `make format` to fail.
- The intent is to keep runtime imports unchanged while satisfying static type checkers and linters.

### Description

- Added `from typing import TYPE_CHECKING` to `src/heart/renderers/slide_transition/provider.py`.
- Added a `if TYPE_CHECKING: import pygame` block so `pygame` is only imported for type checking and not at runtime.
- Kept the existing type annotation `pygame.time.Clock` on `_advance` intact so static analysis recognizes the type.

### Testing

- Ran `make format` before the change and it failed with `F821 Undefined name "pygame"` from Ruff.
- After the change, re-ran `make format` and the formatting/lint checks completed with "All checks passed!".

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964516d42d483218bb807eed0d1707e)