### PR TITLE
Fix Totem and Beats reconnect handshakes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 Use the tooling in this repository to manage environments. Prefer `uv` for Python dependency resolution.
 
 - Pin prerelease Python dependencies with exact versions in `pyproject.toml` so `uv.lock` resolves the intended alpha or beta release.
+- `experimental/beats` test and lint commands require that workspace's Node dependencies to be installed first; `npm exec` alone is not enough because the Vite/Vitest config imports project-local plugins such as `@vitejs/plugin-react`.
 - Scene and asset bootstrap can run before `pygame.display.set_mode`; avoid unconditional `convert()` or `convert_alpha()` calls in asset constructors and defer display-dependent conversion until a surface exists.
 - `DisplayContext` wraps the active `pygame.Surface`; renderers that need surface-only APIs such as `subsurface()` must use `window.screen` after confirming it is initialized instead of calling those APIs on `DisplayContext` directly.
 - Only the real display-owned `DisplayContext` may change pygame display modes; scratch or post-processing contexts must keep `can_configure_display=False` and never call `pygame.display.set_mode()`.
@@ -242,3 +243,7 @@ Define CLI default values as module-level constants so they stay consistent acro
 - `2026-03-30`: `.venv/bin/docformatter -i -r --config ./pyproject.toml docs`
 - `2026-03-30`: `.venv/bin/mdformat docs`
 - `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/94af/heart/.uv-cache make test`
+- `2026-03-31`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/3af3/heart/.uv-cache make format`
+- `2026-03-31`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/3af3/heart/.uv-cache .venv/bin/pytest tests/device/test_beats_websocket.py tests/runtime/test_peripheral_runtime.py`
+- `2026-03-31`: `npm test -- --run src/tests/unit/actions/ws/websocket.test.tsx` in `experimental/beats` failed because `vitest` was not installed in that workspace (`node_modules` missing).
+- `2026-03-31`: `npm exec vitest run src/tests/unit/actions/ws/websocket.test.tsx` in `experimental/beats` failed because the workspace dependencies were not installed, so `@vitejs/plugin-react` could not be resolved from `vitest.config.ts`.

