### PR TITLE
Fix missing overrides in peripheral sensor deck

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,9 @@ Define CLI default values as module-level constants so they stay consistent acro
 ## Recent Validation
 
 - `2026-03-31`: `cd experimental/beats && npm install --package-lock=false`
+- `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/prettier --check src/components/peripheral-sensor-deck.tsx src/tests/unit/components/peripheral-sensor-deck.test.tsx`
+- `2026-03-31`: `cd experimental/beats && npm run test -- --run src/tests/unit/components/peripheral-sensor-deck.test.tsx`
+- `2026-03-31`: `cd experimental/beats && npm install --package-lock=false`
 - `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/prettier --write src/routes/index.tsx src/tests/unit/routes/home.test.ts`
 - `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/eslint src/routes/index.tsx src/tests/unit/routes/home.test.ts`
 - `2026-03-31`: `cd experimental/beats && npm run test -- --run src/tests/unit/routes/home.test.ts`

--- a/experimental/beats/src/components/peripheral-sensor-deck.tsx
+++ b/experimental/beats/src/components/peripheral-sensor-deck.tsx
@@ -80,6 +80,7 @@ export function PeripheralSensorDeck() {
         override={getSensorOverrideForPanel(
           selectedSensor ? overrides[selectedSensor.id] : undefined,
         )}
+        overrides={overrides}
         selectedSensor={selectedSensor}
         selectedSensorHistory={selectedSensorHistory}
         sensors={resolvedSensors}

--- a/experimental/beats/src/tests/unit/components/peripheral-sensor-deck.test.tsx
+++ b/experimental/beats/src/tests/unit/components/peripheral-sensor-deck.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PeripheralSensorDeck } from "@/components/peripheral-sensor-deck";
+
+const simulationState = vi.hoisted(() => {
+  const selectedSensor = {
+    id: "dpad / payload.x",
+    peripheralId: "dpad",
+    label: "dpad / payload.x",
+    path: "payload.x",
+    value: 1,
+    rawValue: 1,
+    displayValue: "1.000",
+    updatedAt: 0,
+    tags: [],
+    source: "live" as const,
+    effectiveValue: 1,
+    referenceValue: null,
+    evaluationError: null,
+  };
+
+  return {
+    clockSeconds: 3.5,
+    history: {},
+    overrides: {
+      [selectedSensor.id]: {
+        mode: "live" as const,
+        constantValue: 0,
+        expression: "0.4 + 0.2 * sin(t * 1.25)",
+      },
+    },
+    resolvedSensors: [selectedSensor],
+    selectedSensor,
+    selectedSensorHistory: [],
+    selectedSensorId: selectedSensor.id,
+    setSelectedSensorId: vi.fn(),
+    updateSensorOverride: vi.fn(),
+    resetSensorOverride: vi.fn(),
+    clearSelectedSensorHistory: vi.fn(),
+  };
+});
+
+vi.mock("@/actions/ws/providers/PeripheralEventsProvider", () => ({
+  usePeripheralEvents: () => [],
+}));
+
+vi.mock("@/features/stream-console/use-sensor-simulation", () => ({
+  useSensorSimulation: () => simulationState,
+}));
+
+describe("PeripheralSensorDeck", () => {
+  it("renders the selected sensor terminal when a slash-delimited sensor id is active", () => {
+    render(<PeripheralSensorDeck />);
+
+    expect(
+      screen.getByRole("textbox", { name: "Sensor terminal command" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("dpad / payload.x").length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- pass `overrides` through to `SensorLabPanel` so the sensor terminal can read the selected sensor state safely
- add a regression test covering a slash-delimited sensor id like `dpad / payload.x`
- record the focused Beats validation commands in `AGENTS.md`

## Testing
- `cd experimental/beats && npm install --package-lock=false`
- `cd experimental/beats && ./node_modules/.bin/prettier --check src/components/peripheral-sensor-deck.tsx src/tests/unit/components/peripheral-sensor-deck.test.tsx`
- `cd experimental/beats && npm run test -- --run src/tests/unit/components/peripheral-sensor-deck.test.tsx`