### PR TITLE
Add DAW-style scene controls and sensor mocking to Beats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 Use the tooling in this repository to manage environments. Prefer `uv` for Python dependency resolution.
 
 - Pin prerelease Python dependencies with exact versions in `pyproject.toml` so `uv.lock` resolves the intended alpha or beta release.
+- When `experimental/beats/package-lock.json` drifts behind `package.json`, run `npm install` in `experimental/beats` to resync the lockfile before using `npm ci`; `npm ci` will refuse to install while the files are out of sync.
 - Scene and asset bootstrap can run before `pygame.display.set_mode`; avoid unconditional `convert()` or `convert_alpha()` calls in asset constructors and defer display-dependent conversion until a surface exists.
 - `DisplayContext` wraps the active `pygame.Surface`; renderers that need surface-only APIs such as `subsurface()` must use `window.screen` after confirming it is initialized instead of calling those APIs on `DisplayContext` directly.
 - Only the real display-owned `DisplayContext` may change pygame display modes; scratch or post-processing contexts must keep `can_configure_display=False` and never call `pygame.display.set_mode()`.
@@ -203,6 +204,12 @@ Define CLI default values as module-level constants so they stay consistent acro
 - `2026-03-30`: `.venv/bin/docformatter -i -r --config ./pyproject.toml docs`
 - `2026-03-30`: `.venv/bin/mdformat docs`
 - `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/94af/heart/.uv-cache make test`
+- `2026-03-31`: `npm install` in `experimental/beats` to resync `package-lock.json` after `npm ci` failed because the lockfile was missing `protobufjs` and related transitive dependencies.
+- `2026-03-31`: `./node_modules/.bin/prettier --write src/components/stream.tsx src/components/stream-cube.tsx src/components/scene-plugin-dock.tsx src/components/sensor-lab-panel.tsx src/components/sensor-history-chart.tsx src/features/stream-console/sensor-simulation.ts src/features/stream-console/use-sensor-simulation.ts` in `experimental/beats`
+- `2026-03-31`: `./node_modules/.bin/eslint src/components/stream.tsx src/components/stream-cube.tsx src/components/scene-plugin-dock.tsx src/components/sensor-lab-panel.tsx src/components/sensor-history-chart.tsx src/features/stream-console/scene-config.ts src/features/stream-console/sensor-simulation.ts src/features/stream-console/use-sensor-simulation.ts src/tests/unit/features/stream-console/sensor-simulation.test.ts` in `experimental/beats`
+- `2026-03-31`: `./node_modules/.bin/prettier --check src/components/stream.tsx src/components/stream-cube.tsx src/components/scene-plugin-dock.tsx src/components/sensor-lab-panel.tsx src/components/sensor-history-chart.tsx src/features/stream-console/scene-config.ts src/features/stream-console/sensor-simulation.ts src/features/stream-console/use-sensor-simulation.ts src/tests/unit/features/stream-console/sensor-simulation.test.ts` in `experimental/beats`
+- `2026-03-31`: `npm run test -- src/tests/unit/features/stream-console/sensor-simulation.test.ts` in `experimental/beats`
+- `2026-03-31`: `./node_modules/.bin/tsc --noEmit` in `experimental/beats` still fails because of pre-existing TypeScript issues in the app and its dependencies, including `@electron-forge/plugin-vite` types, the protobuf `?raw` import declaration, existing route typing drift, and unrelated component typing errors outside the new stream-console files.
 - `2026-03-30`: `.venv/bin/pytest tests/navigation/test_game_modes.py`
 - `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/e46a/heart/.uv-cache make format`
 - `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/e46a/heart/.uv-cache make test`

--- a/docs/research/beats_scene_control_console.md
+++ b/docs/research/beats_scene_control_console.md
@@ -1,0 +1,32 @@
+# Beats Scene Control Console Research Note
+
+## Summary
+
+Add a DAW-style control surface to the Beats Electron stream view so operators can tune scene parameters, bind sensor-driven reactions, and mock sensor values from the same screen.
+
+## Motivation
+
+The previous stream page was a passive viewer with only websocket status and FPS readouts. That made it hard to shape the Three.js scene, inspect sensor values, or rehearse telemetry-driven behavior without editing code or attaching real hardware.
+
+## Implementation Notes
+
+- The stream route now presents a transport-style header, a scene mixer, a responsive plugin rack, and a dedicated sensor console on the same page.
+- Scene controls are modeled in `experimental/beats/src/features/stream-console/scene-config.ts` and applied live in `experimental/beats/src/components/stream-cube.tsx`.
+- Sensor extraction, override evaluation, and history sampling live under `experimental/beats/src/features/stream-console/` so the UI reads one consistent model for live and mocked channels.
+- The plugin rack and sensor console are implemented in `experimental/beats/src/components/scene-plugin-dock.tsx`, `experimental/beats/src/components/sensor-lab-panel.tsx`, and `experimental/beats/src/components/sensor-history-chart.tsx`.
+- Focused unit coverage for the sensor simulation utilities lives in `experimental/beats/src/tests/unit/features/stream-console/sensor-simulation.test.ts`.
+
+## Source References
+
+- `experimental/beats/src/components/stream.tsx`
+- `experimental/beats/src/components/stream-cube.tsx`
+- `experimental/beats/src/components/scene-plugin-dock.tsx`
+- `experimental/beats/src/components/sensor-lab-panel.tsx`
+- `experimental/beats/src/components/sensor-history-chart.tsx`
+- `experimental/beats/src/features/stream-console/scene-config.ts`
+- `experimental/beats/src/features/stream-console/sensor-simulation.ts`
+- `experimental/beats/src/features/stream-console/use-sensor-simulation.ts`
+
+## Materials
+
+- Node.js and npm for the Electron/Vite workspace under `experimental/beats`

--- a/experimental/beats/package-lock.json
+++ b/experimental/beats/package-lock.json
@@ -32,6 +32,7 @@
         "electron-squirrel-startup": "^1.0.1",
         "i18next": "^25.6.3",
         "lucide-react": "^0.553.0",
+        "protobufjs": "^7.5.4",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-i18next": "^16.2.4",
@@ -3314,6 +3315,70 @@
         "node": ">=18"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
@@ -4215,6 +4280,7 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.4.2.tgz",
       "integrity": "sha512-H4B4+FDNHpvIb4FmphH4ubxOfX5bxmfOw0+3pkQwR9u9wFiyMS7wUDkNn0m4RqQuiLWeia9jfN1eBvtyAVGEog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/react-reconciler": "^0.32.0",
@@ -5600,7 +5666,6 @@
       "version": "24.10.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
-      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -11855,6 +11920,12 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -13407,6 +13478,30 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.3",
@@ -15883,7 +15978,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unique-filename": {

