### PR TITLE
Add hierarchical grouping for detected sensors in Beats

### DIFF
--- a/experimental/beats/src/actions/peripherals/peripheral_tree.tsx
+++ b/experimental/beats/src/actions/peripherals/peripheral_tree.tsx
@@ -16,8 +16,65 @@ type PeripheralSnapshot = {
   last_data: unknown;
 };
 
+type PeripheralHierarchyNode = {
+  key: string;
+  label: string;
+  tagName: string;
+  count: number;
+  children: PeripheralHierarchyNode[];
+  peripherals: PeripheralSnapshot[];
+};
+
+const DEFAULT_HIERARCHY_HEADING = "Connected Peripherals";
+const UNSPECIFIED_VARIANT = "Unspecified";
+
 function tagsByName(peripheral: PeripheralInfo) {
   return Object.fromEntries(peripheral.tags.map((t) => [t.name, t]));
+}
+
+function findTagVariant(peripheral: PeripheralInfo, tagName: string) {
+  return peripheral.tags.find((tag) => tag.name === tagName)?.variant;
+}
+
+function formatHierarchyLabel(tagName: string, variant: string) {
+  return `${tagName.replaceAll("_", " ")} / ${variant}`;
+}
+
+function buildHierarchyTree(
+  peripheralEntries: PeripheralSnapshot[],
+  hierarchy: string[],
+  depth = 0,
+): PeripheralHierarchyNode[] {
+  if (depth >= hierarchy.length) {
+    return [];
+  }
+
+  const tagName = hierarchy[depth];
+  const groupedEntries = new Map<string, PeripheralSnapshot[]>();
+
+  peripheralEntries.forEach((snapshot) => {
+    const variant =
+      findTagVariant(snapshot.info, tagName) ?? UNSPECIFIED_VARIANT;
+    const existing = groupedEntries.get(variant);
+
+    if (existing) {
+      existing.push(snapshot);
+      return;
+    }
+
+    groupedEntries.set(variant, [snapshot]);
+  });
+
+  return Array.from(groupedEntries.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([variant, snapshots]) => ({
+      key: `${tagName}:${variant}`,
+      label: formatHierarchyLabel(tagName, variant),
+      tagName,
+      count: snapshots.length,
+      children: buildHierarchyTree(snapshots, hierarchy, depth + 1),
+      peripherals: depth === hierarchy.length - 1 ? snapshots : [],
+    }));
 }
 
 const SpecialRenderer = ({ snapshot }: { snapshot: PeripheralSnapshot }) => {
@@ -60,7 +117,7 @@ export function PeripheralTree({
         <PaperCard key={idx} className="flex flex-col gap-5">
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div className="space-y-2">
-              <p className="beats-kicker">Connected Peripherals</p>
+              <p className="beats-kicker">{DEFAULT_HIERARCHY_HEADING}</p>
               <h2 className="font-tomorrow text-2xl tracking-[0.1em]">
                 {h.join(" / ")}
               </h2>
@@ -72,12 +129,13 @@ export function PeripheralTree({
               Awaiting peripheral registration.
             </p>
           ) : (
-            <div className="grid gap-4 xl:grid-cols-2">
-              {peripheralEntries.map((p) => (
-                <PeripheralBranch
-                  key={p.info.id ?? `unknown-${p.ts}`}
-                  snapshot={p}
+            <div className="grid gap-4">
+              {buildHierarchyTree(peripheralEntries, h).map((node) => (
+                <HierarchyBranch
+                  key={node.key}
                   hierarchy={h}
+                  node={node}
+                  depth={0}
                 />
               ))}
             </div>
@@ -85,6 +143,57 @@ export function PeripheralTree({
         </PaperCard>
       ))}
     </div>
+  );
+}
+
+function HierarchyBranch({
+  depth,
+  hierarchy,
+  node,
+}: {
+  depth: number;
+  hierarchy: string[];
+  node: PeripheralHierarchyNode;
+}) {
+  return (
+    <section
+      className="border-border/70 bg-background/40 space-y-4 border border-dashed p-4"
+      style={{ marginLeft: `${depth * 1.25}rem` }}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <p className="text-muted-foreground font-mono text-[0.68rem] tracking-[0.18em] uppercase">
+            {node.tagName.replaceAll("_", " ")}
+          </p>
+          <h3 className="font-tomorrow text-lg tracking-[0.08em]">
+            {node.label}
+          </h3>
+        </div>
+        <SpecChip tone="muted">{node.count} Units</SpecChip>
+      </div>
+      {node.children.length > 0 ? (
+        <div className="grid gap-4">
+          {node.children.map((child) => (
+            <HierarchyBranch
+              key={`${node.key}/${child.key}`}
+              depth={depth + 1}
+              hierarchy={hierarchy}
+              node={child}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="grid gap-4 xl:grid-cols-2">
+          {node.peripherals.map((snapshot) => (
+            <PeripheralBranch
+              key={snapshot.info.id ?? `unknown-${snapshot.ts}`}
+              snapshot={snapshot}
+              hierarchy={hierarchy}
+            />
+          ))}
+        </div>
+      )}
+    </section>
   );
 }
 
@@ -97,12 +206,9 @@ function PeripheralBranch({
 }) {
   const peripheral = snapshot.info;
   // Tags in the desired order
-  const orderedTags = [
-    ...hierarchy.map((name) => tagsByName(peripheral)[name]).filter(Boolean),
-    ...peripheral.tags
-      .filter((t) => !hierarchy.includes(t.name))
-      .sort((a, b) => a.name.localeCompare(b.name)),
-  ];
+  const orderedTags = peripheral.tags
+    .filter((t) => !hierarchy.includes(t.name))
+    .sort((a, b) => a.name.localeCompare(b.name));
 
   return (
     <div className="border-border bg-background/70 border p-4">
@@ -113,15 +219,24 @@ function PeripheralBranch({
             {peripheral.id ?? "Unknown Unit"}
           </h3>
         </div>
-        <SpecChip tone="muted">{orderedTags.length} Tags</SpecChip>
+        <SpecChip tone="muted">
+          {orderedTags.length > 0 ? `${orderedTags.length} Tags` : "Preview"}
+        </SpecChip>
       </div>
 
-      <div className="mt-4 grid gap-4 lg:grid-cols-[220px_1fr]">
-        <div className="space-y-1">
-          {orderedTags.map((tag, idx) => (
-            <TagNode key={`${tag.name}-${idx}`} tag={tag} depth={idx} />
-          ))}
-        </div>
+      <div
+        className={
+          "mt-4 grid gap-4 " +
+          (orderedTags.length > 0 ? "lg:grid-cols-[220px_1fr]" : "")
+        }
+      >
+        {orderedTags.length > 0 ? (
+          <div className="space-y-1">
+            {orderedTags.map((tag, idx) => (
+              <TagNode key={`${tag.name}-${idx}`} tag={tag} depth={idx} />
+            ))}
+          </div>
+        ) : null}
         <div className="min-w-0">
           <LeafPeripheralName
             renderAsComponent={<SpecialRenderer snapshot={snapshot} />}

--- a/experimental/beats/src/tests/unit/actions/peripherals/peripheral_tree.test.tsx
+++ b/experimental/beats/src/tests/unit/actions/peripherals/peripheral_tree.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PeripheralTree } from "@/actions/peripherals/peripheral_tree";
+
+type MockPeripheralSnapshot = {
+  ts: number;
+  info: {
+    id: string | null;
+    tags: Array<{
+      name: string;
+      variant: string;
+      metadata?: Record<string, string>;
+    }>;
+  };
+  last_data: unknown;
+};
+
+const connectedPeripheralState = vi.hoisted(() => ({
+  peripherals: {} as Record<string, MockPeripheralSnapshot>,
+}));
+
+vi.mock("@/actions/ws/providers/PeripheralProvider", () => ({
+  useConnectedPeripherals: () => connectedPeripheralState.peripherals,
+}));
+
+describe("PeripheralTree", () => {
+  it("renders detected sensors under shared input-variant and mode branches", () => {
+    connectedPeripheralState.peripherals = {
+      "imu.1": createPeripheralSnapshot({
+        id: "imu.1",
+        variant: "accelerometer",
+        mode: "stream",
+        ts: 2_000,
+      }),
+      "imu.2": createPeripheralSnapshot({
+        id: "imu.2",
+        variant: "accelerometer",
+        mode: "stream",
+        ts: 1_000,
+      }),
+      "switch.1": createPeripheralSnapshot({
+        id: "switch.1",
+        variant: "button",
+        mode: "event",
+        ts: 3_000,
+      }),
+    };
+
+    render(<PeripheralTree hierarchy={[["input_variant", "mode"]]} />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 3,
+        name: "input variant / accelerometer",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 3,
+        name: "mode / stream",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("imu.1")).toBeInTheDocument();
+    expect(screen.getByText("imu.2")).toBeInTheDocument();
+    expect(screen.getAllByText("input variant / accelerometer")).toHaveLength(
+      1,
+    );
+    expect(screen.getByText("switch.1")).toBeInTheDocument();
+  });
+});
+
+function createPeripheralSnapshot({
+  id,
+  mode,
+  ts,
+  variant,
+}: {
+  id: string;
+  mode: string;
+  ts: number;
+  variant: string;
+}): MockPeripheralSnapshot {
+  return {
+    ts,
+    info: {
+      id,
+      tags: [
+        {
+          name: "input_variant",
+          variant,
+        },
+        {
+          name: "mode",
+          variant: mode,
+        },
+      ],
+    },
+    last_data: {
+      value: ts,
+    },
+  };
+}

--- a/src/heart/device/beats/device.py
+++ b/src/heart/device/beats/device.py
@@ -40,5 +40,3 @@ class StreamedScreen(Device):
             kind="frame",
             payload=frame_bytes,
         )
-
-    


### PR DESCRIPTION
## Summary
- Build a hierarchy tree for connected peripherals in Beats using configured tag order such as `input_variant` then `mode`
- Render nested branch sections with per-branch unit counts so shared sensor families appear once instead of as repeated flat cards
- Keep peripheral cards focused on non-hierarchy tags and add a unit test covering shared-branch rendering
- Include incidental Python file edits in `src/heart/device/beats/device.py` and `src/heart/device/selection.py`

## Testing
- Not run (not requested)