### PR TITLE
Add sensor deck and generic peripheral previews to Beats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,10 @@ Define CLI default values as module-level constants so they stay consistent acro
 - `2026-03-31`: `cd experimental/beats && npm run lint` still fails because of pre-existing errors in `src/actions/ws/providers/PeripheralEventsProvider.tsx`, `src/actions/ws/providers/PeripheralProvider.tsx`, `src/components/ui/sidebar.tsx`, `src/hooks/use-mobile.ts`, and `src/layouts/base-layout.tsx`.
 - `2026-03-31`: `cd experimental/beats && npm run test`
 - `2026-03-31`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/535d/heart/.uv-cache make format`
+- `2026-03-31`: `experimental/beats: npm install --package-lock=false`
+- `2026-03-31`: `experimental/beats: ./node_modules/.bin/prettier --write src/actions/peripherals/peripheral_tree.tsx src/components/peripheral-sensor-deck.tsx src/components/ui/peripherals/generic_sensor.tsx src/routes/peripherals/connected.tsx src/tests/unit/components/generic_sensor.test.ts`
+- `2026-03-31`: `experimental/beats: ./node_modules/.bin/eslint src/actions/peripherals/peripheral_tree.tsx src/components/peripheral-sensor-deck.tsx src/components/ui/peripherals/generic_sensor.tsx src/routes/peripherals/connected.tsx src/tests/unit/components/generic_sensor.test.ts`
+- `2026-03-31`: `experimental/beats: npm run test -- src/tests/unit/components/generic_sensor.test.ts src/tests/unit/components/stream.test.tsx`
 - `2026-03-31`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/535d/heart/.uv-cache make test`
 - `2026-03-31`: `npm install` in `experimental/beats` to resync `package-lock.json` after `npm ci` failed because the lockfile was missing `protobufjs` and related transitive dependencies.
 - `2026-03-31`: `./node_modules/.bin/prettier --write src/components/stream.tsx src/components/stream-cube.tsx src/components/scene-plugin-dock.tsx src/components/sensor-lab-panel.tsx src/components/sensor-history-chart.tsx src/features/stream-console/sensor-simulation.ts src/features/stream-console/use-sensor-simulation.ts` in `experimental/beats`

--- a/experimental/beats/src/actions/peripherals/peripheral_tree.tsx
+++ b/experimental/beats/src/actions/peripherals/peripheral_tree.tsx
@@ -1,4 +1,5 @@
 import { AccelerometerView } from "@/components/ui/peripherals/accelerometer";
+import { GenericSensorPeripheralView } from "@/components/ui/peripherals/generic_sensor";
 import { RotarySwitchView } from "@/components/ui/peripherals/rotary_button";
 import { UWBPositionView } from "@/components/ui/peripherals/uwb_positioning";
 import { PaperCard, SpecChip } from "@/components/usgc";
@@ -9,11 +10,18 @@ import {
   useConnectedPeripherals,
 } from "../ws/providers/PeripheralProvider";
 
+type PeripheralSnapshot = {
+  ts: number;
+  info: PeripheralInfo;
+  last_data: unknown;
+};
+
 function tagsByName(peripheral: PeripheralInfo) {
   return Object.fromEntries(peripheral.tags.map((t) => [t.name, t]));
 }
 
