### PR TITLE
Fix Beats stream chrome and collapsed sidebar overlap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ Define CLI default values as module-level constants so they stay consistent acro
 
 ## Recent Validation
 
+- `2026-03-31`: `experimental/beats: ./node_modules/.bin/prettier --write src/layouts/base-layout.tsx src/components/app-sidebar.tsx src/components/stream-console-header.tsx src/components/stream-visual-mixer-panel.tsx` could not run because this worktree does not currently have `experimental/beats/node_modules` installed.
 - `2026-03-31`: `cd experimental/beats && npm install --package-lock=false`
 - `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/prettier --write src/routes/index.tsx src/tests/unit/routes/home.test.ts`
 - `2026-03-31`: `cd experimental/beats && ./node_modules/.bin/eslint src/routes/index.tsx src/tests/unit/routes/home.test.ts`

--- a/experimental/beats/src/components/app-sidebar.tsx
+++ b/experimental/beats/src/components/app-sidebar.tsx
@@ -83,6 +83,8 @@ const items = {
   ],
 };
 
+const SIDEBAR_TOP_OFFSET_CLASS = "pt-[52px]";
+
 export function AppSidebar() {
   const [appVersion, setAppVersion] = useState("0.0.0");
   const [, startGetAppVersion] = useTransition();
@@ -102,19 +104,23 @@ export function AppSidebar() {
       : pathname === path || pathname.startsWith(`${path}/`);
 
   return (
-    <Sidebar collapsible="icon" variant="floating" className="pt-[38px]">
-      <SidebarHeader className="gap-3 p-3">
-        <div className="border-sidebar-border bg-sidebar overflow-hidden border p-3">
+    <Sidebar
+      collapsible="icon"
+      variant="floating"
+      className={SIDEBAR_TOP_OFFSET_CLASS}
+    >
+      <SidebarHeader className="gap-2 px-2.5 pt-2 pb-1">
+        <div className="border-sidebar-border bg-sidebar overflow-hidden border px-3 py-3 group-data-[collapsible=icon]:hidden">
           <div className="flex items-start justify-between gap-3">
             <div className="space-y-2">
-              <p className="font-tomorrow text-sidebar-foreground/60 text-[0.58rem] tracking-[0.34em] uppercase">
+              <p className="font-tomorrow text-sidebar-foreground/60 text-[0.52rem] tracking-[0.3em] uppercase">
                 U.S. Graphics Company
               </p>
               <div>
-                <h2 className="font-tomorrow text-sidebar-foreground text-lg tracking-[0.2em]">
+                <h2 className="font-tomorrow text-sidebar-foreground text-base tracking-[0.18em]">
                   BEATS
                 </h2>
-                <p className="text-sidebar-foreground/70 font-mono text-[0.68rem] tracking-[0.16em] uppercase">
+                <p className="text-sidebar-foreground/70 font-mono text-[0.62rem] tracking-[0.14em] uppercase">
                   Telemetry Department
                 </p>
               </div>
@@ -134,8 +140,13 @@ export function AppSidebar() {
             />
           </div>
         </div>
+        <div className="border-sidebar-border bg-sidebar text-sidebar-foreground hidden h-16 items-center justify-center border group-data-[collapsible=icon]:flex">
+          <div className="flex h-10 w-10 items-center justify-center border border-current/45 font-tomorrow text-lg tracking-[0.14em]">
+            B
+          </div>
+        </div>
       </SidebarHeader>
-      <SidebarSeparator className="mx-3" />
+      <SidebarSeparator className="mx-2.5" />
       <SidebarContent>
         <SidebarGroup>
           <SidebarMenu>
@@ -145,7 +156,7 @@ export function AppSidebar() {
                   asChild
                   tooltip={item.title}
                   isActive={isPathActive(item.url)}
-                  className="font-tomorrow tracking-[0.16em] uppercase"
+                  className="font-tomorrow text-[0.74rem] tracking-[0.14em] uppercase"
                 >
                   <Link to={item.url}>
                     {item.icon && <item.icon />}
@@ -157,7 +168,7 @@ export function AppSidebar() {
           </SidebarMenu>
         </SidebarGroup>
         <SidebarGroup>
-          <SidebarGroupLabel className="font-tomorrow tracking-[0.18em] uppercase">
+          <SidebarGroupLabel className="font-tomorrow text-[0.68rem] tracking-[0.16em] uppercase">
             Entities
           </SidebarGroupLabel>
           <SidebarMenu>
@@ -175,7 +186,7 @@ export function AppSidebar() {
                       isActive={item.items.some((subItem) =>
                         isPathActive(subItem.url),
                       )}
-                      className="font-tomorrow tracking-[0.16em] uppercase"
+                      className="font-tomorrow text-[0.74rem] tracking-[0.14em] uppercase"
                     >
                       {item.icon && <item.icon />}
                       <span>{item.title}</span>

--- a/experimental/beats/src/components/stream-console-header.tsx
+++ b/experimental/beats/src/components/stream-console-header.tsx
@@ -27,10 +27,10 @@ export function StreamConsoleHeader({
             ]}
           />
           <div>
-            <p className="beats-console-kicker font-tomorrow text-[11px] tracking-[0.26em] uppercase">
+            <p className="beats-console-kicker font-tomorrow text-[10px] tracking-[0.22em] uppercase">
               Beats Transport
             </p>
-            <h1 className="font-tomorrow text-xl tracking-[0.14em] text-slate-100 uppercase md:text-[1.65rem]">
+            <h1 className="font-tomorrow text-lg tracking-[0.1em] text-slate-100 uppercase md:text-[1.4rem]">
               Scene Control Console
             </h1>
           </div>

--- a/experimental/beats/src/components/stream-visual-mixer-panel.tsx
+++ b/experimental/beats/src/components/stream-visual-mixer-panel.tsx
@@ -36,13 +36,13 @@ export function StreamVisualMixerPanel({
     <div className="beats-console-panel rounded-[1.5rem] p-4 md:p-5">
       <div className="mb-4 flex flex-wrap items-start justify-between gap-4">
         <div>
-          <p className="beats-console-kicker font-tomorrow text-[11px] tracking-[0.24em] uppercase">
+          <p className="beats-console-kicker font-tomorrow text-[10px] tracking-[0.2em] uppercase">
             Stream Scene
           </p>
-          <h2 className="font-tomorrow text-2xl tracking-[0.12em] text-slate-100 uppercase">
+          <h2 className="font-tomorrow text-[1.55rem] tracking-[0.09em] text-slate-100 uppercase md:text-[1.65rem]">
             Visual Mixer
           </h2>
-          <p className="beats-console-copy mt-2 max-w-3xl text-sm leading-6">
+          <p className="beats-console-copy mt-2 max-w-3xl text-sm leading-5.5">
             Tune the renderer, bind telemetry-reactive plugins, and rehearse
             sensor behavior against the live stream.
           </p>

--- a/experimental/beats/src/layouts/base-layout.tsx
+++ b/experimental/beats/src/layouts/base-layout.tsx
@@ -7,6 +7,9 @@ import React, { useEffect, useState, useTransition } from "react";
 import { getAppVersion } from "../actions/app";
 import { AppSidebar } from "../components/app-sidebar";
 
+const TOP_CHROME_HEIGHT = "44px";
+const TOP_CHROME_OFFSET_CLASS = "pt-[52px]";
+
 export default function BaseLayout({
   children,
 }: {
@@ -22,11 +25,14 @@ export default function BaseLayout({
 
   return (
     <SidebarProvider>
-      <div className="border-border bg-background/95 fixed inset-x-0 top-0 z-[15] flex h-[38px] items-center border-b px-16 backdrop-blur-sm [-webkit-app-region:drag]">
-        <div className="font-tomorrow text-muted-foreground flex items-center gap-3 text-[0.62rem] tracking-[0.32em] uppercase">
+      <div
+        className="border-border bg-background/95 fixed inset-x-0 top-0 z-[15] flex items-center border-b px-14 backdrop-blur-sm [-webkit-app-region:drag]"
+        style={{ height: TOP_CHROME_HEIGHT }}
+      >
+        <div className="font-tomorrow text-muted-foreground flex min-w-0 items-center gap-3 text-[0.56rem] tracking-[0.28em] uppercase sm:text-[0.6rem]">
           <span className="hidden sm:inline">U.S. Graphics Company</span>
           <span className="text-border hidden sm:inline">/</span>
-          <span>Beats Telemetry Terminal</span>
+          <span className="truncate">Beats Telemetry Terminal</span>
         </div>
         <div className="ml-auto flex items-center gap-2 [-webkit-app-region:no-drag]">
           <span className="border-border bg-card text-muted-foreground hidden rounded-[3px] border px-2 py-1 font-mono text-[0.68rem] tracking-[0.18em] uppercase md:inline-flex">
@@ -37,7 +43,7 @@ export default function BaseLayout({
       </div>
       <AppSidebar />
       <SidebarInset className="h-svh min-h-0">
-        <div className="flex min-h-0 flex-1 flex-col pt-[38px]">
+        <div className={`flex min-h-0 flex-1 flex-col ${TOP_CHROME_OFFSET_CLASS}`}>
           <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
         </div>
       </SidebarInset>


### PR DESCRIPTION
## Summary
- reduce the stream header and visual mixer title sizing to better fit the console layout
- push the main content and floating sidebar below the top chrome to remove the fold/box collision
- replace the collapsed sidebar's stacked brand block with a compact badge and tighten sidebar typography spacing
- record that Prettier could not run in this worktree because `experimental/beats/node_modules` is missing

## Testing
- Not run (not requested)