--- a/experimental/beats/src/components/scene-plugin-dock.tsx
+++ b/experimental/beats/src/components/scene-plugin-dock.tsx
@@ -1,0 +1,478 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  DEFAULT_SCENE_CONFIGURATION,
+  type SceneConfiguration,
+} from "@/features/stream-console/scene-config";
+import { cn } from "@/utils/tailwind";
+import { Aperture, Boxes, Orbit, Radar, Sparkles, Zap } from "lucide-react";
+import type { ReactNode } from "react";
+
+type SensorOption = {
+  id: string;
+  label: string;
+};
+
+export function ScenePluginDock({
+  sceneConfig,
+  sensorOptions,
+  onChange,
+  onReset,
+}: {
+  sceneConfig: SceneConfiguration;
+  sensorOptions: SensorOption[];
+  onChange: (next: SceneConfiguration) => void;
+  onReset: () => void;
+}) {
+  function updateMotion(patch: Partial<SceneConfiguration["motion"]>) {
+    onChange({
+      ...sceneConfig,
+      motion: {
+        ...sceneConfig.motion,
+        ...patch,
+      },
+    });
+  }
+
+  function updateCamera(patch: Partial<SceneConfiguration["camera"]>) {
+    onChange({
+      ...sceneConfig,
+      camera: {
+        ...sceneConfig.camera,
+        ...patch,
+      },
+    });
+  }
+
+  function updateStage(patch: Partial<SceneConfiguration["stage"]>) {
+    onChange({
+      ...sceneConfig,
+      stage: {
+        ...sceneConfig.stage,
+        ...patch,
+      },
+    });
+  }
+
+  function updateSurface(patch: Partial<SceneConfiguration["surface"]>) {
+    onChange({
+      ...sceneConfig,
+      surface: {
+        ...sceneConfig.surface,
+        ...patch,
+      },
+    });
+  }
+
+  function updateTelemetry(patch: Partial<SceneConfiguration["telemetry"]>) {
+    onChange({
+      ...sceneConfig,
+      telemetry: {
+        ...sceneConfig.telemetry,
+        ...patch,
+      },
+    });
+  }
+
+  return (
+    <section className="rounded-[1.5rem] border border-[#2f353f] bg-[linear-gradient(180deg,_rgba(29,33,40,0.96),_rgba(15,18,24,0.98))] p-4 shadow-[0_24px_60px_rgba(0,0,0,0.45)]">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <p className="font-tomorrow text-[11px] tracking-[0.22em] text-[#7f8ea3] uppercase">
+            Device Rack
+          </p>
+          <h2 className="font-tomorrow text-lg tracking-[0.14em] text-slate-100 uppercase">
+            Configurable Plugins
+          </h2>
+          <p className="text-sm text-[#a4b0c2]">
+            Tune the stream scene like a modular effects chain.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onReset}
+          className="border-[#404754] bg-[#10141a] text-slate-200 hover:bg-[#171c23]"
+        >
+          Reset
+        </Button>
+      </div>
+
+      <div className="flex gap-3 overflow-x-auto pb-1 xl:grid xl:grid-cols-1 xl:overflow-visible">
+        <PluginCard
+          icon={<Orbit className="h-4 w-4" />}
+          title="Motion"
+          description="Drive cube rotation and idle drift."
+          stateLabel={sceneConfig.motion.autoRotate ? "Armed" : "Manual"}
+          tone="emerald"
+        >
+          <BooleanField
+            label="Auto Rotate"
+            value={sceneConfig.motion.autoRotate}
+            onToggle={(value) => updateMotion({ autoRotate: value })}
+          />
+          <RangeField
+            label="Pitch Speed"
+            value={sceneConfig.motion.rotationX}
+            min={0}
+            max={0.05}
+            step={0.001}
+            onChange={(value) => updateMotion({ rotationX: value })}
+          />
+          <RangeField
+            label="Yaw Speed"
+            value={sceneConfig.motion.rotationY}
+            min={0}
+            max={0.05}
+            step={0.001}
+            onChange={(value) => updateMotion({ rotationY: value })}
+          />
+          <RangeField
+            label="Wobble"
+            value={sceneConfig.motion.wobbleAmount}
+            min={0}
+            max={0.5}
+            step={0.01}
+            onChange={(value) => updateMotion({ wobbleAmount: value })}
+          />
+          <RangeField
+            label="Hover"
+            value={sceneConfig.motion.hoverAmount}
+            min={0}
+            max={0.5}
+            step={0.01}
+            onChange={(value) => updateMotion({ hoverAmount: value })}
+          />
+        </PluginCard>
+
+        <PluginCard
+          icon={<Aperture className="h-4 w-4" />}
+          title="Camera"
+          description="Move the viewer closer or widen the lens."
+          stateLabel={`${sceneConfig.camera.distance.toFixed(1)}u`}
+          tone="sky"
+        >
+          <RangeField
+            label="Distance"
+            value={sceneConfig.camera.distance}
+            min={2.5}
+            max={8}
+            step={0.1}
+            onChange={(value) => updateCamera({ distance: value })}
+          />
+          <RangeField
+            label="Field of View"
+            value={sceneConfig.camera.fov}
+            min={28}
+            max={75}
+            step={1}
+            onChange={(value) => updateCamera({ fov: value })}
+          />
+        </PluginCard>
+
+        <PluginCard
+          icon={<Boxes className="h-4 w-4" />}
+          title="Stage"
+          description="Control lighting, grid, and background energy."
+          stateLabel={sceneConfig.stage.showGrid ? "Live Grid" : "Grid Hidden"}
+          tone="amber"
+        >
+          <BooleanField
+            label="Grid"
+            value={sceneConfig.stage.showGrid}
+            onToggle={(value) => updateStage({ showGrid: value })}
+          />
+          <RangeField
+            label="Grid Opacity"
+            value={sceneConfig.stage.gridOpacity}
+            min={0}
+            max={0.8}
+            step={0.01}
+            onChange={(value) => updateStage({ gridOpacity: value })}
+          />
+          <RangeField
+            label="Ambient Light"
+            value={sceneConfig.stage.ambientIntensity}
+            min={0}
+            max={1.6}
+            step={0.05}
+            onChange={(value) => updateStage({ ambientIntensity: value })}
+          />
+          <RangeField
+            label="Key Light"
+            value={sceneConfig.stage.keyIntensity}
+            min={0}
+            max={2}
+            step={0.05}
+            onChange={(value) => updateStage({ keyIntensity: value })}
+          />
+          <RangeField
+            label="Backdrop"
+            value={sceneConfig.stage.backgroundTint}
+            min={0}
+            max={1}
+            step={0.01}
+            onChange={(value) => updateStage({ backgroundTint: value })}
+          />
+        </PluginCard>
+
+        <PluginCard
+          icon={<Sparkles className="h-4 w-4" />}
+          title="Surface"
+          description="Adjust cube scale and material response."
+          stateLabel={`${sceneConfig.surface.textureRepeat.toFixed(1)}x tile`}
+          tone="violet"
+        >
+          <RangeField
+            label="Scale"
+            value={sceneConfig.surface.cubeScale}
+            min={0.8}
+            max={2}
+            step={0.02}
+            onChange={(value) => updateSurface({ cubeScale: value })}
+          />
+          <RangeField
+            label="Texture Repeat"
+            value={sceneConfig.surface.textureRepeat}
+            min={1}
+            max={4}
+            step={0.1}
+            onChange={(value) => updateSurface({ textureRepeat: value })}
+          />
+          <RangeField
+            label="Metalness"
+            value={sceneConfig.surface.metalness}
+            min={0}
+            max={1}
+            step={0.01}
+            onChange={(value) => updateSurface({ metalness: value })}
+          />
+          <RangeField
+            label="Roughness"
+            value={sceneConfig.surface.roughness}
+            min={0}
+            max={1}
+            step={0.01}
+            onChange={(value) => updateSurface({ roughness: value })}
+          />
+        </PluginCard>
+
+        <PluginCard
+          icon={<Radar className="h-4 w-4" />}
+          title="Telemetry Reactor"
+          description="Let a sensor push motion, hover, or scale in real time."
+          stateLabel={sceneConfig.telemetry.enabled ? "Coupled" : "Bypassed"}
+          tone="rose"
+        >
+          <BooleanField
+            label="Sensor Driven"
+            value={sceneConfig.telemetry.enabled}
+            onToggle={(value) => updateTelemetry({ enabled: value })}
+          />
+          <LabeledField label="Sensor">
+            <select
+              className="h-9 w-full rounded-md border border-[#404754] bg-[#0c1015] px-3 text-sm text-[#e3edf7]"
+              value={sceneConfig.telemetry.sensorId ?? ""}
+              onChange={(event) =>
+                updateTelemetry({
+                  sensorId: event.target.value || null,
+                })
+              }
+            >
+              <option value="">Use selected sensor</option>
+              {sensorOptions.map((sensor) => (
+                <option key={sensor.id} value={sensor.id}>
+                  {sensor.label}
+                </option>
+              ))}
+            </select>
+          </LabeledField>
+          <LabeledField label="Target">
+            <select
+              className="h-9 w-full rounded-md border border-[#404754] bg-[#0c1015] px-3 text-sm text-[#e3edf7]"
+              value={sceneConfig.telemetry.target}
+              onChange={(event) =>
+                updateTelemetry({
+                  target: event.target
+                    .value as SceneConfiguration["telemetry"]["target"],
+                })
+              }
+            >
+              <option value="hover">Hover</option>
+              <option value="rotation">Rotation</option>
+              <option value="scale">Scale</option>
+            </select>
+          </LabeledField>
+          <RangeField
+            label="Gain"
+            value={sceneConfig.telemetry.gain}
+            min={0}
+            max={0.5}
+            step={0.01}
+            onChange={(value) => updateTelemetry({ gain: value })}
+          />
+        </PluginCard>
+      </div>
+
+      <div className="mt-4 rounded-xl border border-[#3a414c] bg-[#0c1015] px-3 py-2 text-xs text-[#95a2b6]">
+        Reset returns the scene to the default dock profile from{" "}
+        <span className="font-mono text-[#e3edf7]">
+          {DEFAULT_SCENE_CONFIGURATION.motion.rotationY.toFixed(3)}
+        </span>{" "}
+        yaw speed, a visible grid, and telemetry-driven hover.
+      </div>
+    </section>
+  );
+}
+
+function PluginCard({
+  children,
+  description,
+  icon,
+  stateLabel,
+  title,
+  tone,
+}: {
+  children: ReactNode;
+  description: string;
+  icon: ReactNode;
+  stateLabel: string;
+  title: string;
+  tone: "amber" | "emerald" | "rose" | "sky" | "violet";
+}) {
+  return (
+    <section className="relative min-w-[280px] flex-1 overflow-hidden rounded-[1.25rem] border border-[#3a414c] bg-[linear-gradient(180deg,_rgba(39,44,54,0.96),_rgba(20,23,30,0.98))] p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] xl:min-w-0">
+      <div
+        className={cn(
+          "absolute inset-y-0 left-0 w-1.5",
+          toneMeterClassNames[tone],
+        )}
+      />
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2 text-sm font-semibold text-slate-100">
+            <span
+              className={cn(
+                "rounded-[0.9rem] border border-white/8 p-2",
+                toneClassNames[tone],
+              )}
+            >
+              {icon}
+            </span>
+            {title}
+          </div>
+          <p className="text-xs text-[#a4b0c2]">{description}</p>
+        </div>
+        <span className="font-tomorrow rounded-full border border-[#454d59] bg-[#0d1116] px-2 py-1 text-[10px] tracking-[0.2em] text-[#9ca9bb] uppercase">
+          {stateLabel}
+        </span>
+      </div>
+      <div className="space-y-3">{children}</div>
+    </section>
+  );
+}
+
+function LabeledField({
+  children,
+  label,
+}: {
+  children: ReactNode;
+  label: string;
+}) {
+  return (
+    <label className="block space-y-2">
+      <span className="font-tomorrow text-[10px] tracking-[0.2em] text-[#7f8ea3] uppercase">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+function RangeField({
+  label,
+  max,
+  min,
+  onChange,
+  step,
+  value,
+}: {
+  label: string;
+  max: number;
+  min: number;
+  onChange: (next: number) => void;
+  step: number;
+  value: number;
+}) {
+  return (
+    <label className="block space-y-2">
+      <div className="font-tomorrow flex items-center justify-between gap-2 text-[10px] tracking-[0.2em] text-[#7f8ea3] uppercase">
+        <span>{label}</span>
+        <span className="rounded-md bg-[#0d1116] px-2 py-1 font-mono text-[#dce6f5]">
+          {value.toFixed(step >= 1 ? 0 : step >= 0.1 ? 1 : 2)}
+        </span>
+      </div>
+      <Input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(event) => onChange(Number(event.target.value))}
+        className="h-2 cursor-ew-resize border-[#404754] bg-[#0b0f14] px-0 py-0"
+      />
+    </label>
+  );
+}
+
+function BooleanField({
+  label,
+  onToggle,
+  value,
+}: {
+  label: string;
+  onToggle: (value: boolean) => void;
+  value: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-xl border border-[#404754] bg-[#10141a] px-3 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+      <div>
+        <div className="text-sm font-medium text-slate-100">{label}</div>
+        <div className="text-xs text-[#8d9bb0]">
+          {value ? "Enabled" : "Disabled"}
+        </div>
+      </div>
+      <Button
+        type="button"
+        variant={value ? "default" : "outline"}
+        size="sm"
+        onClick={() => onToggle(!value)}
+        className={
+          value
+            ? "bg-[#3b82f6] text-white hover:bg-[#2563eb]"
+            : "border-[#404754] bg-[#171c23] text-slate-200 hover:bg-[#1f252d]"
+        }
+      >
+        <Zap className="h-4 w-4" />
+        {value ? "On" : "Off"}
+      </Button>
+    </div>
+  );
+}
+
+const toneClassNames = {
+  amber: "bg-amber-500/12 text-amber-300",
+  emerald: "bg-emerald-500/12 text-emerald-300",
+  rose: "bg-rose-500/12 text-rose-300",
+  sky: "bg-sky-500/12 text-sky-300",
+  violet: "bg-violet-500/12 text-violet-300",
+};
+
+const toneMeterClassNames = {
+  amber: "bg-gradient-to-b from-amber-300 via-amber-500 to-amber-700",
+  emerald: "bg-gradient-to-b from-emerald-300 via-emerald-500 to-emerald-700",
+  rose: "bg-gradient-to-b from-rose-300 via-rose-500 to-rose-700",
+  sky: "bg-gradient-to-b from-sky-300 via-sky-500 to-sky-700",
+  violet: "bg-gradient-to-b from-violet-300 via-violet-500 to-violet-700",
+};

--- a/experimental/beats/src/components/sensor-history-chart.tsx
+++ b/experimental/beats/src/components/sensor-history-chart.tsx
@@ -1,0 +1,234 @@
+import type { SensorHistoryPoint } from "@/features/stream-console/sensor-simulation";
+
+const CHART_HEIGHT = 220;
+const CHART_WIDTH = 720;
+const DEFAULT_WINDOW_SECONDS = 30;
+
+type ChartLine = {
+  color: string;
+  key: "effectiveValue" | "liveValue" | "referenceValue";
+  label: string;
+};
+
+const CHART_LINES: ChartLine[] = [
+  {
+    color: "#34d399",
+    key: "effectiveValue",
+    label: "Applied",
+  },
+  {
+    color: "#e2e8f0",
+    key: "liveValue",
+    label: "Live",
+  },
+  {
+    color: "#f59e0b",
+    key: "referenceValue",
+    label: "Function",
+  },
+];
+
+export function SensorHistoryChart({
+  points,
+  windowSeconds = DEFAULT_WINDOW_SECONDS,
+}: {
+  points: SensorHistoryPoint[];
+  windowSeconds?: number;
+}) {
+  if (points.length === 0) {
+    return (
+      <div className="flex h-[220px] items-center justify-center rounded-xl border border-dashed border-[#404754] bg-[#0b0f14] text-sm text-[#95a2b6]">
+        History will appear after the first sensor samples are collected.
+      </div>
+    );
+  }
+
+  const endTime = points[points.length - 1]?.timeSeconds ?? 0;
+  const startTime = Math.max(0, endTime - windowSeconds);
+  const visiblePoints = points.filter(
+    (point) => point.timeSeconds >= startTime,
+  );
+  const domain = computeDomain(visiblePoints);
+  const hasFunctionSeries = visiblePoints.some(
+    (point) => point.referenceValue !== null,
+  );
+
+  return (
+    <div className="rounded-xl border border-[#404754] bg-[#0b0f14] p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <p className="font-tomorrow text-[10px] tracking-[0.22em] text-[#738194] uppercase">
+            Sensor Trace
+          </p>
+          <h3 className="font-tomorrow text-sm tracking-[0.12em] text-slate-100 uppercase">
+            Last {windowSeconds}s
+          </h3>
+        </div>
+        <div className="flex flex-wrap gap-3 text-[11px] tracking-[0.16em] text-[#8d9bb0] uppercase">
+          {CHART_LINES.filter(
+            (line) => hasFunctionSeries || line.key !== "referenceValue",
+          ).map((line) => (
+            <span key={line.key} className="flex items-center gap-2">
+              <span
+                className="h-2.5 w-2.5 rounded-full"
+                style={{ backgroundColor: line.color }}
+              />
+              {line.label}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="relative">
+        <svg
+          viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+          className="h-[220px] w-full rounded-lg bg-slate-950/80"
+          role="img"
+          aria-label="Sensor history chart"
+        >
+          {Array.from({ length: 5 }).map((_, index) => {
+            const y = (index / 4) * CHART_HEIGHT;
+            return (
+              <line
+                key={`h-${index}`}
+                x1={0}
+                y1={y}
+                x2={CHART_WIDTH}
+                y2={y}
+                stroke="rgba(148, 163, 184, 0.16)"
+                strokeWidth={1}
+              />
+            );
+          })}
+          {Array.from({ length: 7 }).map((_, index) => {
+            const x = (index / 6) * CHART_WIDTH;
+            return (
+              <line
+                key={`v-${index}`}
+                x1={x}
+                y1={0}
+                x2={x}
+                y2={CHART_HEIGHT}
+                stroke="rgba(148, 163, 184, 0.12)"
+                strokeWidth={1}
+              />
+            );
+          })}
+
+          {CHART_LINES.filter(
+            (line) => hasFunctionSeries || line.key !== "referenceValue",
+          ).map((line) => {
+            const polylinePoints = toPolylinePoints(
+              visiblePoints,
+              line.key,
+              startTime,
+              endTime,
+              domain,
+            );
+            if (!polylinePoints) {
+              return null;
+            }
+
+            return (
+              <polyline
+                key={line.key}
+                fill="none"
+                points={polylinePoints}
+                stroke={line.color}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={line.key === "effectiveValue" ? 3 : 2}
+              />
+            );
+          })}
+        </svg>
+
+        <div className="pointer-events-none absolute inset-x-0 top-0 flex justify-between px-2 pt-2 text-[10px] tracking-[0.14em] text-slate-300 uppercase">
+          <span>{domain.max.toFixed(2)}</span>
+          <span>Now</span>
+        </div>
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-between px-2 pb-2 text-[10px] tracking-[0.14em] text-slate-400 uppercase">
+          <span>{domain.min.toFixed(2)}</span>
+          <span>{startTime.toFixed(0)}s</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function computeDomain(points: SensorHistoryPoint[]) {
+  const values = points.flatMap((point) => [
+    point.liveValue,
+    point.effectiveValue,
+    point.referenceValue,
+  ]);
+  const numericValues = values.filter(
+    (value): value is number =>
+      typeof value === "number" && Number.isFinite(value),
+  );
+
+  if (numericValues.length === 0) {
+    return { min: -1, max: 1 };
+  }
+
+  let min = Math.min(...numericValues);
+  let max = Math.max(...numericValues);
+
+  if (min === max) {
+    min -= 1;
+    max += 1;
+  }
+
+  const padding = (max - min) * 0.1;
+  return {
+    min: min - padding,
+    max: max + padding,
+  };
+}
+
+function toPolylinePoints(
+  points: SensorHistoryPoint[],
+  key: ChartLine["key"],
+  startTime: number,
+  endTime: number,
+  domain: { min: number; max: number },
+) {
+  const samples = points.flatMap((point) => {
+    const value = point[key];
+    if (value === null || !Number.isFinite(value)) {
+      return [];
+    }
+
+    return [
+      `${scaleX(point.timeSeconds, startTime, endTime)},${scaleY(
+        value,
+        domain.min,
+        domain.max,
+      )}`,
+    ];
+  });
+
+  if (samples.length === 0) {
+    return null;
+  }
+
+  if (samples.length === 1) {
+    return `${samples[0]} ${samples[0]}`;
+  }
+
+  return samples.join(" ");
+}
+
+function scaleX(value: number, min: number, max: number) {
+  if (max <= min) {
+    return CHART_WIDTH;
+  }
+  return ((value - min) / (max - min)) * CHART_WIDTH;
+}
+
+function scaleY(value: number, min: number, max: number) {
+  if (max <= min) {
+    return CHART_HEIGHT / 2;
+  }
+  return CHART_HEIGHT - ((value - min) / (max - min)) * CHART_HEIGHT;
+}

--- a/experimental/beats/src/components/sensor-lab-panel.tsx
+++ b/experimental/beats/src/components/sensor-lab-panel.tsx
@@ -1,0 +1,343 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { SensorHistoryChart } from "@/components/sensor-history-chart";
+import {
+  SENSOR_FUNCTION_PRESETS,
+  defaultSensorOverride,
+  formatSensorValue,
+  type ResolvedSensorChannel,
+  type SensorHistoryPoint,
+  type SensorOverride,
+} from "@/features/stream-console/sensor-simulation";
+import { Activity, Gauge, SlidersHorizontal, Waveform } from "lucide-react";
+
+export function SensorLabPanel({
+  clockSeconds,
+  onClearHistory,
+  onResetOverride,
+  onSelectSensor,
+  onUpdateOverride,
+  override,
+  selectedSensor,
+  selectedSensorHistory,
+  sensors,
+}: {
+  clockSeconds: number;
+  onClearHistory: () => void;
+  onResetOverride: (sensorId: string) => void;
+  onSelectSensor: (sensorId: string) => void;
+  onUpdateOverride: (sensorId: string, patch: Partial<SensorOverride>) => void;
+  override: SensorOverride;
+  selectedSensor: ResolvedSensorChannel | null;
+  selectedSensorHistory: SensorHistoryPoint[];
+  sensors: ResolvedSensorChannel[];
+}) {
+  return (
+    <section className="rounded-[1.5rem] border border-[#2f353f] bg-[linear-gradient(180deg,_rgba(29,33,40,0.96),_rgba(14,17,23,0.98))] p-4 shadow-[0_24px_60px_rgba(0,0,0,0.45)]">
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="font-tomorrow text-[11px] tracking-[0.22em] text-[#7f8ea3] uppercase">
+            Sensor Rack
+          </p>
+          <h2 className="font-tomorrow text-lg tracking-[0.14em] text-slate-100 uppercase">
+            Mocking and Trace Console
+          </h2>
+          <p className="text-sm text-[#a4b0c2]">
+            Compare live values, applied overrides, and time-driven functions in
+            one panel.
+          </p>
+        </div>
+        <div className="rounded-xl border border-[#3a414c] bg-[#0b0f14] px-3 py-2 text-right shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+          <div className="font-tomorrow text-[10px] tracking-[0.2em] text-[#738194] uppercase">
+            Simulation Clock
+          </div>
+          <div className="font-mono text-xl text-[#e3edf7]">
+            {clockSeconds.toFixed(1)}s
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[280px_minmax(0,1fr)]">
+        <div className="space-y-3">
+          <div className="rounded-xl border border-[#3a414c] bg-[#10141a] p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+            <div className="mb-3 flex items-center gap-2">
+              <Activity className="h-4 w-4 text-emerald-500" />
+              <h3 className="font-tomorrow text-sm tracking-[0.12em] text-slate-100 uppercase">
+                Detected Sensors
+              </h3>
+            </div>
+            <div className="space-y-2">
+              {sensors.map((sensor) => (
+                <button
+                  key={sensor.id}
+                  type="button"
+                  onClick={() => onSelectSensor(sensor.id)}
+                  className={`w-full rounded-xl border px-3 py-3 text-left transition ${
+                    selectedSensor?.id === sensor.id
+                      ? "border-[#5b8cff] bg-[#162235] shadow-[inset_0_0_0_1px_rgba(91,140,255,0.2)]"
+                      : "border-[#3a414c] bg-[#181d24] hover:bg-[#1d232c]"
+                  }`}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-sm font-medium text-slate-100">
+                      {sensor.label}
+                    </span>
+                    <span className="font-tomorrow rounded-full border border-[#464e5b] px-2 py-0.5 text-[10px] tracking-[0.16em] text-[#96a3b7] uppercase">
+                      {sensor.source}
+                    </span>
+                  </div>
+                  <div className="mt-1 flex items-center justify-between gap-3 text-xs text-[#95a2b6]">
+                    <span>Live {sensor.displayValue}</span>
+                    <span>
+                      Applied {formatSensorValue(sensor.effectiveValue, 2)}
+                    </span>
+                  </div>
+                  <div className="mt-3 h-2 overflow-hidden rounded-full bg-[#0d1116]">
+                    <div
+                      className="h-full rounded-full bg-gradient-to-r from-emerald-400 via-amber-300 to-rose-400"
+                      style={{
+                        width: `${Math.max(
+                          8,
+                          Math.round(
+                            Math.abs(Math.tanh(sensor.effectiveValue)) * 100,
+                          ),
+                        )}%`,
+                      }}
+                    />
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          {selectedSensor ? (
+            <>
+              <div className="rounded-xl border border-[#3a414c] bg-[#10141a] p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+                <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <Gauge className="h-4 w-4 text-sky-500" />
+                      <h3 className="text-base font-semibold text-slate-100">
+                        {selectedSensor.label}
+                      </h3>
+                    </div>
+                    <p className="mt-1 text-sm text-[#9aa7ba]">
+                      Path:{" "}
+                      <span className="font-mono text-[#dfe8f5]">
+                        {selectedSensor.path}
+                      </span>
+                    </p>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={onClearHistory}
+                      className="border-[#404754] bg-[#171c23] text-slate-200 hover:bg-[#1f252d]"
+                    >
+                      Clear History
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => onResetOverride(selectedSensor.id)}
+                      className="border-[#404754] bg-[#171c23] text-slate-200 hover:bg-[#1f252d]"
+                    >
+                      Reset Mock
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="grid gap-3 md:grid-cols-3">
+                  <MetricTile
+                    label="Live"
+                    value={formatSensorValue(selectedSensor.value, 2)}
+                    helper={selectedSensor.displayValue}
+                  />
+                  <MetricTile
+                    label="Applied"
+                    value={formatSensorValue(selectedSensor.effectiveValue, 2)}
+                    helper={
+                      override.mode === "live"
+                        ? "Following hardware"
+                        : override.mode === "constant"
+                          ? "Pinned constant"
+                          : "Function output"
+                    }
+                  />
+                  <MetricTile
+                    label="Reference"
+                    value={formatSensorValue(selectedSensor.referenceValue, 2)}
+                    helper={
+                      selectedSensor.evaluationError
+                        ? selectedSensor.evaluationError
+                        : override.mode === "function"
+                          ? "Function target"
+                          : "No function"
+                    }
+                    accent={
+                      selectedSensor.evaluationError
+                        ? "text-amber-500"
+                        : undefined
+                    }
+                  />
+                </div>
+              </div>
+
+              <div className="rounded-xl border border-[#3a414c] bg-[#10141a] p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+                <div className="mb-4 flex items-center gap-2">
+                  <SlidersHorizontal className="h-4 w-4 text-violet-500" />
+                  <h3 className="font-tomorrow text-sm tracking-[0.12em] text-slate-100 uppercase">
+                    Mock Source
+                  </h3>
+                </div>
+                <div className="mb-4 flex flex-wrap gap-2">
+                  {(["live", "constant", "function"] as const).map((mode) => (
+                    <Button
+                      key={mode}
+                      type="button"
+                      size="sm"
+                      variant={override.mode === mode ? "default" : "outline"}
+                      onClick={() =>
+                        onUpdateOverride(selectedSensor.id, { mode })
+                      }
+                      className={
+                        override.mode === mode
+                          ? "bg-[#3b82f6] text-white hover:bg-[#2563eb]"
+                          : "border-[#404754] bg-[#171c23] text-slate-200 hover:bg-[#1f252d]"
+                      }
+                    >
+                      {mode}
+                    </Button>
+                  ))}
+                </div>
+
+                {override.mode === "constant" ? (
+                  <label className="block space-y-2">
+                    <span className="font-tomorrow text-[10px] tracking-[0.2em] text-[#7f8ea3] uppercase">
+                      Constant Value
+                    </span>
+                    <Input
+                      type="number"
+                      value={override.constantValue}
+                      step="0.1"
+                      className="border-[#404754] bg-[#0c1015] font-mono text-[#e3edf7]"
+                      onChange={(event) =>
+                        onUpdateOverride(selectedSensor.id, {
+                          constantValue: Number(event.target.value),
+                        })
+                      }
+                    />
+                  </label>
+                ) : null}
+
+                {override.mode === "function" ? (
+                  <div className="space-y-3">
+                    <label className="block space-y-2">
+                      <span className="font-tomorrow text-[10px] tracking-[0.2em] text-[#7f8ea3] uppercase">
+                        Function of t (seconds)
+                      </span>
+                      <textarea
+                        className="min-h-[96px] w-full rounded-md border border-[#404754] bg-[#0c1015] px-3 py-2 font-mono text-sm text-[#e3edf7] transition outline-none focus-visible:border-[#6f9fff] focus-visible:ring-2 focus-visible:ring-[#6f9fff]/30"
+                        value={override.expression}
+                        onChange={(event) =>
+                          onUpdateOverride(selectedSensor.id, {
+                            expression: event.target.value,
+                          })
+                        }
+                      />
+                    </label>
+                    <div className="flex flex-wrap gap-2">
+                      {SENSOR_FUNCTION_PRESETS.map((preset) => (
+                        <Button
+                          key={preset.label}
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          className="border-[#404754] bg-[#171c23] text-slate-200 hover:bg-[#1f252d]"
+                          onClick={() =>
+                            onUpdateOverride(selectedSensor.id, {
+                              expression: preset.expression,
+                            })
+                          }
+                        >
+                          {preset.label}
+                        </Button>
+                      ))}
+                    </div>
+                    <div className="rounded-xl border border-[#404754] bg-[#171c23] p-3 text-xs text-[#95a2b6]">
+                      Available helpers: <span className="font-mono">sin</span>,{" "}
+                      <span className="font-mono">cos</span>,{" "}
+                      <span className="font-mono">triangle</span>,{" "}
+                      <span className="font-mono">pulse</span>,{" "}
+                      <span className="font-mono">saw</span>,{" "}
+                      <span className="font-mono">clamp</span>, and{" "}
+                      <span className="font-mono">mix</span>.
+                    </div>
+                  </div>
+                ) : null}
+
+                {override.mode === "live" ? (
+                  <div className="rounded-xl border border-[#404754] bg-[#171c23] p-3 text-sm text-[#95a2b6]">
+                    Live mode forwards the latest connected peripheral value
+                    without modification.
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="rounded-xl border border-[#3a414c] bg-[#10141a] p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+                <div className="mb-4 flex items-center gap-2">
+                  <Waveform className="h-4 w-4 text-amber-500" />
+                  <h3 className="font-tomorrow text-sm tracking-[0.12em] text-slate-100 uppercase">
+                    Observed vs Reference
+                  </h3>
+                </div>
+                <SensorHistoryChart points={selectedSensorHistory} />
+              </div>
+            </>
+          ) : (
+            <div className="flex min-h-[320px] items-center justify-center rounded-xl border border-dashed border-[#404754] bg-[#10141a] text-sm text-[#95a2b6]">
+              No sensor selected.
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function MetricTile({
+  accent,
+  helper,
+  label,
+  value,
+}: {
+  accent?: string;
+  helper: string;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-xl border border-[#404754] bg-[#0b0f14] p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+      <div className="font-tomorrow text-[10px] tracking-[0.2em] text-[#738194] uppercase">
+        {label}
+      </div>
+      <div className="mt-1 font-mono text-2xl text-[#e3edf7] tabular-nums">
+        {value}
+      </div>
+      <div className={`mt-1 text-xs text-[#95a2b6] ${accent ?? ""}`}>
+        {helper}
+      </div>
+    </div>
+  );
+}
+
+export function getSensorOverrideForPanel(
+  override: SensorOverride | undefined,
+) {
+  return override ?? defaultSensorOverride();
+}

--- a/experimental/beats/src/components/stream-cube.tsx
+++ b/experimental/beats/src/components/stream-cube.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import { type SceneConfiguration } from "@/features/stream-console/scene-config";
 import {
   AmbientLight,
   BoxGeometry,
@@ -18,24 +19,29 @@ import {
 
 import { Skeleton } from "./ui/skeleton";
 
-const CAMERA_DISTANCE = 4;
-const ROTATION_DELTA = { x: 0.01, y: 0.015 } as const;
 const GRID_SIZE = 6;
 const GRID_DIVISIONS = 10;
 const GRID_COLOR = 0xffffff;
-const GRID_OPACITY = 0.18;
+const GRID_BASELINE_Y = -1.2;
+const MAX_TELEMETRY_SIGNAL = 1;
 
 export type StreamCubeProps = {
   imgURL: string | null;
   onContextError?: () => void;
+  sceneConfig: SceneConfiguration;
+  telemetryValue: number;
 };
 
-export function StreamCube({ imgURL, onContextError }: StreamCubeProps) {
+export function StreamCube({
+  imgURL,
+  onContextError,
+  sceneConfig,
+  telemetryValue,
+}: StreamCubeProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
   const rendererRef = useRef<WebGLRenderer | null>(null);
-  const sceneRef = useRef<Scene | null>(null);
   const cameraRef = useRef<PerspectiveCamera | null>(null);
   const cubeRef = useRef<Mesh<BoxGeometry, MeshStandardMaterial[]> | null>(
     null,
@@ -45,6 +51,18 @@ export function StreamCube({ imgURL, onContextError }: StreamCubeProps) {
   const lastTextureRef = useRef<Texture | null>(null);
   const animationRef = useRef<number | null>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const readyFrameRef = useRef<number | null>(null);
+  const sceneConfigRef = useRef(sceneConfig);
+  const telemetryValueRef = useRef(telemetryValue);
+  const [isRendererReady, setIsRendererReady] = useState(false);
+
+  useEffect(() => {
+    sceneConfigRef.current = sceneConfig;
+  }, [sceneConfig]);
+
+  useEffect(() => {
+    telemetryValueRef.current = telemetryValue;
+  }, [telemetryValue]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -65,32 +83,47 @@ export function StreamCube({ imgURL, onContextError }: StreamCubeProps) {
       scene.background = null;
 
       const { clientWidth: width, clientHeight: height } = container;
-      const camera = new PerspectiveCamera(45, width / height, 0.1, 100);
-      camera.position.set(0, 0, CAMERA_DISTANCE);
+      const camera = new PerspectiveCamera(
+        sceneConfigRef.current.camera.fov,
+        width / height,
+        0.1,
+        100,
+      );
+      camera.position.set(0, 0, sceneConfigRef.current.camera.distance);
 
-      const ambient = new AmbientLight(0xffffff, 0.6);
-      const directional = new DirectionalLight(0xffffff, 0.8);
+      const ambient = new AmbientLight(
+        0xffffff,
+        sceneConfigRef.current.stage.ambientIntensity,
+      );
+      const directional = new DirectionalLight(
+        0xffffff,
+        sceneConfigRef.current.stage.keyIntensity,
+      );
       directional.position.set(2, 3, 4);
       scene.add(ambient, directional);
 
-      const grid = new GridHelper(GRID_SIZE, GRID_DIVISIONS, GRID_COLOR, GRID_COLOR);
-      grid.position.y = -1.2;
-      const gridMaterial = grid.material;
-      if (Array.isArray(gridMaterial)) {
-        gridMaterial.forEach((material) => {
-          material.transparent = true;
-          material.opacity = GRID_OPACITY;
-        });
-      } else {
-        gridMaterial.transparent = true;
-        gridMaterial.opacity = GRID_OPACITY;
-      }
+      const grid = new GridHelper(
+        GRID_SIZE,
+        GRID_DIVISIONS,
+        GRID_COLOR,
+        GRID_COLOR,
+      );
+      grid.position.y = GRID_BASELINE_Y;
+      applyGridOpacity(grid, sceneConfigRef.current.stage.gridOpacity);
       scene.add(grid);
 
       const geometry = new BoxGeometry(2, 2, 2);
-      const fallbackTexture = createFallbackTexture();
-      const materials = Array.from({ length: 6 }, () =>
-        new MeshStandardMaterial({ map: fallbackTexture }),
+      const fallbackTexture = createFallbackTexture(
+        sceneConfigRef.current.surface.textureRepeat,
+      );
+      const materials = Array.from(
+        { length: 6 },
+        () =>
+          new MeshStandardMaterial({
+            map: fallbackTexture,
+            metalness: sceneConfigRef.current.surface.metalness,
+            roughness: sceneConfigRef.current.surface.roughness,
+          }),
       );
       const cube = new Mesh(geometry, materials);
       scene.add(cube);
@@ -98,15 +131,68 @@ export function StreamCube({ imgURL, onContextError }: StreamCubeProps) {
       renderer.setSize(width, height, false);
 
       rendererRef.current = renderer;
-      sceneRef.current = scene;
       cameraRef.current = camera;
       cubeRef.current = cube;
       gridRef.current = grid;
       fallbackTextureRef.current = fallbackTexture;
+      readyFrameRef.current = window.requestAnimationFrame(() => {
+        setIsRendererReady(true);
+      });
 
       const renderFrame = () => {
-        cube.rotation.x += ROTATION_DELTA.x;
-        cube.rotation.y += ROTATION_DELTA.y;
+        const elapsedSeconds = performance.now() / 1000;
+        const currentConfig = sceneConfigRef.current;
+        const rawTelemetry = currentConfig.telemetry.enabled
+          ? Math.tanh(telemetryValueRef.current * currentConfig.telemetry.gain)
+          : 0;
+        const telemetrySignal = Math.max(
+          -MAX_TELEMETRY_SIGNAL,
+          Math.min(MAX_TELEMETRY_SIGNAL, rawTelemetry),
+        );
+        const hoverOffset =
+          Math.sin(elapsedSeconds * 0.9) * currentConfig.motion.hoverAmount +
+          (currentConfig.telemetry.target === "hover"
+            ? telemetrySignal * 0.5
+            : 0);
+        const wobbleOffset =
+          Math.sin(elapsedSeconds * 1.2) * currentConfig.motion.wobbleAmount;
+        const telemetryScale =
+          currentConfig.telemetry.target === "scale"
+            ? 1 + telemetrySignal * 0.22
+            : 1;
+
+        if (currentConfig.motion.autoRotate) {
+          cube.rotation.x +=
+            currentConfig.motion.rotationX +
+            (currentConfig.telemetry.target === "rotation"
+              ? telemetrySignal * 0.004
+              : 0);
+          cube.rotation.y +=
+            currentConfig.motion.rotationY +
+            (currentConfig.telemetry.target === "rotation"
+              ? telemetrySignal * 0.006
+              : 0);
+        } else if (currentConfig.telemetry.target === "rotation") {
+          cube.rotation.y += telemetrySignal * 0.008;
+        }
+
+        cube.rotation.z = wobbleOffset * 0.3;
+        cube.position.y = hoverOffset;
+        cube.scale.setScalar(currentConfig.surface.cubeScale * telemetryScale);
+
+        camera.position.z = currentConfig.camera.distance;
+        if (camera.fov !== currentConfig.camera.fov) {
+          camera.fov = currentConfig.camera.fov;
+          camera.updateProjectionMatrix();
+        }
+
+        ambient.intensity = currentConfig.stage.ambientIntensity;
+        directional.intensity = currentConfig.stage.keyIntensity;
+        grid.visible = currentConfig.stage.showGrid;
+        grid.position.y = GRID_BASELINE_Y - wobbleOffset * 0.5;
+        applyGridOpacity(grid, currentConfig.stage.gridOpacity);
+        applySurfaceSettings(cube.material, currentConfig);
+
         renderer.render(scene, camera);
         animationRef.current = window.requestAnimationFrame(renderFrame);
       };
@@ -130,6 +216,9 @@ export function StreamCube({ imgURL, onContextError }: StreamCubeProps) {
     return () => {
       if (animationRef.current) {
         cancelAnimationFrame(animationRef.current);
+      }
+      if (readyFrameRef.current) {
+        cancelAnimationFrame(readyFrameRef.current);
       }
 
       resizeObserverRef.current?.disconnect();
@@ -162,7 +251,6 @@ export function StreamCube({ imgURL, onContextError }: StreamCubeProps) {
 
       rendererRef.current?.dispose();
       rendererRef.current = null;
-      sceneRef.current = null;
       cameraRef.current = null;
       cubeRef.current = null;
       gridRef.current = null;
@@ -180,7 +268,15 @@ export function StreamCube({ imgURL, onContextError }: StreamCubeProps) {
 
       let nextTexture: Texture | null = null;
       try {
-        nextTexture = imgURL ? await loadTexture(imgURL) : fallbackTextureRef.current;
+        nextTexture = imgURL
+          ? await loadTexture(imgURL)
+          : fallbackTextureRef.current;
+        if (nextTexture) {
+          applyTextureSettings(
+            nextTexture,
+            sceneConfigRef.current.surface.textureRepeat,
+          );
+        }
       } catch (error) {
         console.warn("Failed to load streamed texture; using fallback", error);
         nextTexture = fallbackTextureRef.current;
@@ -198,7 +294,11 @@ export function StreamCube({ imgURL, onContextError }: StreamCubeProps) {
         const previousMap = material.map;
         material.map = nextTexture;
         material.needsUpdate = true;
-        if (previousMap && previousMap !== nextTexture && previousMap !== fallbackTextureRef.current) {
+        if (
+          previousMap &&
+          previousMap !== nextTexture &&
+          previousMap !== fallbackTextureRef.current
+        ) {
           previousMap.dispose();
         }
       });
@@ -207,7 +307,8 @@ export function StreamCube({ imgURL, onContextError }: StreamCubeProps) {
         lastTextureRef.current.dispose();
       }
 
-      lastTextureRef.current = nextTexture === fallbackTextureRef.current ? null : nextTexture;
+      lastTextureRef.current =
+        nextTexture === fallbackTextureRef.current ? null : nextTexture;
     };
 
     applyTexture();
@@ -217,15 +318,27 @@ export function StreamCube({ imgURL, onContextError }: StreamCubeProps) {
     };
   }, [imgURL]);
 
+  const backgroundTint = Math.round(sceneConfig.stage.backgroundTint * 100);
+
   return (
-    <div ref={containerRef} className="relative flex-1 min-h-[240px] w-full rounded-md bg-muted/40">
+    <div
+      ref={containerRef}
+      className="relative min-h-[240px] w-full flex-1 overflow-hidden rounded-[1.5rem] border border-[#343b45]"
+      style={{
+        background: `radial-gradient(circle at 20% 20%, rgba(14, 165, 233, ${
+          0.08 + backgroundTint / 500
+        }), transparent 35%), radial-gradient(circle at 80% 20%, rgba(244, 63, 94, ${
+          0.05 + backgroundTint / 700
+        }), transparent 28%), linear-gradient(180deg, rgba(15, 23, 42, 0.95), rgba(2, 6, 23, 1))`,
+      }}
+    >
       <canvas ref={canvasRef} className="size-full" />
-      {!rendererRef.current && <Skeleton className="absolute inset-0" />}
+      {!isRendererReady && <Skeleton className="absolute inset-0" />}
     </div>
   );
 }
 
-function createFallbackTexture() {
+function createFallbackTexture(repeat: number) {
   const size = 128;
   const canvas = document.createElement("canvas");
   canvas.width = size;
@@ -248,11 +361,47 @@ function createFallbackTexture() {
 
   const texture = new CanvasTexture(canvas);
   texture.colorSpace = SRGBColorSpace;
-  texture.wrapS = RepeatWrapping;
-  texture.wrapT = RepeatWrapping;
-  texture.repeat.set(2, 2);
+  applyTextureSettings(texture, repeat);
 
   return texture;
+}
+
+function applyGridOpacity(grid: GridHelper, opacity: number) {
+  const gridMaterial = grid.material;
+  if (Array.isArray(gridMaterial)) {
+    gridMaterial.forEach((material) => {
+      material.transparent = true;
+      material.opacity = opacity;
+    });
+  } else {
+    gridMaterial.transparent = true;
+    gridMaterial.opacity = opacity;
+  }
+}
+
+function applySurfaceSettings(
+  materials: MeshStandardMaterial[],
+  sceneConfig: SceneConfiguration,
+) {
+  for (const material of materials) {
+    material.metalness = sceneConfig.surface.metalness;
+    material.roughness = sceneConfig.surface.roughness;
+    if (material.map) {
+      applyTextureSettings(material.map, sceneConfig.surface.textureRepeat);
+    }
+  }
+}
+
+function applyTextureSettings(texture: Texture, repeat: number) {
+  if (texture.userData.repeat === repeat) {
+    return;
+  }
+
+  texture.wrapS = RepeatWrapping;
+  texture.wrapT = RepeatWrapping;
+  texture.repeat.set(repeat, repeat);
+  texture.userData.repeat = repeat;
+  texture.needsUpdate = true;
 }
 
 function loadTexture(url: string) {

--- a/experimental/beats/src/components/stream.tsx
+++ b/experimental/beats/src/components/stream.tsx
@@ -1,82 +1,301 @@
 import { useStreamedImage } from "@/actions/ws/providers/ImageProvider";
 import { useWS } from "@/actions/ws/websocket";
+import { DEFAULT_SCENE_CONFIGURATION } from "@/features/stream-console/scene-config";
+import { useSensorSimulation } from "@/features/stream-console/use-sensor-simulation";
 import { Antenna } from "lucide-react";
 import { useCallback, useState } from "react";
 import type { ComponentProps } from "react";
 
+import { ScenePluginDock } from "./scene-plugin-dock";
+import { SensorLabPanel, getSensorOverrideForPanel } from "./sensor-lab-panel";
 import { StreamCube } from "./stream-cube";
 import { Separator } from "./ui/separator";
 import { Skeleton } from "./ui/skeleton";
 
 function getStatusClasses(streamIsActive: boolean) {
   return streamIsActive
-    ? "text-green-500 status-green-blink"
-    : "text-red-500 status-red-blink";
+    ? "text-green-400 status-green-blink"
+    : "text-rose-400 status-red-blink";
 }
 
-export function StreamStatus(
-  {
-    streamIsActive,
-    ...divProps
-  }: ComponentProps<"div"> & {
-    streamIsActive: boolean;
-  },
-) {
+export function StreamStatus({
+  streamIsActive,
+  ...divProps
+}: ComponentProps<"div"> & {
+  streamIsActive: boolean;
+}) {
   return (
     <div
       {...divProps}
-      className="font-tomorrow text-muted-foreground flex items-center text-[0.7rem] uppercase justify-end"
+      className="font-tomorrow flex items-center justify-end text-[0.7rem] tracking-[0.22em] text-[#94a3b8] uppercase"
     >
-      <Antenna className={`h-[1rem] mr-1 ${getStatusClasses(streamIsActive)}`} />
-      <span>{streamIsActive ? "Active" : "Not Active"}</span>
+      <Antenna
+        className={`mr-1 h-[1rem] ${getStatusClasses(streamIsActive)}`}
+      />
+      <span>{streamIsActive ? "Active" : "Offline"}</span>
     </div>
   );
 }
 
 export function StreamedImage({ imgURL }: { imgURL: string | null }) {
-  if (!imgURL) return <Skeleton className="size-full" />;
+  if (!imgURL) {
+    return <Skeleton className="size-full" />;
+  }
 
-  return (
-    <img
-      src={imgURL}
-      alt="stream"
-      className="size-full object-contain"
-    />
-  );
+  return <img src={imgURL} alt="stream" className="size-full object-contain" />;
 }
 
 export function Stream() {
   const ws = useWS();
   const { imgURL, isActive, fps } = useStreamedImage();
   const [useImageFallback, setUseImageFallback] = useState(false);
+  const [sceneConfig, setSceneConfig] = useState(DEFAULT_SCENE_CONFIGURATION);
+  const {
+    clockSeconds,
+    overrides,
+    resolvedSensors,
+    selectedSensor,
+    selectedSensorHistory,
+    selectedSensorId,
+    setSelectedSensorId,
+    updateSensorOverride,
+    resetSensorOverride,
+    clearSelectedSensorHistory,
+  } = useSensorSimulation();
+
   const handleContextError = useCallback(() => {
     setUseImageFallback(true);
   }, []);
 
+  const telemetrySensorId = sceneConfig.telemetry.sensorId ?? selectedSensorId;
+  const telemetrySensor =
+    resolvedSensors.find((sensor) => sensor.id === telemetrySensorId) ?? null;
+  const telemetryValue = telemetrySensor?.effectiveValue ?? 0;
+
   return (
-    <div className="flex h-full flex-col select-none">
-      <div className="flex-1 w-full min-h-0">
-        {useImageFallback ? (
-          <StreamedImage imgURL={imgURL} />
-        ) : (
-          <StreamCube
-            imgURL={imgURL}
-            onContextError={handleContextError}
-          />
-        )}
+    <div className="flex h-full flex-col gap-4 rounded-[1.75rem] bg-[radial-gradient(circle_at_top_left,_rgba(16,185,129,0.08),_transparent_28%),linear-gradient(180deg,_#11151b,_#090b0f)] p-4 text-slate-100 shadow-[0_30px_80px_rgba(0,0,0,0.45)] select-none">
+      <div className="rounded-[1.4rem] border border-[#2f353f] bg-[linear-gradient(180deg,_rgba(26,30,38,0.96),_rgba(14,17,23,0.98))] px-4 py-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <div className="grid grid-cols-3 gap-1 rounded-[0.9rem] border border-[#3b434f] bg-[#0a0d12] p-2">
+              {[
+                isActive ? "#34d399" : "#29303a",
+                telemetrySensor ? "#fbbf24" : "#29303a",
+                useImageFallback ? "#fb7185" : "#38bdf8",
+              ].map((color, index) => (
+                <span
+                  key={index}
+                  className="h-2.5 w-2.5 rounded-full"
+                  style={{ backgroundColor: color }}
+                />
+              ))}
+            </div>
+            <div>
+              <p className="font-tomorrow text-[11px] tracking-[0.26em] text-[#7f8ea3] uppercase">
+                Beats Transport
+              </p>
+              <h1 className="font-tomorrow text-xl tracking-[0.14em] text-slate-100 uppercase">
+                Scene Control Console
+              </h1>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <TransportChip
+              label="Clock"
+              value={`${clockSeconds.toFixed(1)}s`}
+            />
+            <TransportChip label="FPS" value={String(isActive ? fps : 0)} />
+            <TransportChip
+              label="Sensor"
+              value={telemetrySensor?.label ?? "Unassigned"}
+            />
+            <TransportChip
+              label="Render"
+              value={useImageFallback ? "Fallback" : "Realtime"}
+            />
+          </div>
+        </div>
       </div>
 
-      <Separator className="my-4 flex-none" />
+      <div className="grid min-h-0 flex-1 gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(340px,420px)]">
+        <section className="flex min-h-0 flex-col gap-4">
+          <div className="rounded-[1.5rem] border border-[#2f353f] bg-[linear-gradient(180deg,_rgba(28,32,39,0.96),_rgba(13,16,21,0.98))] p-4 shadow-[0_24px_60px_rgba(0,0,0,0.45)]">
+            <div className="mb-4 flex flex-wrap items-start justify-between gap-4">
+              <div>
+                <p className="font-tomorrow text-[11px] tracking-[0.24em] text-[#7f8ea3] uppercase">
+                  Stream Scene
+                </p>
+                <h2 className="font-tomorrow text-2xl tracking-[0.12em] text-slate-100 uppercase">
+                  Visual Mixer
+                </h2>
+                <p className="mt-2 max-w-3xl text-sm text-[#a4b0c2]">
+                  Tune the renderer, bind telemetry-reactive plugins, and
+                  rehearse sensor behavior against the live stream.
+                </p>
+              </div>
+              <div className="grid gap-2 sm:grid-cols-3">
+                <StatusChip
+                  label="Telemetry Sensor"
+                  value={telemetrySensor?.label ?? "None"}
+                />
+                <StatusChip
+                  label="Renderer"
+                  value={useImageFallback ? "Image fallback" : "Three.js"}
+                />
+                <StatusChip
+                  label="WebSocket"
+                  value={ws?.socket?.url ?? "Disconnected"}
+                />
+              </div>
+            </div>
 
-      {/* Footer */}
-      <div className="flex-none mb-2 flex items-center justify-between gap-4 px-2">
-        <span className="text-xs text-muted-foreground font-tomorrow uppercase">
-          fps: <b>{isActive ? fps : 0}</b>
+            <div className="mb-4 grid gap-3 lg:grid-cols-[1.2fr_0.8fr]">
+              <div className="rounded-[1.2rem] border border-[#353c46] bg-[#0c1015] px-4 py-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+                <div className="flex items-center justify-between gap-4">
+                  <div>
+                    <p className="font-tomorrow text-[10px] tracking-[0.24em] text-[#6f7d91] uppercase">
+                      Transport
+                    </p>
+                    <p className="mt-1 font-mono text-2xl text-[#e3edf7]">
+                      {clockSeconds.toFixed(1)}s
+                    </p>
+                  </div>
+                  <div className="flex flex-1 items-end gap-1">
+                    {Array.from({ length: 16 }).map((_, index) => {
+                      const threshold = (index + 1) / 16;
+                      const signal = Math.abs(Math.tanh(telemetryValue));
+                      const active = signal >= threshold;
+                      return (
+                        <span
+                          key={index}
+                          className="flex-1 rounded-sm"
+                          style={{
+                            height: `${index > 11 ? 38 : index > 7 ? 30 : 22}px`,
+                            backgroundColor: active
+                              ? index > 12
+                                ? "#fb7185"
+                                : index > 8
+                                  ? "#fbbf24"
+                                  : "#34d399"
+                              : "#1d242d",
+                          }}
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-[1.2rem] border border-[#353c46] bg-[#0c1015] px-4 py-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+                <p className="font-tomorrow text-[10px] tracking-[0.24em] text-[#6f7d91] uppercase">
+                  Active Module
+                </p>
+                <p className="font-tomorrow mt-2 text-lg tracking-[0.12em] text-slate-100 uppercase">
+                  {sceneConfig.telemetry.target} Reactor
+                </p>
+                <p className="mt-1 text-sm text-[#a4b0c2]">
+                  Gain {sceneConfig.telemetry.gain.toFixed(2)} | Camera{" "}
+                  {sceneConfig.camera.distance.toFixed(1)}u
+                </p>
+              </div>
+            </div>
+
+            <div className="min-h-0">
+              {useImageFallback ? (
+                <div className="relative min-h-[420px] overflow-hidden rounded-[1.5rem] border border-[#343b45] bg-[#0a0d12]">
+                  <StreamedImage imgURL={imgURL} />
+                  <div className="font-tomorrow absolute top-4 left-4 rounded-full border border-[#3b434f] bg-[#11161d] px-3 py-1 text-[11px] tracking-[0.2em] text-[#9ba8ba] uppercase">
+                    WebGL fallback active
+                  </div>
+                </div>
+              ) : (
+                <StreamCube
+                  imgURL={imgURL}
+                  onContextError={handleContextError}
+                  sceneConfig={sceneConfig}
+                  telemetryValue={telemetryValue}
+                />
+              )}
+            </div>
+          </div>
+
+          <div className="xl:hidden">
+            <ScenePluginDock
+              sceneConfig={sceneConfig}
+              sensorOptions={resolvedSensors.map((sensor) => ({
+                id: sensor.id,
+                label: sensor.label,
+              }))}
+              onChange={setSceneConfig}
+              onReset={() => setSceneConfig(DEFAULT_SCENE_CONFIGURATION)}
+            />
+          </div>
+
+          <SensorLabPanel
+            clockSeconds={clockSeconds}
+            onClearHistory={clearSelectedSensorHistory}
+            onResetOverride={resetSensorOverride}
+            onSelectSensor={setSelectedSensorId}
+            onUpdateOverride={updateSensorOverride}
+            override={getSensorOverrideForPanel(
+              selectedSensor ? overrides[selectedSensor.id] : undefined,
+            )}
+            selectedSensor={selectedSensor}
+            selectedSensorHistory={selectedSensorHistory}
+            sensors={resolvedSensors}
+          />
+        </section>
+
+        <aside className="hidden min-h-0 xl:flex xl:flex-col xl:gap-4">
+          <ScenePluginDock
+            sceneConfig={sceneConfig}
+            sensorOptions={resolvedSensors.map((sensor) => ({
+              id: sensor.id,
+              label: sensor.label,
+            }))}
+            onChange={setSceneConfig}
+            onReset={() => setSceneConfig(DEFAULT_SCENE_CONFIGURATION)}
+          />
+        </aside>
+      </div>
+
+      <Separator className="flex-none bg-[#252b33]" />
+
+      <div className="mb-2 flex flex-none flex-wrap items-center justify-between gap-4 rounded-[1.1rem] border border-[#2f353f] bg-[#10141a] px-3 py-2">
+        <span className="font-tomorrow text-[11px] tracking-[0.22em] text-[#7f8ea3] uppercase">
+          fps: <b className="text-slate-100">{isActive ? fps : 0}</b>
         </span>
-        <div className="text-xs text-muted-foreground font-tomorrow">
+        <div className="font-mono text-xs text-[#8d9bb0]">
           {ws?.socket?.url}
         </div>
         <StreamStatus streamIsActive={isActive} />
+      </div>
+    </div>
+  );
+}
+
+function StatusChip({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-[1rem] border border-[#343c46] bg-[#0c1015] px-3 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+      <div className="font-tomorrow text-[10px] tracking-[0.2em] text-[#6f7d91] uppercase">
+        {label}
+      </div>
+      <div className="mt-1 max-w-[180px] truncate font-mono text-sm text-[#dce6f5]">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function TransportChip({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-[108px] rounded-[0.95rem] border border-[#3a414c] bg-[#0b0e13] px-3 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+      <div className="font-tomorrow text-[10px] tracking-[0.22em] text-[#738194] uppercase">
+        {label}
+      </div>
+      <div className="mt-1 truncate font-mono text-sm text-[#e5edf8]">
+        {value}
       </div>
     </div>
   );

--- a/experimental/beats/src/features/stream-console/scene-config.ts
+++ b/experimental/beats/src/features/stream-console/scene-config.ts
@@ -1,0 +1,67 @@
+export type TelemetryTarget = "rotation" | "hover" | "scale";
+
+export type SceneConfiguration = {
+  motion: {
+    autoRotate: boolean;
+    rotationX: number;
+    rotationY: number;
+    wobbleAmount: number;
+    hoverAmount: number;
+  };
+  camera: {
+    distance: number;
+    fov: number;
+  };
+  stage: {
+    showGrid: boolean;
+    gridOpacity: number;
+    ambientIntensity: number;
+    keyIntensity: number;
+    backgroundTint: number;
+  };
+  surface: {
+    cubeScale: number;
+    textureRepeat: number;
+    metalness: number;
+    roughness: number;
+  };
+  telemetry: {
+    enabled: boolean;
+    sensorId: string | null;
+    gain: number;
+    target: TelemetryTarget;
+  };
+};
+
+export const DEFAULT_SCENE_CONFIGURATION: SceneConfiguration = {
+  motion: {
+    autoRotate: true,
+    rotationX: 0.01,
+    rotationY: 0.015,
+    wobbleAmount: 0.12,
+    hoverAmount: 0.18,
+  },
+  camera: {
+    distance: 4.4,
+    fov: 45,
+  },
+  stage: {
+    showGrid: true,
+    gridOpacity: 0.18,
+    ambientIntensity: 0.6,
+    keyIntensity: 0.8,
+    backgroundTint: 0.35,
+  },
+  surface: {
+    cubeScale: 1,
+    textureRepeat: 2,
+    metalness: 0.08,
+    roughness: 0.72,
+  },
+  telemetry: {
+    enabled: true,
+    sensorId: null,
+    gain: 0.08,
+    target: "hover",
+  },
+};

--- a/experimental/beats/src/features/stream-console/sensor-simulation.ts
+++ b/experimental/beats/src/features/stream-console/sensor-simulation.ts
@@ -1,0 +1,360 @@
+import type {
+  PeripheralInfo,
+  PeripheralTag,
+} from "@/actions/ws/providers/PeripheralProvider";
+
+const DEFAULT_DEMO_TIMESTAMP = 0;
+const DEMO_SENSOR_CHANNELS: SensorChannel[] = [
+  {
+    id: "demo.temperature",
+    peripheralId: "demo.temperature",
+    label: "Demo Temperature",
+    path: "value",
+    value: 21.4,
+    rawValue: 21.4,
+    displayValue: "21.40",
+    updatedAt: DEFAULT_DEMO_TIMESTAMP,
+    tags: [
+      {
+        name: "input_variant",
+        variant: "demo",
+      },
+    ],
+    source: "demo",
+  },
+  {
+    id: "demo.motion",
+    peripheralId: "demo.motion",
+    label: "Demo Motion",
+    path: "value",
+    value: 0.28,
+    rawValue: 0.28,
+    displayValue: "0.28",
+    updatedAt: DEFAULT_DEMO_TIMESTAMP,
+    tags: [
+      {
+        name: "input_variant",
+        variant: "demo",
+      },
+    ],
+    source: "demo",
+  },
+];
+
+const MATH_SCOPE = {
+  PI: Math.PI,
+  E: Math.E,
+  abs: Math.abs,
+  ceil: Math.ceil,
+  clamp: (value: number, min: number, max: number) =>
+    Math.min(max, Math.max(min, value)),
+  cos: Math.cos,
+  exp: Math.exp,
+  floor: Math.floor,
+  log: Math.log,
+  max: Math.max,
+  min: Math.min,
+  mix: (start: number, end: number, amount: number) =>
+    start + (end - start) * amount,
+  pow: Math.pow,
+  pulse: (timeSeconds: number, periodSeconds: number, dutyCycle = 0.5) => {
+    if (periodSeconds <= 0) {
+      return 0;
+    }
+    const cycle =
+      ((timeSeconds % periodSeconds) + periodSeconds) % periodSeconds;
+    return cycle / periodSeconds <= dutyCycle ? 1 : 0;
+  },
+  round: Math.round,
+  saw: (timeSeconds: number, periodSeconds = 1) => {
+    if (periodSeconds <= 0) {
+      return 0;
+    }
+    const cycle =
+      ((timeSeconds % periodSeconds) + periodSeconds) % periodSeconds;
+    return cycle / periodSeconds;
+  },
+  sin: Math.sin,
+  smoothstep: (edge0: number, edge1: number, x: number) => {
+    if (edge0 === edge1) {
+      return 0;
+    }
+    const normalized = Math.min(1, Math.max(0, (x - edge0) / (edge1 - edge0)));
+    return normalized * normalized * (3 - 2 * normalized);
+  },
+  sqrt: Math.sqrt,
+  tan: Math.tan,
+  triangle: (timeSeconds: number, periodSeconds = 1) => {
+    if (periodSeconds <= 0) {
+      return 0;
+    }
+    const cycle =
+      ((timeSeconds % periodSeconds) + periodSeconds) % periodSeconds;
+    const normalized = cycle / periodSeconds;
+    return 1 - Math.abs(normalized * 2 - 1);
+  },
+};
+
+const MATH_SCOPE_KEYS = Object.keys(MATH_SCOPE);
+const MATH_SCOPE_VALUES = Object.values(MATH_SCOPE);
+
+export const SENSOR_FUNCTION_PRESETS = [
+  {
+    label: "Breath",
+    expression: "0.4 + 0.2 * sin(t * 1.25)",
+  },
+  {
+    label: "Pulse",
+    expression: "pulse(t, 1.5, 0.18)",
+  },
+  {
+    label: "Sweep",
+    expression: "triangle(t, 8)",
+  },
+];
+
+export type LivePeripheralSnapshot = {
+  ts: number;
+  info: PeripheralInfo;
+  last_data: unknown;
+};
+
+export type SensorSource = "live" | "demo";
+
+export type SensorChannel = {
+  id: string;
+  peripheralId: string;
+  label: string;
+  path: string;
+  value: number;
+  rawValue: number | boolean;
+  displayValue: string;
+  updatedAt: number;
+  tags: PeripheralTag[];
+  source: SensorSource;
+};
+
+export type SensorOverrideMode = "live" | "constant" | "function";
+
+export type SensorOverride = {
+  mode: SensorOverrideMode;
+  constantValue: number;
+  expression: string;
+};
+
+export type ResolvedSensorChannel = SensorChannel & {
+  effectiveValue: number;
+  referenceValue: number | null;
+  evaluationError: string | null;
+};
+
+export type SensorHistoryPoint = {
+  timeSeconds: number;
+  liveValue: number;
+  effectiveValue: number;
+  referenceValue: number | null;
+};
+
+export function defaultSensorOverride(): SensorOverride {
+  return {
+    mode: "live",
+    constantValue: 0,
+    expression: SENSOR_FUNCTION_PRESETS[0].expression,
+  };
+}
+
+export function extractSensorChannels(
+  peripherals: Record<string, LivePeripheralSnapshot>,
+): SensorChannel[] {
+  const channels = Object.values(peripherals).flatMap((snapshot) =>
+    flattenSensorPayload(snapshot.info, snapshot.last_data, snapshot.ts),
+  );
+
+  if (channels.length === 0) {
+    return DEMO_SENSOR_CHANNELS;
+  }
+
+  return channels.sort((left, right) => left.label.localeCompare(right.label));
+}
+
+export function compileSensorExpression(expression: string) {
+  if (!expression.trim()) {
+    return {
+      evaluate: null,
+      error: "Enter a function that returns a numeric value.",
+    };
+  }
+
+  try {
+    const compiled = new Function(
+      "t",
+      ...MATH_SCOPE_KEYS,
+      `"use strict"; return (${expression});`,
+    ) as (...args: unknown[]) => unknown;
+
+    return {
+      evaluate: (timeSeconds: number) => {
+        const result = compiled(timeSeconds, ...MATH_SCOPE_VALUES);
+        if (typeof result !== "number" || !Number.isFinite(result)) {
+          throw new Error("The function must return a finite number.");
+        }
+        return result;
+      },
+      error: null,
+    };
+  } catch (error) {
+    return {
+      evaluate: null,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to compile expression.",
+    };
+  }
+}
+
+export function resolveSensorChannel(
+  sensor: SensorChannel,
+  override: SensorOverride | undefined,
+  timeSeconds: number,
+): ResolvedSensorChannel {
+  if (!override || override.mode === "live") {
+    return {
+      ...sensor,
+      effectiveValue: sensor.value,
+      referenceValue: null,
+      evaluationError: null,
+    };
+  }
+
+  if (override.mode === "constant") {
+    return {
+      ...sensor,
+      effectiveValue: override.constantValue,
+      referenceValue: override.constantValue,
+      evaluationError: null,
+    };
+  }
+
+  const compiled = compileSensorExpression(override.expression);
+  if (!compiled.evaluate) {
+    return {
+      ...sensor,
+      effectiveValue: sensor.value,
+      referenceValue: null,
+      evaluationError: compiled.error,
+    };
+  }
+
+  try {
+    const nextValue = compiled.evaluate(timeSeconds);
+    return {
+      ...sensor,
+      effectiveValue: nextValue,
+      referenceValue: nextValue,
+      evaluationError: null,
+    };
+  } catch (error) {
+    return {
+      ...sensor,
+      effectiveValue: sensor.value,
+      referenceValue: null,
+      evaluationError:
+        error instanceof Error
+          ? error.message
+          : "Unable to evaluate expression.",
+    };
+  }
+}
+
+export function appendSensorHistory(
+  history: SensorHistoryPoint[],
+  nextPoint: SensorHistoryPoint,
+  limit: number,
+) {
+  const nextHistory = [...history, nextPoint];
+  if (nextHistory.length <= limit) {
+    return nextHistory;
+  }
+  return nextHistory.slice(nextHistory.length - limit);
+}
+
+export function formatSensorValue(value: number | null, digits = 3) {
+  if (value === null || Number.isNaN(value)) {
+    return "n/a";
+  }
+  return value.toFixed(digits);
+}
+
+function flattenSensorPayload(
+  peripheral: PeripheralInfo,
+  value: unknown,
+  timestamp: number,
+) {
+  const peripheralId = peripheral.id ?? "unknown";
+  const entries = collectNumericEntries(value);
+
+  return entries.map(({ path, numericValue, rawValue }) => {
+    const label =
+      path.length === 0 ? peripheralId : `${peripheralId} / ${path.join(".")}`;
+
+    return {
+      id: label,
+      peripheralId,
+      label,
+      path: path.length === 0 ? "value" : path.join("."),
+      value: numericValue,
+      rawValue,
+      displayValue:
+        typeof rawValue === "boolean"
+          ? String(rawValue)
+          : numericValue.toFixed(3),
+      updatedAt: timestamp,
+      tags: peripheral.tags,
+      source: "live" as const,
+    };
+  });
+}
+
+function collectNumericEntries(
+  value: unknown,
+  path: string[] = [],
+): Array<{
+  path: string[];
+  numericValue: number;
+  rawValue: number | boolean;
+}> {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return [
+      {
+        path,
+        numericValue: value,
+        rawValue: value,
+      },
+    ];
+  }
+
+  if (typeof value === "boolean") {
+    return [
+      {
+        path,
+        numericValue: value ? 1 : 0,
+        rawValue: value,
+      },
+    ];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((entry, index) =>
+      collectNumericEntries(entry, [...path, String(index)]),
+    );
+  }
+
+  if (value && typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>).flatMap(
+      ([key, entry]) => collectNumericEntries(entry, [...path, key]),
+    );
+  }
+
+  return [];
+}

--- a/experimental/beats/src/features/stream-console/use-sensor-simulation.ts
+++ b/experimental/beats/src/features/stream-console/use-sensor-simulation.ts
@@ -1,0 +1,138 @@
+import { useEffect, useRef, useState } from "react";
+import { useConnectedPeripherals } from "@/actions/ws/providers/PeripheralProvider";
+import {
+  appendSensorHistory,
+  defaultSensorOverride,
+  extractSensorChannels,
+  resolveSensorChannel,
+  type SensorHistoryPoint,
+  type SensorOverride,
+} from "./sensor-simulation";
+
+const HISTORY_LIMIT = 180;
+const SENSOR_SAMPLE_INTERVAL_MS = 250;
+
+export function useSensorSimulation() {
+  const peripherals = useConnectedPeripherals();
+  const [clockSeconds, setClockSeconds] = useState(0);
+  const [requestedSensorId, setRequestedSensorId] = useState<string | null>(
+    null,
+  );
+  const [overrides, setOverrides] = useState<Record<string, SensorOverride>>(
+    {},
+  );
+  const [history, setHistory] = useState<Record<string, SensorHistoryPoint[]>>(
+    {},
+  );
+
+  const startTimeRef = useRef(0);
+  const sensors = extractSensorChannels(peripherals);
+  const sensorsRef = useRef(sensors);
+  const overridesRef = useRef(overrides);
+  const selectedSensorId =
+    requestedSensorId &&
+    sensors.some((sensor) => sensor.id === requestedSensorId)
+      ? requestedSensorId
+      : (sensors[0]?.id ?? null);
+
+  useEffect(() => {
+    sensorsRef.current = sensors;
+  }, [sensors]);
+
+  useEffect(() => {
+    overridesRef.current = overrides;
+  }, [overrides]);
+
+  useEffect(() => {
+    startTimeRef.current = performance.now();
+
+    const interval = window.setInterval(() => {
+      const timeSeconds = (performance.now() - startTimeRef.current) / 1000;
+      setClockSeconds(timeSeconds);
+
+      const resolved = sensorsRef.current.map((sensor) =>
+        resolveSensorChannel(
+          sensor,
+          overridesRef.current[sensor.id],
+          timeSeconds,
+        ),
+      );
+
+      setHistory((previous) => {
+        const next: Record<string, SensorHistoryPoint[]> = {};
+        for (const sensor of resolved) {
+          const prior = previous[sensor.id] ?? [];
+          next[sensor.id] = appendSensorHistory(
+            prior,
+            {
+              timeSeconds,
+              liveValue: sensor.value,
+              effectiveValue: sensor.effectiveValue,
+              referenceValue: sensor.referenceValue,
+            },
+            HISTORY_LIMIT,
+          );
+        }
+        return next;
+      });
+    }, SENSOR_SAMPLE_INTERVAL_MS);
+
+    return () => window.clearInterval(interval);
+  }, []);
+
+  const resolvedSensors = sensors.map((sensor) =>
+    resolveSensorChannel(sensor, overrides[sensor.id], clockSeconds),
+  );
+  const selectedSensor =
+    resolvedSensors.find((sensor) => sensor.id === selectedSensorId) ?? null;
+  const selectedSensorHistory = selectedSensorId
+    ? (history[selectedSensorId] ?? [])
+    : [];
+
+  function updateSensorOverride(
+    sensorId: string,
+    patch: Partial<SensorOverride>,
+  ) {
+    setOverrides((previous) => ({
+      ...previous,
+      [sensorId]: {
+        ...defaultSensorOverride(),
+        ...previous[sensorId],
+        ...patch,
+      },
+    }));
+  }
+
+  function resetSensorOverride(sensorId: string) {
+    setOverrides((previous) => {
+      const next = { ...previous };
+      delete next[sensorId];
+      return next;
+    });
+  }
+
+  function clearSelectedSensorHistory() {
+    if (!selectedSensorId) {
+      return;
+    }
+
+    setHistory((previous) => ({
+      ...previous,
+      [selectedSensorId]: [],
+    }));
+  }
+
+  return {
+    clockSeconds,
+    history,
+    overrides,
+    resolvedSensors,
+    selectedSensor,
+    selectedSensorHistory,
+    selectedSensorId,
+    setSelectedSensorId: setRequestedSensorId,
+    updateSensorOverride,
+    resetSensorOverride,
+    clearSelectedSensorHistory,
+  };
+}

--- a/experimental/beats/src/tests/unit/features/stream-console/sensor-simulation.test.ts
+++ b/experimental/beats/src/tests/unit/features/stream-console/sensor-simulation.test.ts
@@ -1,0 +1,121 @@
+import {
+  appendSensorHistory,
+  compileSensorExpression,
+  extractSensorChannels,
+  resolveSensorChannel,
+} from "@/features/stream-console/sensor-simulation";
+
+describe("sensor simulation utilities", () => {
+  it("extracts numeric and boolean channels from connected peripherals", () => {
+    const channels = extractSensorChannels({
+      accel: {
+        ts: 100,
+        info: {
+          id: "accel",
+          tags: [
+            {
+              name: "input_variant",
+              variant: "accelerometer",
+            },
+          ],
+        },
+        last_data: {
+          x: 0.25,
+          y: -0.5,
+          ready: true,
+        },
+      },
+    });
+
+    expect(channels.map((channel) => channel.label)).toEqual([
+      "accel / ready",
+      "accel / x",
+      "accel / y",
+    ]);
+    expect(channels[0]?.value).toBe(1);
+    expect(channels[1]?.value).toBe(0.25);
+    expect(channels[2]?.value).toBe(-0.5);
+  });
+
+  it("falls back to demo channels when no live numeric sensors are available", () => {
+    const channels = extractSensorChannels({});
+
+    expect(channels).toHaveLength(2);
+    expect(channels.every((channel) => channel.source === "demo")).toBe(true);
+  });
+
+  it("compiles helper-based functions that depend on time", () => {
+    const compiled = compileSensorExpression("mix(10, 20, triangle(t, 8))");
+
+    expect(compiled.error).toBeNull();
+    expect(compiled.evaluate?.(2)).toBeCloseTo(15);
+  });
+
+  it("falls back to live sensor values when function evaluation fails", () => {
+    const resolved = resolveSensorChannel(
+      {
+        id: "demo.motion",
+        label: "Demo Motion",
+        path: "value",
+        peripheralId: "demo.motion",
+        value: 0.5,
+        rawValue: 0.5,
+        displayValue: "0.50",
+        updatedAt: 0,
+        tags: [],
+        source: "demo",
+      },
+      {
+        mode: "function",
+        constantValue: 0,
+        expression: "missing_function(t)",
+      },
+      4,
+    );
+
+    expect(resolved.effectiveValue).toBe(0.5);
+    expect(resolved.referenceValue).toBeNull();
+    expect(resolved.evaluationError).toContain("missing_function");
+  });
+
+  it("caps stored sensor history to the requested limit", () => {
+    const history = appendSensorHistory(
+      [
+        {
+          timeSeconds: 1,
+          liveValue: 1,
+          effectiveValue: 1,
+          referenceValue: null,
+        },
+        {
+          timeSeconds: 2,
+          liveValue: 2,
+          effectiveValue: 2,
+          referenceValue: null,
+        },
+      ],
+      {
+        timeSeconds: 3,
+        liveValue: 3,
+        effectiveValue: 3,
+        referenceValue: null,
+      },
+      2,
+    );
+
+    expect(history).toEqual([
+      {
+        timeSeconds: 2,
+        liveValue: 2,
+        effectiveValue: 2,
+        referenceValue: null,
+      },
+      {
+        timeSeconds: 3,
+        liveValue: 3,
+        effectiveValue: 3,
+        referenceValue: null,
+      },
+    ]);
+  });
+});

--- a/experimental/beats/src/tests/unit/setup.ts
+++ b/experimental/beats/src/tests/unit/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Summary
- add a DAW-inspired control surface to the Beats stream view with transport-style status, a scene mixer, and a responsive plugin dock
- add configurable scene controls for motion, camera, stage, surface, and telemetry-reactive behavior in the Three.js renderer
- add a dedicated sensor lab for selecting sensors, mocking them with constant values or time-based functions, and comparing live vs applied values over time
- add sensor simulation utilities, focused unit tests, and a research note documenting the new console
- update `AGENTS.md` with the frontend lockfile/install pitfall and validation notes, and sync the Beats lockfile

## Testing
- `./node_modules/.bin/eslint src/components/stream.tsx src/components/stream-cube.tsx src/components/scene-plugin-dock.tsx src/components/sensor-lab-panel.tsx src/components/sensor-history-chart.tsx src/features/stream-console/scene-config.ts src/features/stream-console/sensor-simulation.ts src/features/stream-console/use-sensor-simulation.ts src/tests/unit/features/stream-console/sensor-simulation.test.ts`
- `./node_modules/.bin/prettier --check src/components/stream.tsx src/components/stream-cube.tsx src/components/scene-plugin-dock.tsx src/components/sensor-lab-panel.tsx src/components/sensor-history-chart.tsx src/features/stream-console/scene-config.ts src/features/stream-console/sensor-simulation.ts src/features/stream-console/use-sensor-simulation.ts src/tests/unit/features/stream-console/sensor-simulation.test.ts`
- `npm run test -- src/tests/unit/features/stream-console/sensor-simulation.test.ts`
- `./node_modules/.bin/tsc --noEmit` still fails due to pre-existing unrelated type issues in `experimental/beats` and dependencies