### PR TITLE
Fix beats report header overflow and remove homepage branding reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,8 @@ Define CLI default values as module-level constants so they stay consistent acro
 
 ## Recent Validation
 
+- `2026-03-31`: `experimental/beats: ./node_modules/.bin/prettier --write src/components/usgc.tsx src/routes/index.tsx` failed because this worktree does not currently have `experimental/beats/node_modules`.
+- `2026-03-31`: `experimental/beats: ./node_modules/.bin/eslint src/components/usgc.tsx src/routes/index.tsx` failed because this worktree does not currently have `experimental/beats/node_modules`.
 - `2026-03-31`: `cd experimental/beats && npm install`
 - `2026-03-31`: `cd experimental/beats && npm ci`
 - `2026-03-31`: `cd experimental/beats && npm install --package-lock=false`

--- a/experimental/beats/src/components/usgc.tsx
+++ b/experimental/beats/src/components/usgc.tsx
@@ -38,17 +38,17 @@ export function SectionHeader({
   return (
     <div
       className={cn(
-        "flex flex-col gap-4 md:flex-row md:items-end md:justify-between",
+        "flex flex-col gap-4 md:flex-row md:items-start md:justify-between",
         className,
       )}
     >
-      <div className="space-y-2">
+      <div className="min-w-0 flex-1 space-y-2">
         <p className={cn("usgc-kicker", invert && "text-[#bdb3a6]")}>
           {eyebrow}
         </p>
         <h1
           className={cn(
-            "font-tomorrow text-3xl tracking-[0.06em] md:text-4xl",
+            "font-tomorrow break-words text-3xl tracking-[0.06em] md:text-4xl",
             invert ? "text-[#f6efe6]" : "text-foreground",
           )}
         >
@@ -65,7 +65,11 @@ export function SectionHeader({
           </div>
         ) : null}
       </div>
-      {aside ? <div className="shrink-0">{aside}</div> : null}
+      {aside ? (
+        <div className="max-w-full self-start md:max-w-[40%] md:text-right">
+          {aside}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -80,7 +84,7 @@ export function SpecChip({
   return (
     <span
       className={cn(
-        "usgc-chip",
+        "usgc-chip whitespace-normal",
         tone === "muted" && "usgc-chip-muted",
         tone === "dark" && "usgc-chip-dark",
         className,

--- a/experimental/beats/src/routes/index.tsx
+++ b/experimental/beats/src/routes/index.tsx
@@ -145,9 +145,6 @@ function HomePage() {
             eyebrow="TR-100 Machine Report"
             title="Operational Summary"
             invert
-            aside={
-              <SpecChip tone="dark">United States Graphics Company</SpecChip>
-            }
           />
           <div className="space-y-1 font-mono text-sm">
             <DataRow label="Program" value="Beats Telemetry Terminal" />


### PR DESCRIPTION
## Summary
- update the shared `SectionHeader` layout so titles can shrink and wrap instead of overflowing beside aside content
- allow spec chips to wrap when space is tight
- remove the homepage machine report branding chip from the operational summary card
- record the blocked frontend validation attempts in `AGENTS.md`

## Testing
- Not run (not requested)