### PR TITLE
Fix Beats sidebar metadata wrapping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,10 @@ Define CLI default values as module-level constants so they stay consistent acro
 ## Recent Validation
 
 - `2026-03-31`: `cd experimental/beats && npm install --package-lock=false`
+- `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/prettier --write src/components/app-sidebar.tsx src/components/usgc.tsx`
+- `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/eslint src/components/app-sidebar.tsx src/components/usgc.tsx`
+- `2026-03-31`: No tests run after restacking the Beats sidebar `Program` and `Signal` metadata rows because the change was limited to presentational layout in existing React components.
+- `2026-03-31`: `cd experimental/beats && npm install --package-lock=false`
 - `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/prettier --write src/routes/index.tsx src/tests/unit/routes/home.test.ts`
 - `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/eslint src/routes/index.tsx src/tests/unit/routes/home.test.ts`
 - `2026-03-31`: `cd experimental/beats && npm run test -- --run src/tests/unit/routes/home.test.ts`

--- a/experimental/beats/src/components/app-sidebar.tsx
+++ b/experimental/beats/src/components/app-sidebar.tsx
@@ -125,12 +125,14 @@ export function AppSidebar() {
             <DataRow
               label="Program"
               value="Machine Report"
-              className="text-sidebar-foreground"
+              className="text-sidebar-foreground grid-cols-1 gap-1"
+              valueClassName="break-normal"
             />
             <DataRow
               label="Signal"
               value="ws://localhost:8765"
-              className="text-sidebar-foreground"
+              className="text-sidebar-foreground grid-cols-1 gap-1"
+              valueClassName="break-all"
             />
           </div>
         </div>

--- a/experimental/beats/src/components/usgc.tsx
+++ b/experimental/beats/src/components/usgc.tsx
@@ -48,7 +48,7 @@ export function SectionHeader({
         </p>
         <h1
           className={cn(
-            "font-tomorrow break-words text-3xl tracking-[0.06em] md:text-4xl",
+            "font-tomorrow text-3xl tracking-[0.06em] break-words md:text-4xl",
             invert ? "text-[#f6efe6]" : "text-foreground",
           )}
         >
@@ -98,15 +98,19 @@ export function DataRow({
   label,
   value,
   className,
+  labelClassName,
+  valueClassName,
 }: {
   label: string;
   value: ReactNode;
   className?: string;
+  labelClassName?: string;
+  valueClassName?: string;
 }) {
   return (
     <div className={cn("usgc-data-row", className)}>
-      <span className="usgc-data-label">{label}</span>
-      <span className="min-w-0 break-words">{value}</span>
+      <span className={cn("usgc-data-label", labelClassName)}>{label}</span>
+      <span className={cn("min-w-0 break-words", valueClassName)}>{value}</span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- restack the Beats sidebar `Program` and `Signal` rows into a single-column layout so values no longer collapse into narrow vertical wraps
- add optional `labelClassName` and `valueClassName` hooks to `DataRow` so sidebar-specific formatting can override the shared default without affecting other usages
- record the targeted frontend validation commands in `AGENTS.md`

## Testing
- `cd experimental/beats && npm install --package-lock=false`
- `cd experimental/beats && ./node_modules/.bin/prettier --write src/components/app-sidebar.tsx src/components/usgc.tsx`
- `cd experimental/beats && ./node_modules/.bin/eslint src/components/app-sidebar.tsx src/components/usgc.tsx`
- Not run (not requested)