### PR TITLE
Add pause and key-value filtering to the Beats event log

### DIFF
--- a/experimental/beats/src/actions/peripherals/event_list.tsx
+++ b/experimental/beats/src/actions/peripherals/event_list.tsx
@@ -1,8 +1,22 @@
+import { useDeferredValue, useState } from "react";
+
 import { TechnicalCard } from "@/components/beats-shell";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { usePeripheralEvents } from "../ws/providers/PeripheralEventsProvider";
 
 export function EventList() {
   const events = usePeripheralEvents();
+  const [pausedEvents, setPausedEvents] = useState<typeof events | null>(null);
+  const [filterKey, setFilterKey] = useState("");
+  const [filterValue, setFilterValue] = useState("");
+  const isPaused = pausedEvents !== null;
+  const displayedEvents = isPaused ? pausedEvents : events;
+  const deferredFilterKey = useDeferredValue(filterKey);
+  const deferredFilterValue = useDeferredValue(filterValue);
+  const filteredEvents = displayedEvents.filter((event) =>
+    matchesEventFilter(event, deferredFilterKey, deferredFilterValue),
+  );
 
   return (
     <TechnicalCard className="flex h-full flex-col gap-5 select-none">
@@ -13,9 +27,45 @@ export function EventList() {
             Signal Log
           </h2>
         </div>
-        <p className="font-mono text-[0.72rem] tracking-[0.18em] text-[#bdb3a6] uppercase">
-          {events.length} Entries Cached
-        </p>
+        <div className="flex flex-wrap items-center justify-end gap-3">
+          <p className="font-mono text-[0.72rem] tracking-[0.18em] text-[#bdb3a6] uppercase">
+            {filteredEvents.length} Visible / {displayedEvents.length} Cached
+          </p>
+          <Button
+            type="button"
+            variant={isPaused ? "default" : "outline"}
+            onClick={() =>
+              setPausedEvents((current) => (current === null ? events : null))
+            }
+          >
+            {isPaused ? "Resume" : "Pause"}
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
+        <label className="space-y-2">
+          <span className="font-mono text-[0.68rem] tracking-[0.18em] text-[#bdb3a6] uppercase">
+            Filter Key
+          </span>
+          <Input
+            aria-label="Event filter key"
+            placeholder="id"
+            value={filterKey}
+            onChange={(event) => setFilterKey(event.target.value)}
+          />
+        </label>
+        <label className="space-y-2">
+          <span className="font-mono text-[0.68rem] tracking-[0.18em] text-[#bdb3a6] uppercase">
+            Filter Value
+          </span>
+          <Input
+            aria-label="Event filter value"
+            placeholder="alpha"
+            value={filterValue}
+            onChange={(event) => setFilterValue(event.target.value)}
+          />
+        </label>
       </div>
 
       <div className="beats-scroll-panel max-h-screen overflow-y-auto border-white/20 bg-white/5">
@@ -29,22 +79,89 @@ export function EventList() {
           </thead>
 
           <tbody>
-            {events.map((evt, idx) => (
-              <tr key={idx}>
-                <td className="px-2 py-1 whitespace-nowrap">
-                  {new Date(evt.ts).toLocaleTimeString()}
-                </td>
-                <td className="px-2 py-1">{evt.msg.type}</td>
-                <td className="px-2 py-1">
-                  <pre className="whitespace-pre-wrap">
-                    {JSON.stringify(evt.msg.payload, null, 2)}
-                  </pre>
+            {filteredEvents.length > 0 ? (
+              filteredEvents.map((evt, idx) => (
+                <tr key={`${evt.ts}:${idx}`}>
+                  <td className="px-2 py-1 whitespace-nowrap">
+                    {new Date(evt.ts).toLocaleTimeString()}
+                  </td>
+                  <td className="px-2 py-1">{evt.msg.type}</td>
+                  <td className="px-2 py-1">
+                    <pre className="whitespace-pre-wrap">
+                      {JSON.stringify(evt.msg.payload, null, 2)}
+                    </pre>
+                  </td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td
+                  className="px-2 py-6 font-mono text-[0.72rem] tracking-[0.12em] text-[#bdb3a6] uppercase"
+                  colSpan={3}
+                >
+                  No events match the current filter.
                 </td>
               </tr>
-            ))}
+            )}
           </tbody>
         </table>
       </div>
     </TechnicalCard>
   );
+}
+
+function matchesEventFilter(
+  event: ReturnType<typeof usePeripheralEvents>[number],
+  filterKey: string,
+  filterValue: string,
+) {
+  const normalizedKey = filterKey.trim().toLowerCase();
+  const normalizedValue = filterValue.trim().toLowerCase();
+
+  if (!normalizedKey && !normalizedValue) {
+    return true;
+  }
+
+  const scalarEntries = collectScalarEntries(event.msg.payload);
+
+  return scalarEntries.some(({ key, value }) => {
+    const keyMatches = normalizedKey ? key === normalizedKey : true;
+    const valueMatches = normalizedValue
+      ? value.toLowerCase().includes(normalizedValue)
+      : true;
+    return keyMatches && valueMatches;
+  });
+}
+
+function collectScalarEntries(
+  input: unknown,
+  currentKey?: string,
+): Array<{ key: string; value: string }> {
+  if (input === null || input === undefined) {
+    return currentKey
+      ? [{ key: currentKey.toLowerCase(), value: String(input) }]
+      : [];
+  }
+
+  if (
+    typeof input === "string" ||
+    typeof input === "number" ||
+    typeof input === "boolean"
+  ) {
+    return currentKey
+      ? [{ key: currentKey.toLowerCase(), value: String(input) }]
+      : [];
+  }
+
+  if (Array.isArray(input)) {
+    return input.flatMap((entry) => collectScalarEntries(entry, currentKey));
+  }
+
+  if (typeof input === "object") {
+    return Object.entries(input).flatMap(([key, value]) =>
+      collectScalarEntries(value, key),
+    );
+  }
+
+  return [];
 }

--- a/experimental/beats/src/tests/unit/actions/peripherals/event_list.test.tsx
+++ b/experimental/beats/src/tests/unit/actions/peripherals/event_list.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { EventList } from "@/actions/peripherals/event_list";
+
+type MockPeripheralEvent = {
+  ts: number;
+  msg: {
+    type: "peripheral";
+    payload: {
+      peripheralInfo: {
+        id: string | null;
+        tags: Array<{
+          name: string;
+          variant: string;
+          metadata?: Record<string, string>;
+        }>;
+      };
+      data: unknown;
+      payloadEncoding: number | null;
+    };
+  };
+};
+
+const peripheralEventsState = vi.hoisted(() => ({
+  events: [] as MockPeripheralEvent[],
+}));
+
+vi.mock("@/actions/ws/providers/PeripheralEventsProvider", () => ({
+  usePeripheralEvents: () => peripheralEventsState.events,
+}));
+
+describe("EventList", () => {
+  it("freezes the rendered event rows while the operator pauses the log", async () => {
+    const user = userEvent.setup();
+    peripheralEventsState.events = [
+      createPeripheralEvent({
+        id: "alpha",
+        variant: "dial",
+        ts: 1_000,
+      }),
+    ];
+
+    const { rerender } = render(<EventList />);
+
+    expect(screen.getByText("1 Visible / 1 Cached")).toBeInTheDocument();
+    expect(screen.getByText(/"id": "alpha"/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Pause" }));
+
+    peripheralEventsState.events = [
+      createPeripheralEvent({
+        id: "beta",
+        variant: "gyro",
+        ts: 2_000,
+      }),
+      ...peripheralEventsState.events,
+    ];
+    rerender(<EventList />);
+
+    expect(screen.getByRole("button", { name: "Resume" })).toBeInTheDocument();
+    expect(screen.getByText("1 Visible / 1 Cached")).toBeInTheDocument();
+    expect(screen.queryByText(/"id": "beta"/)).not.toBeInTheDocument();
+    expect(screen.getByText(/"id": "alpha"/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Resume" }));
+
+    expect(screen.getByText("2 Visible / 2 Cached")).toBeInTheDocument();
+    expect(screen.getByText(/"id": "beta"/)).toBeInTheDocument();
+  });
+
+  it("filters rows by nested payload keys such as variant values", async () => {
+    const user = userEvent.setup();
+    peripheralEventsState.events = [
+      createPeripheralEvent({
+        id: "alpha",
+        variant: "dial",
+        ts: 1_000,
+      }),
+      createPeripheralEvent({
+        id: "beta",
+        variant: "gyro",
+        ts: 2_000,
+      }),
+    ];
+
+    render(<EventList />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Event filter key" }),
+      "variant",
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: "Event filter value" }),
+      "gyro",
+    );
+
+    expect(screen.getByText("1 Visible / 2 Cached")).toBeInTheDocument();
+    expect(screen.getByText(/"id": "beta"/)).toBeInTheDocument();
+    expect(screen.queryByText(/"id": "alpha"/)).not.toBeInTheDocument();
+  });
+});
+
+function createPeripheralEvent({
+  id,
+  variant,
+  ts,
+}: {
+  id: string;
+  variant: string;
+  ts: number;
+}): MockPeripheralEvent {
+  return {
+    ts,
+    msg: {
+      type: "peripheral",
+      payload: {
+        peripheralInfo: {
+          id,
+          tags: [
+            {
+              name: "input_variant",
+              variant,
+            },
+          ],
+        },
+        data: {
+          id,
+          variant,
+        },
+        payloadEncoding: 1,
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add pause and resume controls so the Events view can freeze the current log while new websocket traffic continues arriving
- add key/value filters for event payload fields, including nested values such as `id` and `variant`
- add unit coverage for paused snapshots and nested field filtering in the event list

## Testing
- `cd experimental/beats && npm run test -- --run src/tests/unit/actions/peripherals/event_list.test.tsx`