### PR TITLE
Update Current Stream cube defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,7 @@ Define CLI default values as module-level constants so they stay consistent acro
 - `2026-03-31`: `experimental/beats: npm run lint`
 - `2026-03-31`: `experimental/beats: ./node_modules/.bin/tsc --noEmit`
 - `2026-03-31`: `experimental/beats: npm run test -- --passWithNoTests` (no Vitest files matched)
+- `2026-03-31`: No validation run after updating `experimental/beats/src/features/stream-console/scene-config.ts` to keep the Current Stream cube fixed by default and slightly increase the default camera distance; these were small config-only changes.
 - `2026-03-31`: `cd experimental/beats && npm ci` failed because `experimental/beats/package-lock.json` is out of sync with `package.json`.
 - `2026-03-31`: `cd experimental/beats && npm install --package-lock=false`
 - `2026-03-31`: `cd experimental/beats && npm run format:write`

--- a/experimental/beats/src/features/stream-console/scene-config.ts
+++ b/experimental/beats/src/features/stream-console/scene-config.ts
@@ -35,14 +35,14 @@ export type SceneConfiguration = {
 
 export const DEFAULT_SCENE_CONFIGURATION: SceneConfiguration = {
   motion: {
-    autoRotate: true,
+    autoRotate: false,
     rotationX: 0.01,
     rotationY: 0.015,
     wobbleAmount: 0.12,
     hoverAmount: 0.18,
   },
   camera: {
-    distance: 4.4,
+    distance: 4.9,
     fov: 45,
   },
   stage: {


### PR DESCRIPTION
## Summary
- Disable auto-rotation for the Current Stream cube by default
- Increase the default camera distance slightly so the cube starts a bit more zoomed out
- Record in `AGENTS.md` that no validation was run for this config-only change

## Testing
- Not run (not requested)