### PR TITLE
Fix churn in Beats recently active device ordering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,9 @@ Define CLI default values as module-level constants so they stay consistent acro
 - `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/prettier --write src/components/stream.tsx src/components/scene-plugin-dock.tsx src/components/sensor-lab-panel.tsx src/components/sensor-history-chart.tsx src/styles/global.css`
 - `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/eslint src/components/stream.tsx src/components/scene-plugin-dock.tsx src/components/sensor-lab-panel.tsx src/components/sensor-history-chart.tsx`
 - `2026-03-31`: `cd experimental/beats && npm run test -- --run src/tests/unit/components/stream.test.tsx src/tests/unit/features/stream-console/sensor-simulation.test.ts`
+- `2026-03-31`: `cd experimental/beats && npm install --package-lock=false`
+- `2026-03-31`: `cd experimental/beats && npm run test -- --run src/tests/unit/routes/home.test.ts`
+- `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/prettier --check src/routes/index.tsx src/tests/unit/routes/home.test.ts`
 - `2026-03-30`: `.venv/bin/pytest tests/navigation/test_game_modes.py`
 - `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/e46a/heart/.uv-cache make format`
 - `2026-03-30`: `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/e46a/heart/.uv-cache make test`

--- a/experimental/beats/src/routes/index.tsx
+++ b/experimental/beats/src/routes/index.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/components/usgc";
 import { Link, createFileRoute } from "@tanstack/react-router";
 import { Binary, Mouse, RadioTower, ScanLine, Tv } from "lucide-react";
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 
 const RECENT_DEVICE_LIMIT = 4;
 const RECENT_ACTIVITY_WINDOW_MS = 60_000;
@@ -61,11 +61,43 @@ export type RecentPeripheralActivity = {
   eventCount: number;
 };
 
+export function selectStableRecentPeripheralActivity(
+  previousVisibleIds: string[],
+  activeDevices: RecentPeripheralActivity[],
+  limit = RECENT_DEVICE_LIMIT,
+): RecentPeripheralActivity[] {
+  const activeById = new Map(
+    activeDevices.map((activity) => [activity.id, activity] as const),
+  );
+  const stableVisibleDevices: RecentPeripheralActivity[] = [];
+  const seenIds = new Set<string>();
+
+  for (const id of previousVisibleIds) {
+    const activity = activeById.get(id);
+    if (!activity) {
+      continue;
+    }
+
+    stableVisibleDevices.push(activity);
+    seenIds.add(id);
+  }
+
+  for (const activity of activeDevices) {
+    if (seenIds.has(activity.id)) {
+      continue;
+    }
+
+    stableVisibleDevices.push(activity);
+    seenIds.add(activity.id);
+  }
+
+  return stableVisibleDevices.slice(0, limit);
+}
+
 export function summarizeRecentPeripheralActivity(
   peripheralEntries: HomePeripheralSnapshot[],
   events: HomePeripheralEvent[],
   now: number,
-  limit = RECENT_DEVICE_LIMIT,
 ): RecentPeripheralActivity[] {
   const activityById = new Map<string, RecentPeripheralActivity>();
 
@@ -122,8 +154,7 @@ export function summarizeRecentPeripheralActivity(
       }
 
       return left.id.localeCompare(right.id);
-    })
-    .slice(0, limit);
+    });
 }
 
 export function formatPeripheralRecency(
@@ -152,6 +183,7 @@ function HomePage() {
   const [appVersion, setAppVersion] = useState("0.0.0");
   const [now, setNow] = useState(() => Date.now());
   const [, startGetAppVersion] = useTransition();
+  const recentPeripheralOrderRef = useRef<string[]>([]);
 
   useEffect(
     () => startGetAppVersion(() => getAppVersion().then(setAppVersion)),
@@ -170,10 +202,17 @@ function HomePage() {
     (left, right) => right.ts - left.ts,
   );
   const readyStateLabel = getReadyStateLabel(ws.readyState);
-  const recentPeripheralActivity = summarizeRecentPeripheralActivity(
+  const activePeripheralActivity = summarizeRecentPeripheralActivity(
     peripheralEntries,
     events,
     now,
+  );
+  const recentPeripheralActivity = selectStableRecentPeripheralActivity(
+    recentPeripheralOrderRef.current,
+    activePeripheralActivity,
+  );
+  recentPeripheralOrderRef.current = recentPeripheralActivity.map(
+    (device) => device.id,
   );
 
   return (

--- a/experimental/beats/src/tests/unit/routes/home.test.ts
+++ b/experimental/beats/src/tests/unit/routes/home.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   formatPeripheralRecency,
+  selectStableRecentPeripheralActivity,
   summarizeRecentPeripheralActivity,
 } from "@/routes/index";
 
@@ -80,6 +81,28 @@ describe("home recent peripheral activity", () => {
     );
 
     expect(summary).toEqual([]);
+  });
+
+  it("preserves visible ordering while appending newly active devices", () => {
+    const activeDevices = [
+      { id: "delta", lastSeenTs: 99_000, eventCount: 3 },
+      { id: "alpha", lastSeenTs: 98_000, eventCount: 2 },
+      { id: "gamma", lastSeenTs: 97_000, eventCount: 1 },
+      { id: "beta", lastSeenTs: 96_000, eventCount: 1 },
+    ];
+
+    const summary = selectStableRecentPeripheralActivity(
+      ["alpha", "beta", "gamma"],
+      activeDevices,
+      4,
+    );
+
+    expect(summary.map((device) => device.id)).toEqual([
+      "alpha",
+      "beta",
+      "gamma",
+      "delta",
+    ]);
   });
 
   it("formats recency labels for fast-moving devices", () => {


### PR DESCRIPTION
## Summary
- preserve the visible order of recently active devices on the Beats home page while items remain active
- append newly active devices after the existing visible set instead of re-sorting the list on every timestamp update
- add a unit test covering the stable-order behavior and record the validation commands in `AGENTS.md`

## Testing
- `cd experimental/beats && npm install --package-lock=false`
- `cd experimental/beats && npm run test -- --run src/tests/unit/routes/home.test.ts`
- `cd experimental/beats && ./node_modules/.bin/prettier --check src/routes/index.tsx src/tests/unit/routes/home.test.ts`