### PR TITLE
Fix Beats startup crash from unconditional React DevTools install

### DIFF
--- a/experimental/beats/src/main.ts
+++ b/experimental/beats/src/main.ts
@@ -9,6 +9,8 @@ import path from "path";
 import { IPC_CHANNELS } from "./constants";
 
 const inDevelopment = process.env.NODE_ENV === "development";
+const installReactDevTools =
+  inDevelopment && process.env.BEATS_INSTALL_REACT_DEVTOOLS === "1";
 
 function createWindow() {
   const preload = path.join(__dirname, "preload.js");
@@ -40,11 +42,15 @@ function createWindow() {
 }
 
 async function installExtensions() {
+  if (!installReactDevTools) {
+    return;
+  }
+
   try {
     const result = await installExtension(REACT_DEVELOPER_TOOLS);
     console.log(`Extensions installed successfully: ${result.name}`);
-  } catch {
-    console.error("Failed to install extensions");
+  } catch (error) {
+    console.error("Failed to install React Developer Tools", error);
   }
 }
 


### PR DESCRIPTION
## Summary
- gate React Developer Tools installation behind `BEATS_INSTALL_REACT_DEVTOOLS=1` in development
- avoid Electron sandbox renderer crashes during normal Beats startup
- log the underlying install error when the optional extension install fails

## Testing
- Not run (not requested)