### PR TITLE
Improve 3D Viewer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 Use the tooling in this repository to manage environments. Prefer `uv` for Python dependency resolution.
 
 - Pin prerelease Python dependencies with exact versions in `pyproject.toml` so `uv.lock` resolves the intended alpha or beta release.
+- When `experimental/beats/package-lock.json` is out of sync with `package.json`, `npm ci` will fail; use `npm install --package-lock=false` for local validation unless the task explicitly includes repairing the lockfile.
 - Scene and asset bootstrap can run before `pygame.display.set_mode`; avoid unconditional `convert()` or `convert_alpha()` calls in asset constructors and defer display-dependent conversion until a surface exists.
 - `DisplayContext` wraps the active `pygame.Surface`; renderers that need surface-only APIs such as `subsurface()` must use `window.screen` after confirming it is initialized instead of calling those APIs on `DisplayContext` directly.
 - Only the real display-owned `DisplayContext` may change pygame display modes; scratch or post-processing contexts must keep `can_configure_display=False` and never call `pygame.display.set_mode()`.
@@ -203,6 +204,14 @@ Define CLI default values as module-level constants so they stay consistent acro
 - `2026-03-30`: `.venv/bin/docformatter -i -r --config ./pyproject.toml docs`
 - `2026-03-30`: `.venv/bin/mdformat docs`
 - `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/94af/heart/.uv-cache make test`
+- `2026-03-31`: `cd experimental/beats && npm ci` failed because `experimental/beats/package-lock.json` is out of sync with `package.json`.
+- `2026-03-31`: `cd experimental/beats && npm install --package-lock=false`
+- `2026-03-31`: `cd experimental/beats && npm run format:write`
+- `2026-03-31`: `cd experimental/beats && npx eslint src/components/stream-cube.tsx src/components/stream.tsx src/tests/unit/components/stream.test.tsx src/tests/unit/setup.ts`
+- `2026-03-31`: `cd experimental/beats && npm run lint` still fails because of pre-existing errors in `src/actions/ws/providers/PeripheralEventsProvider.tsx`, `src/actions/ws/providers/PeripheralProvider.tsx`, `src/components/ui/sidebar.tsx`, `src/hooks/use-mobile.ts`, and `src/layouts/base-layout.tsx`.
+- `2026-03-31`: `cd experimental/beats && npm run test`
+- `2026-03-31`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/535d/heart/.uv-cache make format`
+- `2026-03-31`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/535d/heart/.uv-cache make test`
 - `2026-03-30`: `.venv/bin/pytest tests/navigation/test_game_modes.py`
 - `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/e46a/heart/.uv-cache make format`
 - `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/e46a/heart/.uv-cache make test`

--- a/experimental/beats/src/components/stream-cube.tsx
+++ b/experimental/beats/src/components/stream-cube.tsx
@@ -1,14 +1,26 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
+  ACESFilmicToneMapping,
   AmbientLight,
   BoxGeometry,
   CanvasTexture,
+  CircleGeometry,
+  Color,
   DirectionalLight,
-  GridHelper,
+  EdgesGeometry,
+  FogExp2,
+  Group,
+  LineBasicMaterial,
+  LineSegments,
+  Material,
+  MathUtils,
   Mesh,
+  MeshBasicMaterial,
+  MeshPhysicalMaterial,
   MeshStandardMaterial,
   PerspectiveCamera,
-  RepeatWrapping,
+  PointLight,
+  RingGeometry,
   Scene,
   SRGBColorSpace,
   Texture,