--- a/experimental/beats/src/actions/ws/websocket.tsx
+++ b/experimental/beats/src/actions/ws/websocket.tsx
@@ -42,10 +42,12 @@ export function WSProvider({
   const retryRef = useRef(retryDelay);
   const reconnectTimeoutRef = useRef<number | null>(null);
   const isMountedRef = useRef(true);
+  const socketRef = useRef<WebSocket | null>(null);
+  const attemptRef = useRef(0);
 
   useEffect(() => {
     isMountedRef.current = true;
-    retryRef.current = retryDelay; // reset on URL / config change
+    retryRef.current = retryDelay;
 
     const cleanupSocket = (ws: WebSocket | null) => {
       if (!ws) return;
@@ -60,36 +62,48 @@ export function WSProvider({
       }
     };
 
+    const clearReconnectTimer = () => {
+      if (reconnectTimeoutRef.current !== null) {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
+      }
+    };
+
     const scheduleReconnect = () => {
-      if (!isMountedRef.current) return;
+      if (!isMountedRef.current || reconnectTimeoutRef.current !== null) return;
 
       const delay = retryRef.current;
       const nextDelay = Math.min(delay * 2, maxRetryDelay);
       retryRef.current = nextDelay;
 
       reconnectTimeoutRef.current = window.setTimeout(() => {
+        reconnectTimeoutRef.current = null;
         connect();
       }, delay);
     };
 
     const connect = () => {
-      // Make sure we don't keep an old socket alive
-      setSocket((prev) => {
-        cleanupSocket(prev);
-        return prev;
-      });
+      clearReconnectTimer();
+      attemptRef.current += 1;
+      const attempt = attemptRef.current;
+
+      cleanupSocket(socketRef.current);
 
       const ws = new WebSocket(url);
       ws.binaryType = "arraybuffer";
+      socketRef.current = ws;
       setSocket(ws);
       setReadyState(ws.readyState);
 
       ws.onopen = () => {
-        retryRef.current = retryDelay; // reset backoff on successful connect
+        if (socketRef.current !== ws || attemptRef.current !== attempt) return;
+        clearReconnectTimer();
+        retryRef.current = retryDelay;
         setReadyState(ws.readyState);
       };
 
       ws.onmessage = (ev: MessageEvent) => {
+        if (socketRef.current !== ws || attemptRef.current !== attempt) return;
         if (!(ev.data instanceof ArrayBuffer)) {
           return;
         }
@@ -99,14 +113,12 @@ export function WSProvider({
             stream.next(decoded);
           }
         } catch (err) {
-          stream.error(err);
           console.error("WebSocket message parse error:", err, ev.data);
         }
       };
 
       ws.onerror = () => {
-        console.log("error");
-        // error generally followed by close, but make sure we close + reconnect
+        if (socketRef.current !== ws || attemptRef.current !== attempt) return;
         setReadyState(ws.readyState);
         try {
           ws.close();
@@ -116,7 +128,9 @@ export function WSProvider({
       };
 
       ws.onclose = () => {
-        console.log("close");
+        if (socketRef.current !== ws || attemptRef.current !== attempt) return;
+        socketRef.current = null;
+        setSocket((current) => (current === ws ? null : current));
         setReadyState(ws.readyState);
         scheduleReconnect();
       };
@@ -126,13 +140,10 @@ export function WSProvider({
 
     return () => {
       isMountedRef.current = false;
-      if (reconnectTimeoutRef.current !== null) {
-        clearTimeout(reconnectTimeoutRef.current);
-      }
-      setSocket((prev) => {
-        cleanupSocket(prev);
-        return null;
-      });
+      clearReconnectTimer();
+      cleanupSocket(socketRef.current);
+      socketRef.current = null;
+      setSocket(null);
       setReadyState(WebSocket.CLOSED);
     };
   }, [url, retryDelay, maxRetryDelay]);

--- a/experimental/beats/src/tests/unit/actions/ws/websocket.test.tsx
+++ b/experimental/beats/src/tests/unit/actions/ws/websocket.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import { act } from "react";
+
+import { WSProvider, useWS } from "@/actions/ws/websocket";
+
+class FakeWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+
+  url: string;
+  binaryType = "blob";
+  readyState = FakeWebSocket.CONNECTING;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+
+  close() {
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+
+  triggerOpen() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  triggerClose() {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.();
+  }
+}
+
+function ReadyStateProbe() {
+  const { readyState } = useWS();
+  return <div data-testid="ready-state">{readyState}</div>;
+}
+
+describe("WSProvider", () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    vi.useFakeTimers();
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  test("reconnects once after a disconnect and ignores stale socket callbacks", () => {
+    render(
+      <WSProvider
+        url="ws://localhost:8765"
+        retryDelay={100}
+        maxRetryDelay={200}
+      >
+        <ReadyStateProbe />
+      </WSProvider>,
+    );
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(screen.getByTestId("ready-state")).toHaveTextContent("0");
+
+    act(() => {
+      FakeWebSocket.instances[0].triggerOpen();
+    });
+    expect(screen.getByTestId("ready-state")).toHaveTextContent("1");
+
+    act(() => {
+      FakeWebSocket.instances[0].triggerClose();
+    });
+    expect(screen.getByTestId("ready-state")).toHaveTextContent("3");
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(FakeWebSocket.instances).toHaveLength(2);
+
+    act(() => {
+      FakeWebSocket.instances[0].triggerClose();
+      vi.advanceTimersByTime(200);
+    });
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+});

--- a/experimental/beats/src/tests/unit/setup.ts
+++ b/experimental/beats/src/tests/unit/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/src/heart/device/beats/websocket.py
+++ b/src/heart/device/beats/websocket.py
@@ -21,6 +21,10 @@ from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
 beats_streaming_pb2 = cast(Any, _beats_streaming_pb2)
+WEBSOCKET_HOST = "localhost"
+WEBSOCKET_PORT = 8765
+WEBSOCKET_PING_INTERVAL_SECONDS = 20
+WEBSOCKET_RETRY_DELAY_SECONDS = 1.0
 
 
 def _encode_peripheral_message(
@@ -114,6 +118,17 @@ def decode_stream_envelope(frame: bytes) -> tuple[str, object] | None:
     return None
 
 
+def _peripheral_cache_key(envelope: PeripheralMessageEnvelope[Any]) -> str:
+    info = envelope.peripheral_info
+    if info.id:
+        return info.id
+    tag_key = ",".join(
+        f"{tag.name}:{tag.variant}:{sorted(tag.metadata.items())}" for tag in info.tags
+    )
+    payload_type = type(envelope.data).__name__
+    return f"{payload_type}:{tag_key}"
+
+
 
 @dataclass
 class WebSocket:
@@ -126,6 +141,9 @@ class WebSocket:
     _thread: threading.Thread | None = field(default=None, init=False)
     _loop: asyncio.AbstractEventLoop | None = field(default=None, init=False)
     _broadcast_queue: asyncio.Queue[bytes] | None = field(default=None, init=False)
+    _replay_lock: threading.Lock = field(default_factory=threading.Lock, init=False)
+    _latest_frame: bytes | None = field(default=None, init=False)
+    _latest_peripheral_frames: dict[str, bytes] = field(default_factory=dict, init=False)
     _streaming_settings = BeatsStreamingConfiguration.settings()
 
     def __new__(cls, *args: Any, **kwargs: Any) -> "WebSocket":
@@ -161,6 +179,8 @@ class WebSocket:
         async def handler(ws: Any) -> None:
             self.clients.add(ws)
             try:
+                for frame in self._replay_frames():
+                    await ws.send(frame)
                 await ws.wait_closed()
             finally:
                 self.clients.discard(ws)
@@ -183,38 +203,78 @@ class WebSocket:
                         self.clients.discard(ws)
 
         async def main() -> None:
-            self._server = await websockets.serve(
-                handler,
-                "localhost",
-                8765,
-                ping_interval=20,
-            )
             loop.create_task(broadcast_worker())
-            await self._server.wait_closed()
+            while True:
+                try:
+                    self._server = await websockets.serve(
+                        handler,
+                        WEBSOCKET_HOST,
+                        WEBSOCKET_PORT,
+                        ping_interval=WEBSOCKET_PING_INTERVAL_SECONDS,
+                    )
+                    logger.info(
+                        "Beats websocket server listening on ws://%s:%d",
+                        WEBSOCKET_HOST,
+                        WEBSOCKET_PORT,
+                    )
+                    await self._server.wait_closed()
+                except OSError:
+                    logger.exception(
+                        "Beats websocket server failed to start; retrying in %.1fs",
+                        WEBSOCKET_RETRY_DELAY_SECONDS,
+                    )
+                except Exception:
+                    logger.exception(
+                        "Beats websocket server stopped unexpectedly; retrying in %.1fs",
+                        WEBSOCKET_RETRY_DELAY_SECONDS,
+                    )
+                finally:
+                    self._server = None
+                await asyncio.sleep(WEBSOCKET_RETRY_DELAY_SECONDS)
 
         main_task = loop.create_task(main())
         loop.run_until_complete(main_task)
 
     def send(self, kind: str, payload: object) -> None:
-        if self._broadcast_queue and self._loop:
-            frame_bytes = self._encode_payload(kind=kind, payload=payload)
-            if frame_bytes is None:
-                return
-            if self._streaming_settings.overflow_strategy == QueueOverflowStrategy.ERROR:
-                if threading.current_thread() == self._thread:
-                    self._enqueue_frame(frame_bytes, self._broadcast_queue)
-                else:
-                    future = asyncio.run_coroutine_threadsafe(
-                        self._enqueue_frame_async(
-                            frame_bytes, self._broadcast_queue
-                        ),
-                        self._loop,
-                    )
-                    future.result()
+        frame_bytes = self._encode_payload(kind=kind, payload=payload)
+        if frame_bytes is None:
+            return
+        self._cache_replay_frame(kind=kind, payload=payload, frame_bytes=frame_bytes)
+        if self._broadcast_queue is None or self._loop is None:
+            return
+        if self._streaming_settings.overflow_strategy == QueueOverflowStrategy.ERROR:
+            if threading.current_thread() == self._thread:
+                self._enqueue_frame(frame_bytes, self._broadcast_queue)
             else:
-                self._loop.call_soon_threadsafe(
-                    self._enqueue_frame, frame_bytes, self._broadcast_queue
+                future = asyncio.run_coroutine_threadsafe(
+                    self._enqueue_frame_async(
+                        frame_bytes, self._broadcast_queue
+                    ),
+                    self._loop,
                 )
+                future.result()
+        else:
+            self._loop.call_soon_threadsafe(
+                self._enqueue_frame, frame_bytes, self._broadcast_queue
+            )
+
+    def _cache_replay_frame(
+        self, *, kind: str, payload: object, frame_bytes: bytes
+    ) -> None:
+        with self._replay_lock:
+            if kind == "frame":
+                self._latest_frame = frame_bytes
+                return
+            if kind == "peripheral" and isinstance(payload, PeripheralMessageEnvelope):
+                self._latest_peripheral_frames[_peripheral_cache_key(payload)] = frame_bytes
+
+    def _replay_frames(self) -> tuple[bytes, ...]:
+        with self._replay_lock:
+            frames: list[bytes] = []
+            if self._latest_frame is not None:
+                frames.append(self._latest_frame)
+            frames.extend(self._latest_peripheral_frames.values())
+            return tuple(frames)
 
     def _enqueue_frame(self, frame: bytes, queue: asyncio.Queue[bytes]) -> None:
         if self._streaming_settings.overflow_strategy == QueueOverflowStrategy.ERROR:

--- a/src/heart/runtime/peripheral_runtime.py
+++ b/src/heart/runtime/peripheral_runtime.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+from typing import Any
+
 from heart.device.beats import WebSocket
+from heart.peripheral.core import (PeripheralInfo, PeripheralMessageEnvelope,
+                                   PeripheralTag)
+from heart.peripheral.core.input import InputDebugEnvelope
 from heart.peripheral.core.manager import PeripheralManager
 from heart.utilities.logging import get_logger
 from heart.utilities.reactivex_threads import drain_frame_thread_queue
 
 logger = get_logger(__name__)
+INPUT_DEBUG_STAGE_TAG = "input_debug_stage"
+INPUT_DEBUG_STREAM_TAG = "input_debug_stream"
 
 
 class PeripheralRuntime:
@@ -30,9 +37,29 @@ class PeripheralRuntime:
         ws = websocket or WebSocket()
         self._peripheral_manager.debug_tap.observable().subscribe(
             on_next=lambda envelope: ws.send(
-                kind="input",
-                payload=envelope.as_dict(),
+                kind="peripheral",
+                payload=self._streaming_envelope(envelope),
             ),
+        )
+
+    def _streaming_envelope(
+        self, envelope: InputDebugEnvelope
+    ) -> PeripheralMessageEnvelope[dict[str, Any]]:
+        return PeripheralMessageEnvelope(
+            peripheral_info=PeripheralInfo(
+                id=envelope.source_id,
+                tags=(
+                    PeripheralTag(
+                        name=INPUT_DEBUG_STAGE_TAG,
+                        variant=envelope.stage.value,
+                    ),
+                    PeripheralTag(
+                        name=INPUT_DEBUG_STREAM_TAG,
+                        variant=envelope.stream_name,
+                    ),
+                ),
+            ),
+            data=envelope.as_dict(),
         )
 
     def tick(self) -> None:

--- a/tests/device/test_beats_websocket.py
+++ b/tests/device/test_beats_websocket.py
@@ -1,9 +1,11 @@
 import json
+import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from heart.device.beats.proto import beats_streaming_pb2
-from heart.device.beats.websocket import (_encode_peripheral_message,
+from heart.device.beats.websocket import (WebSocket,
+                                          _encode_peripheral_message,
                                           decode_stream_envelope)
 from heart.peripheral.core import (Input, PeripheralInfo,
                                    PeripheralMessageEnvelope, PeripheralTag)
@@ -188,3 +190,55 @@ class TestStreamEnvelopeDecoding:
         assert payload.peripheral_info == source.peripheral_info
         assert isinstance(payload.data, beats_streaming_pb2.Frame)
         assert payload.data == message
+
+
+class TestWebSocketReplayCache:
+    """Verify replay caching so reconnecting Beats clients immediately recover current stream state."""
+
+    def test_replays_latest_frame_and_latest_peripheral_state(self) -> None:
+        """Verify replay keeps the newest frame and newest payload per peripheral so reconnects recover without waiting for fresh traffic."""
+        websocket = object.__new__(WebSocket)
+        websocket._replay_lock = threading.Lock()
+        websocket._latest_frame = None
+        websocket._latest_peripheral_frames = {}
+
+        websocket._cache_replay_frame(
+            kind="frame",
+            payload=b"old-frame",
+            frame_bytes=b"old-frame",
+        )
+        websocket._cache_replay_frame(
+            kind="frame",
+            payload=b"latest-frame",
+            frame_bytes=b"latest-frame",
+        )
+        websocket._cache_replay_frame(
+            kind="peripheral",
+            payload=PeripheralMessageEnvelope(
+                peripheral_info=PeripheralInfo(id="switch-1"),
+                data={"pressed": False},
+            ),
+            frame_bytes=b"switch-1-old",
+        )
+        websocket._cache_replay_frame(
+            kind="peripheral",
+            payload=PeripheralMessageEnvelope(
+                peripheral_info=PeripheralInfo(id="switch-1"),
+                data={"pressed": True},
+            ),
+            frame_bytes=b"switch-1-latest",
+        )
+        websocket._cache_replay_frame(
+            kind="peripheral",
+            payload=PeripheralMessageEnvelope(
+                peripheral_info=PeripheralInfo(id="sensor-1"),
+                data={"x": 1},
+            ),
+            frame_bytes=b"sensor-1-latest",
+        )
+
+        assert websocket._replay_frames() == (
+            b"latest-frame",
+            b"switch-1-latest",
+            b"sensor-1-latest",
+        )

--- a/tests/runtime/test_peripheral_runtime.py
+++ b/tests/runtime/test_peripheral_runtime.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from reactivex.subject import Subject
+
+from heart.peripheral.core.input import InputDebugEnvelope, InputDebugStage
+from heart.runtime.peripheral_runtime import (INPUT_DEBUG_STAGE_TAG,
+                                              INPUT_DEBUG_STREAM_TAG,
+                                              PeripheralRuntime)
+
+
+class _DebugTapStub:
+    def __init__(self) -> None:
+        self.subject: Subject[InputDebugEnvelope] = Subject()
+
+    def observable(self) -> Subject[InputDebugEnvelope]:
+        return self.subject
+
+
+class _PeripheralManagerStub:
+    def __init__(self) -> None:
+        self.debug_tap = _DebugTapStub()
+
+
+class _WebSocketStub:
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, object]] = []
+
+    def send(self, kind: str, payload: object) -> None:
+        self.sent.append((kind, payload))
+
+
+class TestPeripheralRuntimeStreaming:
+    """Exercise peripheral runtime stream bridging so Beats receives structured reconnect-safe peripheral payloads."""
+
+    def test_configure_streaming_emits_peripheral_envelopes(self) -> None:
+        """Verify debug tap events are wrapped as peripheral payloads so the Beats websocket can replay and decode them after reconnects."""
+        manager = _PeripheralManagerStub()
+        runtime = PeripheralRuntime(manager)  # type: ignore[arg-type]
+        websocket = _WebSocketStub()
+
+        runtime.configure_streaming(websocket=websocket)  # type: ignore[arg-type]
+        manager.debug_tap.subject.on_next(
+            InputDebugEnvelope(
+                stage=InputDebugStage.RAW,
+                stream_name="switch.tick",
+                source_id="switch-1",
+                timestamp_monotonic=12.5,
+                payload={
+                    "rotation": 1,
+                    "timestamp": datetime(2024, 1, 1, tzinfo=timezone.utc),
+                },
+            )
+        )
+
+        assert len(websocket.sent) == 1
+        kind, envelope = websocket.sent[0]
+        assert kind == "peripheral"
+        assert envelope.peripheral_info.id == "switch-1"
+        assert envelope.peripheral_info.tags[0].name == INPUT_DEBUG_STAGE_TAG
+        assert envelope.peripheral_info.tags[0].variant == InputDebugStage.RAW.value
+        assert envelope.peripheral_info.tags[1].name == INPUT_DEBUG_STREAM_TAG
+        assert envelope.peripheral_info.tags[1].variant == "switch.tick"
+        assert envelope.data["stream_name"] == "switch.tick"
+        assert envelope.data["source_id"] == "switch-1"


### PR DESCRIPTION
## Summary
- harden the Totem Beats websocket server with retry-on-startup, replay caching, and reconnect-safe frame/peripheral delivery
- send peripheral debug traffic through structured `peripheral` envelopes so Beats can decode and replay current state consistently
- make the Beats websocket client ignore stale socket callbacks, avoid duplicate reconnect timers, and keep parsing failures from tearing down the stream
- add regression coverage for websocket replay caching, peripheral runtime streaming, and Beats client reconnect behavior
- document the Beats workspace test dependency requirement and record the validation results in `AGENTS.md`

## Testing
- `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/3af3/heart/.uv-cache make format`
- `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/3af3/heart/.uv-cache .venv/bin/pytest tests/device/test_beats_websocket.py tests/runtime/test_peripheral_runtime.py`
- `npm test -- --run src/tests/unit/actions/ws/websocket.test.tsx` failed because `experimental/beats/node_modules` is missing
- `npm exec vitest run src/tests/unit/actions/ws/websocket.test.tsx` failed because workspace dependencies were not installed and `@vitejs/plugin-react` could not be resolved