### PR TITLE
Simplify renderer core abstractions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,8 @@ Run `make format` before committing changes. This applies Ruff fixes, isort, Bla
 - When reading or writing text files, specify an explicit encoding (prefer `utf-8`) to keep behavior consistent across platforms.
 - Use module-level constants for public constructor or function default values so shared configuration is easy to discover and adjust.
 - When parsing PATH-like environment variables, strip whitespace from each entry and ignore empty values before converting to `Path` objects.
+- When a renderer only forwards `builder.observable(peripheral_manager)`, omit the `state_observable()` override and rely on `StatefulBaseRenderer`.
+- Keep post-processors lifecycle-local; avoid provider/state dataclass scaffolding unless the post-processor actually subscribes to streams.
 - Use module-level constants for default argument values and shared string literals in firmware helpers so configuration stays consistent.
 - Keep mixed PyO3 packages in a `rust/<package>/` layout with the Rust crate in `src/`, Python shims in `python/<package>/`, and a private native submodule exposed via `tool.maturin.module-name` to avoid import ambiguity.
 - PyO3 stub-generation binaries require a linkable Python 3.11 runtime in addition to Rust; if `cargo run --bin stub_gen` fails with unresolved `Py*` symbols, install or point PyO3 at a Python 3.11 build before retrying.
@@ -108,6 +110,8 @@ Define CLI default values as module-level constants so they stay consistent acro
 
 ## Recent Validation
 
+- `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/e808/heart/.uv-cache make format`
+- `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/e808/heart/.uv-cache make test`
 - `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/14cd/heart/.uv-cache make format`
 - `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/14cd/heart/.uv-cache make test`
 - `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/14cd/heart/.uv-cache make format` after removing `BaseRenderer`, the `AtomicBaseRenderer.process()` compatibility path, and the unused renderer `warmup` flag.

--- a/docs/research/renderer_core_simplification.md
+++ b/docs/research/renderer_core_simplification.md
@@ -1,0 +1,32 @@
+# Renderer Core Simplification
+
+## Problem Statement
+
+Several renderer modules carried leftover forwarding methods and helper wrappers that no longer added behavior. The renderer core also modeled post-processors as reactive stateful renderers even though they only needed direct access to the active `PeripheralManager`. That extra structure made the renderer layer harder to read and easier to drift.
+
+## Materials
+
+- `src/heart/renderers/stateful.py`
+- `src/heart/renderers/post_processing.py`
+- `src/heart/navigation/game_modes.py`
+- `src/heart/renderers/sliding_image/renderer.py`
+- `src/heart/renderers/spritesheet/renderer.py`
+- `src/heart/renderers/image/renderer.py`
+- `src/heart/renderers/text/renderer.py`
+
+## Notes
+
+- Renderers that only forwarded `state_observable()` to `builder.observable(peripheral_manager)` now rely on `StatefulBaseRenderer` directly instead of repeating the same wrapper method.
+- `SlidingImage` and `SlidingRenderer` now construct their providers directly instead of routing through single-use `_default_provider()` helpers.
+- The dead `create_spritesheet_loop()` factory and its export were removed because it referenced a renderer API that no longer exists.
+- Post-processors now keep the active `PeripheralManager` on the renderer instance and manage initialization/reset locally instead of creating unused state dataclasses and faux reactive initialization paths.
+- `GameModes` now installs only the real post-processors and no longer carries the unused `handle_state()` navigation path.
+
+## Sources
+
+- `src/heart/renderers/post_processing.py`
+- `src/heart/navigation/game_modes.py`
+- `src/heart/renderers/sliding_image/renderer.py`
+- `src/heart/renderers/spritesheet/renderer.py`
+- `src/heart/renderers/image/renderer.py`
+- `src/heart/renderers/text/renderer.py`

--- a/src/heart/navigation/game_modes.py
+++ b/src/heart/navigation/game_modes.py
@@ -8,12 +8,10 @@ import pygame
 from heart.device import Orientation
 from heart.display.color import Color
 from heart.peripheral.core.manager import PeripheralManager
