### PR TITLE
Fix Beats app scroll and layout overflow handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,9 @@ Define CLI default values as module-level constants so they stay consistent acro
 
 ## Recent Validation
 
+- `2026-03-31`: `cd experimental/beats && npm install --package-lock=false`
+- `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/prettier --write src/layouts/base-layout.tsx src/styles/global.css src/components/usgc.tsx src/components/stream.tsx`
+- `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/eslint src/layouts/base-layout.tsx src/components/usgc.tsx src/components/stream.tsx`
 - `2026-03-31`: `cd experimental/beats && npm install`
 - `2026-03-31`: `cd experimental/beats && npm ci`
 - `2026-03-31`: `cd experimental/beats && npm install --package-lock=false`

--- a/experimental/beats/src/components/stream.tsx
+++ b/experimental/beats/src/components/stream.tsx
@@ -41,7 +41,7 @@ export function Stream() {
   const activeFps = isActive ? fps : 0;
 
   return (
-    <div className="flex h-full flex-col gap-4 rounded-[1.75rem] bg-[radial-gradient(circle_at_top_left,_rgba(16,185,129,0.08),_transparent_28%),linear-gradient(180deg,_#11151b,_#090b0f)] p-4 text-slate-100 shadow-[0_30px_80px_rgba(0,0,0,0.45)] select-none">
+    <div className="flex min-h-full flex-col gap-4 rounded-[1.75rem] bg-[radial-gradient(circle_at_top_left,_rgba(16,185,129,0.08),_transparent_28%),linear-gradient(180deg,_#11151b,_#090b0f)] p-4 text-slate-100 shadow-[0_30px_80px_rgba(0,0,0,0.45)] select-none">
       <StreamConsoleHeader
         clockSeconds={clockSeconds}
         isActive={isActive}
@@ -50,7 +50,7 @@ export function Stream() {
       />
 
       <div className="grid min-h-0 flex-1 gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(340px,420px)]">
-        <section className="flex min-h-0 flex-col gap-4">
+        <section className="flex min-h-0 min-w-0 flex-col gap-4">
           <StreamVisualMixerPanel
             clockSeconds={clockSeconds}
             fps={activeFps}
@@ -93,7 +93,7 @@ export function Stream() {
           />
         </section>
 
-        <aside className="hidden min-h-0 xl:flex xl:flex-col xl:gap-4">
+        <aside className="hidden min-h-0 min-w-0 xl:flex xl:flex-col xl:gap-4">
           <ScenePluginDock
             sceneConfig={sceneConfig}
             sensorOptions={resolvedSensors.map((sensor) => ({

--- a/experimental/beats/src/components/usgc.tsx
+++ b/experimental/beats/src/components/usgc.tsx
@@ -102,7 +102,7 @@ export function DataRow({
   return (
     <div className={cn("usgc-data-row", className)}>
       <span className="usgc-data-label">{label}</span>
-      <span>{value}</span>
+      <span className="min-w-0 break-words">{value}</span>
     </div>
   );
 }

--- a/experimental/beats/src/layouts/base-layout.tsx
+++ b/experimental/beats/src/layouts/base-layout.tsx
@@ -36,8 +36,10 @@ export default function BaseLayout({
         </div>
       </div>
       <AppSidebar />
-      <SidebarInset className="mt-[38px]">
-        <div className="h-full overflow-y-auto">{children}</div>
+      <SidebarInset className="h-svh min-h-0">
+        <div className="flex min-h-0 flex-1 flex-col pt-[38px]">
+          <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
+        </div>
       </SidebarInset>
     </SidebarProvider>
   );

--- a/experimental/beats/src/styles/global.css
+++ b/experimental/beats/src/styles/global.css
@@ -181,8 +181,14 @@
 }
 
 @layer base {
+  html,
+  body,
+  #app {
+    min-height: 100%;
+  }
+
   body {
-    @apply overflow-hidden;
+    @apply overflow-x-hidden;
     background:
       linear-gradient(
         180deg,
@@ -294,7 +300,7 @@
 
 @layer components {
   .usgc-page {
-    @apply mx-auto flex h-full max-w-[1680px] flex-col gap-6 px-2 pt-4 pb-6 md:px-4 lg:px-6;
+    @apply mx-auto flex min-h-full max-w-[1680px] flex-col gap-6 px-2 pt-4 pb-6 md:px-4 lg:px-6;
   }
 
   .usgc-card {


### PR DESCRIPTION
## Summary
- update the Beats shell layout so the main content area scrolls correctly beneath the fixed header
- replace viewport-locking height rules with `min-height` behavior in shared layout styles
- prevent stream panels and shared data rows from overflowing by allowing columns to shrink and long values to wrap
- record the validation commands in `AGENTS.md`

## Testing
- `cd experimental/beats && npm install --package-lock=false`
- `cd experimental/beats && ./node_modules/.bin/prettier --write src/layouts/base-layout.tsx src/styles/global.css src/components/usgc.tsx src/components/stream.tsx`
- `cd experimental/beats && ./node_modules/.bin/eslint src/layouts/base-layout.tsx src/components/usgc.tsx src/components/stream.tsx`