### PR TITLE
Fix Beats cube rendering by delaying frame blob URL revocation

### DIFF
--- a/experimental/beats/src/actions/ws/providers/ImageProvider.tsx
+++ b/experimental/beats/src/actions/ws/providers/ImageProvider.tsx
@@ -3,6 +3,9 @@ import { createContext, useContext, useEffect, useState } from "react";
 import { useRef } from "react";
 import { frameStream } from "../streams";
 
+const ACTIVE_STATUS_POLL_INTERVAL_MS = 200;
+const STALE_URL_REVOKE_DELAY_MS = 1000;
+
 type ImageState = {
   imgURL: string | null;
   isActive: boolean;
@@ -32,6 +35,24 @@ export function ImageProvider({
 
   const lastFrameRef = useRef<number>(0);
   const frameTimesRef = useRef<number[]>([]);
+  const revokeTimeoutsRef = useRef<number[]>([]);
+
+  const clearPendingRevocations = () => {
+    revokeTimeoutsRef.current.forEach((timeoutId) => {
+      window.clearTimeout(timeoutId);
+    });
+    revokeTimeoutsRef.current = [];
+  };
+
+  const scheduleUrlRevocation = (url: string) => {
+    const timeoutId = window.setTimeout(() => {
+      URL.revokeObjectURL(url);
+      revokeTimeoutsRef.current = revokeTimeoutsRef.current.filter(
+        (pendingId) => pendingId !== timeoutId,
+      );
+    }, STALE_URL_REVOKE_DELAY_MS);
+    revokeTimeoutsRef.current.push(timeoutId);
+  };
 
   useEffect(() => {
     const sub = frameStream.subscribe((msg) => {
@@ -69,7 +90,9 @@ export function ImageProvider({
       const newURL = URL.createObjectURL(blob);
 
       setImgURL((old) => {
-        if (old) URL.revokeObjectURL(old);
+        if (old) {
+          scheduleUrlRevocation(old);
+        }
         return newURL;
       });
 
@@ -80,14 +103,17 @@ export function ImageProvider({
     const interval = setInterval(() => {
       const now = performance.now();
       setIsActive(now - lastFrameRef.current < recentThreshold);
-    }, 200);
+    }, ACTIVE_STATUS_POLL_INTERVAL_MS);
 
     return () => {
       sub.unsubscribe();
       clearInterval(interval);
+      clearPendingRevocations();
 
       setImgURL((old) => {
-        if (old) URL.revokeObjectURL(old);
+        if (old) {
+          URL.revokeObjectURL(old);
+        }
         return null;
       });
 

--- a/experimental/beats/src/tests/unit/actions/ws/image_provider.test.tsx
+++ b/experimental/beats/src/tests/unit/actions/ws/image_provider.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  ImageProvider,
+  useStreamedImage,
+} from "@/actions/ws/providers/ImageProvider";
+import { stream } from "@/actions/ws/websocket";
+
+function ImageProbe() {
+  const { imgURL, fps, isActive } = useStreamedImage();
+
+  return (
+    <div data-testid="image-state">
+      {JSON.stringify({ imgURL, fps, isActive })}
+    </div>
+  );
+}
+
+function emitFrame(value: number) {
+  stream.next({
+    type: "frame",
+    payload: {
+      pngData: new Uint8Array([value]),
+    },
+  });
+}
+
+describe("ImageProvider", () => {
+  const createObjectURL = vi.fn();
+  const revokeObjectURL = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("URL", {
+      createObjectURL,
+      revokeObjectURL,
+    });
+    createObjectURL.mockReset();
+    revokeObjectURL.mockReset();
+    createObjectURL
+      .mockReturnValueOnce("blob:first-frame")
+      .mockReturnValueOnce("blob:second-frame");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  test("keeps the previous blob url alive briefly so async consumers can finish decoding", () => {
+    render(
+      <ImageProvider>
+        <ImageProbe />
+      </ImageProvider>,
+    );
+
+    act(() => {
+      emitFrame(1);
+      vi.advanceTimersByTime(16);
+      emitFrame(2);
+    });
+
+    expect(screen.getByTestId("image-state")).toHaveTextContent(
+      JSON.stringify({
+        imgURL: "blob:second-frame",
+        fps: 125,
+        isActive: true,
+      }),
+    );
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:first-frame");
+  });
+});


### PR DESCRIPTION
## Summary
- delay revocation of prior streamed frame blob URLs so async texture consumers can finish decoding
- extract the active-status poll interval and stale URL revoke delay into named constants
- add a Vitest regression test covering the blob URL lifecycle across successive frames

## Testing
- `./node_modules/.bin/prettier --check src/actions/ws/providers/ImageProvider.tsx src/tests/unit/actions/ws/image_provider.test.tsx`
- `./node_modules/.bin/eslint src/actions/ws/providers/ImageProvider.tsx src/tests/unit/actions/ws/image_provider.test.tsx`
- `npm run test -- --run src/tests/unit/actions/ws/image_provider.test.tsx`