-from heart.peripheral.switch import SwitchState
 from heart.renderers import StatefulBaseRenderer
 from heart.renderers.color import RenderColor
 from heart.renderers.post_processing import (EdgePostProcessor,
                                              HueShiftPostProcessor,
-                                             NullPostProcessor,
                                              SaturationPostProcessor)
 from heart.renderers.slide_transition import \
     DEFAULT_GAUSSIAN_SIGMA as SLIDE_DEFAULT_GAUSSIAN_SIGMA
@@ -265,24 +263,6 @@ class GameModes(StatefulBaseRenderer[GameModeState]):
     ) -> None:
         raise NotImplementedError("GameModes.real_process is not implemented")
 
-    def handle_state(self, input: SwitchState) -> None:
-        new_long_button_value = input.long_button_value
-        if new_long_button_value != self.state.last_long_button_value:
-            if self.state.in_select_mode:
-                self.state._active_mode_index += self.state.mode_offset
-                self.state.mode_offset = 0
-            else:
-                for entry in self.state.entries:
-                    entry.renderer.reset()
-                for renderer in self.state.post_processors:
-                    renderer.reset()
-
-            self.state.in_select_mode = not self.state.in_select_mode
-            self.state.last_long_button_value = new_long_button_value
-
-        if self.state.in_select_mode:
-            self.state.mode_offset = input.rotation_since_last_long_button_press
-
     def _handle_browse_delta(self, delta: int) -> None:
         if not self.state.in_select_mode or delta == 0:
             return
@@ -420,7 +400,6 @@ class GameModes(StatefulBaseRenderer[GameModeState]):
             SaturationPostProcessor(),
             HueShiftPostProcessor(),
             EdgePostProcessor(),
-            NullPostProcessor(),
         ]
 
     def _build_title_renderer(

--- a/src/heart/renderers/README.md
+++ b/src/heart/renderers/README.md
@@ -1,1 +1,1 @@
-Self-contained visual renderers and demos. Each subpackage bundles assets and logic for a specific experience (for example, Mario scenes or cellular automata) that can be scheduled by the runtime.
+Self-contained visual renderers and demos. Each subpackage bundles only the assets and logic needed for a specific experience so the shared runtime can stay small.

--- a/src/heart/renderers/color/renderer.py
+++ b/src/heart/renderers/color/renderer.py
@@ -1,5 +1,3 @@
-import pygame
-
 from heart.device import Orientation
 from heart.display.color import Color
 from heart.renderers import StatefulBaseRenderer
@@ -24,9 +22,7 @@ class RenderColor(StatefulBaseRenderer[RenderColorState]):
         window: DisplayContext,
         orientation: Orientation,
     ) -> None:
-        image = pygame.Surface(window.get_size())
-        image.fill(self.state.color._as_tuple())
-        window.blit(image, (0, 0))
+        window.fill(self.state.color._as_tuple())
 
     @property
     def color(self) -> Color:

--- a/src/heart/renderers/combined_bpm_screen/renderer.py
+++ b/src/heart/renderers/combined_bpm_screen/renderer.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import reactivex
-
 from heart import DeviceDisplayMode
 from heart.device import Orientation
 from heart.navigation import ComposedRenderer
@@ -64,11 +62,6 @@ class CombinedBpmScreen(StatefulBaseRenderer[CombinedBpmScreenState]):
             orientation=orientation,
         )
         super().initialize(window, peripheral_manager, orientation)
