### PR TITLE
Remove U.S. Graphics Company references from Beats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,10 @@ Define CLI default values as module-level constants so they stay consistent acro
 ## Recent Validation
 
 - `2026-03-31`: `cd experimental/beats && npm install --package-lock=false`
+- `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/prettier --write src/components/beats-shell.tsx`
+- `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/prettier --check src/components/beats-shell.tsx src/routes/index.tsx src/layouts/base-layout.tsx src/components/app-sidebar.tsx src/routes/peripherals/connected.tsx src/routes/peripherals/events.tsx src/routes/peripherals/snapshots.tsx src/actions/peripherals/event_list.tsx src/actions/peripherals/peripheral_tree.tsx src/actions/peripherals/peripheral_snapshots.tsx src/styles/global.css`
+- `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/eslint src/components/beats-shell.tsx src/routes/index.tsx src/layouts/base-layout.tsx src/components/app-sidebar.tsx src/routes/peripherals/connected.tsx src/routes/peripherals/events.tsx src/routes/peripherals/snapshots.tsx src/actions/peripherals/event_list.tsx src/actions/peripherals/peripheral_tree.tsx src/actions/peripherals/peripheral_snapshots.tsx`
+- `2026-03-31`: `cd experimental/beats && npm install --package-lock=false`
 - `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/prettier --write src/routes/index.tsx src/tests/unit/routes/home.test.ts`
 - `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/eslint src/routes/index.tsx src/tests/unit/routes/home.test.ts`
 - `2026-03-31`: `cd experimental/beats && npm run test -- --run src/tests/unit/routes/home.test.ts`

