### PR TITLE
Add Gaussian slide transition mode

### DIFF
--- a/docs/renderers/slide_transition_modes.md
+++ b/docs/renderers/slide_transition_modes.md
@@ -1,0 +1,48 @@
+# Slide transition modes for game mode selection
+
+Game mode selection uses `SlideTransitionRenderer` to move between title scenes. In
+some deployments the motion can be distracting or misleading when the knob changes
+state quickly. `GameModeState` now supports a static transition mode that keeps the
+scenes aligned while still using the slide transition render loop to update and
+swap title renderers. The static mode replaces pixels in random order over a fixed
+series of masks (defaulting to 20 steps) until scene B fully replaces scene A. A
+Gaussian mode uses blurred noise to create softer clustered regions that fade in
+over the same step cadence.
+
+## Configuration
+
+Set `transition_mode` on `GameModeState` to control the behavior:
+
+```python
+from heart.navigation.game_modes import GameModeState, SlideTransitionMode
+
+state = GameModeState(
+    transition_mode=SlideTransitionMode.STATIC,
+    static_mask_steps=20,
+)
+```
+
+`SlideTransitionMode.SLIDE` is the default and preserves left-to-right motion.
+`SlideTransitionMode.STATIC` keeps both title scenes aligned and cross-fades via a
+random pixel mask over the configured number of steps.
+
+To use Gaussian clusters instead of random pixels:
+
+```python
+from heart.navigation.game_modes import GameModeState, SlideTransitionMode
+
+state = GameModeState(
+    transition_mode=SlideTransitionMode.GAUSSIAN,
+    static_mask_steps=20,
+    gaussian_sigma=1.5,
+)
+```
+
+`SlideTransitionMode.GAUSSIAN` keeps both title scenes aligned and replaces pixels
+using a blurred noise mask; increasing `gaussian_sigma` produces larger clusters.
+
+**Materials:**
+
+- Python 3.11+
+- `src/heart/navigation/game_modes.py`
+- `src/heart/renderers/slide_transition/renderer.py`

--- a/src/heart/navigation/__init__.py
+++ b/src/heart/navigation/__init__.py
@@ -1,4 +1,6 @@
 from heart.renderers.slide_transition import \
+    SlideTransitionMode as SlideTransitionMode
+from heart.renderers.slide_transition import \
     SlideTransitionProvider as SlideTransitionProvider
 from heart.renderers.slide_transition import \
     SlideTransitionRenderer as SlideTransitionRenderer

--- a/src/heart/renderers/slide_transition/__init__.py
+++ b/src/heart/renderers/slide_transition/__init__.py
@@ -2,5 +2,6 @@ from heart.renderers.slide_transition.provider import \
     SlideTransitionProvider  # noqa: F401
 from heart.renderers.slide_transition.renderer import \
     SlideTransitionRenderer  # noqa: F401
-from heart.renderers.slide_transition.state import \
-    SlideTransitionState  # noqa: F401
+from heart.renderers.slide_transition.state import (  # noqa: F401
+    DEFAULT_GAUSSIAN_SIGMA, DEFAULT_STATIC_MASK_STEPS, SlideTransitionMode,
+    SlideTransitionState)

--- a/src/heart/renderers/slide_transition/provider.py
+++ b/src/heart/renderers/slide_transition/provider.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 from dataclasses import replace
 
+import pygame
 import reactivex
 from reactivex import operators as ops
 
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import ObservableProvider
 from heart.renderers import StatefulBaseRenderer
-from heart.renderers.slide_transition.state import SlideTransitionState
+from heart.renderers.slide_transition.state import (DEFAULT_GAUSSIAN_SIGMA,
+                                                    DEFAULT_STATIC_MASK_STEPS,
+                                                    SlideTransitionMode,
+                                                    SlideTransitionState)
 from heart.utilities.reactivex_threads import pipe_in_background
 
 DEFAULT_SLIDE_DURATION_MS = 333
@@ -23,11 +27,17 @@ class SlideTransitionProvider(ObservableProvider[SlideTransitionState]):
         *,
         direction: int = 1,
         slide_duration_ms: int = DEFAULT_SLIDE_DURATION_MS,
+        transition_mode: SlideTransitionMode = SlideTransitionMode.SLIDE,
+        static_mask_steps: int = DEFAULT_STATIC_MASK_STEPS,
+        gaussian_sigma: float = DEFAULT_GAUSSIAN_SIGMA,
     ) -> None:
         self.renderer_a = renderer_a
         self.renderer_b = renderer_b
         self.direction = direction
         self.slide_duration_ms = max(slide_duration_ms, MIN_SLIDE_DURATION_MS)