-
-    def state_observable(
-        self, peripheral_manager: PeripheralManager
-    ) -> reactivex.Observable[CombinedBpmScreenState]:
-        return self._provider.observable(peripheral_manager)
 
     def real_process(
         self,

--- a/src/heart/renderers/flame/renderer.py
+++ b/src/heart/renderers/flame/renderer.py
@@ -4,12 +4,10 @@ import numpy as np
 import pygame
 import pygame.surfarray as sarr
 import pygame.transform as pgt
-import reactivex
 from pygame import Surface
 
 from heart import DeviceDisplayMode
 from heart.device import Orientation
-from heart.peripheral.core.manager import PeripheralManager
 from heart.renderers import StatefulBaseRenderer
 from heart.renderers.flame.provider import FlameStateProvider
 from heart.renderers.flame.state import FlameState
@@ -243,11 +241,6 @@ class FlameRenderer(StatefulBaseRenderer[FlameState]):
         super().__init__(builder=self._provider)
         self.device_display_mode = DeviceDisplayMode.MIRRORED
         self._flame_generator = FlameGenerator(64, 16)
-
-    def state_observable(
-        self, peripheral_manager: PeripheralManager
-    ) -> reactivex.Observable[FlameState]:
-        return self._provider.observable(peripheral_manager)
 
     def real_process(
         self,

--- a/src/heart/renderers/free_text/renderer.py
+++ b/src/heart/renderers/free_text/renderer.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import pygame
-import reactivex
 
 from heart import DeviceDisplayMode
 from heart.device import Orientation
-from heart.peripheral.core.manager import PeripheralManager
 from heart.renderers import StatefulBaseRenderer
 from heart.renderers.free_text.provider import FreeTextStateProvider
 from heart.renderers.free_text.state import FreeTextRendererState
@@ -22,11 +20,6 @@ class FreeTextRenderer(StatefulBaseRenderer[FreeTextRendererState]):
         self._provider = provider or FreeTextStateProvider()
         super().__init__(builder=self._provider)
         self.device_display_mode = DeviceDisplayMode.MIRRORED
-
-    def state_observable(
-        self, peripheral_manager: PeripheralManager
-    ) -> reactivex.Observable[FreeTextRendererState]:
-        return self._provider.observable(peripheral_manager)
 
     def set_text(self, text: str) -> None:
         if self._provider is not None:

--- a/src/heart/renderers/image/renderer.py
+++ b/src/heart/renderers/image/renderer.py
@@ -1,8 +1,6 @@
 import pygame
-import reactivex
 
 from heart.device import Orientation
-from heart.peripheral.core.manager import PeripheralManager
 from heart.renderers import StatefulBaseRenderer
 from heart.renderers.image.provider import RenderImageStateProvider
 from heart.renderers.image.state import RenderImageState
@@ -25,11 +23,6 @@ class RenderImage(StatefulBaseRenderer[RenderImageState]):
         super().__init__(builder=self._provider)
         self._scaled_image: pygame.Surface | None = None
         self._scaled_size: tuple[int, int] | None = None
-
-    def state_observable(
-        self, peripheral_manager: PeripheralManager
-    ) -> reactivex.Observable[RenderImageState]:
-        return self._provider.observable(peripheral_manager=peripheral_manager)
 
     def real_process(
         self,

--- a/src/heart/renderers/max_bpm_screen/renderer.py
+++ b/src/heart/renderers/max_bpm_screen/renderer.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import reactivex
 from pygame import Surface, font, time
 
 from heart import DeviceDisplayMode
 from heart.assets.loader import Loader
 from heart.device import Orientation
-from heart.peripheral.core.manager import PeripheralManager
 from heart.renderers import StatefulBaseRenderer
 from heart.renderers.max_bpm_screen.provider import (AVATAR_MAPPINGS,
                                                      AvatarBpmStateProvider)
@@ -60,8 +58,3 @@ class AvatarBpmRenderer(StatefulBaseRenderer[AvatarBpmRendererState]):
         window.blit(image, (center_x, center_y))
 
         self.display_number(window, state.bpm, window_width // 2, center_y)
-
-    def state_observable(
-        self, peripheral_manager: PeripheralManager
-    ) -> reactivex.Observable[AvatarBpmRendererState]:
-        return self._provider.observable(peripheral_manager)

--- a/src/heart/renderers/metadata_screen/renderer.py
+++ b/src/heart/renderers/metadata_screen/renderer.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, Iterable
 
-import reactivex
 from pygame import Rect, Surface, draw, time
 
 from heart import DeviceDisplayMode
 from heart.assets.loader import Loader
 from heart.device import Orientation
-from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.heart_rates import battery_status, current_bpms
 from heart.renderers import StatefulBaseRenderer
 from heart.renderers.metadata_screen.provider import \
@@ -129,8 +127,3 @@ class MetadataScreen(StatefulBaseRenderer[MetadataScreenState]):
                     window.blit(image, (pos_x, pos_y - 8))
                 self.display_number(window, current_bpm, pos_x, pos_y)
                 self.display_battery_status(window, monitor_id, pos_x, pos_y)
-
-    def state_observable(
-        self, peripheral_manager: PeripheralManager
-    ) -> reactivex.Observable[MetadataScreenState]:
-        return self.provider.observable(peripheral_manager)

--- a/src/heart/renderers/post_processing.py
+++ b/src/heart/renderers/post_processing.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 import numpy as np
 import pygame
 
@@ -23,29 +21,35 @@ EDGE_BACKGROUND_DIM = 0.75
 EDGE_GAMMA = 0.5
 
 
-@dataclass
-class PostProcessorState:
-    peripheral_manager: PeripheralManager
-
-
 def _get_image_view(surface: pygame.Surface) -> tuple[np.ndarray, np.ndarray]:
     pixels = pygame.surfarray.pixels3d(surface)
     image = pixels.swapaxes(0, 1)
     return image, pixels
 
 
-class BasePostProcessor(StatefulBaseRenderer[PostProcessorState]):
+class BasePostProcessor(StatefulBaseRenderer[None]):
     def __init__(self) -> None:
         super().__init__()
         self.device_display_mode = DeviceDisplayMode.FULL
+        self._peripheral_manager: PeripheralManager | None = None
 
-    def _create_initial_state(
+    def initialize(
         self,
         window: DisplayContext,
         peripheral_manager: PeripheralManager,
         orientation: Orientation,
-    ) -> PostProcessorState:
-        return PostProcessorState(peripheral_manager=peripheral_manager)
+    ) -> None:
+        self._peripheral_manager = peripheral_manager
+        self.initialized = True
+
+    def reset(self) -> None:
+        self._peripheral_manager = None
+        self.initialized = False
+
+    def _bluetooth_switch(self):
+        if self._peripheral_manager is None:
+            return None
+        return self._peripheral_manager.bluetooth_switch()
 
 
 class SaturationPostProcessor(BasePostProcessor):
@@ -54,7 +58,7 @@ class SaturationPostProcessor(BasePostProcessor):
         window: DisplayContext,
         orientation: Orientation,
     ) -> None:
-        bluetooth = self.state.peripheral_manager.bluetooth_switch()
+        bluetooth = self._bluetooth_switch()
         if bluetooth is None:
             return
         if (switch_one := bluetooth.switch_one()) is None:
@@ -86,7 +90,7 @@ class HueShiftPostProcessor(BasePostProcessor):
         window: DisplayContext,
         orientation: Orientation,
     ) -> None:
-        bluetooth = self.state.peripheral_manager.bluetooth_switch()
+        bluetooth = self._bluetooth_switch()
         if bluetooth is None:
             return
         hue_switch = bluetooth.switch_two()
@@ -120,7 +124,7 @@ class EdgePostProcessor(BasePostProcessor):
         window: DisplayContext,
         orientation: Orientation,
     ) -> None:
-        bluetooth = self.state.peripheral_manager.bluetooth_switch()
+        bluetooth = self._bluetooth_switch()
         if bluetooth is None:
             return
         edge_switch = bluetooth.switch_three()
@@ -163,12 +167,3 @@ class EdgePostProcessor(BasePostProcessor):
         out = np.clip(base + edges, 0, 255)
         image[:] = out.astype(np.uint8)
         del pixels
-
-
-class NullPostProcessor(BasePostProcessor):
-    def real_process(
-        self,
-        window: DisplayContext,
-        orientation: Orientation,
-    ) -> None:
-        return

--- a/src/heart/renderers/sliding_image/renderer.py
+++ b/src/heart/renderers/sliding_image/renderer.py
@@ -4,7 +4,6 @@ from dataclasses import replace
 from typing import Callable
 
 import pygame
-import reactivex
 
 from heart import DeviceDisplayMode
 from heart.assets.loader import Loader
@@ -31,21 +30,12 @@ class SlidingImage(StatefulBaseRenderer[SlidingImageState]):
     ) -> None:
         self._image_file = image_file
         initial_state = SlidingImageState(speed=max(1, speed))
