### PR TITLE
Remove sitemap from the Beats home page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,8 @@ Define CLI default values as module-level constants so they stay consistent acro
 
 ## Recent Validation
 
+- `2026-03-31`: `rg -n "Sitemap|siteMap|usgc-ascii-map" experimental/beats/src/routes/index.tsx` returned no matches after removing the Beats home-page sitemap.
+- `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/prettier --check src/routes/index.tsx` could not run because this worktree does not currently have `experimental/beats/node_modules` installed.
 - `2026-03-31`: `cd experimental/beats && npm install`
 - `2026-03-31`: `cd experimental/beats && npm ci`
 - `2026-03-31`: `cd experimental/beats && npm install --package-lock=false`

--- a/experimental/beats/src/routes/index.tsx
+++ b/experimental/beats/src/routes/index.tsx
@@ -16,20 +16,6 @@ import { Link, createFileRoute } from "@tanstack/react-router";
 import { Binary, Mouse, Orbit, RadioTower, ScanLine, Tv } from "lucide-react";
 import { useEffect, useState, useTransition } from "react";
 
-const siteMap = `Home
-├── Mission Control
-│   ├── Playback
-│   ├── Status Matrix
-│   └── Event Console
-├── Current Stream
-│   ├── Live Viewport
-│   ├── Machine Report
-│   └── Frame Cadence
-└── Peripherals
-    ├── Connected
-    ├── Events
-    └── Snapshots`;
-
 const routeCards = [
   {
     title: "Mission Control",
@@ -181,7 +167,7 @@ function HomePage() {
         </TechnicalCard>
       </section>
 
-      <section className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
+      <section>
         <PaperCard className="flex flex-col gap-6">
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div className="space-y-2">
@@ -230,15 +216,6 @@ function HomePage() {
               </p>
             </div>
           </div>
-        </PaperCard>
-
-        <PaperCard className="flex flex-col gap-5">
-          <SectionHeader
-            eyebrow="Engineering"
-            title="Sitemap"
-            description="Everything in the Beats terminal in one place."
-          />
-          <pre className="usgc-ascii-map">{siteMap}</pre>
         </PaperCard>
       </section>
 


### PR DESCRIPTION
## Summary
- remove the ASCII sitemap block from the Beats app home route
- simplify the surrounding section layout now that the secondary sitemap card is gone
- record the targeted validation and the blocked Prettier check in `AGENTS.md`

## Testing
- Not run (not requested)