### PR TITLE
Refactor beats stream console into reusable components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,6 +268,9 @@ Define CLI default values as module-level constants so they stay consistent acro
 - `2026-03-30`: `.venv/bin/mdformat docs`
 - `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/94af/heart/.uv-cache make test`
 - `2026-03-31`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/3af3/heart/.uv-cache make format`
+- `2026-03-31`: `experimental/beats: npm install --package-lock=false`
+- `2026-03-31`: `experimental/beats: ./node_modules/.bin/prettier --write src/components/stream.tsx src/components/stream-console-header.tsx src/components/stream-visual-mixer-panel.tsx src/components/stream-footer-bar.tsx`
+- `2026-03-31`: `experimental/beats: npm run test -- src/tests/unit/components/stream.test.tsx`
 - `2026-03-31`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/3af3/heart/.uv-cache .venv/bin/pytest tests/device/test_beats_websocket.py tests/runtime/test_peripheral_runtime.py`
 - `2026-03-31`: `npm test -- --run src/tests/unit/actions/ws/websocket.test.tsx` in `experimental/beats` failed because `vitest` was not installed in that workspace (`node_modules` missing).
 - `2026-03-31`: `npm exec vitest run src/tests/unit/actions/ws/websocket.test.tsx` in `experimental/beats` failed because the workspace dependencies were not installed, so `@vitejs/plugin-react` could not be resolved from `vitest.config.ts`.