-        self._provider = (provider_factory or self._default_provider)(initial_state)
+        provider_builder = provider_factory or SlidingImageStateProvider
+        self._provider = provider_builder(initial_state)
         self._image: pygame.Surface | None = None
 
         super().__init__(builder=self._provider)
         self.device_display_mode = DeviceDisplayMode.FULL
-
-    def _default_provider(
-        self, initial_state: SlidingImageState
-    ) -> SlidingImageStateProvider:
-        return SlidingImageStateProvider(initial_state=initial_state)
-
-    def state_observable(
-        self, peripheral_manager: PeripheralManager
-    ) -> reactivex.Observable[SlidingImageState]:
-        return self._provider.observable(peripheral_manager=peripheral_manager)
 
     def initialize(
         self,
@@ -101,21 +91,12 @@ class SlidingRenderer(StatefulBaseRenderer[SlidingRendererState]):
     ) -> None:
         self.composed = renderer
         initial_state = SlidingRendererState(speed=max(1, speed))
-        self._provider = (provider_factory or self._default_provider)(initial_state)
+        provider_builder = provider_factory or SlidingRendererStateProvider
+        self._provider = provider_builder(initial_state)
         self._peripheral_manager: PeripheralManager | None = None
 
         super().__init__(builder=self._provider)
         self.device_display_mode = DeviceDisplayMode.FULL
