### PR TITLE
Fix Beats sidebar collapsed layout sizing

### DIFF
--- a/experimental/beats/src/components/app-sidebar.tsx
+++ b/experimental/beats/src/components/app-sidebar.tsx
@@ -109,7 +109,7 @@ export function AppSidebar() {
       variant="floating"
       className={SIDEBAR_TOP_OFFSET_CLASS}
     >
-      <SidebarHeader className="gap-2 px-2.5 pt-2 pb-1">
+      <SidebarHeader className="gap-2 px-2.5 pt-2 pb-1 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:px-2 group-data-[collapsible=icon]:pb-2">
         <div className="border-sidebar-border bg-sidebar overflow-hidden border px-3 py-3 group-data-[collapsible=icon]:hidden">
           <div className="flex items-start justify-between gap-3">
             <div className="space-y-2">
@@ -142,8 +142,8 @@ export function AppSidebar() {
             />
           </div>
         </div>
-        <div className="border-sidebar-border bg-sidebar text-sidebar-foreground hidden h-16 items-center justify-center border group-data-[collapsible=icon]:flex">
-          <div className="font-tomorrow flex h-10 w-10 items-center justify-center border border-current/45 text-lg tracking-[0.14em]">
+        <div className="border-sidebar-border bg-sidebar text-sidebar-foreground hidden w-full items-center justify-center border px-1.5 py-2 group-data-[collapsible=icon]:flex">
+          <div className="font-tomorrow flex h-8 w-8 items-center justify-center border border-current/45 text-base tracking-[0.14em]">
             B
           </div>
         </div>

--- a/experimental/beats/src/components/ui/sidebar.tsx
+++ b/experimental/beats/src/components/ui/sidebar.tsx
@@ -37,7 +37,7 @@ const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = "16rem";
 const SIDEBAR_WIDTH_MOBILE = "18rem";
-const SIDEBAR_WIDTH_ICON = "3rem";
+const SIDEBAR_WIDTH_ICON = "4rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
 
 type SidebarContextProps = {
@@ -230,7 +230,7 @@ function Sidebar({
           "group-data-[collapsible=offcanvas]:w-0",
           "group-data-[side=right]:rotate-180",
           variant === "floating" || variant === "inset"
-            ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
+            ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+1rem)]"
             : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
         )}
       />
@@ -243,7 +243,7 @@ function Sidebar({
             : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
           // Adjust the padding for floating and inset variants.
           variant === "floating" || variant === "inset"
-            ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
+            ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+1rem+2px)]"
             : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
           className,
         )}


### PR DESCRIPTION
## Summary
- increase the collapsed floating sidebar icon width from `3rem` to `4rem` so icon mode has enough space
- adjust the floating sidebar width calculations to match the new collapsed rail sizing
- tighten collapsed header padding and reduce the monogram tile size so the logo stays centered without clipping

## Testing
- `./node_modules/.bin/prettier --check src/components/app-sidebar.tsx src/components/ui/sidebar.tsx`
- `./node_modules/.bin/eslint src/components/app-sidebar.tsx src/components/ui/sidebar.tsx`
- `make format`
- `make test`