### PR TITLE
Fix runtime helpers and reactive streams for test stability

### DIFF
--- a/src/heart/navigation/renderer_specs.py
+++ b/src/heart/navigation/renderer_specs.py
@@ -8,6 +8,24 @@ RendererT = TypeVar("RendererT", bound=StatefulBaseRenderer)
 RendererSpec = StatefulBaseRenderer | type[StatefulBaseRenderer]
 
 
+class RendererResolver(Protocol):
+    def resolve(self, dependency: type[RendererT]) -> RendererT:
+        """Resolve renderer instances from the shared container."""
+
+
 class RendererFactory(Protocol[RendererT]):
     def __call__(self) -> RendererT:
         """Instantiate a renderer."""
+
+
+def resolve_renderer_spec(
+    renderer: RendererSpec,
+    resolver: RendererResolver | None = None,
+) -> StatefulBaseRenderer:
+    if isinstance(renderer, type):
+        if not issubclass(renderer, StatefulBaseRenderer):
+            raise TypeError("Requires StatefulBaseRenderer subclasses")
+        if resolver is None:
+            raise ValueError("renderer resolver is required for class specs")
+        return resolver.resolve(renderer)
+    return renderer

--- a/src/heart/renderers/sliding_image/provider.py
+++ b/src/heart/renderers/sliding_image/provider.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from typing import cast
 
 import reactivex
 from reactivex import operators as ops
 
+import pygame
+from heart.peripheral.core import Peripheral, PeripheralMessageEnvelope
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import ObservableProvider
 from heart.renderers.sliding_image.state import SlidingImageState, SlidingRendererState
 from heart.utilities.reactivex_threads import pipe_in_background
+
+SLIDING_IMAGE_DEVICE_NAME = "sliding-image"
+SLIDING_RENDERER_DEVICE_NAME = "sliding-renderer"
 
 
 @dataclass(frozen=True)
@@ -18,44 +24,155 @@ class SlidingStateSnapshot:
 
 
 class SlidingImageStateProvider(ObservableProvider[SlidingImageState]):
-    def __init__(self, peripheral_manager: PeripheralManager):
+    def __init__(
+        self,
+        initial_state: SlidingImageState | None = None,
+        peripheral_manager: PeripheralManager | None = None,
+    ) -> None:
+        self._initial_state = initial_state or SlidingImageState()
         self._peripheral_manager = peripheral_manager
 
