### PR TITLE
Fix Beats payload encoding for frozenset input snapshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ Define CLI default values as module-level constants so they stay consistent acro
 
 ## Recent Validation
 
+- `2026-03-31`: `pytest tests/device/test_beats_websocket.py`
 - `2026-03-31`: `cd experimental/beats && npm install`
 - `2026-03-31`: `cd experimental/beats && npm ci`
 - `2026-03-31`: `cd experimental/beats && npm install --package-lock=false`

--- a/src/heart/peripheral/core/encoding.py
+++ b/src/heart/peripheral/core/encoding.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+from collections.abc import Set as AbstractSet
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from enum import Enum, StrEnum
@@ -102,7 +103,10 @@ def _decode_input_event(message: Message) -> Input:
 
 def _normalize_payload(payload: object) -> object:
     if dataclasses.is_dataclass(payload):
-        return dataclasses.asdict(payload)  # type: ignore[arg-type]
+        return {
+            field.name: _normalize_payload(getattr(payload, field.name))
+            for field in dataclasses.fields(payload)
+        }
 
     if isinstance(payload, Enum):
         return payload.value
@@ -121,6 +125,18 @@ def _normalize_payload(payload: object) -> object:
             str(key): _normalize_payload(value)
             for key, value in payload.items()
         }
+
+    if isinstance(payload, AbstractSet):
+        normalized_values = [_normalize_payload(value) for value in payload]
+        return sorted(
+            normalized_values,
+            key=lambda value: json.dumps(
+                value,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+        )
 
     if isinstance(payload, Sequence) and not isinstance(payload, (str, bytes, bytearray)):
         return [_normalize_payload(value) for value in payload]

--- a/tests/device/test_beats_websocket.py
+++ b/tests/device/test_beats_websocket.py
@@ -96,6 +96,26 @@ class TestInputPayloadEncoding:
         assert event.event_type == payload.event_type
         assert json.loads(event.data_json.decode("utf-8")) == payload.data
 
+    def test_encodes_input_payloads_with_frozensets(self) -> None:
+        """Verify Input payloads normalize frozensets into JSON arrays so websocket streaming does not crash on immutable input snapshots."""
+        payload = Input(
+            event_type="peripheral.keyboard.snapshot",
+            data={"pressed_keys": frozenset({3, 1, 2})},
+        )
+
+        encoded = encode_peripheral_payload(payload)
+
+        assert encoded.encoding == PeripheralPayloadEncoding.PROTOBUF
+        message_class = protobuf_registry.get_message_class(
+            PeripheralPayloadType.INPUT_EVENT
+        )
+        assert message_class is not None
+        event = message_class()
+        event.ParseFromString(encoded.payload)
+        assert json.loads(event.data_json.decode("utf-8")) == {
+            "pressed_keys": [1, 2, 3]
+        }
+
 
 class TestPeripheralPayloadDecoding:
     """Validate protobuf-aware payload decoding so inbound streams round-trip correctly."""


### PR DESCRIPTION
## Summary
- recurse through dataclass fields when normalizing peripheral payloads instead of relying on `dataclasses.asdict()`
- normalize sets and frozensets into stable JSON arrays so Beats websocket encoding does not fail on immutable input snapshots
- add a regression test covering `Input` payload encoding with a `frozenset`
- record the targeted websocket validation run in `AGENTS.md`

## Testing
- `pytest tests/device/test_beats_websocket.py`