-const SpecialRenderer = ({ peripheral }: { peripheral: PeripheralInfo }) => {
+const SpecialRenderer = ({ snapshot }: { snapshot: PeripheralSnapshot }) => {
+  const { info: peripheral, last_data: lastData } = snapshot;
   const c = tagsByName(peripheral);
   switch (c.input_variant?.variant) {
     case "uwb_positioning":
@@ -24,9 +32,10 @@ const SpecialRenderer = ({ peripheral }: { peripheral: PeripheralInfo }) => {
       return <RotarySwitchView peripheral={peripheral} />;
     default:
       return (
-        <div className="border-border bg-background/60 border p-4 font-mono text-sm">
-          {peripheral.id ?? "Unknown peripheral"}
-        </div>
+        <GenericSensorPeripheralView
+          lastData={lastData}
+          peripheral={peripheral}
+        />
       );
   }
 };
@@ -67,7 +76,7 @@ export function PeripheralTree({
               {peripheralEntries.map((p) => (
                 <PeripheralBranch
                   key={p.info.id ?? `unknown-${p.ts}`}
-                  peripheral={p.info}
+                  snapshot={p}
                   hierarchy={h}
                 />
               ))}
@@ -80,12 +89,13 @@ export function PeripheralTree({
 }
 
 function PeripheralBranch({
-  peripheral,
+  snapshot,
   hierarchy,
 }: {
-  peripheral: PeripheralInfo;
+  snapshot: PeripheralSnapshot;
   hierarchy: string[];
 }) {
+  const peripheral = snapshot.info;
   // Tags in the desired order
   const orderedTags = [
     ...hierarchy.map((name) => tagsByName(peripheral)[name]).filter(Boolean),
@@ -114,7 +124,7 @@ function PeripheralBranch({
         </div>
         <div className="min-w-0">
           <LeafPeripheralName
-            renderAsComponent={<SpecialRenderer peripheral={peripheral} />}
+            renderAsComponent={<SpecialRenderer snapshot={snapshot} />}
           />
         </div>
       </div>

--- a/experimental/beats/src/components/peripheral-sensor-deck.tsx
+++ b/experimental/beats/src/components/peripheral-sensor-deck.tsx
@@ -1,0 +1,109 @@
+import {
+  SensorLabPanel,
+  getSensorOverrideForPanel,
+} from "@/components/sensor-lab-panel";
+import { useSensorSimulation } from "@/features/stream-console/use-sensor-simulation";
+
+function uniquePeripheralCount(sensorIds: string[]) {
+  return new Set(sensorIds).size;
+}
+
+export function PeripheralSensorDeck() {
+  const {
+    clockSeconds,
+    overrides,
+    resolvedSensors,
+    selectedSensor,
+    selectedSensorHistory,
+    setSelectedSensorId,
+    updateSensorOverride,
+    resetSensorOverride,
+    clearSelectedSensorHistory,
+  } = useSensorSimulation();
+
+  return (
+    <div className="grid gap-6">
+      <section className="rounded-[1.5rem] border border-[#2f353f] bg-[linear-gradient(180deg,_rgba(21,26,33,0.96),_rgba(11,14,19,0.99))] p-5 text-slate-100 shadow-[0_24px_60px_rgba(0,0,0,0.45)]">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-2">
+            <p className="font-tomorrow text-[11px] tracking-[0.24em] text-[#7f8ea3] uppercase">
+              Sensor Console
+            </p>
+            <h2 className="font-tomorrow text-2xl tracking-[0.12em] uppercase">
+              Live Sensor Deck
+            </h2>
+            <p className="max-w-3xl text-sm text-[#a4b0c2]">
+              Inspect numeric channels discovered from connected peripherals,
+              pick a live source, and rehearse override behavior without leaving
+              the device catalog.
+            </p>
+          </div>
+          <div className="rounded-[1rem] border border-[#39414c] bg-[#0b0f14] px-4 py-3 text-right shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+            <p className="font-tomorrow text-[10px] tracking-[0.22em] text-[#738194] uppercase">
+              Clock
+            </p>
+            <p className="font-mono text-2xl text-[#e3edf7]">
+              {clockSeconds.toFixed(1)}s
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-5 grid gap-3 md:grid-cols-3">
+          <SensorDeckMetric
+            label="Channels"
+            value={String(resolvedSensors.length)}
+            helper="Numeric and boolean leaves available to the UI."
+          />
+          <SensorDeckMetric
+            label="Peripherals"
+            value={String(
+              uniquePeripheralCount(
+                resolvedSensors.map((sensor) => sensor.peripheralId),
+              ),
+            )}
+            helper="Distinct devices contributing live sensor paths."
+          />
+          <SensorDeckMetric
+            label="Selection"
+            value={selectedSensor?.label ?? "Awaiting selection"}
+            helper={selectedSensor?.path ?? "Choose a sensor from the rack."}
+          />
+        </div>
+      </section>
+
+      <SensorLabPanel
+        clockSeconds={clockSeconds}
+        onClearHistory={clearSelectedSensorHistory}
+        onResetOverride={resetSensorOverride}
+        onSelectSensor={setSelectedSensorId}
+        onUpdateOverride={updateSensorOverride}
+        override={getSensorOverrideForPanel(
+          selectedSensor ? overrides[selectedSensor.id] : undefined,
+        )}
+        selectedSensor={selectedSensor}
+        selectedSensorHistory={selectedSensorHistory}
+        sensors={resolvedSensors}
+      />
+    </div>
+  );
+}
+
+function SensorDeckMetric({
+  helper,
+  label,
+  value,
+}: {
+  helper: string;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-[1rem] border border-[#39414c] bg-[#10141a] px-4 py-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+      <p className="font-tomorrow text-[10px] tracking-[0.22em] text-[#738194] uppercase">
+        {label}
+      </p>
+      <p className="mt-2 truncate font-mono text-xl text-[#e3edf7]">{value}</p>
+      <p className="mt-1 text-xs text-[#93a0b4]">{helper}</p>
+    </div>
+  );
+}

--- a/experimental/beats/src/components/ui/peripherals/generic_sensor.tsx
+++ b/experimental/beats/src/components/ui/peripherals/generic_sensor.tsx
@@ -1,0 +1,174 @@
+import type { PeripheralInfo } from "@/actions/ws/providers/PeripheralProvider";
+
+type PreviewMetric = {
+  id: string;
+  label: string;
+  kind: "numeric" | "boolean";
+  value: number | boolean;
+};
+
+const MAX_PREVIEW_METRICS = 6;
+
+export function collectPreviewMetrics(payload: unknown): PreviewMetric[] {
+  const metrics: PreviewMetric[] = [];
+
+  function visit(value: unknown, path: string[]) {
+    if (metrics.length >= MAX_PREVIEW_METRICS) {
+      return;
+    }
+
+    if (typeof value === "number" && Number.isFinite(value)) {
+      metrics.push({
+        id: path.join("."),
+        label: path.join("."),
+        kind: "numeric",
+        value,
+      });
+      return;
+    }
+
+    if (typeof value === "boolean") {
+      metrics.push({
+        id: path.join("."),
+        label: path.join("."),
+        kind: "boolean",
+        value,
+      });
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      value.forEach((entry, index) => {
+        visit(entry, [...path, String(index)]);
+      });
+      return;
+    }
+
+    if (value && typeof value === "object") {
+      Object.entries(value as Record<string, unknown>).forEach(
+        ([key, entry]) => {
+          visit(entry, [...path, key]);
+        },
+      );
+    }
+  }
+
+  visit(payload, []);
+  return metrics.filter((metric) => metric.label.length > 0);
+}
+
+function formatMetricValue(metric: PreviewMetric) {
+  if (metric.kind === "boolean") {
+    return metric.value ? "On" : "Off";
+  }
+
+  return typeof metric.value === "number"
+    ? metric.value.toFixed(2)
+    : String(metric.value);
+}
+
+function metricWidth(metric: PreviewMetric) {
+  if (metric.kind === "boolean") {
+    return metric.value ? 100 : 18;
+  }
+
+  if (typeof metric.value !== "number") {
+    return 18;
+  }
+
+  return Math.max(
+    12,
+    Math.min(100, Math.round(Math.abs(Math.tanh(metric.value)) * 100)),
+  );
+}
+
+export function GenericSensorPeripheralView({
+  className,
+  lastData,
+  peripheral,
+}: {
+  className?: string;
+  lastData: unknown;
+  peripheral: PeripheralInfo;
+}) {
+  const metrics = collectPreviewMetrics(lastData);
+
+  if (metrics.length === 0) {
+    return (
+      <div
+        className={
+          "border-border bg-background/60 text-foreground flex flex-col gap-3 border p-3 text-xs " +
+          (className ?? "")
+        }
+      >
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex flex-col">
+            <span className="text-muted-foreground font-mono text-[0.7rem] tracking-wide uppercase">
+              Payload Monitor
+            </span>
+            <span className="font-mono text-sm">
+              {peripheral.id ?? "unknown_peripheral"}
+            </span>
+          </div>
+          <span className="text-muted-foreground font-mono text-[0.7rem] uppercase">
+            Raw
+          </span>
+        </div>
+        <pre className="border-border/70 bg-background/80 overflow-x-auto border p-3 font-mono text-[0.68rem] leading-5 whitespace-pre-wrap text-slate-200">
+          {JSON.stringify(lastData, null, 2) ?? "null"}
+        </pre>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={
+        "border-border bg-background/60 text-foreground flex flex-col gap-3 border p-3 text-xs " +
+        (className ?? "")
+      }
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex flex-col">
+          <span className="text-muted-foreground font-mono text-[0.7rem] tracking-wide uppercase">
+            Sensor Preview
+          </span>
+          <span className="font-mono text-sm">
+            {peripheral.id ?? "unknown_peripheral"}
+          </span>
+        </div>
+        <span className="text-muted-foreground font-mono text-[0.7rem] uppercase">
+          {metrics.length} metrics
+        </span>
+      </div>
+
+      <div className="grid gap-2">
+        {metrics.map((metric) => (
+          <div
+            key={metric.id}
+            className="border-border/70 bg-background/80 rounded-sm border px-3 py-2"
+          >
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-muted-foreground truncate font-mono text-[0.68rem] uppercase">
+                {metric.label}
+              </span>
+              <span className="font-mono text-sm text-slate-100">
+                {formatMetricValue(metric)}
+              </span>
+            </div>
+            <div className="bg-border/40 mt-2 h-1.5 overflow-hidden rounded-full">
+              <div
+                className={
+                  metric.kind === "boolean"
+                    ? "h-full rounded-full bg-cyan-400"
+                    : "h-full rounded-full bg-gradient-to-r from-emerald-400 via-amber-300 to-rose-400"
+                }
+                style={{ width: `${metricWidth(metric)}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/experimental/beats/src/routes/peripherals/connected.tsx
+++ b/experimental/beats/src/routes/peripherals/connected.tsx
@@ -1,4 +1,5 @@
 import { PeripheralTree } from "@/actions/peripherals/peripheral_tree";
+import { PeripheralSensorDeck } from "@/components/peripheral-sensor-deck";
 import {
   PageFrame,
   PaperCard,
@@ -22,6 +23,7 @@ function RouteComponent() {
           aside={<SpecChip tone="muted">Input Variant / Mode</SpecChip>}
         />
       </PaperCard>
+      <PeripheralSensorDeck />
       <PeripheralTree hierarchy={[["input_variant", "mode"]]} />
     </PageFrame>
   );

--- a/experimental/beats/src/tests/unit/components/generic_sensor.test.ts
+++ b/experimental/beats/src/tests/unit/components/generic_sensor.test.ts
@@ -1,0 +1,58 @@
+import { collectPreviewMetrics } from "@/components/ui/peripherals/generic_sensor";
+import { describe, expect, it } from "vitest";
+
+describe("collectPreviewMetrics", () => {
+  it("collects numeric and boolean leaves from nested payloads", () => {
+    expect(
+      collectPreviewMetrics({
+        battery: {
+          charging: true,
+          voltage: 3.71,
+        },
+        imu: {
+          x: 0.14,
+          y: -0.22,
+        },
+      }),
+    ).toEqual([
+      {
+        id: "battery.charging",
+        kind: "boolean",
+        label: "battery.charging",
+        value: true,
+      },
+      {
+        id: "battery.voltage",
+        kind: "numeric",
+        label: "battery.voltage",
+        value: 3.71,
+      },
+      {
+        id: "imu.x",
+        kind: "numeric",
+        label: "imu.x",
+        value: 0.14,
+      },
+      {
+        id: "imu.y",
+        kind: "numeric",
+        label: "imu.y",
+        value: -0.22,
+      },
+    ]);
+  });
+
+  it("caps preview metrics to the first six leaves", () => {
+    expect(
+      collectPreviewMetrics({
+        a: 1,
+        b: 2,
+        c: 3,
+        d: 4,
+        e: 5,
+        f: 6,
+        g: 7,
+      }),
+    ).toHaveLength(6);
+  });
+});


### PR DESCRIPTION
## Summary
- add a live sensor deck to the Beats connected peripherals page using the existing sensor simulation panel
- render generic numeric and boolean payload previews for unsupported peripherals instead of a plain fallback box
- pass full peripheral snapshots through the tree so preview components can inspect the latest payload
- add unit coverage for preview metric extraction and record the Beats validation commands in `AGENTS.md`

## Testing
- `experimental/beats: npm install --package-lock=false`
- `experimental/beats: ./node_modules/.bin/prettier --write src/actions/peripherals/peripheral_tree.tsx src/components/peripheral-sensor-deck.tsx src/components/ui/peripherals/generic_sensor.tsx src/routes/peripherals/connected.tsx src/tests/unit/components/generic_sensor.test.ts`
- `experimental/beats: ./node_modules/.bin/eslint src/actions/peripherals/peripheral_tree.tsx src/components/peripheral-sensor-deck.tsx src/components/ui/peripherals/generic_sensor.tsx src/routes/peripherals/connected.tsx src/tests/unit/components/generic_sensor.test.ts`
- `experimental/beats: npm run test -- src/tests/unit/components/generic_sensor.test.ts src/tests/unit/components/stream.test.tsx`