+        self.transition_mode = transition_mode
+        self.static_mask_steps = max(static_mask_steps, 1)
+        self.gaussian_sigma = max(gaussian_sigma, 0.1)
 
     def observable(
         self,

--- a/src/heart/renderers/slide_transition/renderer.py
+++ b/src/heart/renderers/slide_transition/renderer.py
@@ -1,6 +1,8 @@
 import logging
 import time
 
+import numpy as np
+import pygame
 import reactivex
 
 from heart import DeviceDisplayMode
@@ -8,7 +10,8 @@ from heart.device import Orientation, Rectangle
 from heart.peripheral.core.manager import PeripheralManager
 from heart.renderers import StatefulBaseRenderer
 from heart.renderers.slide_transition.provider import SlideTransitionProvider
-from heart.renderers.slide_transition.state import SlideTransitionState
+from heart.renderers.slide_transition.state import (SlideTransitionMode,
+                                                    SlideTransitionState)
 from heart.runtime.display_context import DisplayContext
 from heart.utilities.logging import get_logger
 from heart.utilities.logging_control import get_logging_controller
@@ -24,6 +27,9 @@ class SlideTransitionRenderer(StatefulBaseRenderer[SlideTransitionState]):
         self.provider = provider
         self.device_display_mode = DeviceDisplayMode.MIRRORED
         self._initial_state: SlideTransitionState | None = None
+        self._static_mask_indices: np.ndarray | None = None
+        self._static_mask_values: np.ndarray | None = None
+        self._static_mask_shape: tuple[int, int] | None = None
         logger.info(f"Created SlideTransitionRenderer from {provider.renderer_a.name} and {provider.renderer_b.name}")
         super().__init__(builder=self.provider)
 
@@ -96,7 +102,6 @@ class SlideTransitionRenderer(StatefulBaseRenderer[SlideTransitionState]):
         state = self.state
         new_orientation = Rectangle.with_layout(1, 1)
 
-
         window_a = window.get_scratch_screen(
             orientation=new_orientation,
             display_mode=self.provider.renderer_a.device_display_mode,
@@ -122,9 +127,136 @@ class SlideTransitionRenderer(StatefulBaseRenderer[SlideTransitionState]):
             "slide.B",
         )
 
+        if self.provider.transition_mode is SlideTransitionMode.STATIC:
+            self._render_static_transition(window, window_a, window_b)
+            return
+        if self.provider.transition_mode is SlideTransitionMode.GAUSSIAN:
+            self._render_gaussian_transition(window, window_a, window_b)
+            return
+
         image_width = window_a.get_width()
         offset_a = (-self.provider.direction * state.fraction_offset * image_width, 0)
         offset_b = (offset_a[0] + self.provider.direction * image_width, 0)
 
         window.screen.blit(window_a.screen, offset_a)
         window.screen.blit(window_b.screen, offset_b)
+
+    def _render_static_transition(
+        self,
+        window: DisplayContext,
+        window_a: DisplayContext,
+        window_b: DisplayContext,
+    ) -> None:
+        array_a = pygame.surfarray.array3d(window_a.screen)
+        array_b = pygame.surfarray.array3d(window_b.screen)
+        mask_indices = self._get_static_mask_indices(array_a.shape[:2])
+        blended = self._blend_static_arrays(array_a, array_b, mask_indices)
+        pygame.surfarray.blit_array(window.screen, blended)
+
+    def _render_gaussian_transition(
+        self,
+        window: DisplayContext,
+        window_a: DisplayContext,
+        window_b: DisplayContext,
+    ) -> None:
+        array_a = pygame.surfarray.array3d(window_a.screen)
+        array_b = pygame.surfarray.array3d(window_b.screen)
+        mask_values = self._get_gaussian_mask_values(array_a.shape[:2])
+        blended = self._blend_gaussian_arrays(array_a, array_b, mask_values)
+        pygame.surfarray.blit_array(window.screen, blended)
+
+    def _get_static_mask_indices(self, shape: tuple[int, int]) -> np.ndarray:
+        if self._static_mask_indices is None or self._static_mask_shape != shape:
+            width, height = shape
+            total_pixels = width * height
+            rng = np.random.default_rng()
+            indices = np.arange(total_pixels, dtype=np.int32)
+            rng.shuffle(indices)
+            self._static_mask_indices = indices
+            self._static_mask_shape = shape
+        return self._static_mask_indices
+
+    def _get_gaussian_mask_values(self, shape: tuple[int, int]) -> np.ndarray:
+        if self._static_mask_values is None or self._static_mask_shape != shape:
+            width, height = shape
+            rng = np.random.default_rng()
+            noise = rng.random((width, height), dtype=np.float32)
+            blurred = self._gaussian_blur(noise, self.provider.gaussian_sigma)
+            self._static_mask_values = blurred
+            self._static_mask_shape = shape
+        return self._static_mask_values
+
+    def _blend_static_arrays(
+        self,
+        array_a: np.ndarray,
+        array_b: np.ndarray,
+        mask_indices: np.ndarray,
+    ) -> np.ndarray:
+        total_pixels = array_a.shape[0] * array_a.shape[1]
+        step = min(
+            int(self.state.fraction_offset * self.provider.static_mask_steps),
+            self.provider.static_mask_steps,
+        )
+        threshold = int(total_pixels * (step / self.provider.static_mask_steps))
+        blended = array_a.copy()
+        if threshold <= 0:
+            return blended
+        flat_a = blended.reshape(-1, 3)
+        flat_b = array_b.reshape(-1, 3)
+        selected = mask_indices[:threshold]
+        flat_a[selected] = flat_b[selected]
+        return blended
+
+    def _blend_gaussian_arrays(
+        self,
+        array_a: np.ndarray,
+        array_b: np.ndarray,
+        mask_values: np.ndarray,
+    ) -> np.ndarray:
+        step = min(
+            int(self.state.fraction_offset * self.provider.static_mask_steps),
+            self.provider.static_mask_steps,
+        )
+        threshold = step / self.provider.static_mask_steps
+        blended = array_a.copy()
+        if threshold <= 0:
+            return blended
+        mask = mask_values <= threshold
+        blended[mask] = array_b[mask]
+        return blended
+
+    @staticmethod
+    def _gaussian_blur(values: np.ndarray, sigma: float) -> np.ndarray:
+        radius = max(int(3 * sigma), 1)
+        kernel = SlideTransitionRenderer._gaussian_kernel(radius, sigma)
+        blurred = SlideTransitionRenderer._convolve_axis(values, kernel, axis=0)
+        blurred = SlideTransitionRenderer._convolve_axis(blurred, kernel, axis=1)
+        return blurred
+
+    @staticmethod
+    def _gaussian_kernel(radius: int, sigma: float) -> np.ndarray:
+        axis = np.arange(-radius, radius + 1, dtype=np.float32)
+        kernel = np.exp(-(axis ** 2) / (2 * sigma ** 2))
+        kernel /= np.sum(kernel)
+        return kernel
+
+    @staticmethod
+    def _convolve_axis(
+        values: np.ndarray, kernel: np.ndarray, *, axis: int
+    ) -> np.ndarray:
+        pad = len(kernel) // 2
+        pad_width = [(0, 0)] * values.ndim
+        pad_width[axis] = (pad, pad)
+        padded = np.pad(values, pad_width=pad_width, mode="edge")
+        output = np.empty_like(values)
+        for index in range(values.shape[axis]):
+            start = index
+            end = index + len(kernel)
+            slicer = [slice(None)] * values.ndim
+            slicer[axis] = slice(start, end)
+            output_slicer = [slice(None)] * values.ndim
+            output_slicer[axis] = index
+            output[tuple(output_slicer)] = np.tensordot(
+                padded[tuple(slicer)], kernel, axes=([axis], [0])
+            )
+        return output

--- a/src/heart/renderers/slide_transition/state.py
+++ b/src/heart/renderers/slide_transition/state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
 
 from heart.peripheral.core.manager import PeripheralManager
 
@@ -10,3 +11,13 @@ class SlideTransitionState:
     peripheral_manager: PeripheralManager
     fraction_offset: float = 0.0
     sliding: bool = True
+
+
+class SlideTransitionMode(StrEnum):
+    SLIDE = "slide"
+    STATIC = "static"
+    GAUSSIAN = "gaussian"
+
+
+DEFAULT_STATIC_MASK_STEPS = 20
+DEFAULT_GAUSSIAN_SIGMA = 1.5


### PR DESCRIPTION
### Motivation
- Provide a softer, clustered alternative to the existing random pixel `STATIC` mask so transitions look less noisy and more organic.
- Give a configurable parameter to control cluster size using a Gaussian blur so visual density can be tuned for different devices.
- Reuse the existing slide transition plumbing so rendering, timing and provider wiring remain consistent with current transitions.

### Description
- Add `SlideTransitionMode.GAUSSIAN` and `DEFAULT_GAUSSIAN_SIGMA` in `src/heart/renderers/slide_transition/state.py`. 
- Extend `SlideTransitionProvider` to accept `gaussian_sigma` and store `transition_mode`/`static_mask_steps`/`gaussian_sigma` for the renderer. 
- Implement Gaussian clustered masks in `SlideTransitionRenderer` by generating noise, applying a separable Gaussian blur (`_gaussian_blur`/`_gaussian_kernel`/`_convolve_axis`), and blending with `_get_gaussian_mask_values` and `_blend_gaussian_arrays`. 
- Expose `gaussian_sigma` in `GameModeState`, treat `GAUSSIAN` like `STATIC` for direction resolution, and update documentation in `docs/renderers/slide_transition_modes.md`. 

### Testing
- Ran `make format` and formatting checks passed. 
- Ran `uv run pytest tests/navigation/test_game_modes.py` and all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964517ea0b8832197e52d47ee2e38f4)