### PR TITLE
Fix game loop frame presentation for streamed devices

### DIFF
--- a/src/heart/runtime/game_loop/__init__.py
+++ b/src/heart/runtime/game_loop/__init__.py
@@ -62,6 +62,7 @@ class GameLoop:
             self._apply_post_processors(render_surface)
             self.components.display.blit(render_surface, (0, 0))
             pygame.display.flip()
+            self.device.set_screen(self.components.display.screen)
 
     def _apply_post_processors(self, surface: pygame.Surface) -> None:
         post_processors = self.components.game_modes.get_post_processors()

--- a/tests/runtime/test_game_loop.py
+++ b/tests/runtime/test_game_loop.py
@@ -1,3 +1,4 @@
+import pygame
 import pytest
 
 from heart.runtime.game_loop import GameLoop
@@ -29,3 +30,25 @@ class TestGameLoop:
 
         with pytest.raises(RuntimeError, match="GameLoop screen is not initialized"):
             loop._one_loop([])
+
+    def test_one_loop_presents_rendered_frame_to_device(
+        self,
+        device,
+        resolver,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Ensure _one_loop forwards each rendered frame to the device so live outputs and streaming targets stay updated."""
+        loop = GameLoop(device=device, resolver=resolver)
+        loop.ensure_screen_initialized()
+        assert loop.components.display.screen is not None
+
+        rendered_surface = pygame.Surface(loop.components.display.screen.get_size())
+        monkeypatch.setattr(loop, "render_frame", lambda renderers: rendered_surface)
+        monkeypatch.setattr(loop, "_apply_post_processors", lambda surface: None)
+
+        presented_screens: list[pygame.Surface] = []
+        monkeypatch.setattr(device, "set_screen", presented_screens.append)
+
+        loop._one_loop([])
+
+        assert presented_screens == [loop.components.display.screen]


### PR DESCRIPTION
## Summary
- forward the display surface to the active device after each rendered frame
- restore continuous frame delivery for Beats streaming instead of only sending the initial screen
- add a regression test covering per-frame device presentation in the game loop

## Testing
- `uv run pytest tests/runtime/test_game_loop.py`