### PR TITLE
Fix Beats frame decoding for Totem stream rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Use the tooling in this repository to manage environments. Prefer `uv` for Pytho
 - Only the real display-owned `DisplayContext` may change pygame display modes; scratch or post-processing contexts must keep `can_configure_display=False` and never call `pygame.display.set_mode()`.
 - OpenGL-backed renderers must treat `reset()` as lifecycle teardown: cascade reset into nested runtimes and restore mutated UI state such as mouse visibility so mode switches can leave GPU-backed scenes cleanly.
 - Vite `.mts` configs that are shared with Storybook or other native-ESM tooling must derive `__dirname` via `fileURLToPath(new URL(".", import.meta.url))` instead of relying on the CommonJS global.
+- Beats websocket protobuf decoders must accept both snake_case and camelCase field names from `protobufjs` decode output so streamed frame rendering does not depend on field-name normalization details.
 
 ## Formatting
 
@@ -113,6 +114,10 @@ Define CLI default values as module-level constants so they stay consistent acro
 
 ## Recent Validation
 
+- `2026-03-31`: `cd experimental/beats && npm install --package-lock=false`
+- `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/prettier --write src/actions/ws/protocol.ts src/tests/unit/actions/ws/protocol.test.ts`
+- `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/eslint src/actions/ws/protocol.ts src/tests/unit/actions/ws/protocol.test.ts`
+- `2026-03-31`: `cd experimental/beats && npm run test -- --run src/tests/unit/actions/ws/protocol.test.ts src/tests/unit/actions/ws/websocket.test.tsx`
 - `2026-03-31`: `cd experimental/beats && npm install --package-lock=false`
 - `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/prettier --write src/routes/index.tsx src/tests/unit/routes/home.test.ts`
 - `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/eslint src/routes/index.tsx src/tests/unit/routes/home.test.ts`

--- a/experimental/beats/src/actions/ws/protocol.ts
+++ b/experimental/beats/src/actions/ws/protocol.ts
@@ -31,6 +31,19 @@ const root = parse(protoSchema, { keepCase: true }).root;
 const StreamEnvelope = root.lookupType("heart.beats.streaming.StreamEnvelope");
 const textDecoder = new TextDecoder("utf-8");
 
+type DecodedFrameEnvelope = {
+  png_data?: Uint8Array;
+  pngData?: Uint8Array;
+};
+
+type DecodedPeripheralEnvelope = {
+  peripheral_info?: unknown;
+  peripheralInfo?: unknown;
+  payload?: Uint8Array;
+  payload_encoding?: number;
+  payloadEncoding?: number;
+};
+
 function normalizePeripheralInfo(raw: unknown): PeripheralInfo {
   if (!raw || typeof raw !== "object") {
     return { id: null, tags: [] };
@@ -42,28 +55,41 @@ function normalizePeripheralInfo(raw: unknown): PeripheralInfo {
   };
 }
 
+function getFrameBytes(frame: DecodedFrameEnvelope | null | undefined) {
+  return frame?.pngData ?? frame?.png_data ?? null;
+}
+
+function getPeripheralInfo(
+  peripheral: DecodedPeripheralEnvelope | null | undefined,
+) {
+  return peripheral?.peripheralInfo ?? peripheral?.peripheral_info ?? null;
+}
+
+function getPayloadEncoding(
+  peripheral: DecodedPeripheralEnvelope | null | undefined,
+) {
+  return peripheral?.payloadEncoding ?? peripheral?.payload_encoding ?? null;
+}
+
 export function decodeStreamEvent(buffer: ArrayBuffer): StreamEvent | null {
   const envelope = StreamEnvelope.decode(new Uint8Array(buffer)) as {
-    frame?: { png_data?: Uint8Array } | null;
-    peripheral?: {
-      peripheral_info?: unknown;
-      payload?: Uint8Array;
-      payload_encoding?: number;
-    } | null;
+    frame?: DecodedFrameEnvelope | null;
+    peripheral?: DecodedPeripheralEnvelope | null;
   };
+  const pngData = getFrameBytes(envelope.frame);
 
-  if (envelope.frame?.png_data) {
+  if (pngData) {
     return {
       type: "frame",
       payload: {
-        pngData: envelope.frame.png_data,
+        pngData,
       },
     };
   }
 
   if (envelope.peripheral?.payload) {
     let data: unknown = null;
-    const payloadEncoding = envelope.peripheral.payload_encoding ?? null;
+    const payloadEncoding = getPayloadEncoding(envelope.peripheral);
     if (payloadEncoding === 1) {
       try {
         data = JSON.parse(textDecoder.decode(envelope.peripheral.payload));
@@ -75,7 +101,7 @@ export function decodeStreamEvent(buffer: ArrayBuffer): StreamEvent | null {
       type: "peripheral",
       payload: {
         peripheralInfo: normalizePeripheralInfo(
-          envelope.peripheral.peripheral_info,
+          getPeripheralInfo(envelope.peripheral),
         ),
         data,
         payloadEncoding,

--- a/experimental/beats/src/tests/unit/actions/ws/protocol.test.ts
+++ b/experimental/beats/src/tests/unit/actions/ws/protocol.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const FRAME_BYTES = new Uint8Array([1, 2, 3, 4]);
+
+async function importProtocolWithDecodedEnvelope(decodedEnvelope: unknown) {
+  vi.resetModules();
+  vi.doMock("protobufjs", () => ({
+    parse: () => ({
+      root: {
+        lookupType: () => ({
+          decode: () => decodedEnvelope,
+        }),
+      },
+    }),
+  }));
+
+  return import("@/actions/ws/protocol");
+}
+
+describe("decodeStreamEvent", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("protobufjs");
+  });
+
+  it("accepts camelCase frame payloads so streamed images survive decoder field normalization", async () => {
+    const { decodeStreamEvent } = await importProtocolWithDecodedEnvelope({
+      frame: {
+        pngData: FRAME_BYTES,
+      },
+    });
+
+    const decoded = decodeStreamEvent(new ArrayBuffer(0));
+
+    expect(decoded).toEqual({
+      type: "frame",
+      payload: {
+        pngData: FRAME_BYTES,
+      },
+    });
+  });
+
+  it("accepts snake_case frame payloads so the protobuf schema remains wire compatible", async () => {
+    const { decodeStreamEvent } = await importProtocolWithDecodedEnvelope({
+      frame: {
+        png_data: FRAME_BYTES,
+      },
+    });
+
+    const decoded = decodeStreamEvent(new ArrayBuffer(0));
+
+    expect(decoded).toEqual({
+      type: "frame",
+      payload: {
+        pngData: FRAME_BYTES,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- make the Beats websocket decoder accept both `snake_case` and `camelCase` protobuf field names from `protobufjs`
- restore frame delivery to the Beats/Totem renderer when decoded frame payloads use `pngData` instead of `png_data`
- add focused Vitest coverage for both frame field shapes
- document the decoder compatibility requirement and validation history in `AGENTS.md`

## Testing
- `cd experimental/beats && npm install --package-lock=false`
- `cd experimental/beats && ./node_modules/.bin/prettier --write src/actions/ws/protocol.ts src/tests/unit/actions/ws/protocol.test.ts`
- `cd experimental/beats && ./node_modules/.bin/eslint src/actions/ws/protocol.ts src/tests/unit/actions/ws/protocol.test.ts`
- `cd experimental/beats && npm run test -- --run src/tests/unit/actions/ws/protocol.test.ts src/tests/unit/actions/ws/websocket.test.tsx`