### PR TITLE
Add sensor deck shortcuts from Beats peripheral previews

### DIFF
--- a/experimental/beats/src/components/peripheral-sensor-deck.tsx
+++ b/experimental/beats/src/components/peripheral-sensor-deck.tsx
@@ -8,7 +8,11 @@ function uniquePeripheralCount(sensorIds: string[]) {
   return new Set(sensorIds).size;
 }
 
-export function PeripheralSensorDeck() {
+export function PeripheralSensorDeck({
+  preferredSensorKey,
+}: {
+  preferredSensorKey?: string;
+}) {
   const {
     clockSeconds,
     overrides,
@@ -19,10 +23,10 @@ export function PeripheralSensorDeck() {
     updateSensorOverride,
     resetSensorOverride,
     clearSelectedSensorHistory,
-  } = useSensorSimulation();
+  } = useSensorSimulation(preferredSensorKey);
 
   return (
-    <div className="grid gap-6">
+    <div id="sensor-deck" className="grid gap-6">
       <section className="rounded-[1.5rem] border border-[#2f353f] bg-[linear-gradient(180deg,_rgba(21,26,33,0.96),_rgba(11,14,19,0.99))] p-5 text-slate-100 shadow-[0_24px_60px_rgba(0,0,0,0.45)]">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="space-y-2">

--- a/experimental/beats/src/components/ui/peripherals/generic_sensor.tsx
+++ b/experimental/beats/src/components/ui/peripherals/generic_sensor.tsx
@@ -1,4 +1,6 @@
 import type { PeripheralInfo } from "@/actions/ws/providers/PeripheralProvider";
+import { useNavigate } from "@tanstack/react-router";
+import { useEffect, useState, type MouseEvent as ReactMouseEvent } from "react";
 
 type PreviewMetric = {
   id: string;
@@ -13,6 +15,12 @@ type PreviewMetricGroup = {
   id: string;
   label: string;
   metrics: PreviewMetric[];
+};
+
+type SensorContextMenuState = {
+  x: number;
+  y: number;
+  metric: PreviewMetric;
 };
 
 const MAX_PREVIEW_METRICS = 6;
@@ -152,8 +160,63 @@ export function GenericSensorPeripheralView({
   lastData: unknown;
   peripheral: PeripheralInfo;
 }) {
+  const navigate = useNavigate();
   const metrics = collectPreviewMetrics(lastData);
   const metricGroups = groupPreviewMetrics(metrics);
+  const [contextMenu, setContextMenu] = useState<SensorContextMenuState | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!contextMenu) {
+      return;
+    }
+
+    function dismissMenu() {
+      setContextMenu(null);
+    }
+
+    function dismissOnEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setContextMenu(null);
+      }
+    }
+
+    window.addEventListener("click", dismissMenu);
+    window.addEventListener("scroll", dismissMenu, true);
+    window.addEventListener("keydown", dismissOnEscape);
+
+    return () => {
+      window.removeEventListener("click", dismissMenu);
+      window.removeEventListener("scroll", dismissMenu, true);
+      window.removeEventListener("keydown", dismissOnEscape);
+    };
+  }, [contextMenu]);
+
+  function openContextMenu(
+    event: ReactMouseEvent<HTMLDivElement>,
+    metric: PreviewMetric,
+  ) {
+    event.preventDefault();
+    event.stopPropagation();
+    setContextMenu({
+      x: event.clientX,
+      y: event.clientY,
+      metric,
+    });
+  }
+
+  function openSensorDeck(metric: PreviewMetric) {
+    const peripheralId = peripheral.id ?? "unknown";
+    setContextMenu(null);
+    void navigate({
+      to: "/peripherals/connected",
+      hash: "sensor-deck",
+      search: () => ({
+        sensor: `${peripheralId}:${metric.label}`,
+      }),
+    });
+  }
 
   if (metrics.length === 0) {
     return (
@@ -186,7 +249,7 @@ export function GenericSensorPeripheralView({
   return (
     <div
       className={
-        "border-border bg-background/60 text-foreground flex flex-col gap-3 border p-3 text-xs " +
+        "border-border bg-background/60 text-foreground relative flex flex-col gap-3 border p-3 text-xs " +
         (className ?? "")
       }
     >
@@ -223,6 +286,7 @@ export function GenericSensorPeripheralView({
                 <div
                   key={metric.id}
                   className="border-border/70 bg-background/80 rounded-sm border px-3 py-2"
+                  onContextMenu={(event) => openContextMenu(event, metric)}
                 >
                   <div className="flex items-center justify-between gap-3">
                     <span className="text-muted-foreground truncate font-mono text-[0.68rem] uppercase">
@@ -248,6 +312,28 @@ export function GenericSensorPeripheralView({
           </section>
         ))}
       </div>
+
+      {contextMenu ? (
+        <div
+          className="border-border/80 bg-background fixed z-50 min-w-56 rounded-md border p-1 shadow-[0_18px_48px_rgba(0,0,0,0.4)]"
+          style={{
+            left: contextMenu.x,
+            top: contextMenu.y,
+          }}
+        >
+          <button
+            type="button"
+            className="hover:bg-accent hover:text-accent-foreground flex w-full flex-col rounded-sm px-3 py-2 text-left"
+            onClick={() => openSensorDeck(contextMenu.metric)}
+          >
+            <span className="text-sm font-medium">Open In Sensor Deck</span>
+            <span className="text-muted-foreground text-[0.7rem]">
+              Set a constant value or drive {contextMenu.metric.signalLabel}{" "}
+              with a function.
+            </span>
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/experimental/beats/src/features/stream-console/use-sensor-simulation.ts
+++ b/experimental/beats/src/features/stream-console/use-sensor-simulation.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useConnectedPeripherals } from "@/actions/ws/providers/PeripheralProvider";
+import { getSensorCommandKey } from "@/features/stream-console/terminal-commands";
 import {
   appendSensorHistory,
   defaultSensorOverride,
@@ -12,7 +13,7 @@ import {
 const HISTORY_LIMIT = 180;
 const SENSOR_SAMPLE_INTERVAL_MS = 250;
 
-export function useSensorSimulation() {
+export function useSensorSimulation(preferredSensorKey?: string | null) {
   const peripherals = useConnectedPeripherals();
   const [clockSeconds, setClockSeconds] = useState(0);
   const [requestedSensorId, setRequestedSensorId] = useState<string | null>(
@@ -29,11 +30,16 @@ export function useSensorSimulation() {
   const sensors = extractSensorChannels(peripherals);
   const sensorsRef = useRef(sensors);
   const overridesRef = useRef(overrides);
+  const preferredSensorId = preferredSensorKey
+    ? (sensors.find(
+        (sensor) => getSensorCommandKey(sensor) === preferredSensorKey,
+      )?.id ?? null)
+    : null;
   const selectedSensorId =
     requestedSensorId &&
     sensors.some((sensor) => sensor.id === requestedSensorId)
       ? requestedSensorId
-      : (sensors[0]?.id ?? null);
+      : (preferredSensorId ?? sensors[0]?.id ?? null);
 
   useEffect(() => {
     sensorsRef.current = sensors;

--- a/experimental/beats/src/routes/peripherals/connected.tsx
+++ b/experimental/beats/src/routes/peripherals/connected.tsx
@@ -7,12 +7,18 @@ import {
   SpecChip,
 } from "@/components/beats-shell";
 import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
 
 export const Route = createFileRoute("/peripherals/connected")({
+  validateSearch: z.object({
+    sensor: z.string().optional(),
+  }),
   component: RouteComponent,
 });
 
 function RouteComponent() {
+  const search = Route.useSearch();
+
   return (
     <PageFrame>
       <PaperCard>
@@ -23,7 +29,7 @@ function RouteComponent() {
           aside={<SpecChip tone="muted">Input Variant / Mode</SpecChip>}
         />
       </PaperCard>
-      <PeripheralSensorDeck />
+      <PeripheralSensorDeck preferredSensorKey={search.sensor} />
       <PeripheralTree hierarchy={[["input_variant", "mode"]]} />
     </PageFrame>
   );

--- a/experimental/beats/src/tests/unit/components/generic_sensor.test.ts
+++ b/experimental/beats/src/tests/unit/components/generic_sensor.test.ts
@@ -1,8 +1,17 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { createElement } from "react";
 import {
   collectPreviewMetrics,
+  GenericSensorPeripheralView,
   groupPreviewMetrics,
 } from "@/components/ui/peripherals/generic_sensor";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+const navigateMock = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigateMock,
+}));
 
 describe("collectPreviewMetrics", () => {
   it("collects numeric and boolean leaves from nested payloads", () => {
@@ -116,5 +125,40 @@ describe("groupPreviewMetrics", () => {
         ],
       },
     ]);
+  });
+});
+
+describe("GenericSensorPeripheralView", () => {
+  it("opens the sensor deck for a right-clicked preview signal", () => {
+    render(
+      createElement(GenericSensorPeripheralView, {
+        peripheral: {
+          id: "imu.1",
+          tags: [],
+        },
+        lastData: {
+          imu: {
+            x: 0.14,
+            y: -0.22,
+          },
+        },
+      }),
+    );
+
+    fireEvent.contextMenu(screen.getByText("x"));
+    fireEvent.click(
+      screen.getByRole("button", { name: /open in sensor deck/i }),
+    );
+
+    expect(navigateMock).toHaveBeenCalledWith({
+      hash: "sensor-deck",
+      search: expect.any(Function),
+      to: "/peripherals/connected",
+    });
+
+    const navigateArgs = navigateMock.mock.calls.at(-1)?.[0];
+    expect(navigateArgs.search()).toEqual({
+      sensor: "imu.1:imu.x",
+    });
   });
 });

--- a/experimental/beats/src/tests/unit/components/peripheral-sensor-deck.test.tsx
+++ b/experimental/beats/src/tests/unit/components/peripheral-sensor-deck.test.tsx
@@ -41,12 +41,14 @@ const simulationState = vi.hoisted(() => {
   };
 });
 
+const useSensorSimulationMock = vi.hoisted(() => vi.fn(() => simulationState));
+
 vi.mock("@/actions/ws/providers/PeripheralEventsProvider", () => ({
   usePeripheralEvents: () => [],
 }));
 
 vi.mock("@/features/stream-console/use-sensor-simulation", () => ({
-  useSensorSimulation: () => simulationState,
+  useSensorSimulation: useSensorSimulationMock,
 }));
 
 describe("PeripheralSensorDeck", () => {
@@ -57,5 +59,11 @@ describe("PeripheralSensorDeck", () => {
       screen.getByRole("textbox", { name: "Sensor terminal command" }),
     ).toBeInTheDocument();
     expect(screen.getAllByText("dpad / payload.x").length).toBeGreaterThan(0);
+  });
+
+  it("passes a preferred sensor key into the simulation hook", () => {
+    render(<PeripheralSensorDeck preferredSensorKey="dpad:payload.x" />);
+
+    expect(useSensorSimulationMock).toHaveBeenLastCalledWith("dpad:payload.x");
   });
 });


### PR DESCRIPTION
## Summary
- add a right-click context menu for generic Beats sensor preview metrics
- deep-link `Open In Sensor Deck` to `/peripherals/connected` with the selected sensor in route search params
- update the sensor deck and simulation hook to honor a preferred sensor key and focus the matching channel
- add unit coverage for the new context-menu navigation and preferred-sensor selection flow

## Testing
- `./node_modules/.bin/prettier --write src/routes/peripherals/connected.tsx src/components/peripheral-sensor-deck.tsx src/components/ui/peripherals/generic_sensor.tsx src/features/stream-console/use-sensor-simulation.ts src/tests/unit/components/peripheral-sensor-deck.test.tsx src/tests/unit/components/generic_sensor.test.ts`
- `./node_modules/.bin/eslint src/routes/peripherals/connected.tsx src/components/peripheral-sensor-deck.tsx src/components/ui/peripherals/generic_sensor.tsx src/features/stream-console/use-sensor-simulation.ts src/tests/unit/components/peripheral-sensor-deck.test.tsx src/tests/unit/components/generic_sensor.test.ts`
- `npm run test -- --run src/tests/unit/components/peripheral-sensor-deck.test.tsx src/tests/unit/components/generic_sensor.test.ts`