### PR TITLE
Fix TX-24 overflow in the Beats sidebar header

### DIFF
--- a/experimental/beats/src/components/app-sidebar.tsx
+++ b/experimental/beats/src/components/app-sidebar.tsx
@@ -110,13 +110,13 @@ export function AppSidebar() {
       className={SIDEBAR_TOP_OFFSET_CLASS}
     >
       <SidebarHeader className="gap-2 px-2.5 pt-2 pb-1">
-        <div className="border-sidebar-border bg-sidebar overflow-hidden border px-3 py-3 group-data-[collapsible=icon]:hidden">
-          <div className="flex items-start justify-between gap-3">
-            <div className="space-y-2">
+        <div className="border-sidebar-border bg-sidebar w-full min-w-0 overflow-hidden border px-3 py-3 group-data-[collapsible=icon]:hidden">
+          <div className="flex w-full min-w-0 items-start justify-between gap-3">
+            <div className="min-w-0 flex-1 space-y-2">
               <p className="font-tomorrow text-sidebar-foreground/60 text-[0.52rem] tracking-[0.3em] uppercase">
                 Beats
               </p>
-              <div>
+              <div className="min-w-0">
                 <h2 className="font-tomorrow text-sidebar-foreground text-base tracking-[0.18em]">
                   BEATS
                 </h2>
@@ -125,7 +125,9 @@ export function AppSidebar() {
                 </p>
               </div>
             </div>
-            <SpecChip className="px-2 py-0.5 text-[0.62rem]">TX-24</SpecChip>
+            <SpecChip className="shrink-0 self-start px-2 py-0.5 text-[0.62rem]">
+              TX-24
+            </SpecChip>
           </div>
           <div className="mt-4 grid gap-2 group-data-[collapsible=icon]:hidden">
             <DataRow


### PR DESCRIPTION
## Summary
- constrain the sidebar header card and row to the available sidebar width
- allow the header text column to shrink with `min-w-0` and `flex-1`
- keep the `TX-24` spec chip pinned without stretching the floating sidebar

## Testing
- `cd experimental/beats && npm install --package-lock=false`
- `cd experimental/beats && ./node_modules/.bin/prettier --write src/components/app-sidebar.tsx`
- `cd experimental/beats && ./node_modules/.bin/eslint src/components/app-sidebar.tsx`