@@ -18,12 +30,18 @@ import {
 
 import { Skeleton } from "./ui/skeleton";
 
-const CAMERA_DISTANCE = 4;
-const ROTATION_DELTA = { x: 0.01, y: 0.015 } as const;
-const GRID_SIZE = 6;
-const GRID_DIVISIONS = 10;
-const GRID_COLOR = 0xffffff;
-const GRID_OPACITY = 0.18;
+const CAMERA_DISTANCE = 4.8;
+const PANEL_WIDTH = 2.6;
+const PANEL_HEIGHT = 1.55;
+const PANEL_DEPTH = 0.28;
+const FLOOR_RADIUS = 4.2;
+const RING_INNER_RADIUS = 1.85;
+const RING_OUTER_RADIUS = 2.18;
+
+type PointerState = {
+  x: number;
+  y: number;
+};
 
 export type StreamCubeProps = {
   imgURL: string | null;
@@ -37,196 +55,391 @@ export function StreamCube({ imgURL, onContextError }: StreamCubeProps) {
   const rendererRef = useRef<WebGLRenderer | null>(null);
   const sceneRef = useRef<Scene | null>(null);
   const cameraRef = useRef<PerspectiveCamera | null>(null);
-  const cubeRef = useRef<Mesh<BoxGeometry, MeshStandardMaterial[]> | null>(
-    null,
-  );
-  const gridRef = useRef<GridHelper | null>(null);
+  const stageRef = useRef<Group | null>(null);
+  const panelRef = useRef<Mesh<BoxGeometry, Material[]> | null>(null);
+  const floorRef = useRef<Mesh<CircleGeometry, MeshBasicMaterial> | null>(null);
+  const ringRef = useRef<Mesh<RingGeometry, MeshBasicMaterial> | null>(null);
+  const outlineRef = useRef<LineSegments<
+    EdgesGeometry,
+    LineBasicMaterial
+  > | null>(null);
+  const accentLightRef = useRef<PointLight | null>(null);
+  const screenMaterialsRef = useRef<MeshStandardMaterial[]>([]);
+  const disposableMaterialsRef = useRef<Material[]>([]);
   const fallbackTextureRef = useRef<Texture | null>(null);
-  const lastTextureRef = useRef<Texture | null>(null);
-  const animationRef = useRef<number | null>(null);
+  const currentTextureRef = useRef<Texture | null>(null);
+  const animationFrameRef = useRef<number | null>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const pointerTargetRef = useRef<PointerState>({ x: 0, y: 0 });
+  const pointerOffsetRef = useRef<PointerState>({ x: 0, y: 0 });
+  const hasRenderedFrameRef = useRef(false);
+  const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
     const container = containerRef.current;
     const canvas = canvasRef.current;
 
-    if (!container || !canvas) return undefined;
+    if (!container || !canvas) {
+      return undefined;
+    }
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const bounds = container.getBoundingClientRect();
+      if (bounds.width === 0 || bounds.height === 0) {
+        return;
+      }
+
+      pointerTargetRef.current = {
+        x: ((event.clientX - bounds.left) / bounds.width) * 2 - 1,
+        y: ((event.clientY - bounds.top) / bounds.height) * 2 - 1,
+      };
+    };
+
+    const handlePointerLeave = () => {
+      pointerTargetRef.current = { x: 0, y: 0 };
+    };
 
     try {
       const renderer = new WebGLRenderer({
-        antialias: true,
         alpha: true,
+        antialias: true,
         canvas,
+        powerPreference: "high-performance",
       });
-      renderer.setPixelRatio(window.devicePixelRatio);
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+      renderer.setClearAlpha(0);
       renderer.outputColorSpace = SRGBColorSpace;
+      renderer.toneMapping = ACESFilmicToneMapping;
+      renderer.toneMappingExposure = 1.18;
 
       const scene = new Scene();
-      scene.background = null;
+      scene.fog = new FogExp2(0x020617, 0.16);
 
-      const { clientWidth: width, clientHeight: height } = container;
-      const camera = new PerspectiveCamera(45, width / height, 0.1, 100);
-      camera.position.set(0, 0, CAMERA_DISTANCE);
+      const { width, height } = getContainerSize(container);
+      const camera = new PerspectiveCamera(36, width / height, 0.1, 100);
+      camera.position.set(0, 0.35, CAMERA_DISTANCE);
 
-      const ambient = new AmbientLight(0xffffff, 0.6);
-      const directional = new DirectionalLight(0xffffff, 0.8);
-      directional.position.set(2, 3, 4);
-      scene.add(ambient, directional);
+      const stage = new Group();
+      scene.add(stage);
 
-      const grid = new GridHelper(GRID_SIZE, GRID_DIVISIONS, GRID_COLOR, GRID_COLOR);
-      grid.position.y = -1.2;
-      const gridMaterial = grid.material;
-      if (Array.isArray(gridMaterial)) {
-        gridMaterial.forEach((material) => {
-          material.transparent = true;
-          material.opacity = GRID_OPACITY;
-        });
-      } else {
-        gridMaterial.transparent = true;
-        gridMaterial.opacity = GRID_OPACITY;
-      }
-      scene.add(grid);
+      const ambient = new AmbientLight(0xffffff, 0.75);
+      const rim = new DirectionalLight(0xffffff, 1.2);
+      rim.position.set(-3.5, 2.8, 4.5);
+      const fill = new DirectionalLight(0x67e8f9, 0.9);
+      fill.position.set(3.2, 1.6, 2.4);
+      const accentLight = new PointLight(0x38bdf8, 4.4, 12, 2.2);
+      accentLight.position.set(2.1, 0.75, 2.8);
+      scene.add(ambient, rim, fill, accentLight);
 
-      const geometry = new BoxGeometry(2, 2, 2);
-      const fallbackTexture = createFallbackTexture();
-      const materials = Array.from({ length: 6 }, () =>
-        new MeshStandardMaterial({ map: fallbackTexture }),
+      const floorMaterial = new MeshBasicMaterial({
+        color: 0x0f172a,
+        opacity: 0.92,
+        transparent: true,
+      });
+      const floor = new Mesh(
+        new CircleGeometry(FLOOR_RADIUS, 72),
+        floorMaterial,
       );
-      const cube = new Mesh(geometry, materials);
-      scene.add(cube);
+      floor.position.set(0, -1.42, 0);
+      floor.rotation.x = -Math.PI / 2;
+      scene.add(floor);
+
+      const ringMaterial = new MeshBasicMaterial({
+        color: 0x38bdf8,
+        opacity: 0.14,
+        transparent: true,
+      });
+      const ring = new Mesh(
+        new RingGeometry(RING_INNER_RADIUS, RING_OUTER_RADIUS, 72),
+        ringMaterial,
+      );
+      ring.position.set(0, -1.39, 0);
+      ring.rotation.x = -Math.PI / 2;
+      scene.add(ring);
+
+      const panelGeometry = new BoxGeometry(
+        PANEL_WIDTH,
+        PANEL_HEIGHT,
+        PANEL_DEPTH,
+      );
+      const fallbackTexture = createFallbackTexture(renderer);
+      const chassisMaterial = new MeshPhysicalMaterial({
+        clearcoat: 1,
+        clearcoatRoughness: 0.18,
+        color: 0x0f172a,
+        metalness: 0.72,
+        roughness: 0.24,
+      });
+      const frontMaterial = new MeshStandardMaterial({
+        emissive: new Color(0x1d4ed8),
+        emissiveIntensity: 0.18,
+        map: fallbackTexture,
+        metalness: 0.08,
+        roughness: 0.22,
+      });
+      const backMaterial = new MeshStandardMaterial({
+        emissive: new Color(0x0f172a),
+        emissiveIntensity: 0.08,
+        map: fallbackTexture,
+        metalness: 0.2,
+        roughness: 0.28,
+      });
+      const panel = new Mesh(panelGeometry, [
+        chassisMaterial,
+        chassisMaterial,
+        chassisMaterial,
+        chassisMaterial,
+        frontMaterial,
+        backMaterial,
+      ]);
+      panel.position.y = 0.08;
+      panel.rotation.x = 0.18;
+      panel.rotation.y = -0.55;
+      stage.add(panel);
+
+      const outlineMaterial = new LineBasicMaterial({
+        color: 0x93c5fd,
+        opacity: 0.26,
+        transparent: true,
+      });
+      const outline = new LineSegments(
+        new EdgesGeometry(panelGeometry),
+        outlineMaterial,
+      );
+      panel.add(outline);
 
       renderer.setSize(width, height, false);
-
       rendererRef.current = renderer;
       sceneRef.current = scene;
       cameraRef.current = camera;
-      cubeRef.current = cube;
-      gridRef.current = grid;
+      stageRef.current = stage;
+      panelRef.current = panel;
+      floorRef.current = floor;
+      ringRef.current = ring;
+      outlineRef.current = outline;
+      accentLightRef.current = accentLight;
+      screenMaterialsRef.current = [frontMaterial, backMaterial];
+      disposableMaterialsRef.current = [
+        chassisMaterial,
+        frontMaterial,
+        backMaterial,
+        floorMaterial,
+        ringMaterial,
+        outlineMaterial,
+      ];
       fallbackTextureRef.current = fallbackTexture;
 
-      const renderFrame = () => {
-        cube.rotation.x += ROTATION_DELTA.x;
-        cube.rotation.y += ROTATION_DELTA.y;
-        renderer.render(scene, camera);
-        animationRef.current = window.requestAnimationFrame(renderFrame);
-      };
-      renderFrame();
-
       const handleResize = () => {
-        const { clientWidth, clientHeight } = container;
-        renderer.setSize(clientWidth, clientHeight, false);
-        camera.aspect = clientWidth / clientHeight;
+        const nextSize = getContainerSize(container);
+        renderer.setSize(nextSize.width, nextSize.height, false);
+        camera.aspect = nextSize.width / nextSize.height;
         camera.updateProjectionMatrix();
+      };
+
+      const renderFrame = (timestamp: number) => {
+        const elapsedSeconds = timestamp / 1000;
+        const pointerTarget = pointerTargetRef.current;
+        const pointerOffset = pointerOffsetRef.current;
+
+        pointerOffset.x = MathUtils.lerp(
+          pointerOffset.x,
+          pointerTarget.x,
+          0.08,
+        );
+        pointerOffset.y = MathUtils.lerp(
+          pointerOffset.y,
+          pointerTarget.y,
+          0.08,
+        );
+
+        const targetRotationX =
+          0.22 +
+          Math.sin(elapsedSeconds * 0.58) * 0.11 -
+          pointerOffset.y * 0.16;
+        const targetRotationY =
+          -0.58 + elapsedSeconds * 0.28 + pointerOffset.x * 0.24;
+
+        panel.rotation.x = MathUtils.lerp(
+          panel.rotation.x,
+          targetRotationX,
+          0.08,
+        );
+        panel.rotation.y = MathUtils.lerp(
+          panel.rotation.y,
+          targetRotationY,
+          0.08,
+        );
+        panel.rotation.z =
+          Math.sin(elapsedSeconds * 0.36) * 0.035 + pointerOffset.x * 0.04;
+
+        stage.position.y = Math.sin(elapsedSeconds * 0.88) * 0.08;
+        stage.position.x = pointerOffset.x * 0.08;
+
+        camera.position.x =
+          Math.sin(elapsedSeconds * 0.24) * 0.4 + pointerOffset.x * 0.34;
+        camera.position.y =
+          0.28 +
+          Math.cos(elapsedSeconds * 0.33) * 0.16 -
+          pointerOffset.y * 0.22;
+        camera.position.z =
+          CAMERA_DISTANCE + Math.sin(elapsedSeconds * 0.22) * 0.12;
+        camera.lookAt(0, 0.08, 0);
+
+        accentLight.position.x = Math.cos(elapsedSeconds * 0.72) * 2.4;
+        accentLight.position.y = 0.5 + Math.sin(elapsedSeconds * 0.45) * 0.35;
+        accentLight.position.z = 2.6 + Math.sin(elapsedSeconds * 0.53) * 0.4;
+
+        ring.material.opacity =
+          0.1 + (Math.sin(elapsedSeconds * 1.4) + 1) * 0.03;
+        outline.material.opacity =
+          0.22 + (Math.cos(elapsedSeconds * 1.1) + 1) * 0.03;
+
+        if (!hasRenderedFrameRef.current) {
+          hasRenderedFrameRef.current = true;
+          setIsReady(true);
+        }
+
+        renderer.render(scene, camera);
+        animationFrameRef.current = window.requestAnimationFrame(renderFrame);
       };
 
       const resizeObserver = new ResizeObserver(handleResize);
       resizeObserver.observe(container);
       resizeObserverRef.current = resizeObserver;
+
+      container.addEventListener("pointermove", handlePointerMove);
+      container.addEventListener("pointerleave", handlePointerLeave);
+
+      animationFrameRef.current = window.requestAnimationFrame(renderFrame);
+
+      return () => {
+        if (animationFrameRef.current) {
+          window.cancelAnimationFrame(animationFrameRef.current);
+        }
+
+        resizeObserver.disconnect();
+        container.removeEventListener("pointermove", handlePointerMove);
+        container.removeEventListener("pointerleave", handlePointerLeave);
+
+        currentTextureRef.current?.dispose();
+        fallbackTextureRef.current?.dispose();
+
+        outline.geometry.dispose();
+        panel.geometry.dispose();
+        floor.geometry.dispose();
+        ring.geometry.dispose();
+
+        disposableMaterialsRef.current.forEach((material) =>
+          material.dispose(),
+        );
+        renderer.dispose();
+
+        rendererRef.current = null;
+        sceneRef.current = null;
+        cameraRef.current = null;
+        stageRef.current = null;
+        panelRef.current = null;
+        floorRef.current = null;
+        ringRef.current = null;
+        outlineRef.current = null;
+        accentLightRef.current = null;
+        screenMaterialsRef.current = [];
+        disposableMaterialsRef.current = [];
+        fallbackTextureRef.current = null;
+        currentTextureRef.current = null;
+        resizeObserverRef.current = null;
+        pointerTargetRef.current = { x: 0, y: 0 };
+        pointerOffsetRef.current = { x: 0, y: 0 };
+        hasRenderedFrameRef.current = false;
+      };
     } catch (error) {
       onContextError?.();
       console.error("Failed to initialize WebGL renderer", error);
     }
 
-    return () => {
-      if (animationRef.current) {
-        cancelAnimationFrame(animationRef.current);
-      }
-
-      resizeObserverRef.current?.disconnect();
-
-      cubeRef.current?.geometry.dispose();
-      cubeRef.current?.material.forEach((material) => {
-        if (material.map && material.map !== fallbackTextureRef.current) {
-          material.map.dispose();
-        }
-        material.dispose();
-      });
-
-      if (gridRef.current) {
-        gridRef.current.geometry.dispose();
-        const gridMaterial = gridRef.current.material;
-        if (Array.isArray(gridMaterial)) {
-          gridMaterial.forEach((material) => material.dispose());
-        } else {
-          gridMaterial.dispose();
-        }
-      }
-
-      if (fallbackTextureRef.current) {
-        fallbackTextureRef.current.dispose();
-      }
-
-      if (lastTextureRef.current) {
-        lastTextureRef.current.dispose();
-      }
-
-      rendererRef.current?.dispose();
-      rendererRef.current = null;
-      sceneRef.current = null;
-      cameraRef.current = null;
-      cubeRef.current = null;
-      gridRef.current = null;
-      fallbackTextureRef.current = null;
-      lastTextureRef.current = null;
-      resizeObserverRef.current = null;
-    };
+    return undefined;
   }, [onContextError]);
 
   useEffect(() => {
-    let cancelled = false;
+    let isCancelled = false;
 
     const applyTexture = async () => {
-      if (!cubeRef.current || !fallbackTextureRef.current) return;
+      const renderer = rendererRef.current;
+      const fallbackTexture = fallbackTextureRef.current;
+      const materials = screenMaterialsRef.current;
+
+      if (!renderer || !fallbackTexture || materials.length === 0) {
+        return;
+      }
 
       let nextTexture: Texture | null = null;
       try {
-        nextTexture = imgURL ? await loadTexture(imgURL) : fallbackTextureRef.current;
+        nextTexture = imgURL
+          ? await loadTexture(imgURL, renderer)
+          : fallbackTexture;
       } catch (error) {
-        console.warn("Failed to load streamed texture; using fallback", error);
-        nextTexture = fallbackTextureRef.current;
+        console.warn("Falling back to the placeholder stream texture", error);
+        nextTexture = fallbackTexture;
       }
 
-      if (cancelled || !cubeRef.current || !nextTexture) {
-        if (nextTexture && nextTexture !== fallbackTextureRef.current) {
-          nextTexture.dispose();
+      if (isCancelled || !nextTexture) {
+        if (nextTexture !== fallbackTexture) {
+          nextTexture?.dispose();
         }
         return;
       }
 
-      const materials = cubeRef.current.material;
-      materials.forEach((material) => {
-        const previousMap = material.map;
+      materials.forEach((material, index) => {
         material.map = nextTexture;
+        material.emissiveIntensity = index === 0 ? 0.18 : 0.08;
         material.needsUpdate = true;
-        if (previousMap && previousMap !== nextTexture && previousMap !== fallbackTextureRef.current) {
-          previousMap.dispose();
-        }
       });
 
-      if (lastTextureRef.current && lastTextureRef.current !== nextTexture) {
-        lastTextureRef.current.dispose();
+      if (
+        currentTextureRef.current &&
+        currentTextureRef.current !== nextTexture &&
+        currentTextureRef.current !== fallbackTexture
+      ) {
+        currentTextureRef.current.dispose();
       }
 
-      lastTextureRef.current = nextTexture === fallbackTextureRef.current ? null : nextTexture;
+      currentTextureRef.current =
+        nextTexture === fallbackTexture ? null : nextTexture;
     };
 
-    applyTexture();
+    void applyTexture();
 
     return () => {
-      cancelled = true;
+      isCancelled = true;
     };
-  }, [imgURL]);
+  }, [imgURL, isReady]);
 
   return (
-    <div ref={containerRef} className="relative flex-1 min-h-[240px] w-full rounded-md bg-muted/40">
-      <canvas ref={canvasRef} className="size-full" />
-      {!rendererRef.current && <Skeleton className="absolute inset-0" />}
+    <div
+      ref={containerRef}
+      className="border-border/60 relative min-h-[260px] w-full flex-1 overflow-hidden rounded-xl border bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.18),transparent_34%),radial-gradient(circle_at_bottom,rgba(14,165,233,0.14),transparent_42%),linear-gradient(180deg,rgba(15,23,42,0.94),rgba(2,6,23,0.98))] shadow-[0_24px_80px_rgba(2,6,23,0.55)]"
+    >
+      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,transparent,rgba(14,165,233,0.08)_58%,rgba(2,6,23,0.72))]" />
+      <canvas ref={canvasRef} className="relative size-full" />
+      {!isReady && <Skeleton className="absolute inset-0 rounded-none" />}
     </div>
   );
 }
 
-function createFallbackTexture() {
-  const size = 128;
+function getContainerSize(container: HTMLDivElement) {
+  return {
+    height: Math.max(container.clientHeight, 1),
+    width: Math.max(container.clientWidth, 1),
+  };
+}
+
+function configureTexture(texture: Texture, renderer: WebGLRenderer) {
+  texture.anisotropy = renderer.capabilities.getMaxAnisotropy();
+  texture.colorSpace = SRGBColorSpace;
+}
+
+function createFallbackTexture(renderer: WebGLRenderer) {
+  const size = 512;
   const canvas = document.createElement("canvas");
   canvas.width = size;
   canvas.height = size;
@@ -236,32 +449,59 @@ function createFallbackTexture() {
     throw new Error("Failed to create 2D context for fallback texture");
   }
 
-  const colors = ["#111827", "#1f2937"];
-  const squareSize = size / 8;
+  const background = context.createLinearGradient(0, 0, size, size);
+  background.addColorStop(0, "#020617");
+  background.addColorStop(0.55, "#0f172a");
+  background.addColorStop(1, "#1d4ed8");
+  context.fillStyle = background;
+  context.fillRect(0, 0, size, size);
 
-  for (let y = 0; y < 8; y += 1) {
-    for (let x = 0; x < 8; x += 1) {
-      context.fillStyle = colors[(x + y) % 2];
-      context.fillRect(x * squareSize, y * squareSize, squareSize, squareSize);
-    }
+  context.strokeStyle = "rgba(148, 163, 184, 0.14)";
+  context.lineWidth = 1;
+  const gridStep = size / 12;
+  for (let line = gridStep; line < size; line += gridStep) {
+    context.beginPath();
+    context.moveTo(line, 0);
+    context.lineTo(line, size);
+    context.stroke();
+
+    context.beginPath();
+    context.moveTo(0, line);
+    context.lineTo(size, line);
+    context.stroke();
   }
 
-  const texture = new CanvasTexture(canvas);
-  texture.colorSpace = SRGBColorSpace;
-  texture.wrapS = RepeatWrapping;
-  texture.wrapT = RepeatWrapping;
-  texture.repeat.set(2, 2);
+  context.fillStyle = "rgba(15, 23, 42, 0.72)";
+  context.fillRect(92, 116, size - 184, size - 232);
+  context.strokeStyle = "rgba(125, 211, 252, 0.72)";
+  context.lineWidth = 12;
+  context.strokeRect(92, 116, size - 184, size - 232);
 
+  context.fillStyle = "#e2e8f0";
+  context.font = "700 42px sans-serif";
+  context.fillText("WAITING FOR STREAM", 118, 252);
+
+  context.strokeStyle = "rgba(125, 211, 252, 0.9)";
+  context.lineWidth = 8;
+  context.beginPath();
+  context.moveTo(126, 334);
+  context.bezierCurveTo(166, 276, 216, 388, 266, 318);
+  context.bezierCurveTo(306, 272, 344, 364, 390, 326);
+  context.bezierCurveTo(426, 300, 456, 332, 486, 316);
+  context.stroke();
+
+  const texture = new CanvasTexture(canvas);
+  configureTexture(texture, renderer);
   return texture;
 }
 
-function loadTexture(url: string) {
+function loadTexture(url: string, renderer: WebGLRenderer) {
   return new Promise<Texture>((resolve, reject) => {
     const loader = new TextureLoader();
     loader.load(
       url,
       (texture) => {
-        texture.colorSpace = SRGBColorSpace;
+        configureTexture(texture, renderer);
         resolve(texture);
       },
       undefined,

--- a/experimental/beats/src/components/stream.tsx
+++ b/experimental/beats/src/components/stream.tsx
@@ -14,34 +14,39 @@ function getStatusClasses(streamIsActive: boolean) {
     : "text-red-500 status-red-blink";
 }
 
-export function StreamStatus(
-  {
-    streamIsActive,
-    ...divProps
-  }: ComponentProps<"div"> & {
-    streamIsActive: boolean;
-  },
-) {
+export function StreamStatus({
+  streamIsActive,
+  ...divProps
+}: ComponentProps<"div"> & {
+  streamIsActive: boolean;
+}) {
   return (
     <div
       {...divProps}
-      className="font-tomorrow text-muted-foreground flex items-center text-[0.7rem] uppercase justify-end"
+      className="font-tomorrow text-muted-foreground flex items-center justify-end text-[0.7rem] uppercase"
     >
-      <Antenna className={`h-[1rem] mr-1 ${getStatusClasses(streamIsActive)}`} />
+      <Antenna
+        className={`mr-1 h-[1rem] ${getStatusClasses(streamIsActive)}`}
+      />
       <span>{streamIsActive ? "Active" : "Not Active"}</span>
     </div>
   );
 }
 
 export function StreamedImage({ imgURL }: { imgURL: string | null }) {
-  if (!imgURL) return <Skeleton className="size-full" />;
+  if (!imgURL) {
+    return <Skeleton className="size-full min-h-[260px] rounded-xl" />;
+  }
 
   return (
-    <img
-      src={imgURL}
-      alt="stream"
-      className="size-full object-contain"
-    />
+    <div className="border-border/60 relative h-full min-h-[260px] w-full overflow-hidden rounded-xl border bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.12),transparent_34%),linear-gradient(180deg,rgba(15,23,42,0.92),rgba(2,6,23,0.98))] shadow-[0_24px_80px_rgba(2,6,23,0.45)]">
+      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,transparent,rgba(14,165,233,0.06)_58%,rgba(2,6,23,0.72))]" />
+      <img
+        src={imgURL}
+        alt="stream"
+        className="relative size-full object-contain p-4"
+      />
+    </div>
   );
 }
 
@@ -55,25 +60,22 @@ export function Stream() {
 
   return (
     <div className="flex h-full flex-col select-none">
-      <div className="flex-1 w-full min-h-0">
+      <div className="min-h-0 w-full flex-1">
         {useImageFallback ? (
           <StreamedImage imgURL={imgURL} />
         ) : (
-          <StreamCube
-            imgURL={imgURL}
-            onContextError={handleContextError}
-          />
+          <StreamCube imgURL={imgURL} onContextError={handleContextError} />
         )}
       </div>
 
       <Separator className="my-4 flex-none" />
 
       {/* Footer */}
-      <div className="flex-none mb-2 flex items-center justify-between gap-4 px-2">
-        <span className="text-xs text-muted-foreground font-tomorrow uppercase">
+      <div className="mb-2 flex flex-none items-center justify-between gap-4 px-2">
+        <span className="text-muted-foreground font-tomorrow text-xs uppercase">
           fps: <b>{isActive ? fps : 0}</b>
         </span>
-        <div className="text-xs text-muted-foreground font-tomorrow">
+        <div className="text-muted-foreground font-tomorrow text-xs">
           {ws?.socket?.url}
         </div>
         <StreamStatus streamIsActive={isActive} />

--- a/experimental/beats/src/tests/unit/components/stream.test.tsx
+++ b/experimental/beats/src/tests/unit/components/stream.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Stream } from "@/components/stream";
+
+const streamedImageState = vi.hoisted(() => ({
+  fps: 24,
+  imgURL: "blob:frame-texture",
+  isActive: true,
+}));
+
+const websocketState = vi.hoisted(() => ({
+  socket: {
+    url: "ws://localhost:8765/stream",
+  },
+}));
+
+vi.mock("@/actions/ws/providers/ImageProvider", () => ({
+  useStreamedImage: () => streamedImageState,
+}));
+
+vi.mock("@/actions/ws/websocket", () => ({
+  useWS: () => websocketState,
+}));
+
+vi.mock("@/components/stream-cube", () => ({
+  StreamCube: ({ onContextError }: { onContextError?: () => void }) => (
+    <button type="button" onClick={() => onContextError?.()}>
+      trip-webgl
+    </button>
+  ),
+}));
+
+describe("Stream", () => {
+  beforeEach(() => {
+    streamedImageState.fps = 24;
+    streamedImageState.imgURL = "blob:frame-texture";
+    streamedImageState.isActive = true;
+    websocketState.socket.url = "ws://localhost:8765/stream";
+  });
+
+  it("falls back to the image viewer when the WebGL scene reports a context error", async () => {
+    const user = userEvent.setup();
+
+    render(<Stream />);
+
+    await user.click(screen.getByRole("button", { name: "trip-webgl" }));
+
+    expect(screen.getByRole("img", { name: "stream" })).toHaveAttribute(
+      "src",
+      streamedImageState.imgURL,
+    );
+  });
+
+  it("shows live telemetry from the websocket stream in the footer", () => {
+    render(<Stream />);
+
+    expect(screen.getByText(/fps:/i)).toHaveTextContent("fps: 24");
+    expect(screen.getByText("ws://localhost:8765/stream")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+  });
+});

--- a/experimental/beats/src/tests/unit/setup.ts
+++ b/experimental/beats/src/tests/unit/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Summary
- replace the basic rotating cube with a more polished 3D stage, including improved camera framing, lighting, motion, and fallback texture handling
- style the stream fallback image to match the upgraded viewer surface and preserve the existing WebGL error fallback path
- add unit coverage for stream fallback behavior and footer telemetry
- document the Beats `npm ci` lockfile mismatch workaround and record the validation commands in `AGENTS.md`

## Testing
- `cd experimental/beats && npx eslint src/components/stream-cube.tsx src/components/stream.tsx src/tests/unit/components/stream.test.tsx src/tests/unit/setup.ts`
- `cd experimental/beats && npm run test`
- `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/535d/heart/.uv-cache make format`
- `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/535d/heart/.uv-cache make test`
- `cd experimental/beats && npm run lint` still fails due to pre-existing errors in unrelated files