-
-    def _default_provider(
-        self, initial_state: SlidingRendererState
-    ) -> SlidingRendererStateProvider:
-        return SlidingRendererStateProvider(initial_state=initial_state)
-
-    def state_observable(
-        self, peripheral_manager: PeripheralManager
-    ) -> reactivex.Observable[SlidingRendererState]:
-        return self._provider.observable(peripheral_manager=peripheral_manager)
 
     def initialize(
         self,

--- a/src/heart/renderers/spritesheet/__init__.py
+++ b/src/heart/renderers/spritesheet/__init__.py
@@ -2,8 +2,6 @@ from heart.renderers.spritesheet.provider import \
     SpritesheetProvider as SpritesheetProvider
 from heart.renderers.spritesheet.renderer import \
     SpritesheetLoop as SpritesheetLoop
-from heart.renderers.spritesheet.renderer import \
-    create_spritesheet_loop as create_spritesheet_loop
 from heart.renderers.spritesheet.state import BoundingBox as BoundingBox
 from heart.renderers.spritesheet.state import \
     FrameDescription as FrameDescription

--- a/src/heart/renderers/spritesheet/renderer.py
+++ b/src/heart/renderers/spritesheet/renderer.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-import reactivex
-
 from heart import DeviceDisplayMode
 from heart.device import Orientation
-from heart.peripheral.core.manager import PeripheralManager
 from heart.renderers import StatefulBaseRenderer
 from heart.renderers.spritesheet.provider import SpritesheetProvider
 from heart.renderers.spritesheet.state import (FrameDescription,
@@ -83,12 +80,6 @@ class SpritesheetLoop(StatefulBaseRenderer[SpritesheetLoopState]):
         )
         return cls(provider)
 
-    def state_observable(
-        self,
-        peripheral_manager: PeripheralManager,
-    ) -> reactivex.Observable[SpritesheetLoopState]:
-        return self.provider.observable(peripheral_manager=peripheral_manager)
-
     def real_process(
         self,
         window: DisplayContext,
@@ -116,12 +107,3 @@ class SpritesheetLoop(StatefulBaseRenderer[SpritesheetLoopState]):
         final_y = center_y + self.provider.offset_y
 
         window.blit(scaled, (final_x, final_y))
-
-
-def create_spritesheet_loop(
-    peripheral_manager: PeripheralManager, *args: object, **kwargs: object
-) -> SpritesheetLoop:
-    provider = SpritesheetProvider(*args, **kwargs)
-    renderer = SpritesheetLoop(provider)
-    renderer.configure_peripherals(peripheral_manager)
-    return renderer

--- a/src/heart/renderers/spritesheet_random/renderer.py
+++ b/src/heart/renderers/spritesheet_random/renderer.py
@@ -1,8 +1,5 @@
-import reactivex
-
 from heart import DeviceDisplayMode
 from heart.device import Orientation
-from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.providers.randomness import RandomnessProvider
 from heart.renderers import StatefulBaseRenderer
 from heart.renderers.spritesheet_random.provider import \
@@ -58,9 +55,3 @@ class SpritesheetLoopRandom(StatefulBaseRenderer[SpritesheetLoopRandomState]):
             current_kf.frame, (self.screen_width, self.screen_height)
         )
         window.blit(scaled, (state.current_screen * self.screen_width, 0))
-
-    def state_observable(
-        self,
-        peripheral_manager: PeripheralManager,
-    ) -> reactivex.Observable[SpritesheetLoopRandomState]:
-        return self.provider.observable(peripheral_manager=peripheral_manager)

--- a/src/heart/renderers/text/renderer.py
+++ b/src/heart/renderers/text/renderer.py
@@ -1,11 +1,9 @@
 import pygame
 import pygame.ftfont
-import reactivex
 
 from heart.assets.loader import Loader
 from heart.device import Orientation
 from heart.display.color import Color
-from heart.peripheral.core.manager import PeripheralManager
 from heart.renderers import StatefulBaseRenderer
 from heart.renderers.text.provider import TextRenderingProvider
 from heart.renderers.text.state import TextRenderingState
@@ -37,11 +35,6 @@ class TextRendering(StatefulBaseRenderer[TextRenderingState]):
             y_location=y_location,
         )
         super().__init__(builder=self._provider)
