### PR TITLE
Fix BEATS frame streaming and display rendering

### DIFF
--- a/experimental/beats/src/components/stream-cube.tsx
+++ b/experimental/beats/src/components/stream-cube.tsx
@@ -54,6 +54,9 @@ export function StreamCube({
   const animationRef = useRef<number | null>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
   const readyFrameRef = useRef<number | null>(null);
+  const pendingImageUrlRef = useRef<string | null>(imgURL);
+  const isApplyingImageRef = useRef(false);
+  const isMountedRef = useRef(true);
   const sceneConfigRef = useRef(sceneConfig);
   const telemetryValueRef = useRef(telemetryValue);
   const [isRendererReady, setIsRendererReady] = useState(false);
@@ -65,6 +68,14 @@ export function StreamCube({
   useEffect(() => {
     telemetryValueRef.current = telemetryValue;
   }, [telemetryValue]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -261,45 +272,58 @@ export function StreamCube({
   }, [onContextError]);
 
   useEffect(() => {
-    let cancelled = false;
+    pendingImageUrlRef.current = imgURL;
 
-    const applyTexture = async () => {
-      const streamTexture = streamTextureRef.current;
-      const streamContext = streamContextRef.current;
-      const streamCanvas = streamCanvasRef.current;
-      if (!streamTexture || !streamContext || !streamCanvas) return;
-
-      try {
-        if (imgURL) {
-          const image = await loadStreamImage(imgURL);
-          if (cancelled) {
-            return;
-          }
-          drawStreamImage(streamContext, streamCanvas, image);
-        } else {
-          drawFallbackTexture(streamContext, streamCanvas);
-        }
-      } catch (error) {
-        console.warn("Failed to load streamed texture; using fallback", error);
-        drawFallbackTexture(streamContext, streamCanvas);
-      }
-
-      if (cancelled) {
+    const applyPendingTexture = async () => {
+      if (isApplyingImageRef.current) {
         return;
       }
 
-      applyTextureSettings(
-        streamTexture,
-        sceneConfigRef.current.surface.textureRepeat,
-      );
-      streamTexture.needsUpdate = true;
+      isApplyingImageRef.current = true;
+
+      try {
+        while (isMountedRef.current) {
+          const nextUrl = pendingImageUrlRef.current;
+          const streamTexture = streamTextureRef.current;
+          const streamContext = streamContextRef.current;
+          const streamCanvas = streamCanvasRef.current;
+          if (!streamTexture || !streamContext || !streamCanvas) {
+            return;
+          }
+
+          pendingImageUrlRef.current = null;
+
+          try {
+            if (nextUrl) {
+              const image = await loadStreamImage(nextUrl);
+              if (!isMountedRef.current) {
+                return;
+              }
+              drawStreamImage(streamContext, streamCanvas, image);
+            } else {
+              drawFallbackTexture(streamContext, streamCanvas);
+            }
+          } catch (error) {
+            console.warn("Failed to load streamed texture; using fallback", error);
+            drawFallbackTexture(streamContext, streamCanvas);
+          }
+
+          applyTextureSettings(
+            streamTexture,
+            sceneConfigRef.current.surface.textureRepeat,
+          );
+          streamTexture.needsUpdate = true;
+
+          if (pendingImageUrlRef.current === null) {
+            return;
+          }
+        }
+      } finally {
+        isApplyingImageRef.current = false;
+      }
     };
 
-    applyTexture();
-
-    return () => {
-      cancelled = true;
-    };
+    void applyPendingTexture();
   }, [imgURL]);
 
   const backgroundTint = Math.round(sceneConfig.stage.backgroundTint * 100);

--- a/src/heart/utilities/env/system.py
+++ b/src/heart/utilities/env/system.py
@@ -55,7 +55,7 @@ class SystemConfiguration:
 
     @classmethod
     def forward_to_beats_app(cls) -> bool:
-        return _env_flag("FORWARD_TO_BEATS_MAP", default=False)
+        return _env_flag("FORWARD_TO_BEATS_APP", default=False)
 
     @classmethod
     def peripheral_configuration(cls) -> str:

--- a/tests/utilities/test_env.py
+++ b/tests/utilities/test_env.py
@@ -134,6 +134,21 @@ class TestUtilitiesEnv:
         monkeypatch.setenv("DEBUG_MODE", "false")
         assert Configuration.is_debug_mode() is False
 
+    def test_forward_to_beats_app_reads_expected_env_flag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify the Beats forwarding helper reads the documented APP flag so streamed display output reaches the BEATS client."""
+
+        _clear_env(monkeypatch, "FORWARD_TO_BEATS_APP", "FORWARD_TO_BEATS_MAP")
+        assert Configuration.forward_to_beats_app() is False
+
+        monkeypatch.setenv("FORWARD_TO_BEATS_APP", "true")
+        assert Configuration.forward_to_beats_app() is True
+
+        monkeypatch.delenv("FORWARD_TO_BEATS_APP", raising=False)
+        monkeypatch.setenv("FORWARD_TO_BEATS_MAP", "true")
+        assert Configuration.forward_to_beats_app() is False
+
 
     def test_asset_cache_strategy_defaults_all(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Verify asset cache strategy defaults to all. This keeps IO reuse enabled without explicit tuning."""


### PR DESCRIPTION
## Summary
- correct the runtime env flag so `FORWARD_TO_BEATS_APP` enables BEATS display forwarding
- add regression coverage for the BEATS forwarding flag lookup
- update the stream cube texture pipeline to keep applying the latest frame instead of starving on rapid frame updates

## Testing
- `pytest tests/device/test_beats_websocket.py`
- `pytest tests/utilities/test_env.py`
- Frontend checks not run because `experimental/beats/node_modules` was unavailable