-    def observable(self) -> reactivex.Observable[SlidingImageState]:
-        switcher_stream = pipe_in_background(
-            reactivex.merge(
-                *(
-                    peripheral.observe
-                    for peripheral in self._peripheral_manager.peripherals
-                    if peripheral.device_name == "sliding-image"
-                )
-            ),
-            ops.map(SlidingImageState.unwrap_peripheral),
+    def _initial_state_snapshot(self) -> SlidingImageState:
+        return self._initial_state
+
+    def reset_state(self, state: SlidingImageState) -> SlidingImageState:
+        return replace(state, offset=0)
+
+    def advance_state(
+        self, state: SlidingImageState, width: int
+    ) -> SlidingImageState:
+        return _advance_state(state, width)
+
+    def observable(
+        self, peripheral_manager: PeripheralManager | None = None
+    ) -> reactivex.Observable[SlidingImageState]:
+        resolved_manager = peripheral_manager or self._peripheral_manager
+        if resolved_manager is None:
+            raise ValueError("SlidingImageStateProvider requires a PeripheralManager")
+
+        def is_matching_peripheral(peripheral: Peripheral[object]) -> bool:
+            return peripheral.device_name == SLIDING_IMAGE_DEVICE_NAME
+
+        window_stream = pipe_in_background(
+            resolved_manager.window,
+            ops.filter(lambda window: window is not None),
+            ops.map(lambda window: cast(pygame.Surface, window)),
+            ops.map(lambda window: window.get_width()),
+            ops.distinct_until_changed(),
+        )
+        initial_state = self._initial_state_snapshot()
+        window_stream = reactivex.merge(
+            reactivex.just(initial_state.width),
+            window_stream,
+        )
+
+        peripherals = [
+            peripheral.observe
+            for peripheral in getattr(resolved_manager, "peripherals", [])
+            if is_matching_peripheral(peripheral)
+        ]
+        peripheral_stream = pipe_in_background(
+            reactivex.merge(*peripherals) if peripherals else reactivex.empty(),
+            ops.map(PeripheralMessageEnvelope[SlidingImageState].unwrap_peripheral),
         )
         return pipe_in_background(
-            switcher_stream,
+            reactivex.merge(
+                peripheral_stream,
+                pipe_in_background(
+                    resolved_manager.game_tick,
+                    ops.with_latest_from(window_stream),
+                    ops.map(lambda pair: pair[1]),
+                    ops.scan(
+                        lambda state, width: self.advance_state(state, width),
+                        seed=initial_state,
+                    ),
+                    ops.start_with(initial_state),
+                ),
+            ),
             ops.distinct_until_changed(),
             ops.share(),
         )
 
 
 class SlidingRendererStateProvider(ObservableProvider[SlidingRendererState]):
-    def __init__(self, peripheral_manager: PeripheralManager):
+    def __init__(
+        self,
+        initial_state: SlidingRendererState | None = None,
+        peripheral_manager: PeripheralManager | None = None,
+    ) -> None:
+        self._initial_state = initial_state or SlidingRendererState()
         self._peripheral_manager = peripheral_manager
 
-    def observable(self) -> reactivex.Observable[SlidingRendererState]:
-        stream = pipe_in_background(
-            reactivex.merge(
-                *(
-                    peripheral.observe
-                    for peripheral in self._peripheral_manager.peripherals
-                    if peripheral.device_name == "sliding-renderer"
-                )
-            ),
-            ops.map(SlidingRendererState.unwrap_peripheral),
+    def _initial_state_snapshot(self) -> SlidingRendererState:
+        return self._initial_state
+
+    def reset_state(self, state: SlidingRendererState) -> SlidingRendererState:
+        return replace(state, offset=0)
+
+    def advance_state(
+        self, state: SlidingRendererState, width: int
+    ) -> SlidingRendererState:
+        return _advance_state(state, width)
+
+    def observable(
+        self, peripheral_manager: PeripheralManager | None = None
+    ) -> reactivex.Observable[SlidingRendererState]:
+        resolved_manager = peripheral_manager or self._peripheral_manager
+        if resolved_manager is None:
+            raise ValueError(
+                "SlidingRendererStateProvider requires a PeripheralManager"
+            )
+
+        def is_matching_peripheral(peripheral: Peripheral[object]) -> bool:
+            return peripheral.device_name == SLIDING_RENDERER_DEVICE_NAME
+
+        window_stream = pipe_in_background(
+            resolved_manager.window,
+            ops.filter(lambda window: window is not None),
+            ops.map(lambda window: cast(pygame.Surface, window)),
+            ops.map(lambda window: window.get_width()),
+            ops.distinct_until_changed(),
+        )
+        initial_state = self._initial_state_snapshot()
+        window_stream = reactivex.merge(
+            reactivex.just(initial_state.width),
+            window_stream,
+        )
+
+        peripherals = [
+            peripheral.observe
+            for peripheral in getattr(resolved_manager, "peripherals", [])
+            if is_matching_peripheral(peripheral)
+        ]
+        peripheral_stream = pipe_in_background(
+            reactivex.merge(*peripherals) if peripherals else reactivex.empty(),
+            ops.map(PeripheralMessageEnvelope[SlidingRendererState].unwrap_peripheral),
         )
         return pipe_in_background(
-            stream,
+            reactivex.merge(
+                peripheral_stream,
+                pipe_in_background(
+                    resolved_manager.game_tick,
+                    ops.with_latest_from(window_stream),
+                    ops.map(lambda pair: pair[1]),
+                    ops.scan(
+                        lambda state, width: self.advance_state(state, width),
+                        seed=initial_state,
+                    ),
+                    ops.start_with(initial_state),
+                ),
+            ),
             ops.distinct_until_changed(),
             ops.share(),
         )
+
+
+def _advance_state(
+    state: SlidingImageState | SlidingRendererState,
+    width: int,
+) -> SlidingImageState | SlidingRendererState:
+    if width <= 0:
+        return replace(state, width=width)
+
+    offset = (state.offset + state.speed) % width
+    return replace(state, offset=offset, width=width)

--- a/src/heart/renderers/sliding_image/renderer.py
+++ b/src/heart/renderers/sliding_image/renderer.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import dataclass
-from typing import Protocol
+from dataclasses import dataclass, replace
+from typing import Callable, Protocol
 
-import numpy as np
+import pygame
+import reactivex
 
+from heart import DeviceDisplayMode
+from heart.assets.loader import Loader
 from heart.device import Orientation
 from heart.peripheral.core.manager import PeripheralManager
 from heart.renderers import StatefulBaseRenderer
@@ -16,31 +19,145 @@ from heart.renderers.sliding_image.provider import (
 from heart.renderers.sliding_image.state import SlidingImageState, SlidingRendererState
 from heart.runtime.display_context import DisplayContext
 
+DEFAULT_SLIDING_SPEED = 1
+
+
+class SlidingImage(StatefulBaseRenderer[SlidingImageState]):
+    """Render an image that continuously slides horizontally."""
+
+    def __init__(
+        self,
+        image_file: str,
+        *,
+        speed: int = DEFAULT_SLIDING_SPEED,
+        provider_factory: Callable[[SlidingImageState], SlidingImageStateProvider]
+        | None = None,
+    ) -> None:
+        self._image_file = image_file
+        initial_state = SlidingImageState(speed=max(1, speed))
+        self._provider = (provider_factory or self._default_provider)(initial_state)
+        self._image: pygame.Surface | None = None
+
+        super().__init__(builder=self._provider)
+        self.device_display_mode = DeviceDisplayMode.FULL
+
+    def _default_provider(
+        self, initial_state: SlidingImageState
+    ) -> SlidingImageStateProvider:
+        return SlidingImageStateProvider(initial_state=initial_state)
+
+    def state_observable(
+        self, peripheral_manager: PeripheralManager
+    ) -> reactivex.Observable[SlidingImageState]:
+        return self._provider.observable(peripheral_manager=peripheral_manager)
+
+    def initialize(
+        self,
+        window: DisplayContext,
+        peripheral_manager: PeripheralManager,
+        orientation: Orientation,
+    ) -> None:
+        if self._image is None or self._image.get_size() != window.get_size():
+            image = Loader.load(self._image_file)
+            self._image = pygame.transform.scale(image, window.get_size())
+        if self._provider is not None:
+            self._provider._initial_state = replace(
+                self._provider._initial_state,
+                width=window.get_width(),
+            )
+        super().initialize(window, peripheral_manager, orientation)
+        if self._state is not None:
+            self.update_state(
+                offset=self._provider.advance_state(
+                    self._state, window.get_width()
+                ).offset,
+                width=window.get_width(),
+            )
+
+    def real_process(
+        self,
+        window: DisplayContext,
+        orientation: Orientation,
+    ) -> None:
+        if self._image is None or self.state.width <= 0:
+            return
+
+        offset = self.state.offset
+        width = self.state.width
+
+        window.blit(self._image, (-offset, 0))
+        if offset:
+            window.blit(self._image, (width - offset, 0))
+
+
+class SlidingRenderer(StatefulBaseRenderer[SlidingRendererState]):
+    """Wrap another renderer and slide its output horizontally."""
+
+    def __init__(
+        self,
+        renderer: StatefulBaseRenderer,
+        *,
+        speed: int = DEFAULT_SLIDING_SPEED,
+        provider_factory: Callable[[SlidingRendererState], SlidingRendererStateProvider]
+        | None = None,
+    ) -> None:
+        self.composed = renderer
+        initial_state = SlidingRendererState(speed=max(1, speed))
+        self._provider = (provider_factory or self._default_provider)(initial_state)
+        self._peripheral_manager: PeripheralManager | None = None
+
+        super().__init__(builder=self._provider)
+        self.device_display_mode = DeviceDisplayMode.FULL
+
+    def _default_provider(
+        self, initial_state: SlidingRendererState
+    ) -> SlidingRendererStateProvider:
+        return SlidingRendererStateProvider(initial_state=initial_state)
+
+    def state_observable(
+        self, peripheral_manager: PeripheralManager
+    ) -> reactivex.Observable[SlidingRendererState]:
+        return self._provider.observable(peripheral_manager=peripheral_manager)
+
+    def initialize(
+        self,
+        window: DisplayContext,
+        peripheral_manager: PeripheralManager,
+        orientation: Orientation,
+    ) -> None:
+        self._peripheral_manager = peripheral_manager
+        self.composed.initialize(window, peripheral_manager, orientation)
+        super().initialize(window, peripheral_manager, orientation)
+
+    def real_process(
+        self,
+        window: DisplayContext,
+        orientation: Orientation,
+    ) -> None:
+        if self._peripheral_manager is None:
+            return
+
+        self.composed._internal_process(
+            window, self._peripheral_manager, orientation
+        )
+
+        if self.state.width <= 0:
+            return
+
+        offset = self.state.offset
+        width = self.state.width
+        surface = window.screen.copy()
+
+        window.fill((0, 0, 0, 0))
+        window.blit(surface, (-offset, 0))
+        if offset:
+            window.blit(surface, (width - offset, 0))
+
 
 @dataclass(frozen=True)
 class SlidingImageSpec:
     renderer: SlidingRendererState
     image: SlidingImageState
-
-
-class SlidingImageRenderer(StatefulBaseRenderer[SlidingImageState]):
-    def __init__(self, context: DisplayContext, spec: SlidingImageSpec):
-        super().__init__(context, spec.image)
-        self._spec = spec
-
-    def render(self, state: SlidingImageState) -> np.ndarray:
-        return state.render()
-
-    def reset(self) -> None:
-        return self._state.reset()
-
-    @property
-    def width(self) -> int:
-        return self._state.width
-
-    @property
-    def orientation(self) -> Orientation:
-        return self._state.orientation
 
 
 class SlidingImageSpecBuilder(Protocol):

--- a/src/heart/runtime/container/__init__.py
+++ b/src/heart/runtime/container/__init__.py
@@ -1,4 +1,6 @@
-from heart.runtime.container.container import RuntimeContainer
+from lagom import Container
+
+RuntimeContainer = Container
 
 container = RuntimeContainer()
 

--- a/src/heart/runtime/container/initialize.py
+++ b/src/heart/runtime/container/initialize.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
-from typing import cast
+from typing import TYPE_CHECKING, Any, Mapping
 
-from heart.firmware.environment import FirmwareEnvironment
+from lagom import Singleton
+
+from heart.device import Device
+from heart.navigation import AppController
+from heart.peripheral.configuration_loader import PeripheralConfigurationLoader
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import apply_provider_registrations
 from heart.peripheral.registry import PeripheralConfigurationRegistry
@@ -11,49 +15,260 @@ from heart.runtime.container import RuntimeContainer
 from heart.runtime.display_context import DisplayContext
 from heart.runtime.peripheral_runtime import PeripheralRuntime
 from heart.runtime.rendering.pacing import RenderLoopPacer
+from heart.runtime.rendering.pipeline import RendererVariant, RenderPipeline
+from heart.runtime.rendering.surface.provider import RendererSurfaceProvider
+from heart.utilities.env import Configuration
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+if TYPE_CHECKING:
+    from heart.runtime.game_loop import GameLoop
+    from heart.runtime.game_loop.components import GameLoopComponents
+
+
+def _build_peripheral_configuration_loader(
+    resolver: RuntimeContainer,
+) -> PeripheralConfigurationLoader:
+    return PeripheralConfigurationLoader(
+        registry=resolver[PeripheralConfigurationRegistry]
+    )
+
+
+def _build_peripheral_manager(
+    resolver: RuntimeContainer,
+) -> PeripheralManager:
+    return PeripheralManager(
+        configuration_loader=resolver[PeripheralConfigurationLoader]
+    )
+
+
+def _build_display_context(resolver: RuntimeContainer) -> DisplayContext:
+    return DisplayContext(device=resolver[Device])
+
+
+def _build_render_pipeline(resolver: RuntimeContainer) -> RenderPipeline:
+    pipeline = RenderPipeline(
+        display_context=resolver[DisplayContext],
+        peripheral_manager=resolver[PeripheralManager],
+        render_variant=resolver[RendererVariant],
+    )
+    pipeline._renderer_processor._surface_provider._container = resolver
+    return pipeline
+
+
+def _build_render_surface_provider(
+    resolver: RuntimeContainer,
+) -> RendererSurfaceProvider:
+    provider = RendererSurfaceProvider(
+        display_context=resolver[DisplayContext],
+    )
+    provider._container = resolver
+    return provider
+
+
+def _build_peripheral_runtime(resolver: RuntimeContainer) -> PeripheralRuntime:
+    return PeripheralRuntime(resolver[PeripheralManager])
+
+
+def _build_app_controller(resolver: RuntimeContainer) -> AppController:
+    controller = AppController()
+    controller._renderer_resolver = resolver
+    return controller
+
+
+def _build_render_loop_pacer(_: RuntimeContainer) -> RenderLoopPacer:
+    return RenderLoopPacer(
+        strategy=Configuration.render_loop_pacing_strategy(),
+        min_interval_ms=Configuration.render_loop_pacing_min_interval_ms(),
+        utilization_target=Configuration.render_loop_pacing_utilization(),
+    )
+
+
+def _build_game_loop_components(
+    resolver: RuntimeContainer,
+) -> GameLoopComponents:
+    from heart.runtime.game_loop.components import GameLoopComponents
+    from heart.runtime.game_loop.event_handler import PygameEventHandler
+
+    return GameLoopComponents(
+        app_controller=resolver[AppController],
+        display=resolver[DisplayContext],
+        render_pipeline=resolver[RenderPipeline],
+        event_handler=resolver[PygameEventHandler],
+        peripheral_manager=resolver[PeripheralManager],
+        peripheral_runtime=resolver[PeripheralRuntime],
+    )
+
+
+def _build_game_loop(resolver: RuntimeContainer) -> GameLoop:
+    from heart.runtime.game_loop import GameLoop
+
+    return GameLoop(
+        device=resolver[Device],
+        resolver=resolver,
+        render_variant=resolver[RendererVariant],
+    )
 
 
 def build_runtime_container(
-    firmware_environment: FirmwareEnvironment | None = None,
+    device: Device,
+    render_variant: RendererVariant,
+    overrides: Mapping[type[Any], object] | None = None,
 ) -> RuntimeContainer:
-    """Create a runtime container with expected core bindings."""
-
-    container = RuntimeContainer()
-    configure_runtime_container(container, firmware_environment=firmware_environment)
-    return container
+    logger.debug("Created Lagom container for runtime configuration.")
+    runtime_container = RuntimeContainer()
+    configure_runtime_container(
+        container=runtime_container,
+        device=device,
+        render_variant=render_variant,
+        overrides=overrides,
+    )
+    return runtime_container
 
 
 def configure_runtime_container(
+    *,
     container: RuntimeContainer,
-    firmware_environment: FirmwareEnvironment | None = None,
+    device: Device,
+    render_variant: RendererVariant,
+    overrides: Mapping[type[Any], object] | None = None,
 ) -> None:
-    """Register core bindings used by the runtime container."""
-
-    if firmware_environment is None:
-        firmware_environment = FirmwareEnvironment.from_env()
-
-    peripheral_registry = PeripheralConfigurationRegistry.from_env()
-    configuration_registry = ConfigurationRegistry.from_env()
-    peripheral_manager = PeripheralManager.from_registry(peripheral_registry)
-    display_context = DisplayContext(
-        firmware_environment=firmware_environment,
-        peripheral_manager=peripheral_manager,
+    logger.debug(
+        "Configuring Lagom runtime container with overrides=%s.",
+        set(overrides.keys()) if overrides else set(),
     )
-    render_loop_pacer = RenderLoopPacer.from_env()
-    container.bind_instance(FirmwareEnvironment, firmware_environment)
-    container.bind_instance(PeripheralConfigurationRegistry, peripheral_registry)
-    container.bind_instance(ConfigurationRegistry, configuration_registry)
-    container.bind_instance(PeripheralManager, peripheral_manager)
-    container.bind_instance(DisplayContext, display_context)
-    container.bind_instance(PeripheralRuntime, PeripheralRuntime(peripheral_manager))
-    container.bind_instance(RenderLoopPacer, render_loop_pacer)
-
+    _bind(container, overrides, Device, device)
+    _bind(container, overrides, RendererVariant, render_variant)
+    _configure_peripheral_bindings(container, overrides)
+    _configure_display_bindings(container, overrides)
+    _configure_render_bindings(container, overrides)
+    _configure_runtime_bindings(container, overrides)
+    _configure_game_loop_bindings(container, overrides)
     apply_provider_registrations(container)
 
-    container.bind_instance(RuntimeContainer, container)
 
-    if firmware_environment.is_isolated:
-        container.bind_instance(
-            RuntimeContainer,
-            cast(RuntimeContainer, container.reconfigure()),
-        )
+def _bind(
+    container: RuntimeContainer,
+    overrides: Mapping[type[Any], object] | None,
+    key: type[Any],
+    value: object,
+) -> None:
+    if overrides and key in overrides:
+        container[key] = overrides[key]
+        logger.debug("Applied Lagom override for %s.", key)
+        return
+    if key in container.defined_types:
+        logger.debug("Lagom already defined %s; skipping registration.", key)
+        return
+    container[key] = value
+    logger.debug("Registered Lagom provider for %s.", key)
+
+
+def _configure_peripheral_bindings(
+    container: RuntimeContainer,
+    overrides: Mapping[type[Any], object] | None,
+) -> None:
+    _bind(
+        container,
+        overrides,
+        PeripheralConfigurationRegistry,
+        Singleton(PeripheralConfigurationRegistry),
+    )
+    _bind(
+        container,
+        overrides,
+        PeripheralConfigurationLoader,
+        Singleton(_build_peripheral_configuration_loader),
+    )
+    _bind(
+        container,
+        overrides,
+        PeripheralManager,
+        Singleton(_build_peripheral_manager),
+    )
+
+
+def _configure_display_bindings(
+    container: RuntimeContainer,
+    overrides: Mapping[type[Any], object] | None,
+) -> None:
+    _bind(
+        container,
+        overrides,
+        DisplayContext,
+        Singleton(_build_display_context),
+    )
+
+
+def _configure_render_bindings(
+    container: RuntimeContainer,
+    overrides: Mapping[type[Any], object] | None,
+) -> None:
+    _bind(
+        container,
+        overrides,
+        RenderPipeline,
+        Singleton(_build_render_pipeline),
+    )
+    _bind(
+        container,
+        overrides,
+        RendererSurfaceProvider,
+        Singleton(_build_render_surface_provider),
+    )
+
+
+def _configure_runtime_bindings(
+    container: RuntimeContainer,
+    overrides: Mapping[type[Any], object] | None,
+) -> None:
+    from heart.runtime.game_loop.event_handler import PygameEventHandler
+
+    _bind(
+        container,
+        overrides,
+        PeripheralRuntime,
+        Singleton(_build_peripheral_runtime),
+    )
+    _bind(
+        container,
+        overrides,
+        AppController,
+        Singleton(_build_app_controller),
+    )
+    _bind(
+        container,
+        overrides,
+        RenderLoopPacer,
+        Singleton(_build_render_loop_pacer),
+    )
+    _bind(
+        container,
+        overrides,
+        ConfigurationRegistry,
+        Singleton(ConfigurationRegistry),
+    )
+    _bind(container, overrides, PygameEventHandler, Singleton(PygameEventHandler))
+
+
+def _configure_game_loop_bindings(
+    container: RuntimeContainer,
+    overrides: Mapping[type[Any], object] | None,
+) -> None:
+    from heart.runtime.game_loop.components import GameLoopComponents
+
+    _bind(
+        container,
+        overrides,
+        GameLoopComponents,
+        Singleton(_build_game_loop_components),
+    )
+    from heart.runtime.game_loop import GameLoop
+
+    _bind(
+        container,
+        overrides,
+        GameLoop,
+        Singleton(_build_game_loop),
+    )

--- a/src/heart/utilities/reactivex/coalescing.py
+++ b/src/heart/utilities/reactivex/coalescing.py
@@ -1,77 +1,134 @@
-from datetime import timedelta
-from typing import Callable
+import time
+from threading import RLock, Timer
+from typing import Any, Callable, TypeVar
 
 import reactivex
 from reactivex.disposable import Disposable
 
 from heart.utilities.logging import get_logger
-from heart.utilities.reactivex_threads import _COALESCE_SCHEDULER, coalesce_scheduler
+from heart.utilities.reactivex_threads import _COALESCE_SCHEDULER
 
 logger = get_logger(__name__)
 
-CoalesceCallable = Callable[[reactivex.Observable], reactivex.Observable]
+T = TypeVar("T")
+CoalesceCallable = Callable[[reactivex.Observable[T]], reactivex.Observable[T]]
+_NO_PENDING: Any = object()
 
 
-class CoalesceBuffer:
-    def __init__(self, buffer_time: float, scheduler: reactivex.scheduler.SchedulerBase):
-        self._buffer_time = buffer_time
-        self._scheduler = scheduler
-
-    def __call__(self, source: reactivex.Observable) -> reactivex.Observable:
-        return source.pipe(
-            reactivex.operators.buffer_with_time(
-                timedelta(milliseconds=self._buffer_time),
-                scheduler=self._scheduler,
-            ),
-            reactivex.operators.filter(lambda buffer: len(buffer) > 0),
-        )
-
-
-def coalesce_latest(buffer_time: float) -> CoalesceCallable:
-    """Coalesce emissions within the buffer window into the last value.
-
-    This ensures that downstream processing only receives the most recent value in each
-    buffer window, effectively smoothing out high-frequency input streams.
-    """
-
-    def coalesce(source: reactivex.Observable) -> reactivex.Observable:
-        return source.pipe(
-            reactivex.operators.buffer_with_time(
-                timedelta(milliseconds=buffer_time),
-                scheduler=_COALESCE_SCHEDULER,
-            ),
-            reactivex.operators.filter(lambda buffer: len(buffer) > 0),
-            reactivex.operators.map(lambda buffer: buffer[-1]),
-        )
-
-    return coalesce
-
-
-def coalesce_buffer_with_tracking(
-    buffer_time: float,
-    scheduler: reactivex.scheduler.SchedulerBase | None = None,
+def coalesce_latest(
+    window_ms: int,
+    *,
+    stream_name: str | None = None,
 ) -> CoalesceCallable:
-    """Coalesce emissions within the buffer window into the last value.
+    """Coalesce emissions within the buffer window into the last value."""
 
-    This ensures that downstream processing only receives the most recent value in each
-    buffer window, effectively smoothing out high-frequency input streams.
-    """
+    if window_ms <= 0:
+        return lambda source: source
 
-    scheduler = scheduler or coalesce_scheduler()
+    def coalesce(source: reactivex.Observable[T]) -> reactivex.Observable[T]:
+        def _subscribe(observer: Any, scheduler: Any = None) -> Disposable:
+            del scheduler
+            lock = RLock()
+            pending: Any = _NO_PENDING
+            timer: Any | None = None
+            fallback_timer: Timer | None = None
+            due_time: float | None = None
+            window_seconds = window_ms / 1000
 
-    def coalesce(source: reactivex.Observable) -> reactivex.Observable:
-        def inner() -> tuple[reactivex.Observable, Disposable]:
-            buffer: list = []
-            buffered = source.subscribe(buffer.append)
-            report_handle = scheduler.schedule_relative(
-                timedelta(milliseconds=buffer_time),
-                lambda *_: logger.debug(
-                    "Coalescing buffer has %d entries", len(buffer)
-                ),
-                state=None,
+            def _cancel_timers() -> None:
+                nonlocal timer, fallback_timer
+                if timer is not None:
+                    timer.dispose()
+                    timer = None
+                if fallback_timer is not None:
+                    fallback_timer.cancel()
+                    fallback_timer = None
+
+            def _flush() -> None:
+                nonlocal pending, due_time
+                with lock:
+                    value = pending
+                    pending = _NO_PENDING
+                    _cancel_timers()
+                    due_time = None
+                if value is _NO_PENDING:
+                    return
+                observer.on_next(value)
+
+            def _schedule_flush(now: float) -> None:
+                nonlocal timer, fallback_timer, due_time
+                if timer is not None or fallback_timer is not None:
+                    if due_time is not None and now >= due_time:
+                        _cancel_timers()
+                        due_time = None
+                    else:
+                        return
+                due_time = now + window_seconds
+                timer = _COALESCE_SCHEDULER.schedule_relative(
+                    window_seconds,
+                    lambda *_: _flush(),
+                )
+                fallback_timer = Timer(window_seconds, _flush)
+                fallback_timer.daemon = True
+                fallback_timer.start()
+
+            def _on_next(value: Any) -> None:
+                nonlocal pending, due_time
+                now = time.monotonic()
+                flush_value: Any = _NO_PENDING
+                with lock:
+                    if (
+                        pending is not _NO_PENDING
+                        and due_time is not None
+                        and now >= due_time
+                    ):
+                        flush_value = pending
+                        pending = _NO_PENDING
+                        _cancel_timers()
+                        due_time = None
+                    pending = value
+                    _schedule_flush(now)
+                if flush_value is not _NO_PENDING:
+                    observer.on_next(flush_value)
+
+            def _on_error(err: Exception) -> None:
+                nonlocal pending, due_time
+                with lock:
+                    _cancel_timers()
+                    pending = _NO_PENDING
+                    due_time = None
+                observer.on_error(err)
+
+            def _on_completed() -> None:
+                nonlocal due_time
+                with lock:
+                    _cancel_timers()
+                    due_time = None
+                _flush()
+                observer.on_completed()
+
+            subscription = source.subscribe(
+                _on_next,
+                _on_error,
+                _on_completed,
+                scheduler=_COALESCE_SCHEDULER,
             )
-            return (source, Disposable(lambda: (buffered.dispose(), report_handle.dispose())))
 
-        return reactivex.Observable(inner)
+            def _dispose() -> None:
+                nonlocal pending, due_time
+                subscription.dispose()
+                with lock:
+                    pending = _NO_PENDING
+                    _cancel_timers()
+                    due_time = None
+
+            logger.debug(
+                "Coalescing %s with window_ms=%d",
+                stream_name or "reactivex-stream",
+                window_ms,
+            )
+            return Disposable(_dispose)
+
+        return reactivex.create(_subscribe)
 
     return coalesce

--- a/src/heart/utilities/reactivex/sharing.py
+++ b/src/heart/utilities/reactivex/sharing.py
@@ -1,4 +1,6 @@
 from datetime import timedelta
+from threading import RLock
+from typing import Any, TypeVar, cast
 
 import reactivex
 from reactivex import operators as ops
@@ -12,9 +14,14 @@ from heart.utilities.env import (
 from heart.utilities.logging import get_logger
 from heart.utilities.reactivex.coalescing import coalesce_latest
 from heart.utilities.reactivex.instrumentation import instrument_stream
+from heart.utilities.reactivex.settings import StreamShareSettings
+from heart.utilities.reactivex.types import ConnectableStream
 
 logger = get_logger(__name__)
 
+T = TypeVar("T")
+_REPLAY_SCHEDULER = TimeoutScheduler()
+_GRACE_SCHEDULER = TimeoutScheduler()
 
 def _get_replay_window(max_age_ms: int | None) -> timedelta | None:
     if max_age_ms is None:
@@ -36,124 +43,325 @@ def _should_replay(
     return False
 
 
-def _share_stream(
-    source: reactivex.Observable,
+def _share_with_refcount_grace(
+    connectable: ConnectableStream[T],
+    *,
+    grace_ms: int,
+    min_subscribers: int,
     connect_mode: ReactivexStreamConnectMode,
-    share_strategy: ReactivexStreamShareStrategy,
-    replay_buffer_size: int,
+    stream_name: str,
+) -> reactivex.Observable[T]:
+    lock = RLock()
+    connection: Any | None = None
+    disconnect_timer: Any | None = None
+    subscriber_count = 0
+
+    def _disconnect() -> None:
+        nonlocal connection, disconnect_timer, subscriber_count
+        with lock:
+            disconnect_timer = None
+            if connection is None or subscriber_count >= min_subscribers:
+                return
+            logger.debug("Disconnecting %s after refcount grace window", stream_name)
+            connection.dispose()
+            connection = None
+
+    def _subscribe(observer: Any, scheduler: Any = None) -> Disposable:
+        nonlocal connection, disconnect_timer, subscriber_count
+        with lock:
+            subscriber_count += 1
+            if disconnect_timer is not None:
+                disconnect_timer.dispose()
+                disconnect_timer = None
+            if (
+                connection is None
+                and connect_mode is ReactivexStreamConnectMode.EAGER
+                and subscriber_count >= min_subscribers
+            ):
+                logger.debug(
+                    "Connecting %s with refcount grace (grace_ms=%d, mode=%s, min=%d)",
+                    stream_name,
+                    grace_ms,
+                    connect_mode,
+                    min_subscribers,
+                )
+                connection = connectable.connect()
+
+        subscription = connectable.subscribe(observer)
+        if connect_mode is ReactivexStreamConnectMode.LAZY:
+            with lock:
+                if connection is None and subscriber_count >= min_subscribers:
+                    logger.debug(
+                        "Connecting %s with refcount grace (grace_ms=%d, mode=%s, min=%d)",
+                        stream_name,
+                        grace_ms,
+                        connect_mode,
+                        min_subscribers,
+                    )
+                    connection = connectable.connect()
+
+        def _dispose() -> None:
+            nonlocal subscriber_count, disconnect_timer
+            subscription.dispose()
+            with lock:
+                subscriber_count -= 1
+                if subscriber_count >= min_subscribers or connection is None:
+                    return
+                if grace_ms <= 0:
+                    _disconnect()
+                    return
+                logger.debug(
+                    "Scheduling disconnect for %s in %dms (min=%d)",
+                    stream_name,
+                    grace_ms,
+                    min_subscribers,
+                )
+                if disconnect_timer is not None:
+                    disconnect_timer.dispose()
+                    disconnect_timer = None
+                disconnect_timer = _GRACE_SCHEDULER.schedule_relative(
+                    grace_ms / 1000,
+                    lambda *_: _disconnect(),
+                )
+
+        return Disposable(_dispose)
+
+    return reactivex.create(_subscribe)
+
+
+def _replay(
+    source: reactivex.Observable[T],
+    *,
+    buffer_size: int,
     replay_window: timedelta | None,
-    subscriber_limit: int,
-    scheduler: TimeoutScheduler,
-) -> reactivex.Observable:
-    replay_enabled = _should_replay(
-        share_strategy,
-        replay_buffer_size,
-        replay_window,
-    )
-    if replay_enabled:
-        return source.pipe(
+) -> ConnectableStream[T]:
+    if replay_window is None:
+        return cast(
+            ConnectableStream[T],
+            source.pipe(ops.replay(buffer_size=buffer_size)),
+        )
+    return cast(
+        ConnectableStream[T],
+        source.pipe(
             ops.replay(
-                buffer_size=replay_buffer_size,
-                window=replay_window,
-                scheduler=scheduler,
-            ),
-            ops.ref_count(),
-        )
-    return source.pipe(ops.share())
-
-
-class _CoalesceBuffer:
-    def __init__(self, buffer_time_ms: int):
-        self._buffer_time_ms = buffer_time_ms
-
-    def __call__(self, source: reactivex.Observable) -> reactivex.Observable:
-        return source.pipe(
-            ops.buffer_with_time(
-                timedelta(milliseconds=self._buffer_time_ms),
-                scheduler=TimeoutScheduler(),
-            ),
-            ops.filter(lambda buffer: len(buffer) > 0),
-        )
-
-
-class _ShareStream:
-    def __init__(
-        self,
-        connect_mode: ReactivexStreamConnectMode,
-        share_strategy: ReactivexStreamShareStrategy,
-        replay_buffer_size: int,
-        replay_window: timedelta | None,
-        subscriber_limit: int,
-        coalesce_window_ms: int,
-    ):
-        self._connect_mode = connect_mode
-        self._share_strategy = share_strategy
-        self._replay_buffer_size = replay_buffer_size
-        self._replay_window = replay_window
-        self._subscriber_limit = subscriber_limit
-        self._coalesce_window_ms = coalesce_window_ms
-
-    def __call__(self, source: reactivex.Observable) -> reactivex.Observable:
-        scheduler = TimeoutScheduler()
-        if self._connect_mode == ReactivexStreamConnectMode.eager:
-            source = source.pipe(ops.publish(), ops.connect())
-        shared = _share_stream(
-            source,
-            self._connect_mode,
-            self._share_strategy,
-            self._replay_buffer_size,
-            self._replay_window,
-            self._subscriber_limit,
-            scheduler,
-        )
-        if self._coalesce_window_ms > 0:
-            return shared.pipe(
-                _CoalesceBuffer(self._coalesce_window_ms),
-                ops.map(lambda buffer: buffer[-1]),
+                buffer_size=buffer_size,
+                window=replay_window.total_seconds(),
+                scheduler=_REPLAY_SCHEDULER,
             )
-        return shared
+        ),
+    )
 
 
-class _RefcountGrace:
-    def __init__(self, grace_period_ms: int, min_subscribers: int):
-        self._grace_period_ms = grace_period_ms
-        self._min_subscribers = min_subscribers
-
-    def __call__(self, source: reactivex.Observable) -> reactivex.Observable:
-        def subscribe(observer, scheduler=None) -> Disposable:
-            return source.subscribe(observer, scheduler=scheduler)
-
-        return reactivex.defer(subscribe)
+def _coalesce_if_needed(
+    source: reactivex.Observable[T],
+    *,
+    coalesce_window_ms: int,
+    stream_name: str,
+) -> reactivex.Observable[T]:
+    if coalesce_window_ms <= 0:
+        return source
+    return source.pipe(
+        coalesce_latest(coalesce_window_ms, stream_name=stream_name),
+    )
 
 
 def share_stream(
-    source: reactivex.Observable,
-    connect_mode: ReactivexStreamConnectMode,
-    share_strategy: ReactivexStreamShareStrategy,
-    replay_buffer_size: int,
-    replay_window: timedelta | None,
-    subscriber_limit: int,
-    coalesce_window_ms: int,
-    grace_period_ms: int,
-    min_subscribers: int,
-) -> reactivex.Observable:
+    source: reactivex.Observable[T],
+    connect_mode: ReactivexStreamConnectMode | None = None,
+    share_strategy: ReactivexStreamShareStrategy | None = None,
+    replay_buffer_size: int | None = None,
+    replay_window: timedelta | None = None,
+    subscriber_limit: int = 0,
+    coalesce_window_ms: int | None = None,
+    grace_period_ms: int | None = None,
+    min_subscribers: int | None = None,
+    *,
+    stream_name: str | None = None,
+) -> reactivex.Observable[T]:
     """Return a shared observable with support for configurable replay strategies.
 
     The share strategy and connection mode are driven by environment configuration, so
     this helper keeps the behaviour consistent across modules.
     """
 
-    shared = _ShareStream(
-        connect_mode,
-        share_strategy,
-        replay_buffer_size,
-        replay_window,
-        subscriber_limit,
-        coalesce_window_ms,
-    )(source)
-    if grace_period_ms > 0 or min_subscribers > 1:
-        shared = shared.pipe(_RefcountGrace(grace_period_ms, min_subscribers))
-    return instrument_stream(shared)
+    settings = StreamShareSettings.from_environment()
+    resolved_connect_mode = connect_mode or settings.connect_mode
+    resolved_share_strategy = share_strategy or settings.strategy
+    resolved_replay_buffer = (
+        replay_buffer_size
+        if replay_buffer_size is not None
+        else settings.replay_buffer()
+    )
+    resolved_replay_window = (
+        replay_window
+        if replay_window is not None
+        else _get_replay_window(settings.replay_window_ms)
+    )
+    resolved_coalesce_window = (
+        coalesce_window_ms
+        if coalesce_window_ms is not None
+        else settings.coalesce_window_ms
+    )
+    resolved_min_subscribers = (
+        min_subscribers
+        if min_subscribers is not None
+        else settings.refcount_min_subscribers
+    )
+    resolved_grace_period = (
+        grace_period_ms
+        if grace_period_ms is not None
+        else settings.refcount_grace_ms
+    )
+
+    resolved_connect_mode = ReactivexStreamConnectMode(resolved_connect_mode)
+    resolved_share_strategy = ReactivexStreamShareStrategy(resolved_share_strategy)
+
+    settings = StreamShareSettings(
+        strategy=resolved_share_strategy,
+        coalesce_window_ms=resolved_coalesce_window,
+        stats_log_ms=settings.stats_log_ms,
+        replay_window_ms=(
+            int(resolved_replay_window.total_seconds() * 1000)
+            if resolved_replay_window is not None
+            else None
+        ),
+        auto_connect_min_subscribers=settings.auto_connect_min_subscribers,
+        refcount_min_subscribers=resolved_min_subscribers,
+        refcount_grace_ms=resolved_grace_period,
+        connect_mode=resolved_connect_mode,
+    )
+
+    stream_label = stream_name or "reactivex-stream"
+    replay_window_setting = resolved_replay_window
+
+    if resolved_share_strategy is ReactivexStreamShareStrategy.SHARE:
+        if resolved_grace_period > 0 or resolved_min_subscribers > 1:
+            shared = _share_with_refcount_grace(
+                cast(ConnectableStream[T], source.pipe(ops.publish())),
+                grace_ms=resolved_grace_period,
+                min_subscribers=resolved_min_subscribers,
+                connect_mode=resolved_connect_mode,
+                stream_name=stream_label,
+            )
+        else:
+            shared = source.pipe(ops.share())
+        shared = _coalesce_if_needed(
+            shared,
+            coalesce_window_ms=resolved_coalesce_window,
+            stream_name=stream_label,
+        )
+        return instrument_stream(
+            shared,
+            stream_name=stream_label,
+            log_interval_ms=settings.stats_log_ms,
+        )
+
+    if resolved_share_strategy is ReactivexStreamShareStrategy.SHARE_AUTO_CONNECT:
+        shared = source.pipe(ops.publish()).auto_connect(
+            settings.auto_connect_min_subscribers
+        )
+        shared = _coalesce_if_needed(
+            shared,
+            coalesce_window_ms=resolved_coalesce_window,
+            stream_name=stream_label,
+        )
+        return instrument_stream(
+            shared,
+            stream_name=stream_label,
+            log_interval_ms=settings.stats_log_ms,
+        )
+
+    if resolved_share_strategy is ReactivexStreamShareStrategy.REPLAY_LATEST:
+        replayed = _replay(
+            source,
+            buffer_size=1,
+            replay_window=replay_window_setting,
+        )
+        if resolved_grace_period > 0 or resolved_min_subscribers > 1:
+            shared = _share_with_refcount_grace(
+                replayed,
+                grace_ms=resolved_grace_period,
+                min_subscribers=resolved_min_subscribers,
+                connect_mode=resolved_connect_mode,
+                stream_name=stream_label,
+            )
+        else:
+            shared = replayed.pipe(ops.ref_count())
+        shared = _coalesce_if_needed(
+            shared,
+            coalesce_window_ms=resolved_coalesce_window,
+            stream_name=stream_label,
+        )
+        return instrument_stream(
+            shared,
+            stream_name=stream_label,
+            log_interval_ms=settings.stats_log_ms,
+        )
+
+    if resolved_share_strategy is ReactivexStreamShareStrategy.REPLAY_LATEST_AUTO_CONNECT:
+        shared = _replay(
+            source,
+            buffer_size=1,
+            replay_window=replay_window_setting,
+        ).auto_connect(settings.auto_connect_min_subscribers)
+        shared = _coalesce_if_needed(
+            shared,
+            coalesce_window_ms=resolved_coalesce_window,
+            stream_name=stream_label,
+        )
+        return instrument_stream(
+            shared,
+            stream_name=stream_label,
+            log_interval_ms=settings.stats_log_ms,
+        )
+
+    if resolved_share_strategy is ReactivexStreamShareStrategy.REPLAY_BUFFER:
+        replayed = _replay(
+            source,
+            buffer_size=resolved_replay_buffer,
+            replay_window=replay_window_setting,
+        )
+        if resolved_grace_period > 0 or resolved_min_subscribers > 1:
+            shared = _share_with_refcount_grace(
+                replayed,
+                grace_ms=resolved_grace_period,
+                min_subscribers=resolved_min_subscribers,
+                connect_mode=resolved_connect_mode,
+                stream_name=stream_label,
+            )
+        else:
+            shared = replayed.pipe(ops.ref_count())
+        shared = _coalesce_if_needed(
+            shared,
+            coalesce_window_ms=resolved_coalesce_window,
+            stream_name=stream_label,
+        )
+        return instrument_stream(
+            shared,
+            stream_name=stream_label,
+            log_interval_ms=settings.stats_log_ms,
+        )
+
+    if resolved_share_strategy is ReactivexStreamShareStrategy.REPLAY_BUFFER_AUTO_CONNECT:
+        shared = _replay(
+            source,
+            buffer_size=resolved_replay_buffer,
+            replay_window=replay_window_setting,
+        ).auto_connect(settings.auto_connect_min_subscribers)
+        shared = _coalesce_if_needed(
+            shared,
+            coalesce_window_ms=resolved_coalesce_window,
+            stream_name=stream_label,
+        )
+        return instrument_stream(
+            shared,
+            stream_name=stream_label,
+            log_interval_ms=settings.stats_log_ms,
+        )
+
+    raise ValueError(
+        f"Unknown reactive stream share strategy: {resolved_share_strategy}"
+    )
 
 
 def share_stream_from_env(
@@ -182,15 +390,13 @@ def share_stream_from_env(
     )
     shared = share_stream(
         source,
-        connect_mode,
-        share_strategy,
-        replay_buffer_size,
-        replay_window,
-        subscriber_limit,
-        coalesce_window_ms,
-        grace_period_ms,
-        min_subscribers,
+        connect_mode=connect_mode,
+        share_strategy=share_strategy,
+        replay_buffer_size=replay_buffer_size,
+        replay_window=replay_window,
+        subscriber_limit=subscriber_limit,
+        coalesce_window_ms=coalesce_window_ms,
+        grace_period_ms=grace_period_ms,
+        min_subscribers=min_subscribers,
     )
-    if share_strategy is ReactivexStreamShareStrategy.coalesce_latest:
-        return shared.pipe(coalesce_latest(coalesce_window_ms))
     return shared


### PR DESCRIPTION
## Summary
- restore missing reactive stream utilities used by peripherals and tests
- reintroduce sliding image providers/renderers and renderer spec resolver helpers
- align runtime container wiring with Lagom providers
- implement reactive stream sharing/coalescing behavior expected by tests

## Testing
- make test