### PR TITLE
Add generated Beats route tree to gitignore

### DIFF
--- a/experimental/beats/.gitignore
+++ b/experimental/beats/.gitignore
@@ -102,3 +102,4 @@ out/
 
 # Tanstack
 .tanstack/
+src/routeTree.gen.ts


### PR DESCRIPTION
## Summary
- Ignore `experimental/beats/src/routeTree.gen.ts`
- Keep generated TanStack route output out of version control

## Testing
- Not run (not requested)