-
-    def state_observable(
-        self, peripheral_manager: PeripheralManager
-    ) -> reactivex.Observable[TextRenderingState]:
-        return self._provider.observable(peripheral_manager)
 
     @classmethod
     def default(cls, text: str) -> "TextRendering":

--- a/src/heart/renderers/yolisten/renderer.py
+++ b/src/heart/renderers/yolisten/renderer.py
@@ -1,5 +1,4 @@
 import pygame
-import reactivex
 
 from heart import DeviceDisplayMode
 from heart.device import Orientation
@@ -225,8 +224,3 @@ class YoListenRenderer(StatefulBaseRenderer[YoListenState]):
                 self.word_widths[word] = text_width
 
         super().initialize(window, peripheral_manager, orientation)
-
-    def state_observable(
-        self, peripheral_manager: PeripheralManager
-    ) -> reactivex.Observable[YoListenState]:
-        return self.provider.observable(peripheral_manager)


### PR DESCRIPTION
## Summary
- remove redundant renderer `state_observable()` pass-through overrides and related unused imports across the renderer catalog
- simplify post-processing lifecycle management by storing `PeripheralManager` directly on post-processors and deleting the unused null processor/state wrapper
- delete stale renderer helpers and wrappers, including the unused `GameModes.handle_state()` path and dead `create_spritesheet_loop()` export
- reduce per-frame overhead in simple renderers such as `RenderColor`, and document the cleanup with updated agent guidance and a research note

## Testing
- `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/e808/heart/.uv-cache make format`
- `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/e808/heart/.uv-cache make test`