--- a/experimental/beats/src/actions/peripherals/event_list.tsx
+++ b/experimental/beats/src/actions/peripherals/event_list.tsx
@@ -1,4 +1,4 @@
-import { TechnicalCard } from "@/components/usgc";
+import { TechnicalCard } from "@/components/beats-shell";
 import { usePeripheralEvents } from "../ws/providers/PeripheralEventsProvider";
 
 export function EventList() {
@@ -8,7 +8,7 @@ export function EventList() {
     <TechnicalCard className="flex h-full flex-col gap-5 select-none">
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div className="space-y-2">
-          <p className="usgc-kicker text-[#bdb3a6]">Peripheral Events</p>
+          <p className="beats-kicker text-[#bdb3a6]">Peripheral Events</p>
           <h2 className="font-tomorrow text-2xl tracking-[0.1em] text-[#f6efe6]">
             Signal Log
           </h2>
@@ -18,8 +18,8 @@ export function EventList() {
         </p>
       </div>
 
-      <div className="usgc-scroll-panel max-h-screen overflow-y-auto border-white/20 bg-white/5">
-        <table className="usgc-table">
+      <div className="beats-scroll-panel max-h-screen overflow-y-auto border-white/20 bg-white/5">
+        <table className="beats-table">
           <thead>
             <tr>
               <th className="px-2 py-1 text-left">Timestamp</th>

--- a/experimental/beats/src/actions/peripherals/peripheral_snapshots.tsx
+++ b/experimental/beats/src/actions/peripherals/peripheral_snapshots.tsx
@@ -1,4 +1,4 @@
-import { PaperCard } from "@/components/usgc";
+import { PaperCard } from "@/components/beats-shell";
 import { useConnectedPeripherals } from "../ws/providers/PeripheralProvider";
 
 function formatTimestamp(timestamp: number) {
@@ -15,7 +15,7 @@ export function PeripheralSnapshots() {
     <PaperCard className="flex h-full flex-col gap-5 select-none">
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div className="space-y-2">
-          <p className="usgc-kicker">Peripheral Snapshots</p>
+          <p className="beats-kicker">Peripheral Snapshots</p>
           <h2 className="font-tomorrow text-2xl tracking-[0.1em]">
             Latest Peripheral Data
           </h2>
@@ -25,13 +25,13 @@ export function PeripheralSnapshots() {
         </p>
       </div>
 
-      <div className="usgc-scroll-panel max-h-screen overflow-y-auto">
+      <div className="beats-scroll-panel max-h-screen overflow-y-auto">
         {items.length === 0 ? (
           <div className="text-muted-foreground p-4 text-xs">
             No peripheral snapshots have been captured yet.
           </div>
         ) : (
-          <table className="usgc-table">
+          <table className="beats-table">
             <thead>
               <tr>
                 <th className="px-2 py-1 text-left">Peripheral</th>

--- a/experimental/beats/src/actions/peripherals/peripheral_tree.tsx
+++ b/experimental/beats/src/actions/peripherals/peripheral_tree.tsx
@@ -2,7 +2,7 @@ import { AccelerometerView } from "@/components/ui/peripherals/accelerometer";
 import { GenericSensorPeripheralView } from "@/components/ui/peripherals/generic_sensor";
 import { RotarySwitchView } from "@/components/ui/peripherals/rotary_button";
 import { UWBPositionView } from "@/components/ui/peripherals/uwb_positioning";
-import { PaperCard, SpecChip } from "@/components/usgc";
+import { PaperCard, SpecChip } from "@/components/beats-shell";
 import type { ReactNode } from "react";
 import {
   PeripheralInfo,
@@ -60,7 +60,7 @@ export function PeripheralTree({
         <PaperCard key={idx} className="flex flex-col gap-5">
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div className="space-y-2">
-              <p className="usgc-kicker">Connected Peripherals</p>
+              <p className="beats-kicker">Connected Peripherals</p>
               <h2 className="font-tomorrow text-2xl tracking-[0.1em]">
                 {h.join(" / ")}
               </h2>
@@ -108,7 +108,7 @@ function PeripheralBranch({
     <div className="border-border bg-background/70 border p-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="space-y-2">
-          <p className="usgc-kicker">Peripheral</p>
+          <p className="beats-kicker">Peripheral</p>
           <h3 className="font-tomorrow text-xl tracking-[0.08em]">
             {peripheral.id ?? "Unknown Unit"}
           </h3>

--- a/experimental/beats/src/components/app-sidebar.tsx
+++ b/experimental/beats/src/components/app-sidebar.tsx
@@ -24,7 +24,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "./ui/collapsible";
-import { DataRow, SpecChip } from "./usgc";
+import { DataRow, SpecChip } from "./beats-shell";
 import {
   SidebarFooter,
   SidebarHeader,
@@ -108,7 +108,7 @@ export function AppSidebar() {
           <div className="flex items-start justify-between gap-3">
             <div className="space-y-2">
               <p className="font-tomorrow text-sidebar-foreground/60 text-[0.58rem] tracking-[0.34em] uppercase">
-                U.S. Graphics Company
+                Beats
               </p>
               <div>
                 <h2 className="font-tomorrow text-sidebar-foreground text-lg tracking-[0.2em]">

--- a/experimental/beats/src/components/beats-shell.tsx
+++ b/experimental/beats/src/components/beats-shell.tsx
@@ -2,11 +2,11 @@ import { cn } from "@/utils/tailwind";
 import type { ComponentProps, ReactNode } from "react";
 
 export function PageFrame({ className, ...props }: ComponentProps<"div">) {
-  return <div className={cn("usgc-page", className)} {...props} />;
+  return <div className={cn("beats-page", className)} {...props} />;
 }
 
 export function PaperCard({ className, ...props }: ComponentProps<"section">) {
-  return <section className={cn("usgc-card", className)} {...props} />;
+  return <section className={cn("beats-card", className)} {...props} />;
 }
 
 export function TechnicalCard({
@@ -14,7 +14,10 @@ export function TechnicalCard({
   ...props
 }: ComponentProps<"section">) {
   return (
-    <section className={cn("usgc-card usgc-card-dark", className)} {...props} />
+    <section
+      className={cn("beats-card beats-card-dark", className)}
+      {...props}
+    />
   );
 }
 
@@ -43,12 +46,12 @@ export function SectionHeader({
       )}
     >
       <div className="min-w-0 flex-1 space-y-2">
-        <p className={cn("usgc-kicker", invert && "text-[#bdb3a6]")}>
+        <p className={cn("beats-kicker", invert && "text-[#bdb3a6]")}>
           {eyebrow}
         </p>
         <h1
           className={cn(
-            "font-tomorrow break-words text-3xl tracking-[0.06em] md:text-4xl",
+            "font-tomorrow text-3xl tracking-[0.06em] break-words md:text-4xl",
             invert ? "text-[#f6efe6]" : "text-foreground",
           )}
         >
@@ -84,9 +87,9 @@ export function SpecChip({
   return (
     <span
       className={cn(
-        "usgc-chip whitespace-normal",
-        tone === "muted" && "usgc-chip-muted",
-        tone === "dark" && "usgc-chip-dark",
+        "beats-chip whitespace-normal",
+        tone === "muted" && "beats-chip-muted",
+        tone === "dark" && "beats-chip-dark",
         className,
       )}
       {...props}
@@ -104,8 +107,8 @@ export function DataRow({
   className?: string;
 }) {
   return (
-    <div className={cn("usgc-data-row", className)}>
-      <span className="usgc-data-label">{label}</span>
+    <div className={cn("beats-data-row", className)}>
+      <span className="beats-data-label">{label}</span>
       <span className="min-w-0 break-words">{value}</span>
     </div>
   );
@@ -132,8 +135,8 @@ export function MeterBar({
         <span className="text-muted-foreground">{label}</span>
         <span>{valueLabel ?? `${percent.toFixed(0)}%`}</span>
       </div>
-      <div className="usgc-meter">
-        <div className="usgc-meter-fill" style={{ width: `${percent}%` }} />
+      <div className="beats-meter">
+        <div className="beats-meter-fill" style={{ width: `${percent}%` }} />
       </div>
     </div>
   );

--- a/experimental/beats/src/layouts/base-layout.tsx
+++ b/experimental/beats/src/layouts/base-layout.tsx
@@ -24,7 +24,7 @@ export default function BaseLayout({
     <SidebarProvider>
       <div className="border-border bg-background/95 fixed inset-x-0 top-0 z-[15] flex h-[38px] items-center border-b px-16 backdrop-blur-sm [-webkit-app-region:drag]">
         <div className="font-tomorrow text-muted-foreground flex items-center gap-3 text-[0.62rem] tracking-[0.32em] uppercase">
-          <span className="hidden sm:inline">U.S. Graphics Company</span>
+          <span className="hidden sm:inline">Beats</span>
           <span className="text-border hidden sm:inline">/</span>
           <span>Beats Telemetry Terminal</span>
         </div>

--- a/experimental/beats/src/routes/index.tsx
+++ b/experimental/beats/src/routes/index.tsx
@@ -11,7 +11,7 @@ import {
   SectionHeader,
   SpecChip,
   TechnicalCard,
-} from "@/components/usgc";
+} from "@/components/beats-shell";
 import { Link, createFileRoute } from "@tanstack/react-router";
 import { Binary, Mouse, RadioTower, ScanLine, Tv } from "lucide-react";
 import { useEffect, useState, useTransition } from "react";
@@ -181,7 +181,7 @@ function HomePage() {
       <section className="grid gap-6 xl:grid-cols-[1.18fr_0.82fr]">
         <PaperCard className="flex flex-col justify-between gap-8">
           <SectionHeader
-            eyebrow="U.S. Graphics Company / Beats Division"
+            eyebrow="Beats / Telemetry Division"
             title="Beats Telemetry Catalog"
             description={
               <>
@@ -201,7 +201,7 @@ function HomePage() {
           </div>
           <div className="grid gap-4 md:grid-cols-3">
             <div className="border-border bg-background/75 border p-4">
-              <p className="usgc-kicker">Signal</p>
+              <p className="beats-kicker">Signal</p>
               <p className="font-tomorrow mt-3 text-2xl tracking-[0.14em]">
                 {readyStateLabel}
               </p>
@@ -210,7 +210,7 @@ function HomePage() {
               </p>
             </div>
             <div className="border-border bg-background/75 border p-4">
-              <p className="usgc-kicker">Cadence</p>
+              <p className="beats-kicker">Cadence</p>
               <p className="font-tomorrow mt-3 text-2xl tracking-[0.14em]">
                 {isActive ? fps : 0} FPS
               </p>
@@ -219,7 +219,7 @@ function HomePage() {
               </p>
             </div>
             <div className="border-border bg-background/75 border p-4">
-              <p className="usgc-kicker">Devices</p>
+              <p className="beats-kicker">Devices</p>
               <p className="font-tomorrow mt-3 text-2xl tracking-[0.14em]">
                 {peripheralEntries.length}
               </p>
@@ -302,7 +302,7 @@ function HomePage() {
         <PaperCard className="flex flex-col gap-6">
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div className="space-y-2">
-              <p className="usgc-kicker">Typeface / TX-24</p>
+              <p className="beats-kicker">Typeface / TX-24</p>
               <h2 className="font-tomorrow text-3xl tracking-[0.1em]">
                 Beats Monitor
               </h2>
@@ -312,7 +312,7 @@ function HomePage() {
               <SpecChip tone="muted">Machine Report</SpecChip>
             </div>
           </div>
-          <p className="usgc-copy max-w-3xl">
+          <p className="beats-copy max-w-3xl">
             Space grade, device-facing, and unapologetically procedural. Beats
             Monitor is a control-room type system for live image transport,
             sensor traffic, and synchronized playback. It treats interface
@@ -352,11 +352,11 @@ function HomePage() {
 
       <section className="grid gap-4 lg:grid-cols-3">
         {routeCards.map((card) => (
-          <Link key={card.href} to={card.href} className="usgc-link-card">
+          <Link key={card.href} to={card.href} className="beats-link-card">
             <PaperCard className="h-full">
               <div className="flex items-start justify-between gap-4">
                 <div>
-                  <p className="usgc-kicker">Open</p>
+                  <p className="beats-kicker">Open</p>
                   <h2 className="font-tomorrow mt-3 text-2xl tracking-[0.08em]">
                     {card.title}
                   </h2>

--- a/experimental/beats/src/routes/peripherals/connected.tsx
+++ b/experimental/beats/src/routes/peripherals/connected.tsx
@@ -5,7 +5,7 @@ import {
   PaperCard,
   SectionHeader,
   SpecChip,
-} from "@/components/usgc";
+} from "@/components/beats-shell";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/peripherals/connected")({
@@ -19,7 +19,7 @@ function RouteComponent() {
         <SectionHeader
           eyebrow="Peripherals / Connected"
           title="Device Catalog"
-          description="Active input hardware grouped by capability and mode, presented as a U.S.G.C. engineering sheet."
+          description="Active input hardware grouped by capability and mode, presented as a Beats engineering sheet."
           aside={<SpecChip tone="muted">Input Variant / Mode</SpecChip>}
         />
       </PaperCard>

--- a/experimental/beats/src/routes/peripherals/events.tsx
+++ b/experimental/beats/src/routes/peripherals/events.tsx
@@ -4,7 +4,7 @@ import {
   PaperCard,
   SectionHeader,
   SpecChip,
-} from "@/components/usgc";
+} from "@/components/beats-shell";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/peripherals/events")({

--- a/experimental/beats/src/routes/peripherals/snapshots.tsx
+++ b/experimental/beats/src/routes/peripherals/snapshots.tsx
@@ -4,7 +4,7 @@ import {
   PaperCard,
   SectionHeader,
   SpecChip,
-} from "@/components/usgc";
+} from "@/components/beats-shell";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/peripherals/snapshots")({

--- a/experimental/beats/src/styles/global.css
+++ b/experimental/beats/src/styles/global.css
@@ -426,16 +426,16 @@
 }
 
 @layer components {
-  .usgc-page {
+  .beats-page {
     @apply mx-auto flex min-h-full max-w-[1680px] flex-col gap-6 px-2 pt-4 pb-6 md:px-4 lg:px-6;
   }
 
-  .usgc-card {
+  .beats-card {
     @apply border-border bg-card relative overflow-hidden border p-5;
     box-shadow: 6px 6px 0 rgba(0, 0, 0, 0.08);
   }
 
-  .usgc-card::before {
+  .beats-card::before {
     content: "";
     pointer-events: none;
     position: absolute;
@@ -456,18 +456,18 @@
     opacity: 0.75;
   }
 
-  .usgc-card > * {
+  .beats-card > * {
     position: relative;
     z-index: 1;
   }
 
-  .usgc-card-dark {
+  .beats-card-dark {
     @apply bg-[#070707] text-[#f6efe6];
     border-color: rgba(246, 239, 230, 0.25);
     box-shadow: 10px 10px 0 rgba(0, 0, 0, 0.14);
   }
 
-  .usgc-card-dark::before {
+  .beats-card-dark::before {
     background:
       linear-gradient(
         180deg,
@@ -491,54 +491,54 @@
     opacity: 0.72;
   }
 
-  .usgc-kicker {
+  .beats-kicker {
     @apply font-tomorrow text-muted-foreground text-[0.65rem] tracking-[0.34em] uppercase;
   }
 
-  .usgc-copy {
+  .beats-copy {
     @apply text-sm leading-7 text-[#3b3228] dark:text-[#d8cfc1];
   }
 
-  .usgc-chip {
+  .beats-chip {
     @apply border-border text-foreground inline-flex items-center gap-2 border px-3 py-1 font-mono text-[0.7rem] tracking-[0.18em] uppercase;
     background: #f4dd95;
     box-shadow: 3px 3px 0 rgba(0, 0, 0, 0.08);
   }
 
-  .usgc-chip-muted {
+  .beats-chip-muted {
     @apply bg-background;
   }
 
-  .usgc-chip-dark {
+  .beats-chip-dark {
     border-color: rgba(246, 239, 230, 0.3);
     background: rgba(246, 239, 230, 0.08);
     box-shadow: none;
     color: #f6efe6;
   }
 
-  .usgc-data-row {
+  .beats-data-row {
     @apply grid gap-2 border-t border-dashed border-current/20 py-2 font-mono text-sm;
     grid-template-columns: minmax(0, 9rem) minmax(0, 1fr);
   }
 
-  .usgc-data-row:first-child {
+  .beats-data-row:first-child {
     @apply border-t-0 pt-0;
   }
 
-  .usgc-data-label {
+  .beats-data-label {
     @apply text-muted-foreground text-[0.68rem] tracking-[0.2em] uppercase;
   }
 
-  .usgc-card-dark .usgc-data-label {
+  .beats-card-dark .beats-data-label {
     color: rgba(246, 239, 230, 0.58);
   }
 
-  .usgc-meter {
+  .beats-meter {
     @apply border-border bg-background mt-2 overflow-hidden border;
     height: 0.85rem;
   }
 
-  .usgc-meter-fill {
+  .beats-meter-fill {
     @apply bg-primary h-full;
     background-image: linear-gradient(
       90deg,
@@ -550,57 +550,57 @@
     background-size: 18px 100%;
   }
 
-  .usgc-card-dark .usgc-meter {
+  .beats-card-dark .beats-meter {
     border-color: rgba(246, 239, 230, 0.25);
     background: rgba(246, 239, 230, 0.06);
   }
 
-  .usgc-card-dark .usgc-meter-fill {
+  .beats-card-dark .beats-meter-fill {
     background-color: #f4dd95;
   }
 
-  .usgc-link-card {
+  .beats-link-card {
     @apply block transition-transform duration-200;
   }
 
-  .usgc-link-card:hover {
+  .beats-link-card:hover {
     transform: translate(-2px, -2px);
   }
 
-  .usgc-table {
+  .beats-table {
     @apply w-full border-collapse text-left font-mono text-[0.74rem];
   }
 
-  .usgc-table thead th {
+  .beats-table thead th {
     @apply border-border text-muted-foreground border-b px-3 py-2 font-medium tracking-[0.2em] uppercase;
   }
 
-  .usgc-table tbody td {
+  .beats-table tbody td {
     @apply border-border/20 border-b px-3 py-3 align-top;
   }
 
-  .usgc-table tbody tr:hover {
+  .beats-table tbody tr:hover {
     background: rgba(0, 0, 0, 0.04);
   }
 
-  .usgc-card-dark .usgc-table thead th {
+  .beats-card-dark .beats-table thead th {
     border-color: rgba(246, 239, 230, 0.2);
     color: rgba(246, 239, 230, 0.62);
   }
 
-  .usgc-card-dark .usgc-table tbody td {
+  .beats-card-dark .beats-table tbody td {
     border-color: rgba(246, 239, 230, 0.12);
   }
 
-  .usgc-card-dark .usgc-table tbody tr:hover {
+  .beats-card-dark .beats-table tbody tr:hover {
     background: rgba(246, 239, 230, 0.05);
   }
 
-  .usgc-ascii-map {
+  .beats-ascii-map {
     @apply border-border bg-background/80 overflow-auto border p-4 font-mono text-[0.76rem] leading-6 whitespace-pre;
   }
 
-  .usgc-terminal-grid {
+  .beats-terminal-grid {
     background:
       linear-gradient(
         90deg,
@@ -624,7 +624,7 @@
       #070707;
   }
 
-  .usgc-scroll-panel {
+  .beats-scroll-panel {
     @apply border-border bg-background/70 overflow-auto border;
   }
 }


### PR DESCRIPTION
## Summary
- replace the remaining `U.S. Graphics Company` copy in the Beats UI with Beats-specific branding
- rename the shared Beats shell component from `usgc` to `beats-shell` and update imports accordingly
- rename the associated CSS utility classes from `usgc-*` to `beats-*` to remove the old namespace entirely
- record the targeted Beats validation commands in `AGENTS.md`

## Testing
- `cd experimental/beats && npm install --package-lock=false`
- `cd experimental/beats && ./node_modules/.bin/prettier --write src/components/beats-shell.tsx`
- `cd experimental/beats && ./node_modules/.bin/prettier --check src/components/beats-shell.tsx src/routes/index.tsx src/layouts/base-layout.tsx src/components/app-sidebar.tsx src/routes/peripherals/connected.tsx src/routes/peripherals/events.tsx src/routes/peripherals/snapshots.tsx src/actions/peripherals/event_list.tsx src/actions/peripherals/peripheral_tree.tsx src/actions/peripherals/peripheral_snapshots.tsx src/styles/global.css`
- `cd experimental/beats && ./node_modules/.bin/eslint src/components/beats-shell.tsx src/routes/index.tsx src/layouts/base-layout.tsx src/components/app-sidebar.tsx src/routes/peripherals/connected.tsx src/routes/peripherals/events.tsx src/routes/peripherals/snapshots.tsx src/actions/peripherals/event_list.tsx src/actions/peripherals/peripheral_tree.tsx src/actions/peripherals/peripheral_snapshots.tsx`