--- a/experimental/beats/src/components/stream-console-header.tsx
+++ b/experimental/beats/src/components/stream-console-header.tsx
@@ -1,0 +1,81 @@
+import { cn } from "@/utils/tailwind";
+
+type StreamConsoleHeaderProps = {
+  clockSeconds: number;
+  isActive: boolean;
+  selectedSensorLabel: string;
+  useImageFallback: boolean;
+};
+
+export function StreamConsoleHeader({
+  clockSeconds,
+  isActive,
+  selectedSensorLabel,
+  useImageFallback,
+}: StreamConsoleHeaderProps) {
+  return (
+    <div className="rounded-[1.4rem] border border-[#2f353f] bg-[linear-gradient(180deg,_rgba(26,30,38,0.96),_rgba(14,17,23,0.98))] px-4 py-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <SignalStack
+            lights={[
+              isActive ? "#34d399" : "#29303a",
+              selectedSensorLabel !== "Unassigned" ? "#fbbf24" : "#29303a",
+              useImageFallback ? "#fb7185" : "#38bdf8",
+            ]}
+          />
+          <div>
+            <p className="font-tomorrow text-[11px] tracking-[0.26em] text-[#7f8ea3] uppercase">
+              Beats Transport
+            </p>
+            <h1 className="font-tomorrow text-xl tracking-[0.14em] text-slate-100 uppercase">
+              Scene Control Console
+            </h1>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <TransportChip label="Clock" value={`${clockSeconds.toFixed(1)}s`} />
+          <TransportChip label="Sensor" value={selectedSensorLabel} />
+          <TransportChip
+            label="Render"
+            value={useImageFallback ? "Fallback" : "Realtime"}
+          />
+          <TransportChip label="Signal" value={isActive ? "Online" : "Idle"} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SignalStack({ lights }: { lights: string[] }) {
+  return (
+    <div className="grid grid-cols-3 gap-1 rounded-[0.9rem] border border-[#3b434f] bg-[#0a0d12] p-2">
+      {lights.map((color, index) => (
+        <span
+          key={index}
+          className="h-2.5 w-2.5 rounded-full"
+          style={{ backgroundColor: color }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function TransportChip({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-[108px] rounded-[0.95rem] border border-[#3a414c] bg-[#0b0e13] px-3 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+      <div className="font-tomorrow text-[10px] tracking-[0.22em] text-[#738194] uppercase">
+        {label}
+      </div>
+      <div
+        className={cn(
+          "mt-1 truncate font-mono text-sm",
+          value === "Unassigned" ? "text-[#94a3b8]" : "text-[#e5edf8]",
+        )}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/experimental/beats/src/components/stream-footer-bar.tsx
+++ b/experimental/beats/src/components/stream-footer-bar.tsx
@@ -1,0 +1,53 @@
+import { Antenna } from "lucide-react";
+import type { ComponentProps } from "react";
+
+import { Separator } from "./ui/separator";
+
+function getStatusClasses(streamIsActive: boolean) {
+  return streamIsActive
+    ? "text-green-400 status-green-blink"
+    : "text-rose-400 status-red-blink";
+}
+
+export function StreamFooterBar({
+  fps,
+  socketUrl,
+  streamIsActive,
+}: {
+  fps: number;
+  socketUrl: string;
+  streamIsActive: boolean;
+}) {
+  return (
+    <>
+      <Separator className="flex-none bg-[#252b33]" />
+
+      <div className="mb-2 flex flex-none flex-wrap items-center justify-between gap-4 rounded-[1.1rem] border border-[#2f353f] bg-[#10141a] px-3 py-2">
+        <span className="font-tomorrow text-[11px] tracking-[0.22em] text-[#7f8ea3] uppercase">
+          fps: <b className="text-slate-100">{fps}</b>
+        </span>
+        <div className="font-mono text-xs text-[#8d9bb0]">{socketUrl}</div>
+        <StreamStatus streamIsActive={streamIsActive} />
+      </div>
+    </>
+  );
+}
+
+function StreamStatus({
+  streamIsActive,
+  ...divProps
+}: ComponentProps<"div"> & {
+  streamIsActive: boolean;
+}) {
+  return (
+    <div
+      {...divProps}
+      className="font-tomorrow flex items-center justify-end text-[0.7rem] tracking-[0.22em] text-[#94a3b8] uppercase"
+    >
+      <Antenna
+        className={`mr-1 h-[1rem] ${getStatusClasses(streamIsActive)}`}
+      />
+      <span>{streamIsActive ? "Active" : "Offline"}</span>
+    </div>
+  );
+}

--- a/experimental/beats/src/components/stream-visual-mixer-panel.tsx
+++ b/experimental/beats/src/components/stream-visual-mixer-panel.tsx
@@ -1,0 +1,188 @@
+import { StreamCube } from "@/components/stream-cube";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export type StreamVisualMixerPanelProps = {
+  clockSeconds: number;
+  imgURL: string | null;
+  socketUrl: string;
+  telemetrySensorLabel: string;
+  telemetryTargetLabel: string;
+  telemetryValue: number;
+  useImageFallback: boolean;
+  fps: number;
+  sceneDistance: number;
+  sceneGain: number;
+  onContextError: () => void;
+  sceneConfig: Parameters<typeof StreamCube>[0]["sceneConfig"];
+};
+
+const SIGNAL_BAR_COUNT = 16;
+
+export function StreamVisualMixerPanel({
+  clockSeconds,
+  fps,
+  imgURL,
+  onContextError,
+  sceneConfig,
+  sceneDistance,
+  sceneGain,
+  socketUrl,
+  telemetrySensorLabel,
+  telemetryTargetLabel,
+  telemetryValue,
+  useImageFallback,
+}: StreamVisualMixerPanelProps) {
+  return (
+    <div className="rounded-[1.5rem] border border-[#2f353f] bg-[linear-gradient(180deg,_rgba(28,32,39,0.96),_rgba(13,16,21,0.98))] p-4 shadow-[0_24px_60px_rgba(0,0,0,0.45)]">
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="font-tomorrow text-[11px] tracking-[0.24em] text-[#7f8ea3] uppercase">
+            Stream Scene
+          </p>
+          <h2 className="font-tomorrow text-2xl tracking-[0.12em] text-slate-100 uppercase">
+            Visual Mixer
+          </h2>
+          <p className="mt-2 max-w-3xl text-sm text-[#a4b0c2]">
+            Tune the renderer, bind telemetry-reactive plugins, and rehearse
+            sensor behavior against the live stream.
+          </p>
+        </div>
+        <div className="grid gap-2 sm:grid-cols-3">
+          <StatusChip label="Telemetry Sensor" value={telemetrySensorLabel} />
+          <StatusChip
+            label="Renderer"
+            value={useImageFallback ? "Image fallback" : "Three.js"}
+          />
+          <StatusChip label="WebSocket" value={socketUrl} />
+        </div>
+      </div>
+
+      <div className="mb-4 grid gap-3 lg:grid-cols-[1.2fr_0.8fr]">
+        <TransportSignalCard
+          clockSeconds={clockSeconds}
+          telemetryValue={telemetryValue}
+        />
+        <ActiveModuleCard
+          distance={sceneDistance}
+          fps={fps}
+          gain={sceneGain}
+          telemetryTargetLabel={telemetryTargetLabel}
+        />
+      </div>
+
+      <div className="min-h-0">
+        {useImageFallback ? (
+          <div className="relative min-h-[420px] overflow-hidden rounded-[1.5rem] border border-[#343b45] bg-[#0a0d12]">
+            <StreamedImage imgURL={imgURL} />
+            <div className="font-tomorrow absolute top-4 left-4 rounded-full border border-[#3b434f] bg-[#11161d] px-3 py-1 text-[11px] tracking-[0.2em] text-[#9ba8ba] uppercase">
+              WebGL fallback active
+            </div>
+          </div>
+        ) : (
+          <StreamCube
+            imgURL={imgURL}
+            onContextError={onContextError}
+            sceneConfig={sceneConfig}
+            telemetryValue={telemetryValue}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function StreamedImage({ imgURL }: { imgURL: string | null }) {
+  if (!imgURL) {
+    return <Skeleton className="size-full" />;
+  }
+
+  return <img src={imgURL} alt="stream" className="size-full object-contain" />;
+}
+
+function TransportSignalCard({
+  clockSeconds,
+  telemetryValue,
+}: {
+  clockSeconds: number;
+  telemetryValue: number;
+}) {
+  return (
+    <div className="rounded-[1.2rem] border border-[#353c46] bg-[#0c1015] px-4 py-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <p className="font-tomorrow text-[10px] tracking-[0.24em] text-[#6f7d91] uppercase">
+            Transport
+          </p>
+          <p className="mt-1 font-mono text-2xl text-[#e3edf7]">
+            {clockSeconds.toFixed(1)}s
+          </p>
+        </div>
+        <div className="flex flex-1 items-end gap-1">
+          {Array.from({ length: SIGNAL_BAR_COUNT }).map((_, index) => {
+            const threshold = (index + 1) / SIGNAL_BAR_COUNT;
+            const signal = Math.abs(Math.tanh(telemetryValue));
+            const active = signal >= threshold;
+            return (
+              <span
+                key={index}
+                className="flex-1 rounded-sm"
+                style={{
+                  height: `${index > 11 ? 38 : index > 7 ? 30 : 22}px`,
+                  backgroundColor: active
+                    ? index > 12
+                      ? "#fb7185"
+                      : index > 8
+                        ? "#fbbf24"
+                        : "#34d399"
+                    : "#1d242d",
+                }}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ActiveModuleCard({
+  distance,
+  fps,
+  gain,
+  telemetryTargetLabel,
+}: {
+  distance: number;
+  fps: number;
+  gain: number;
+  telemetryTargetLabel: string;
+}) {
+  return (
+    <div className="rounded-[1.2rem] border border-[#353c46] bg-[#0c1015] px-4 py-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+      <p className="font-tomorrow text-[10px] tracking-[0.24em] text-[#6f7d91] uppercase">
+        Active Module
+      </p>
+      <p className="font-tomorrow mt-2 text-lg tracking-[0.12em] text-slate-100 uppercase">
+        {telemetryTargetLabel} Reactor
+      </p>
+      <p className="mt-1 text-sm text-[#a4b0c2]">
+        Gain {gain.toFixed(2)} | Camera {distance.toFixed(1)}u
+      </p>
+      <p className="mt-3 font-mono text-xs text-[#7f8ea3] uppercase">
+        Render cadence {fps} FPS
+      </p>
+    </div>
+  );
+}
+
+function StatusChip({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-[1rem] border border-[#343c46] bg-[#0c1015] px-3 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+      <div className="font-tomorrow text-[10px] tracking-[0.2em] text-[#6f7d91] uppercase">
+        {label}
+      </div>
+      <div className="mt-1 max-w-[180px] truncate font-mono text-sm text-[#dce6f5]">
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/experimental/beats/src/components/stream.tsx
+++ b/experimental/beats/src/components/stream.tsx
@@ -2,48 +2,13 @@ import { useStreamedImage } from "@/actions/ws/providers/ImageProvider";
 import { useWS } from "@/actions/ws/websocket";
 import { DEFAULT_SCENE_CONFIGURATION } from "@/features/stream-console/scene-config";
 import { useSensorSimulation } from "@/features/stream-console/use-sensor-simulation";
-import { Antenna } from "lucide-react";
 import { useCallback, useState } from "react";
-import type { ComponentProps } from "react";
 
 import { ScenePluginDock } from "./scene-plugin-dock";
+import { StreamConsoleHeader } from "./stream-console-header";
+import { StreamFooterBar } from "./stream-footer-bar";
+import { StreamVisualMixerPanel } from "./stream-visual-mixer-panel";
 import { SensorLabPanel, getSensorOverrideForPanel } from "./sensor-lab-panel";
-import { StreamCube } from "./stream-cube";
-import { Separator } from "./ui/separator";
-import { Skeleton } from "./ui/skeleton";
-
-function getStatusClasses(streamIsActive: boolean) {
-  return streamIsActive
-    ? "text-green-400 status-green-blink"
-    : "text-rose-400 status-red-blink";
-}
-
-export function StreamStatus({
-  streamIsActive,
-  ...divProps
-}: ComponentProps<"div"> & {
-  streamIsActive: boolean;
-}) {
-  return (
-    <div
-      {...divProps}
-      className="font-tomorrow flex items-center justify-end text-[0.7rem] tracking-[0.22em] text-[#94a3b8] uppercase"
-    >
-      <Antenna
-        className={`mr-1 h-[1rem] ${getStatusClasses(streamIsActive)}`}
-      />
-      <span>{streamIsActive ? "Active" : "Offline"}</span>
-    </div>
-  );
-}
-
-export function StreamedImage({ imgURL }: { imgURL: string | null }) {
-  if (!imgURL) {
-    return <Skeleton className="size-full" />;
-  }
-
-  return <img src={imgURL} alt="stream" className="size-full object-contain" />;
-}
 
 export function Stream() {
   const ws = useWS();
@@ -71,154 +36,35 @@ export function Stream() {
   const telemetrySensor =
     resolvedSensors.find((sensor) => sensor.id === telemetrySensorId) ?? null;
   const telemetryValue = telemetrySensor?.effectiveValue ?? 0;
+  const socketUrl = ws?.socket?.url ?? "Disconnected";
+  const telemetrySensorLabel = telemetrySensor?.label ?? "Unassigned";
+  const activeFps = isActive ? fps : 0;
 
   return (
     <div className="flex h-full flex-col gap-4 rounded-[1.75rem] bg-[radial-gradient(circle_at_top_left,_rgba(16,185,129,0.08),_transparent_28%),linear-gradient(180deg,_#11151b,_#090b0f)] p-4 text-slate-100 shadow-[0_30px_80px_rgba(0,0,0,0.45)] select-none">
-      <div className="rounded-[1.4rem] border border-[#2f353f] bg-[linear-gradient(180deg,_rgba(26,30,38,0.96),_rgba(14,17,23,0.98))] px-4 py-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex items-center gap-3">
-            <div className="grid grid-cols-3 gap-1 rounded-[0.9rem] border border-[#3b434f] bg-[#0a0d12] p-2">
-              {[
-                isActive ? "#34d399" : "#29303a",
-                telemetrySensor ? "#fbbf24" : "#29303a",
-                useImageFallback ? "#fb7185" : "#38bdf8",
-              ].map((color, index) => (
-                <span
-                  key={index}
-                  className="h-2.5 w-2.5 rounded-full"
-                  style={{ backgroundColor: color }}
-                />
-              ))}
-            </div>
-            <div>
-              <p className="font-tomorrow text-[11px] tracking-[0.26em] text-[#7f8ea3] uppercase">
-                Beats Transport
-              </p>
-              <h1 className="font-tomorrow text-xl tracking-[0.14em] text-slate-100 uppercase">
-                Scene Control Console
-              </h1>
-            </div>
-          </div>
-
-          <div className="flex flex-wrap gap-2">
-            <TransportChip
-              label="Clock"
-              value={`${clockSeconds.toFixed(1)}s`}
-            />
-            <TransportChip label="FPS" value={String(isActive ? fps : 0)} />
-            <TransportChip
-              label="Sensor"
-              value={telemetrySensor?.label ?? "Unassigned"}
-            />
-            <TransportChip
-              label="Render"
-              value={useImageFallback ? "Fallback" : "Realtime"}
-            />
-          </div>
-        </div>
-      </div>
+      <StreamConsoleHeader
+        clockSeconds={clockSeconds}
+        isActive={isActive}
+        selectedSensorLabel={telemetrySensorLabel}
+        useImageFallback={useImageFallback}
+      />
 
       <div className="grid min-h-0 flex-1 gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(340px,420px)]">
         <section className="flex min-h-0 flex-col gap-4">
-          <div className="rounded-[1.5rem] border border-[#2f353f] bg-[linear-gradient(180deg,_rgba(28,32,39,0.96),_rgba(13,16,21,0.98))] p-4 shadow-[0_24px_60px_rgba(0,0,0,0.45)]">
-            <div className="mb-4 flex flex-wrap items-start justify-between gap-4">
-              <div>
-                <p className="font-tomorrow text-[11px] tracking-[0.24em] text-[#7f8ea3] uppercase">
-                  Stream Scene
-                </p>
-                <h2 className="font-tomorrow text-2xl tracking-[0.12em] text-slate-100 uppercase">
-                  Visual Mixer
-                </h2>
-                <p className="mt-2 max-w-3xl text-sm text-[#a4b0c2]">
-                  Tune the renderer, bind telemetry-reactive plugins, and
-                  rehearse sensor behavior against the live stream.
-                </p>
-              </div>
-              <div className="grid gap-2 sm:grid-cols-3">
-                <StatusChip
-                  label="Telemetry Sensor"
-                  value={telemetrySensor?.label ?? "None"}
-                />
-                <StatusChip
-                  label="Renderer"
-                  value={useImageFallback ? "Image fallback" : "Three.js"}
-                />
-                <StatusChip
-                  label="WebSocket"
-                  value={ws?.socket?.url ?? "Disconnected"}
-                />
-              </div>
-            </div>
-
-            <div className="mb-4 grid gap-3 lg:grid-cols-[1.2fr_0.8fr]">
-              <div className="rounded-[1.2rem] border border-[#353c46] bg-[#0c1015] px-4 py-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
-                <div className="flex items-center justify-between gap-4">
-                  <div>
-                    <p className="font-tomorrow text-[10px] tracking-[0.24em] text-[#6f7d91] uppercase">
-                      Transport
-                    </p>
-                    <p className="mt-1 font-mono text-2xl text-[#e3edf7]">
-                      {clockSeconds.toFixed(1)}s
-                    </p>
-                  </div>
-                  <div className="flex flex-1 items-end gap-1">
-                    {Array.from({ length: 16 }).map((_, index) => {
-                      const threshold = (index + 1) / 16;
-                      const signal = Math.abs(Math.tanh(telemetryValue));
-                      const active = signal >= threshold;
-                      return (
-                        <span
-                          key={index}
-                          className="flex-1 rounded-sm"
-                          style={{
-                            height: `${index > 11 ? 38 : index > 7 ? 30 : 22}px`,
-                            backgroundColor: active
-                              ? index > 12
-                                ? "#fb7185"
-                                : index > 8
-                                  ? "#fbbf24"
-                                  : "#34d399"
-                              : "#1d242d",
-                          }}
-                        />
-                      );
-                    })}
-                  </div>
-                </div>
-              </div>
-
-              <div className="rounded-[1.2rem] border border-[#353c46] bg-[#0c1015] px-4 py-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
-                <p className="font-tomorrow text-[10px] tracking-[0.24em] text-[#6f7d91] uppercase">
-                  Active Module
-                </p>
-                <p className="font-tomorrow mt-2 text-lg tracking-[0.12em] text-slate-100 uppercase">
-                  {sceneConfig.telemetry.target} Reactor
-                </p>
-                <p className="mt-1 text-sm text-[#a4b0c2]">
-                  Gain {sceneConfig.telemetry.gain.toFixed(2)} | Camera{" "}
-                  {sceneConfig.camera.distance.toFixed(1)}u
-                </p>
-              </div>
-            </div>
-
-            <div className="min-h-0">
-              {useImageFallback ? (
-                <div className="relative min-h-[420px] overflow-hidden rounded-[1.5rem] border border-[#343b45] bg-[#0a0d12]">
-                  <StreamedImage imgURL={imgURL} />
-                  <div className="font-tomorrow absolute top-4 left-4 rounded-full border border-[#3b434f] bg-[#11161d] px-3 py-1 text-[11px] tracking-[0.2em] text-[#9ba8ba] uppercase">
-                    WebGL fallback active
-                  </div>
-                </div>
-              ) : (
-                <StreamCube
-                  imgURL={imgURL}
-                  onContextError={handleContextError}
-                  sceneConfig={sceneConfig}
-                  telemetryValue={telemetryValue}
-                />
-              )}
-            </div>
-          </div>
+          <StreamVisualMixerPanel
+            clockSeconds={clockSeconds}
+            fps={activeFps}
+            imgURL={imgURL}
+            onContextError={handleContextError}
+            sceneConfig={sceneConfig}
+            sceneDistance={sceneConfig.camera.distance}
+            sceneGain={sceneConfig.telemetry.gain}
+            socketUrl={socketUrl}
+            telemetrySensorLabel={telemetrySensorLabel}
+            telemetryTargetLabel={sceneConfig.telemetry.target}
+            telemetryValue={telemetryValue}
+            useImageFallback={useImageFallback}
+          />
 
           <div className="xl:hidden">
             <ScenePluginDock
@@ -260,43 +106,11 @@ export function Stream() {
         </aside>
       </div>
 
-      <Separator className="flex-none bg-[#252b33]" />
-
-      <div className="mb-2 flex flex-none flex-wrap items-center justify-between gap-4 rounded-[1.1rem] border border-[#2f353f] bg-[#10141a] px-3 py-2">
-        <span className="font-tomorrow text-[11px] tracking-[0.22em] text-[#7f8ea3] uppercase">
-          fps: <b className="text-slate-100">{isActive ? fps : 0}</b>
-        </span>
-        <div className="font-mono text-xs text-[#8d9bb0]">
-          {ws?.socket?.url}
-        </div>
-        <StreamStatus streamIsActive={isActive} />
-      </div>
-    </div>
-  );
-}
-
-function StatusChip({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-[1rem] border border-[#343c46] bg-[#0c1015] px-3 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
-      <div className="font-tomorrow text-[10px] tracking-[0.2em] text-[#6f7d91] uppercase">
-        {label}
-      </div>
-      <div className="mt-1 max-w-[180px] truncate font-mono text-sm text-[#dce6f5]">
-        {value}
-      </div>
-    </div>
-  );
-}
-
-function TransportChip({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="min-w-[108px] rounded-[0.95rem] border border-[#3a414c] bg-[#0b0e13] px-3 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
-      <div className="font-tomorrow text-[10px] tracking-[0.22em] text-[#738194] uppercase">
-        {label}
-      </div>
-      <div className="mt-1 truncate font-mono text-sm text-[#e5edf8]">
-        {value}
-      </div>
+      <StreamFooterBar
+        fps={activeFps}
+        socketUrl={socketUrl}
+        streamIsActive={isActive}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- extract the stream console header, visual mixer panel, and footer into dedicated `beats` components
- simplify `stream.tsx` so it focuses on state wiring and component composition
- record the targeted `experimental/beats` validation commands in `AGENTS.md`

## Testing
- `experimental/beats: npm install --package-lock=false`
- `experimental/beats: ./node_modules/.bin/prettier --write src/components/stream.tsx src/components/stream-console-header.tsx src/components/stream-visual-mixer-panel.tsx src/components/stream-footer-bar.tsx`
- `experimental/beats: npm run test -- src/tests/unit/components/stream.test.tsx`