### PR TITLE
Fix Beats websocket startup when no endpoint is configured

### DIFF
--- a/experimental/beats/src/App.tsx
+++ b/experimental/beats/src/App.tsx
@@ -6,7 +6,10 @@ import { ImageProvider } from "./actions/ws/providers/ImageProvider";
 import { PeripheralEventsProvider } from "./actions/ws/providers/PeripheralEventsProvider";
 import { PeripheralProvider } from "./actions/ws/providers/PeripheralProvider";
 import { WSProvider } from "./actions/ws/websocket";
+import { getConfiguredBeatsWebSocketUrl } from "./config/websocket";
 import { router } from "./utils/routes";
+
+const websocketUrl = getConfiguredBeatsWebSocketUrl();
 
 export default function App() {
   useEffect(() => {
@@ -18,7 +21,7 @@ export default function App() {
 
 const root = createRoot(document.getElementById("app")!);
 root.render(
-  <WSProvider url="ws://localhost:8765">
+  <WSProvider url={websocketUrl}>
     <React.StrictMode>
       <PeripheralEventsProvider>
         <PeripheralProvider>

--- a/experimental/beats/src/actions/ws/websocket.tsx
+++ b/experimental/beats/src/actions/ws/websocket.tsx
@@ -16,7 +16,7 @@ const WSContext = createContext<WSContextValue>({
 });
 
 interface WSProviderProps {
-  url: string;
+  url: string | null;
   children: React.ReactNode;
   retryDelay?: number;
   maxRetryDelay?: number;
@@ -82,6 +82,13 @@ export function WSProvider({
       const attempt = attemptRef.current;
 
       cleanupSocket(socketRef.current);
+
+      if (!url) {
+        socketRef.current = null;
+        setSocket(null);
+        setReadyState(WebSocket.CLOSED);
+        return;
+      }
 
       const ws = new WebSocket(url);
       ws.binaryType = "arraybuffer";

--- a/experimental/beats/src/components/app-sidebar.tsx
+++ b/experimental/beats/src/components/app-sidebar.tsx
@@ -20,6 +20,10 @@ import { Link, useRouterState } from "@tanstack/react-router";
 import { useEffect, useState, useTransition } from "react";
 import { getAppVersion } from "../actions/app";
 import {
+  DISABLED_WEBSOCKET_LABEL,
+  getConfiguredBeatsWebSocketUrl,
+} from "../config/websocket";
+import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
@@ -35,6 +39,8 @@ import {
   SidebarSeparator,
   useSidebar,
 } from "./ui/sidebar";
+
+const configuredWebsocketUrl = getConfiguredBeatsWebSocketUrl();
 
 // Menu items.
 const items = {
@@ -138,7 +144,7 @@ export function AppSidebar() {
             />
             <DataRow
               label="Signal"
-              value="ws://localhost:8765"
+              value={configuredWebsocketUrl ?? DISABLED_WEBSOCKET_LABEL}
               className="text-sidebar-foreground grid-cols-1 gap-1"
               valueClassName="break-all"
             />

--- a/experimental/beats/src/config/websocket.ts
+++ b/experimental/beats/src/config/websocket.ts
@@ -1,0 +1,13 @@
+const EMPTY_WEBSOCKET_URL = "";
+
+export const DISABLED_WEBSOCKET_LABEL = "Not configured";
+
+export function getConfiguredBeatsWebSocketUrl(): string | null {
+  const configuredUrl = import.meta.env.VITE_BEATS_WEBSOCKET_URL?.trim();
+
+  if (!configuredUrl || configuredUrl === EMPTY_WEBSOCKET_URL) {
+    return null;
+  }
+
+  return configuredUrl;
+}

--- a/experimental/beats/src/routes/index.tsx
+++ b/experimental/beats/src/routes/index.tsx
@@ -12,6 +12,10 @@ import {
   SpecChip,
   TechnicalCard,
 } from "@/components/beats-shell";
+import {
+  DISABLED_WEBSOCKET_LABEL,
+  getConfiguredBeatsWebSocketUrl,
+} from "@/config/websocket";
 import { Link, createFileRoute } from "@tanstack/react-router";
 import { Binary, Mouse, RadioTower, ScanLine, Tv } from "lucide-react";
 import { useEffect, useState, useTransition } from "react";
@@ -19,6 +23,7 @@ import { useEffect, useState, useTransition } from "react";
 const RECENT_DEVICE_LIMIT = 4;
 const RECENT_ACTIVITY_WINDOW_MS = 60_000;
 const RECENT_ACTIVITY_TICK_MS = 5_000;
+const configuredWebsocketUrl = getConfiguredBeatsWebSocketUrl();
 
 const routeCards = [
   {
@@ -272,7 +277,11 @@ function HomePage() {
             <DataRow label="Version" value={appVersion} />
             <DataRow
               label="Signal"
-              value={ws.socket?.url ?? "ws://localhost:8765"}
+              value={
+                ws.socket?.url ??
+                configuredWebsocketUrl ??
+                DISABLED_WEBSOCKET_LABEL
+              }
             />
             <DataRow label="Socket" value={readyStateLabel} />
             <DataRow label="Peripherals" value={peripheralEntries.length} />

--- a/experimental/beats/src/tests/unit/actions/ws/websocket.test.tsx
+++ b/experimental/beats/src/tests/unit/actions/ws/websocket.test.tsx
@@ -90,4 +90,15 @@ describe("WSProvider", () => {
     });
     expect(FakeWebSocket.instances).toHaveLength(2);
   });
+
+  test("stays disconnected when no websocket url is configured", () => {
+    render(
+      <WSProvider url={null} retryDelay={100} maxRetryDelay={200}>
+        <ReadyStateProbe />
+      </WSProvider>,
+    );
+
+    expect(FakeWebSocket.instances).toHaveLength(0);
+    expect(screen.getByTestId("ready-state")).toHaveTextContent("3");
+  });
 });

--- a/experimental/beats/src/types.d.ts
+++ b/experimental/beats/src/types.d.ts
@@ -4,6 +4,14 @@
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string;
 declare const MAIN_WINDOW_VITE_NAME: string;
 
+interface ImportMetaEnv {
+  readonly VITE_BEATS_WEBSOCKET_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
 declare module "*.proto?raw" {
   const value: string;
   export default value;


### PR DESCRIPTION
## Summary
- add a Beats websocket config helper that reads `VITE_BEATS_WEBSOCKET_URL`
- stop `WSProvider` from opening or retrying a socket when no URL is configured
- cover the disconnected-by-default path with a unit test
- declare the new Vite env type for TypeScript

## Testing
- Not run (not requested)