### PR TITLE
Add FlowToy mode spectra and a live spectrum renderer

### DIFF
--- a/packages/heart-firmware-io/src/heart_firmware_io/flowtoy.py
+++ b/packages/heart-firmware-io/src/heart_firmware_io/flowtoy.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping, Sequence
+from functools import lru_cache
+from pathlib import Path
 from typing import Any
 
 FLOWTOY_SYNC_PACKET_SIZE = 21
@@ -13,6 +16,20 @@ FLOWTOY_PAGE_OFFSET = 18
 FLOWTOY_MODE_OFFSET = 19
 FLOWTOY_COMMAND_FLAGS_OFFSET = 20
 FLOWTOY_UNKNOWN_MODE_NAME = "flowtoy-unknown"
+FLOWTOY_MODE_REFERENCE_PATH = Path(__file__).with_name("flowtoy_modes.json")
+
+
+@lru_cache(maxsize=1)
+def _documented_modes_by_key() -> dict[tuple[int, int], dict[str, Any]]:
+    """Return the documented FlowToy mode reference keyed by page and mode."""
+
+    mode_reference = json.loads(
+        FLOWTOY_MODE_REFERENCE_PATH.read_text(encoding="utf-8")
+    )
+    return {
+        (int(entry["page"]), int(entry["mode"])): dict(entry)
+        for entry in mode_reference
+    }
 
 
 def normalize_payload(
@@ -70,6 +87,17 @@ def mode_name_from_decoded(decoded: Mapping[str, Any] | None) -> str:
     return mode_name_from_values(page, mode)
 
 
+def documented_mode_metadata(
+    page: int | None,
+    mode: int | None,
+) -> Mapping[str, Any] | None:
+    """Return the documented reference entry for a FlowToy page and mode."""
+
+    if page is None or mode is None:
+        return None
+    return _documented_modes_by_key().get((int(page), int(mode)))
+
+
 def decode_sync_packet(
     payload: bytes | bytearray | memoryview | Sequence[int],
 ) -> dict[str, Any]:
@@ -108,6 +136,7 @@ def decode_sync_packet(
         "page": page,
         "mode": mode,
         "mode_name": mode_name_from_values(page, mode),
+        "mode_documentation": documented_mode_metadata(page, mode),
         "command_flags": {
             "adjust_active": bool(command_flags & (1 << 0)),
             "wakeup": bool(command_flags & (1 << 1)),

--- a/packages/heart-firmware-io/src/heart_firmware_io/flowtoy_modes.json
+++ b/packages/heart-firmware-io/src/heart_firmware_io/flowtoy_modes.json
@@ -1,0 +1,526 @@
+[
+  {
+    "page": 1,
+    "mode": 1,
+    "key": "flowtoy-page-1-mode-1",
+    "display_name": "rainbow",
+    "adjust": ["density"],
+    "kinetic_trigger": ["low_force"],
+    "kinetic_response": ["rainbow_speed"],
+    "runtime": {"static_hours": 6, "kinetic_hours": null, "qualifier": "approx"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ff3b30"},
+      {"t": 0.17, "hex": "#ff9500"},
+      {"t": 0.33, "hex": "#ffcc00"},
+      {"t": 0.5, "hex": "#34c759"},
+      {"t": 0.67, "hex": "#32ade6"},
+      {"t": 0.83, "hex": "#007aff"},
+      {"t": 1.0, "hex": "#af52de"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 1,
+    "mode": 2,
+    "key": "flowtoy-page-1-mode-2",
+    "display_name": "rainbow drops",
+    "adjust": ["density"],
+    "kinetic_trigger": ["low_force"],
+    "kinetic_response": ["rainbow_speed"],
+    "runtime": {"static_hours": 11, "kinetic_hours": null, "qualifier": "approx"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ff453a"},
+      {"t": 0.16, "hex": "#ff9f0a"},
+      {"t": 0.32, "hex": "#ffd60a"},
+      {"t": 0.48, "hex": "#30d158"},
+      {"t": 0.64, "hex": "#64d2ff"},
+      {"t": 0.8, "hex": "#0a84ff"},
+      {"t": 1.0, "hex": "#bf5af2"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 1,
+    "mode": 3,
+    "key": "flowtoy-page-1-mode-3",
+    "display_name": "bold",
+    "adjust": ["hue", "saturation"],
+    "kinetic_trigger": ["variable_force", "zero_g"],
+    "kinetic_response": ["brightness"],
+    "runtime": {"static_hours": 7, "kinetic_hours": 2, "qualifier": "approx"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#f2f2ff"},
+      {"t": 0.5, "hex": "#c7b8ff"},
+      {"t": 1.0, "hex": "#8e7dff"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 1,
+    "mode": 4,
+    "key": "flowtoy-page-1-mode-4",
+    "display_name": "lantern",
+    "adjust": ["hue", "brightness"],
+    "kinetic_trigger": [],
+    "kinetic_response": [],
+    "runtime": {"static_hours": 4, "kinetic_hours": null, "qualifier": "approx"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#fff4d6"},
+      {"t": 0.5, "hex": "#ffd28a"},
+      {"t": 1.0, "hex": "#ffb457"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 1,
+    "mode": 5,
+    "key": "flowtoy-page-1-mode-5",
+    "display_name": "fire",
+    "adjust": ["hue"],
+    "kinetic_trigger": ["low_force"],
+    "kinetic_response": ["activate_effect"],
+    "runtime": {"static_hours": 4, "kinetic_hours": 6, "qualifier": "approx"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ffffff"},
+      {"t": 0.2, "hex": "#ffd60a"},
+      {"t": 0.45, "hex": "#ff9f0a"},
+      {"t": 0.7, "hex": "#ff5e3a"},
+      {"t": 1.0, "hex": "#ff3b30"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 1,
+    "mode": 6,
+    "key": "flowtoy-page-1-mode-6",
+    "display_name": "water",
+    "adjust": ["hue"],
+    "kinetic_trigger": ["low_force"],
+    "kinetic_response": ["activate_effect"],
+    "runtime": {"static_hours": 4, "kinetic_hours": 8, "qualifier": "approx"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#e8f7ff"},
+      {"t": 0.35, "hex": "#64d2ff"},
+      {"t": 0.7, "hex": "#0a84ff"},
+      {"t": 1.0, "hex": "#0040dd"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 1,
+    "mode": 7,
+    "key": "flowtoy-page-1-mode-7",
+    "display_name": "earth",
+    "adjust": ["hue"],
+    "kinetic_trigger": ["low_force"],
+    "kinetic_response": ["activate_effect"],
+    "runtime": {"static_hours": 7, "kinetic_hours": 6, "qualifier": "approx"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#8e5a2b"},
+      {"t": 0.25, "hex": "#c27c2c"},
+      {"t": 0.5, "hex": "#d6a73a"},
+      {"t": 0.75, "hex": "#6e8b3d"},
+      {"t": 1.0, "hex": "#3f6b2a"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 1,
+    "mode": 8,
+    "key": "flowtoy-page-1-mode-8",
+    "display_name": "air",
+    "adjust": ["hue"],
+    "kinetic_trigger": ["low_force"],
+    "kinetic_response": ["activate_effect"],
+    "runtime": {"static_hours": 9, "kinetic_hours": 5, "qualifier": "approx"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ffffff"},
+      {"t": 0.4, "hex": "#c7f2ff"},
+      {"t": 0.75, "hex": "#78d7ff"},
+      {"t": 1.0, "hex": "#9b8cff"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 1,
+    "mode": 9,
+    "key": "flowtoy-page-1-mode-9",
+    "display_name": "spirit",
+    "adjust": ["hue"],
+    "kinetic_trigger": ["low_force"],
+    "kinetic_response": ["activate_effect"],
+    "runtime": {"static_hours": 13, "kinetic_hours": 10, "qualifier": "approx"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#6e44ff"},
+      {"t": 0.33, "hex": "#7d3cff"},
+      {"t": 0.66, "hex": "#bf5af2"},
+      {"t": 1.0, "hex": "#ff4fd8"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 1,
+    "mode": 10,
+    "key": "flowtoy-page-1-mode-10",
+    "display_name": "pulse",
+    "adjust": ["hue"],
+    "kinetic_trigger": ["low_force", "high_force"],
+    "kinetic_response": ["effect_pulse"],
+    "runtime": {"static_hours": 11, "kinetic_hours": 3, "qualifier": "approx"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ff3b30"},
+      {"t": 0.33, "hex": "#f5f5f5"},
+      {"t": 0.66, "hex": "#0a84ff"},
+      {"t": 1.0, "hex": "#ff3b30"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 2,
+    "mode": 1,
+    "key": "flowtoy-page-2-mode-1",
+    "display_name": "candy",
+    "adjust": ["saturation"],
+    "kinetic_trigger": ["low_force"],
+    "kinetic_response": ["activate_effect"],
+    "runtime": {"static_hours": 6, "kinetic_hours": null, "qualifier": "approx"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ff7edb"},
+      {"t": 0.33, "hex": "#7ee7ff"},
+      {"t": 0.66, "hex": "#b084ff"},
+      {"t": 1.0, "hex": "#ffffff"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 2,
+    "mode": 2,
+    "key": "flowtoy-page-2-mode-2",
+    "display_name": "petals",
+    "adjust": ["saturation", "density"],
+    "kinetic_trigger": [],
+    "kinetic_response": [],
+    "runtime": {"static_hours": 14, "kinetic_hours": null, "qualifier": "approx_plus"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ff73c6"},
+      {"t": 0.33, "hex": "#9a7cff"},
+      {"t": 0.66, "hex": "#4da3ff"},
+      {"t": 1.0, "hex": "#6ff7d9"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 2,
+    "mode": 3,
+    "key": "flowtoy-page-2-mode-3",
+    "display_name": "love",
+    "adjust": ["hue"],
+    "kinetic_trigger": ["low_force", "high_force"],
+    "kinetic_response": ["effect", "saturation"],
+    "runtime": {"static_hours": 7, "kinetic_hours": 5, "qualifier": "approx"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ffd7ef"},
+      {"t": 0.35, "hex": "#ff7eb6"},
+      {"t": 0.7, "hex": "#ff4f8b"},
+      {"t": 1.0, "hex": "#d63384"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 2,
+    "mode": 4,
+    "key": "flowtoy-page-2-mode-4",
+    "display_name": "watermelon",
+    "adjust": ["hues"],
+    "kinetic_trigger": ["low_force", "high_force"],
+    "kinetic_response": ["effect", "brightness"],
+    "runtime": {"static_hours": 13, "kinetic_hours": 5, "qualifier": "approx"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ff5f8f"},
+      {"t": 0.25, "hex": "#ffd9e2"},
+      {"t": 0.5, "hex": "#7ddc5f"},
+      {"t": 0.75, "hex": "#2fb344"},
+      {"t": 1.0, "hex": "#ff5f8f"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 2,
+    "mode": 5,
+    "key": "flowtoy-page-2-mode-5",
+    "display_name": "freedom",
+    "adjust": ["hues"],
+    "kinetic_trigger": ["low_force", "zero_g"],
+    "kinetic_response": ["effect", "saturation"],
+    "runtime": {"static_hours": 6, "kinetic_hours": 4, "qualifier": "approx"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ff453a"},
+      {"t": 0.33, "hex": "#ffffff"},
+      {"t": 0.66, "hex": "#0a84ff"},
+      {"t": 1.0, "hex": "#64d2ff"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 2,
+    "mode": 6,
+    "key": "flowtoy-page-2-mode-6",
+    "display_name": "microdots",
+    "adjust": ["saturation"],
+    "kinetic_trigger": ["low_force"],
+    "kinetic_response": ["activate_effect"],
+    "runtime": {"static_hours": 9, "kinetic_hours": 13, "qualifier": "approx"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ff8ad8"},
+      {"t": 0.25, "hex": "#ffd95a"},
+      {"t": 0.5, "hex": "#7ee7ff"},
+      {"t": 0.75, "hex": "#b084ff"},
+      {"t": 1.0, "hex": "#4d8dff"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 2,
+    "mode": 7,
+    "key": "flowtoy-page-2-mode-7",
+    "display_name": "unicorn",
+    "adjust": ["rainbow_brightness"],
+    "kinetic_trigger": ["low_force"],
+    "kinetic_response": ["activate_effect"],
+    "runtime": {"static_hours": 9, "kinetic_hours": 5, "qualifier": "approx_plus"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ffd6f6"},
+      {"t": 0.25, "hex": "#d9c2ff"},
+      {"t": 0.5, "hex": "#9be7ff"},
+      {"t": 0.75, "hex": "#b8ffd6"},
+      {"t": 1.0, "hex": "#fffdf7"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 2,
+    "mode": 8,
+    "key": "flowtoy-page-2-mode-8",
+    "display_name": "blue blazer",
+    "adjust": ["hue"],
+    "kinetic_trigger": ["low_force"],
+    "kinetic_response": ["activate_effect"],
+    "runtime": {"static_hours": 6, "kinetic_hours": null, "qualifier": "approx_plus"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ffffff"},
+      {"t": 0.25, "hex": "#64d2ff"},
+      {"t": 0.5, "hex": "#0a84ff"},
+      {"t": 0.75, "hex": "#ff9f0a"},
+      {"t": 1.0, "hex": "#ff6a00"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 2,
+    "mode": 9,
+    "key": "flowtoy-page-2-mode-9",
+    "display_name": "solar flare",
+    "adjust": ["hue"],
+    "kinetic_trigger": ["low_force", "high_force"],
+    "kinetic_response": ["effect", "brightness"],
+    "runtime": {"static_hours": 10, "kinetic_hours": 3, "qualifier": "approx_plus"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#fff6d5"},
+      {"t": 0.3, "hex": "#ffd60a"},
+      {"t": 0.6, "hex": "#ffb340"},
+      {"t": 1.0, "hex": "#ff7a1a"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 2,
+    "mode": 10,
+    "key": "flowtoy-page-2-mode-10",
+    "display_name": "strobe",
+    "adjust": ["hue"],
+    "kinetic_trigger": ["variable_force"],
+    "kinetic_response": ["hue_shift"],
+    "runtime": {"static_hours": 13, "kinetic_hours": null, "qualifier": "approx"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#fff0a8"},
+      {"t": 0.35, "hex": "#d7ff5a"},
+      {"t": 0.7, "hex": "#8ddf3f"},
+      {"t": 1.0, "hex": "#fff0a8"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 3,
+    "mode": 1,
+    "key": "flowtoy-page-3-mode-1",
+    "display_name": "flamebow",
+    "adjust": ["hue"],
+    "kinetic_trigger": ["low_force"],
+    "kinetic_response": ["activate_effect"],
+    "runtime": {"static_hours": 7, "kinetic_hours": null, "qualifier": "approx_plus"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ff5b3a"},
+      {"t": 0.2, "hex": "#ff9f0a"},
+      {"t": 0.4, "hex": "#ffd60a"},
+      {"t": 0.6, "hex": "#30d158"},
+      {"t": 0.8, "hex": "#0a84ff"},
+      {"t": 1.0, "hex": "#bf5af2"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 3,
+    "mode": 2,
+    "key": "flowtoy-page-3-mode-2",
+    "display_name": "alicorn",
+    "adjust": ["hue"],
+    "kinetic_trigger": ["low_force", "high_force"],
+    "kinetic_response": ["effect", "brightness"],
+    "runtime": {"static_hours": 9, "kinetic_hours": 2, "qualifier": "approx_plus"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ffffff"},
+      {"t": 0.25, "hex": "#ffd8ef"},
+      {"t": 0.5, "hex": "#d9c2ff"},
+      {"t": 0.75, "hex": "#fff0b8"},
+      {"t": 1.0, "hex": "#b8d8ff"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 3,
+    "mode": 3,
+    "key": "flowtoy-page-3-mode-3",
+    "display_name": "liquid sugar",
+    "adjust": ["saturation"],
+    "kinetic_trigger": ["low_force", "high_force"],
+    "kinetic_response": ["effect", "saturation"],
+    "runtime": {"static_hours": 7, "kinetic_hours": 2, "qualifier": "approx"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ffffff"},
+      {"t": 0.33, "hex": "#c8f1ff"},
+      {"t": 0.66, "hex": "#ffd2f0"},
+      {"t": 1.0, "hex": "#d2c2ff"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 3,
+    "mode": 4,
+    "key": "flowtoy-page-3-mode-4",
+    "display_name": "rainbow dash",
+    "adjust": ["density"],
+    "kinetic_trigger": ["low_force"],
+    "kinetic_response": ["activate_effect"],
+    "runtime": {"static_hours": 6, "kinetic_hours": 5, "qualifier": "approx_plus"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ff9f0a"},
+      {"t": 0.25, "hex": "#ffd60a"},
+      {"t": 0.5, "hex": "#30d158"},
+      {"t": 0.75, "hex": "#0a84ff"},
+      {"t": 1.0, "hex": "#bf5af2"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 3,
+    "mode": 5,
+    "key": "flowtoy-page-3-mode-5",
+    "display_name": "fireball",
+    "adjust": ["hue"],
+    "kinetic_trigger": ["low_force", "high_force"],
+    "kinetic_response": ["effect", "brightness"],
+    "runtime": {"static_hours": 10, "kinetic_hours": 3, "qualifier": "approx_plus"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ffffff"},
+      {"t": 0.25, "hex": "#ffd60a"},
+      {"t": 0.5, "hex": "#ff9f0a"},
+      {"t": 0.75, "hex": "#ff6b2c"},
+      {"t": 1.0, "hex": "#ff3b30"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 3,
+    "mode": 6,
+    "key": "flowtoy-page-3-mode-6",
+    "display_name": "froth",
+    "adjust": ["hue"],
+    "kinetic_trigger": ["low_force", "high_force"],
+    "kinetic_response": ["effect", "saturation"],
+    "runtime": {"static_hours": 6, "kinetic_hours": 3, "qualifier": "approx_plus"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ffffff"},
+      {"t": 0.35, "hex": "#c9f2ff"},
+      {"t": 0.7, "hex": "#71d7ff"},
+      {"t": 1.0, "hex": "#b6a2ff"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 3,
+    "mode": 7,
+    "key": "flowtoy-page-3-mode-7",
+    "display_name": "jammin",
+    "adjust": ["hues"],
+    "kinetic_trigger": ["low_force", "high_force"],
+    "kinetic_response": ["effect", "speed"],
+    "runtime": {"static_hours": 3, "kinetic_hours": 10, "qualifier": "approx"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ff453a"},
+      {"t": 0.33, "hex": "#ffd60a"},
+      {"t": 0.66, "hex": "#30d158"},
+      {"t": 1.0, "hex": "#ff453a"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 3,
+    "mode": 8,
+    "key": "flowtoy-page-3-mode-8",
+    "display_name": "bolder",
+    "adjust": ["hue", "brightness"],
+    "kinetic_trigger": [],
+    "kinetic_response": [],
+    "runtime": {"static_hours": 5, "kinetic_hours": null, "qualifier": "approx_plus"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ffffff"},
+      {"t": 0.5, "hex": "#d9cfff"},
+      {"t": 1.0, "hex": "#b9a5ff"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 3,
+    "mode": 9,
+    "key": "flowtoy-page-3-mode-9",
+    "display_name": "sunset",
+    "adjust": ["hue"],
+    "kinetic_trigger": ["low_force"],
+    "kinetic_response": ["activate_effect"],
+    "runtime": {"static_hours": 4, "kinetic_hours": null, "qualifier": "approx"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ffcc66"},
+      {"t": 0.33, "hex": "#ff9f0a"},
+      {"t": 0.66, "hex": "#ff6b2c"},
+      {"t": 1.0, "hex": "#ff453a"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  },
+  {
+    "page": 3,
+    "mode": 10,
+    "key": "flowtoy-page-3-mode-10",
+    "display_name": "daybreak",
+    "adjust": ["hue"],
+    "kinetic_trigger": ["variable_force"],
+    "kinetic_response": ["hue_shift"],
+    "runtime": {"static_hours": 8, "kinetic_hours": 4, "qualifier": "approx_plus"},
+    "color_spectrum": [
+      {"t": 0.0, "hex": "#ffb3d9"},
+      {"t": 0.33, "hex": "#ff6bb5"},
+      {"t": 0.66, "hex": "#c084ff"},
+      {"t": 1.0, "hex": "#8d5cff"}
+    ],
+    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes"
+  }
+]

--- a/src/heart/renderers/flowtoy_spectrum/__init__.py
+++ b/src/heart/renderers/flowtoy_spectrum/__init__.py
@@ -1,0 +1,8 @@
+from heart.renderers.flowtoy_spectrum.provider import \
+    FlowToySpectrumStateProvider  # noqa: F401
+from heart.renderers.flowtoy_spectrum.renderer import \
+    FlowToySpectrumRenderer  # noqa: F401
+from heart.renderers.flowtoy_spectrum.state import \
+    FlowToySpectrumState  # noqa: F401
+from heart.renderers.flowtoy_spectrum.state import \
+    FlowToySpectrumStop as FlowToySpectrumStop

--- a/src/heart/renderers/flowtoy_spectrum/provider.py
+++ b/src/heart/renderers/flowtoy_spectrum/provider.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import replace
+
+import reactivex
+from reactivex import operators as ops
+
+from heart.peripheral.core import PeripheralMessageEnvelope
+from heart.peripheral.core.manager import PeripheralManager
+from heart.peripheral.core.providers import ObservableProvider
+from heart.peripheral.flowtoy import FlowToyPeripheral
+from heart.peripheral.input_payloads import FlowToyPacket
+from heart.renderers.flowtoy_spectrum.state import (FlowToySpectrumState,
+                                                    FlowToySpectrumStop)
+from heart.utilities.reactivex_threads import pipe_in_background
+
+DEFAULT_FLOWTOY_RENDER_PERIOD_SECONDS = 3.0
+DEFAULT_UNKNOWN_COLOR_SPECTRUM = (
+    FlowToySpectrumStop(t=0.0, hex="#111111"),
+    FlowToySpectrumStop(t=0.5, hex="#555555"),
+    FlowToySpectrumStop(t=1.0, hex="#111111"),
+)
+
+
+class FlowToySpectrumStateProvider(ObservableProvider[FlowToySpectrumState]):
+    def __init__(
+        self,
+        *,
+        period_seconds: float = DEFAULT_FLOWTOY_RENDER_PERIOD_SECONDS,
+    ) -> None:
+        self.period_seconds = period_seconds
+
+    def initial_state(self) -> FlowToySpectrumState:
+        return FlowToySpectrumState(color_spectrum=DEFAULT_UNKNOWN_COLOR_SPECTRUM)
+
+    def observable(
+        self,
+        peripheral_manager: PeripheralManager,
+    ) -> reactivex.Observable[FlowToySpectrumState]:
+        initial_state = self.initial_state()
+        packet_updates = pipe_in_background(
+            self._flowtoy_packet_stream(peripheral_manager),
+            ops.map(lambda packet: lambda state: self._apply_packet(state, packet)),
+        )
+        tick_updates = pipe_in_background(
+            peripheral_manager.frame_tick_controller.observable(),
+            ops.map(lambda frame_tick: lambda state: self._advance(state, frame_tick.delta_s)),
+        )
+        return pipe_in_background(
+            reactivex.merge(packet_updates, tick_updates),
+            ops.scan(lambda state, update: update(state), seed=initial_state),
+            ops.start_with(initial_state),
+            ops.share(),
+        )
+
+    def _flowtoy_packet_stream(
+        self,
+        peripheral_manager: PeripheralManager,
+    ) -> reactivex.Observable[FlowToyPacket]:
+        observables = [
+            peripheral.observe
+            for peripheral in peripheral_manager.peripherals
+            if isinstance(peripheral, FlowToyPeripheral)
+        ]
+        if not observables:
+            return reactivex.empty()
+        return pipe_in_background(
+            reactivex.merge(*observables),
+            ops.map(PeripheralMessageEnvelope[FlowToyPacket].unwrap_peripheral),
+        )
+
+    def _advance(
+        self,
+        state: FlowToySpectrumState,
+        delta_s: float,
+    ) -> FlowToySpectrumState:
+        return replace(state, elapsed_s=max(0.0, state.elapsed_s + max(0.0, delta_s)))
+
+    def _apply_packet(
+        self,
+        state: FlowToySpectrumState,
+        packet: FlowToyPacket,
+    ) -> FlowToySpectrumState:
+        decoded = packet.body.get("decoded")
+        if not isinstance(decoded, Mapping):
+            return state
+
+        mode_documentation = decoded.get("mode_documentation")
+        spectrum = self._color_spectrum(mode_documentation)
+        display_name = "unknown"
+        if isinstance(mode_documentation, Mapping):
+            display_name_value = mode_documentation.get("display_name")
+            if isinstance(display_name_value, str) and display_name_value:
+                display_name = display_name_value
+
+        return FlowToySpectrumState(
+            group_id=self._int_value(decoded.get("group_id")),
+            page=self._int_value(decoded.get("page")),
+            mode=self._int_value(decoded.get("mode")),
+            mode_name=self._string_value(decoded.get("mode_name"), fallback=state.mode_name),
+            display_name=display_name,
+            elapsed_s=state.elapsed_s,
+            color_spectrum=spectrum,
+        )
+
+    def _color_spectrum(
+        self,
+        mode_documentation: object,
+    ) -> tuple[FlowToySpectrumStop, ...]:
+        if not isinstance(mode_documentation, Mapping):
+            return DEFAULT_UNKNOWN_COLOR_SPECTRUM
+
+        raw_spectrum = mode_documentation.get("color_spectrum")
+        if not isinstance(raw_spectrum, list):
+            return DEFAULT_UNKNOWN_COLOR_SPECTRUM
+
+        spectrum: list[FlowToySpectrumStop] = []
+        for stop in raw_spectrum:
+            if not isinstance(stop, Mapping):
+                continue
+            stop_t = stop.get("t")
+            stop_hex = stop.get("hex")
+            if not isinstance(stop_t, (int, float)) or not isinstance(stop_hex, str):
+                continue
+            spectrum.append(FlowToySpectrumStop(t=float(stop_t), hex=stop_hex))
+
+        if len(spectrum) < 2:
+            return DEFAULT_UNKNOWN_COLOR_SPECTRUM
+        return tuple(sorted(spectrum, key=lambda stop: stop.t))
+
+    def _int_value(self, value: object) -> int:
+        if isinstance(value, int):
+            return value
+        return 0
+
+    def _string_value(self, value: object, *, fallback: str) -> str:
+        if isinstance(value, str) and value:
+            return value
+        return fallback

--- a/src/heart/renderers/flowtoy_spectrum/renderer.py
+++ b/src/heart/renderers/flowtoy_spectrum/renderer.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from math import atan2, hypot, pi
+from typing import Any
+
+import pygame
+
+from heart import DeviceDisplayMode
+from heart.device import Orientation
+from heart.display.color import Color
+from heart.renderers import StatefulBaseRenderer
+from heart.renderers.flowtoy_spectrum.provider import (
+    DEFAULT_FLOWTOY_RENDER_PERIOD_SECONDS, FlowToySpectrumStateProvider)
+from heart.renderers.flowtoy_spectrum.state import (FlowToySpectrumState,
+                                                    FlowToySpectrumStop)
+
+DEFAULT_BACKGROUND_COLOR = Color(8, 8, 12)
+DEFAULT_DISC_FILL_RATIO = 0.46
+DEFAULT_DISC_INNER_RATIO = 0.18
+
+
+class FlowToySpectrumRenderer(StatefulBaseRenderer[FlowToySpectrumState]):
+    def __init__(
+        self,
+        provider: FlowToySpectrumStateProvider | None = None,
+    ) -> None:
+        self.provider = provider or FlowToySpectrumStateProvider()
+        super().__init__(builder=self.provider)
+        self.device_display_mode = DeviceDisplayMode.FULL
+
+    def real_process(
+        self,
+        window: Any,
+        orientation: Orientation,
+    ) -> None:
+        screen = self._resolve_surface(window)
+        width, height = screen.get_size()
+        center_x = (width - 1) / 2.0
+        center_y = (height - 1) / 2.0
+        outer_radius = max(1.0, min(width, height) * DEFAULT_DISC_FILL_RATIO)
+        inner_radius = outer_radius * DEFAULT_DISC_INNER_RATIO
+        background = DEFAULT_BACKGROUND_COLOR._as_tuple()
+        screen.fill(background)
+
+        group_phase_offset = (self.state.group_id % 360) / 360.0
+        animated_phase = (
+            self.state.elapsed_s / DEFAULT_FLOWTOY_RENDER_PERIOD_SECONDS
+        ) + group_phase_offset
+
+        for x in range(width):
+            dx = x - center_x
+            for y in range(height):
+                dy = y - center_y
+                radius = hypot(dx, dy)
+                if radius > outer_radius:
+                    continue
+
+                angle = atan2(dy, dx)
+                normalized_t = ((angle / (2.0 * pi)) + animated_phase) % 1.0
+                color = self._interpolate_spectrum(self.state.color_spectrum, normalized_t)
+                if radius < inner_radius:
+                    blend = radius / max(inner_radius, 1.0)
+                    color = self._mix_colors(color, Color(255, 255, 255), blend * 0.2)
+                screen.set_at((x, y), color._as_tuple())
+
+    def _resolve_surface(self, window: Any) -> pygame.Surface:
+        screen = getattr(window, "screen", None)
+        if isinstance(screen, pygame.Surface):
+            return screen
+        if isinstance(window, pygame.Surface):
+            return window
+        raise RuntimeError("FlowToySpectrumRenderer requires a pygame surface")
+
+    def _interpolate_spectrum(
+        self,
+        spectrum: tuple[FlowToySpectrumStop, ...],
+        normalized_t: float,
+    ) -> Color:
+        if not spectrum:
+            return DEFAULT_BACKGROUND_COLOR
+
+        clamped_t = normalized_t % 1.0
+        previous = spectrum[0]
+        for current in spectrum[1:]:
+            if clamped_t <= current.t:
+                return self._interpolate_between(previous, current, clamped_t)
+            previous = current
+
+        wrapped = FlowToySpectrumStop(t=1.0, hex=spectrum[0].hex)
+        return self._interpolate_between(previous, wrapped, clamped_t)
+
+    def _interpolate_between(
+        self,
+        start: FlowToySpectrumStop,
+        end: FlowToySpectrumStop,
+        t: float,
+    ) -> Color:
+        start_color = self._hex_to_color(start.hex)
+        end_color = self._hex_to_color(end.hex)
+        span = max(end.t - start.t, 1e-9)
+        ratio = min(1.0, max(0.0, (t - start.t) / span))
+        return self._mix_colors(start_color, end_color, ratio)
+
+    def _hex_to_color(self, value: str) -> Color:
+        cleaned = value.strip().removeprefix("#")
+        if len(cleaned) != 6:
+            return DEFAULT_BACKGROUND_COLOR
+        return Color(
+            r=int(cleaned[0:2], 16),
+            g=int(cleaned[2:4], 16),
+            b=int(cleaned[4:6], 16),
+        )
+
+    def _mix_colors(
+        self,
+        start: Color,
+        end: Color,
+        ratio: float,
+    ) -> Color:
+        clamped_ratio = min(1.0, max(0.0, ratio))
+        inverse_ratio = 1.0 - clamped_ratio
+        return Color(
+            r=int(round((start.r * inverse_ratio) + (end.r * clamped_ratio))),
+            g=int(round((start.g * inverse_ratio) + (end.g * clamped_ratio))),
+            b=int(round((start.b * inverse_ratio) + (end.b * clamped_ratio))),
+        )

--- a/src/heart/renderers/flowtoy_spectrum/state.py
+++ b/src/heart/renderers/flowtoy_spectrum/state.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True, slots=True)
+class FlowToySpectrumStop:
+    t: float
+    hex: str
+
+
+@dataclass(frozen=True, slots=True)
+class FlowToySpectrumState:
+    group_id: int = 0
+    page: int = 0
+    mode: int = 0
+    mode_name: str = "flowtoy-unknown"
+    display_name: str = "unknown"
+    elapsed_s: float = 0.0
+    color_spectrum: tuple[FlowToySpectrumStop, ...] = field(default_factory=tuple)

--- a/tests/display/test_flowtoy_spectrum_renderer.py
+++ b/tests/display/test_flowtoy_spectrum_renderer.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pygame
+
+from heart.device import Rectangle
+from heart.peripheral.core.manager import PeripheralManager
+from heart.peripheral.flowtoy import FlowToyPeripheral
+from heart.peripheral.input_payloads import FlowToyPacket
+from heart.peripheral.radio import RadioDriver, RawRadioPacket
+from heart.renderers.flowtoy_spectrum import (FlowToySpectrumRenderer,
+                                              FlowToySpectrumState,
+                                              FlowToySpectrumStateProvider,
+                                              FlowToySpectrumStop)
+
+
+class DummyRadioDriver(RadioDriver):
+    """Provide deterministic FlowToy packets so renderer tests can drive the provider directly."""
+
+    def __init__(self, *, port: str = "/dev/ttyACM9") -> None:
+        self.port = port
+
+    def packets(self) -> Iterator[RawRadioPacket]:
+        yield from ()
+
+    def send_raw_command(self, command: str) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+class TestFlowToySpectrumStateProvider:
+    """Validate FlowToy spectrum state updates so renderer inputs stay synchronized with live radio packets."""
+
+    def test_provider_tracks_latest_packet_and_elapsed_time(
+        self,
+        stub_clock_factory,
+    ) -> None:
+        """Verify the provider captures FlowToy mode metadata and advances elapsed time so the renderer can animate a live spectrum reliably."""
+        manager = PeripheralManager()
+        provider = FlowToySpectrumStateProvider()
+        peripheral = FlowToyPeripheral(driver=DummyRadioDriver())
+        manager.register(peripheral)
+        observed: list[FlowToySpectrumState] = []
+
+        subscription = provider.observable(manager).subscribe(on_next=observed.append)
+        try:
+            peripheral.process_packet(
+                RawRadioPacket(
+                    payload=bytes(
+                        [
+                            0x00,
+                            0x01,
+                            0x02,
+                            0x00,
+                            0x00,
+                            0x00,
+                            0x01,
+                            0x02,
+                            0x03,
+                            0x04,
+                            10,
+                            20,
+                            30,
+                            40,
+                            50,
+                            0b0000_0011,
+                            0x00,
+                            0x00,
+                            2,
+                            7,
+                            0b0000_0010,
+                        ]
+                    ),
+                    protocol="flowtoy",
+                )
+            )
+
+            clock = stub_clock_factory(250)
+            manager.frame_tick_controller.advance(clock)
+        finally:
+            subscription.dispose()
+
+        assert observed[0].mode_name == "flowtoy-unknown"
+        latest = observed[-1]
+        assert latest.group_id == 1
+        assert latest.page == 2
+        assert latest.mode == 7
+        assert latest.mode_name == "flowtoy-page-2-mode-7"
+        assert latest.display_name == "unicorn"
+        assert latest.elapsed_s == 0.25
+        assert latest.color_spectrum == (
+            FlowToySpectrumStop(t=0.0, hex="#ffd6f6"),
+            FlowToySpectrumStop(t=0.25, hex="#d9c2ff"),
+            FlowToySpectrumStop(t=0.5, hex="#9be7ff"),
+            FlowToySpectrumStop(t=0.75, hex="#b8ffd6"),
+            FlowToySpectrumStop(t=1.0, hex="#fffdf7"),
+        )
+
+
+class TestFlowToySpectrumRenderer:
+    """Exercise FlowToy spectrum drawing so palette reconstruction remains visually aligned with decoded radio state."""
+
+    def test_renderer_draws_expected_colors_from_spectrum(self) -> None:
+        """Verify the renderer maps circular spectrum time to on-screen color positions so a decoded mode produces a faithful visual preview."""
+        renderer = FlowToySpectrumRenderer()
+        renderer.set_state(
+            FlowToySpectrumState(
+                group_id=0,
+                page=1,
+                mode=1,
+                mode_name="flowtoy-page-1-mode-1",
+                display_name="rainbow",
+                elapsed_s=0.0,
+                color_spectrum=(
+                    FlowToySpectrumStop(t=0.0, hex="#ff0000"),
+                    FlowToySpectrumStop(t=0.5, hex="#00ff00"),
+                    FlowToySpectrumStop(t=1.0, hex="#ff0000"),
+                ),
+            )
+        )
+        renderer.initialized = True
+
+        manager = PeripheralManager()
+        orientation = Rectangle.with_layout(1, 1)
+        window = pygame.Surface((65, 65))
+
+        renderer._internal_process(window, manager, orientation)
+
+        right_color = window.get_at((56, 32))
+        left_color = window.get_at((8, 32))
+
+        assert right_color.r > 200
+        assert right_color.g < 80
+        assert left_color.g > 200
+        assert left_color.r < 80
+
+    def test_renderer_uses_group_id_to_offset_phase(self) -> None:
+        """Verify group identifiers produce stable phase offsets so different FlowToy groups do not render as indistinguishable clones."""
+        renderer = FlowToySpectrumRenderer()
+        renderer.set_state(
+            FlowToySpectrumState(
+                group_id=90,
+                page=1,
+                mode=1,
+                mode_name="flowtoy-page-1-mode-1",
+                display_name="rainbow",
+                elapsed_s=0.0,
+                color_spectrum=(
+                    FlowToySpectrumStop(t=0.0, hex="#ff0000"),
+                    FlowToySpectrumStop(t=0.25, hex="#0000ff"),
+                    FlowToySpectrumStop(t=0.5, hex="#00ff00"),
+                    FlowToySpectrumStop(t=1.0, hex="#ff0000"),
+                ),
+            )
+        )
+        renderer.initialized = True
+
+        manager = PeripheralManager()
+        orientation = Rectangle.with_layout(1, 1)
+        window = pygame.Surface((65, 65))
+
+        renderer._internal_process(window, manager, orientation)
+
+        right_color = window.get_at((56, 32))
+
+        assert right_color.b > 180
+        assert right_color.r < 120
+
+
+class TestFlowToyPacketPayloadShape:
+    """Keep FlowToy packet helpers explicit in renderer tests so state sources remain understandable."""
+
+    def test_packet_to_input_keeps_mode_name(self) -> None:
+        """Verify FlowToy packet payload helpers preserve mode names so renderer-facing debugging stays legible when packets are inspected manually."""
+        packet = FlowToyPacket(body={"decoded": {"page": 1, "mode": 1}}, mode_name="flowtoy-page-1-mode-1")
+
+        rendered = packet.to_input()
+
+        assert rendered.data["mode_name"] == "flowtoy-page-1-mode-1"

--- a/tests/firmware_io/test_flowtoy.py
+++ b/tests/firmware_io/test_flowtoy.py
@@ -62,6 +62,28 @@ class TestFirmwareIoFlowToy:
             "page": 2,
             "mode": 7,
             "mode_name": "flowtoy-page-2-mode-7",
+            "mode_documentation": {
+                "page": 2,
+                "mode": 7,
+                "key": "flowtoy-page-2-mode-7",
+                "display_name": "unicorn",
+                "adjust": ["rainbow_brightness"],
+                "kinetic_trigger": ["low_force"],
+                "kinetic_response": ["activate_effect"],
+                "runtime": {
+                    "static_hours": 9,
+                    "kinetic_hours": 5,
+                    "qualifier": "approx_plus",
+                },
+                "color_spectrum": [
+                    {"t": 0.0, "hex": "#ffd6f6"},
+                    {"t": 0.25, "hex": "#d9c2ff"},
+                    {"t": 0.5, "hex": "#9be7ff"},
+                    {"t": 0.75, "hex": "#b8ffd6"},
+                    {"t": 1.0, "hex": "#fffdf7"},
+                ],
+                "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes",
+            },
             "command_flags": {
                 "adjust_active": False,
                 "wakeup": True,
@@ -107,6 +129,7 @@ class TestFirmwareIoFlowToy:
             "page": 0,
             "mode": 0,
             "mode_name": "flowtoy-page-0-mode-0",
+            "mode_documentation": None,
             "command_flags": {
                 "adjust_active": False,
                 "wakeup": False,

--- a/tests/peripheral/test_flowtoy_peripheral.py
+++ b/tests/peripheral/test_flowtoy_peripheral.py
@@ -152,6 +152,28 @@ class TestFlowToyPeripheralDetectionAndStreaming:
                 "page": 2,
                 "mode": 7,
                 "mode_name": "flowtoy-page-2-mode-7",
+                "mode_documentation": {
+                    "page": 2,
+                    "mode": 7,
+                    "key": "flowtoy-page-2-mode-7",
+                    "display_name": "unicorn",
+                    "adjust": ["rainbow_brightness"],
+                    "kinetic_trigger": ["low_force"],
+                    "kinetic_response": ["activate_effect"],
+                    "runtime": {
+                        "static_hours": 9,
+                        "kinetic_hours": 5,
+                        "qualifier": "approx_plus",
+                    },
+                    "color_spectrum": [
+                        {"t": 0.0, "hex": "#ffd6f6"},
+                        {"t": 0.25, "hex": "#d9c2ff"},
+                        {"t": 0.5, "hex": "#9be7ff"},
+                        {"t": 0.75, "hex": "#b8ffd6"},
+                        {"t": 1.0, "hex": "#fffdf7"},
+                    ],
+                    "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes",
+                },
                 "command_flags": {
                     "adjust_active": False,
                     "wakeup": True,


### PR DESCRIPTION
## Summary
- add a documented FlowToy mode catalog with machine-readable `color_spectrum` timelines keyed by page and mode
- enrich decoded FlowToy packets with referenced mode metadata so downstream consumers can infer likely visuals
- add a `flowtoy_spectrum` renderer and provider that render the active mode as a 3-second looping circular spectrum with group-based phase offset
- extend firmware, peripheral, and display tests to cover the new metadata and renderer behavior

## Testing
- `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/ea4f/heart/.uv-cache make format`
- `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/ea4f/heart/.uv-cache .venv/bin/pytest tests/display/test_flowtoy_spectrum_renderer.py tests/firmware_io/test_flowtoy.py tests/firmware_io/test_radio.py tests/peripheral/test_flowtoy_peripheral.py tests/peripheral/test_radio_peripheral.py`
- Full `make test` not rerun here because the repo still has an existing Beats websocket shutdown failure unrelated to this change