### PR TITLE
Refactor navigation event subscription wiring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,9 @@ Define CLI default values as module-level constants so they stay consistent acro
 
 ## Recent Validation
 
+- `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/15a4/heart/.uv-cache .venv/bin/pytest tests/peripheral/test_input_core.py tests/navigation/test_game_modes.py`
+- `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/15a4/heart/.uv-cache make format`
+- `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/15a4/heart/.uv-cache make test`
 - `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/14cd/heart/.uv-cache make format`
 - `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/14cd/heart/.uv-cache make test`
 - `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/14cd/heart/.uv-cache make format` after removing `BaseRenderer`, the `AtomicBaseRenderer.process()` compatibility path, and the unused renderer `warmup` flag.

--- a/src/heart/navigation/game_modes.py
+++ b/src/heart/navigation/game_modes.py
@@ -144,6 +144,7 @@ class GameModes(StatefulBaseRenderer[GameModeState]):
         super().__init__()
         self._initialization_context: GameModeInitializationContext | None = None
         self._renderer_resolver = renderer_resolver
+        self._navigation_subscription = None
 
     def _create_initial_state(
         self,
@@ -165,14 +166,12 @@ class GameModes(StatefulBaseRenderer[GameModeState]):
             state = GameModeState()
         if not state.post_processors:
             state.post_processors.extend(self._default_post_processors())
-        peripheral_manager.navigation_profile.browse_delta.subscribe(
-            on_next=self._handle_browse_delta,
-        )
-        peripheral_manager.navigation_profile.activate.subscribe(
-            on_next=self._handle_activate,
-        )
-        peripheral_manager.navigation_profile.alternate_activate.subscribe(
-            on_next=self._handle_alternate_activate,
+        self._navigation_subscription = (
+            peripheral_manager.navigation_profile.subscribe_events(
+                on_browse_delta=self._handle_browse_delta,
+                on_activate=self._handle_activate,
+                on_alternate_activate=self._handle_alternate_activate,
+            )
         )
         return state
 

--- a/src/heart/navigation/multi_scene.py
+++ b/src/heart/navigation/multi_scene.py
@@ -31,6 +31,7 @@ class MultiScene(StatefulBaseRenderer[MultiSceneState]):
             resolve_renderer_spec(scene, renderer_resolver)
             for scene in scenes
         ]
+        self._navigation_subscription = None
         scene_names = [scene.name for scene in self.scenes]
         self._scene_manager = scene_manager_backend or build_scene_manager_backend(
             scene_names
@@ -48,8 +49,10 @@ class MultiScene(StatefulBaseRenderer[MultiSceneState]):
     ) -> MultiSceneState:
         state = MultiSceneState(current_button_value=0, offset_of_button_value=None)
         self.set_state(state)
-        peripheral_manager.navigation_profile.activate.subscribe(
-            on_next=self._process_activate,
+        self._navigation_subscription = (
+            peripheral_manager.navigation_profile.subscribe_events(
+                on_activate=self._process_activate,
+            )
         )
 
         for scene in self.scenes:

--- a/src/heart/peripheral/core/input/profiles/navigation.py
+++ b/src/heart/peripheral/core/input/profiles/navigation.py
@@ -7,6 +7,8 @@ from functools import cached_property
 import pygame
 import reactivex
 from reactivex import operators as ops
+from reactivex.abc import DisposableBase
+from reactivex.disposable import CompositeDisposable
 
 from heart.peripheral.core.input.debug import (InputDebugStage, InputDebugTap,
                                                instrument_input_stream)
@@ -56,6 +58,27 @@ class NavigationProfile:
         self._gamepad = gamepad_controller
         self._debug_tap = debug_tap
         self._switch_stream_factory = switch_stream_factory
+
+    def subscribe_events(
+        self,
+        *,
+        on_browse: Callable[[BrowseIntent], None] | None = None,
+        on_browse_delta: Callable[[int], None] | None = None,
+        on_activate: Callable[[ActivateIntent], None] | None = None,
+        on_alternate_activate: Callable[[AlternateActivateIntent], None] | None = None,
+    ) -> DisposableBase:
+        subscriptions: list[DisposableBase] = []
+        if on_browse is not None:
+            subscriptions.append(self.browse.subscribe(on_next=on_browse))
+        if on_browse_delta is not None:
+            subscriptions.append(self.browse_delta.subscribe(on_next=on_browse_delta))
+        if on_activate is not None:
+            subscriptions.append(self.activate.subscribe(on_next=on_activate))
+        if on_alternate_activate is not None:
+            subscriptions.append(
+                self.alternate_activate.subscribe(on_next=on_alternate_activate)
+            )
+        return CompositeDisposable(*subscriptions)
 
     @cached_property
     def intents(self) -> reactivex.Observable[NavigationIntent]:

--- a/src/heart/peripheral/switch.py
+++ b/src/heart/peripheral/switch.py
@@ -82,6 +82,7 @@ class BaseSwitch(Peripheral[SwitchState]):
 class FakeSwitch(BaseSwitch):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+        self._navigation_subscription = None
 
     def _key_press_stream(self, key: int) -> reactivex.Observable[KeyboardEvent]:
         def _unwrap(envelope: PeripheralMessageEnvelope[KeyboardEvent]) -> KeyboardEvent:
@@ -128,23 +129,24 @@ class FakeSwitch(BaseSwitch):
                 return
 
             navigation = loop.peripheral_manager.navigation_profile
-
-            def handle_alternate_activate(_: Any) -> None:
-                self.button_long_press_value += 1
-                self.rotation_value_at_last_long_button_press = self.rotational_value
-
-            def handle_activate(_: Any) -> None:
-                self.button_value += 1
-                self.rotation_value_at_last_button_press = self.rotational_value
-
-            def handle_browse(delta: int) -> None:
-                self.rotational_value += delta
-
-            navigation.alternate_activate.subscribe(on_next=handle_alternate_activate)
-            navigation.activate.subscribe(on_next=handle_activate)
-            navigation.browse_delta.subscribe(on_next=handle_browse)
+            self._navigation_subscription = navigation.subscribe_events(
+                on_browse_delta=self._handle_browse,
+                on_activate=self._handle_activate,
+                on_alternate_activate=self._handle_alternate_activate,
+            )
         else:
             logger.warning("Not running FakeSwitch")
+
+    def _handle_alternate_activate(self, _: Any) -> None:
+        self.button_long_press_value += 1
+        self.rotation_value_at_last_long_button_press = self.rotational_value
+
+    def _handle_activate(self, _: Any) -> None:
+        self.button_value += 1
+        self.rotation_value_at_last_button_press = self.rotational_value
+
+    def _handle_browse(self, delta: int) -> None:
+        self.rotational_value += delta
 
     def _event_stream(
         self

--- a/tests/navigation/test_game_modes.py
+++ b/tests/navigation/test_game_modes.py
@@ -270,9 +270,7 @@ class TestNavigationGameModes:
         game_modes.set_state(GameModeState())
         window = _make_window()
         peripheral_manager = Mock()
-        peripheral_manager.navigation_profile.browse_delta.subscribe = Mock()
-        peripheral_manager.navigation_profile.activate.subscribe = Mock()
-        peripheral_manager.navigation_profile.alternate_activate.subscribe = Mock()
+        peripheral_manager.navigation_profile.subscribe_events = Mock()
         orientation = Mock()
 
         game_modes.initialize(

--- a/tests/peripheral/test_input_core.py
+++ b/tests/peripheral/test_input_core.py
@@ -344,6 +344,39 @@ class TestNavigationProfile:
             ("AlternateActivateIntent", "switch.long_button", 0),
         ]
 
+    def test_subscribe_events_binds_requested_navigation_handlers(self) -> None:
+        """Verify subscribe_events wires the requested logical handlers in one place so navigation consumers do not duplicate reactive subscription setup."""
+        tap = InputDebugTap()
+        keyboard = KeyboardController(tap)
+        gamepad = GamepadController(manager=object(), debug_tap=tap)
+        switch_updates: Subject[SwitchState] = Subject()
+        profile = NavigationProfile(
+            keyboard_controller=keyboard,
+            gamepad_controller=gamepad,
+            debug_tap=tap,
+            switch_stream_factory=lambda: switch_updates,
+        )
+        browse: list[int] = []
+        activate: list[str] = []
+        alternate: list[str] = []
+
+        subscription = profile.subscribe_events(
+            on_browse_delta=browse.append,
+            on_activate=lambda _intent: activate.append("activate"),
+            on_alternate_activate=lambda _intent: alternate.append("alternate"),
+        )
+
+        switch_updates.on_next(SwitchState(0, 0, 0, 0, 0))
+        switch_updates.on_next(SwitchState(3, 0, 0, 3, 3))
+        switch_updates.on_next(SwitchState(3, 1, 0, 0, 3))
+        switch_updates.on_next(SwitchState(3, 1, 1, 0, 0))
+
+        subscription.dispose()
+
+        assert browse == [3]
+        assert activate == ["activate"]
+        assert alternate == ["alternate"]
+
 
 class TestMandelbrotControlProfile:
     """Group Mandelbrot profile tests so consumers receive direct motion state and command events instead of decoding merged revisions."""


### PR DESCRIPTION
## Summary
- add `NavigationProfile.subscribe_events()` to centralize reactive handler wiring
- update `GameModes`, `MultiScene`, and `FakeSwitch` to use the shared subscription helper instead of inline subscriptions
- replace inline fake-switch callbacks with named handlers for clearer state updates
- add coverage for the new subscription helper and update validation history

## Testing
- `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/15a4/heart/.uv-cache .venv/bin/pytest tests/peripheral/test_input_core.py tests/navigation/test_game_modes.py`
- `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/15a4/heart/.uv-cache make format`
- `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/15a4/heart/.uv-cache make test`