### PR TITLE
Fix Beats websocket replay disconnect handling

### DIFF
--- a/src/heart/device/beats/websocket.py
+++ b/src/heart/device/beats/websocket.py
@@ -177,13 +177,7 @@ class WebSocket:
         assert broadcast_queue is not None
 
         async def handler(ws: Any) -> None:
-            self.clients.add(ws)
-            try:
-                for frame in self._replay_frames():
-                    await ws.send(frame)
-                await ws.wait_closed()
-            finally:
-                self.clients.discard(ws)
+            await self._handle_client(ws)
 
         async def broadcast_worker() -> None:
             while True:
@@ -234,6 +228,21 @@ class WebSocket:
 
         main_task = loop.create_task(main())
         loop.run_until_complete(main_task)
+
+    async def _handle_client(self, ws: Any) -> None:
+        self.clients.add(ws)
+        try:
+            try:
+                for frame in self._replay_frames():
+                    await ws.send(frame)
+            except (ConnectionClosedOK, ConnectionClosedError):
+                logger.debug("Beats websocket client disconnected during replay send.")
+                return
+            await ws.wait_closed()
+        except (ConnectionClosedOK, ConnectionClosedError):
+            logger.debug("Beats websocket client disconnected.")
+        finally:
+            self.clients.discard(ws)
 
     def send(self, kind: str, payload: object) -> None:
         frame_bytes = self._encode_payload(kind=kind, payload=payload)

--- a/tests/device/test_beats_websocket.py
+++ b/tests/device/test_beats_websocket.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import threading
 from dataclasses import dataclass
@@ -262,3 +263,31 @@ class TestWebSocketReplayCache:
             b"switch-1-latest",
             b"sensor-1-latest",
         )
+
+
+class TestWebSocketDisconnectHandling:
+    """Validate disconnect handling so expected client drops do not surface as server errors."""
+
+    def test_handler_ignores_disconnect_during_replay_send(self) -> None:
+        """Verify replay send disconnects are treated as normal closure so reconnect churn does not log handler failures."""
+        from websockets.exceptions import ConnectionClosedError
+
+        websocket = object.__new__(WebSocket)
+        websocket.clients = set()
+        websocket._replay_lock = threading.Lock()
+        websocket._latest_frame = b"replay-frame"
+        websocket._latest_peripheral_frames = {}
+
+        class _ClosingConnection:
+            async def send(self, _frame: bytes) -> None:
+                raise ConnectionClosedError(
+                    None,
+                    None,
+                )
+
+            async def wait_closed(self) -> None:
+                raise AssertionError("wait_closed should not run after replay disconnect")
+
+        connection = _ClosingConnection()
+        asyncio.run(websocket._handle_client(connection))
+        assert connection not in websocket.clients


### PR DESCRIPTION
## Summary
- route per-client websocket lifecycle through `_handle_client()` for clearer connection handling
- treat `ConnectionClosedOK` and `ConnectionClosedError` during replay send and close wait as expected disconnects
- add a regression test covering a client drop while replay frames are being sent

## Testing
- `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/343c/heart/.uv-cache .venv/bin/pytest tests/device/test_beats_websocket.py`
- `.venv/bin/ruff check src/heart/device/beats/websocket.py tests/device/test_beats_websocket.py`
- `.venv/bin/isort src/heart/device/beats/websocket.py tests/device/test_beats_websocket.py --check-only`