### PR TITLE
Add a single command to launch totem with the Beats UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ The runtime packages two Typer CLIs: `totem` orchestrates configuration loading,
    ```bash
    uv run totem run --configuration lib_2025
    ```
-4. Review [docs/books/getting_started.md](docs/books/getting_started.md) for Raspberry Pi deployment, hardware wiring, and CLI options.
+4. Launch the default playlist with the Beats UI attached:
+   ```bash
+   uv run totem run-beats --configuration lib_2025
+   ```
+5. Review [docs/books/getting_started.md](docs/books/getting_started.md) for Raspberry Pi deployment, hardware wiring, and CLI options.
 
 ## Command-Line Interfaces
 | Command | Purpose |
@@ -37,6 +41,7 @@ Key `totem run` flags:
 - `--configuration <name>` selects modules from `heart.programs.configurations`.
 - `--x11-forward` forces a pygame window even when the RGB matrix driver is active.
 - `--add-low-power-mode/--no-add-low-power-mode` toggles the standby mode that keeps LEDs dim when no scenes are active.
+- `totem run-beats --configuration <name>` launches the streamed totem runtime and the Beats Electron UI together, wiring `FORWARD_TO_BEATS_APP=1` and `VITE_BEATS_WEBSOCKET_URL=ws://localhost:8765` automatically.
 
 ## Architecture Summary
 - `heart/environment.py` defines the `GameLoop` responsible for frame pacing and peripheral coordination.

--- a/src/heart/cli/commands/run_beats.py
+++ b/src/heart/cli/commands/run_beats.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import time
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from heart.cli.commands.run import (DEFAULT_ADD_LOW_POWER_MODE,
+                                    DEFAULT_CONFIGURATION, DEFAULT_X11_FORWARD)
+from heart.device.beats.websocket import WEBSOCKET_HOST, WEBSOCKET_PORT
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+DEFAULT_BEATS_WORKSPACE = Path("experimental/beats")
+DEFAULT_BEATS_START_SCRIPT = "start"
+DEFAULT_INSTALL_BEATS_DEPS = True
+FORWARD_TO_BEATS_ENV_VAR = "FORWARD_TO_BEATS_APP"
+BEATS_WEBSOCKET_ENV_VAR = "VITE_BEATS_WEBSOCKET_URL"
+PROCESS_POLL_INTERVAL_SECONDS = 0.5
+PROCESS_SHUTDOWN_TIMEOUT_SECONDS = 5.0
+
+
+def run_beats_command(
+    configuration: Annotated[str, typer.Option("--configuration")] = DEFAULT_CONFIGURATION,
+    add_low_power_mode: bool = typer.Option(
+        DEFAULT_ADD_LOW_POWER_MODE,
+        "--add-low-power-mode",
+        help="Add a low power mode",
+    ),
+    x11_forward: bool = typer.Option(
+        DEFAULT_X11_FORWARD,
+        "--x11-forward",
+        help="Use X11 forwarding for RGB display",
+    ),
+    install_beats_deps: bool = typer.Option(
+        DEFAULT_INSTALL_BEATS_DEPS,
+        "--install-beats-deps/--no-install-beats-deps",
+        help="Install Beats node dependencies when node_modules is missing.",
+    ),
+    beats_workspace: Annotated[Path, typer.Option("--beats-workspace")] = DEFAULT_BEATS_WORKSPACE,
+) -> None:
+    repo_root = resolve_repo_root()
+    resolved_beats_workspace = resolve_beats_workspace(repo_root, beats_workspace)
+    validate_beats_workspace(resolved_beats_workspace)
+
+    if install_beats_deps:
+        ensure_beats_dependencies(resolved_beats_workspace)
+    elif not beats_dependencies_installed(resolved_beats_workspace):
+        logger.error(
+            "Beats dependencies are missing. Run `npm install --package-lock=false` in %s or re-run with --install-beats-deps.",
+            resolved_beats_workspace,
+        )
+        raise typer.Exit(code=1)
+
+    websocket_url = build_beats_websocket_url()
+    runtime_command = build_totem_run_command(
+        configuration=configuration,
+        add_low_power_mode=add_low_power_mode,
+        x11_forward=x11_forward,
+    )
+    beats_command = build_beats_start_command()
+    runtime_env = build_runtime_env(os.environ.copy())
+    beats_env = build_beats_env(os.environ.copy(), websocket_url=websocket_url)
+
+    exit_code = run_supervised_processes(
+        repo_root=repo_root,
+        runtime_command=runtime_command,
+        runtime_env=runtime_env,
+        beats_workspace=resolved_beats_workspace,
+        beats_command=beats_command,
+        beats_env=beats_env,
+    )
+    if exit_code != 0:
+        raise typer.Exit(code=exit_code)
+
+
+def resolve_repo_root() -> Path:
+    """Resolve the git repository root or fall back to the current working directory."""
+
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if result.returncode == 0:
+        return Path(result.stdout.strip())
+    return Path.cwd()
+
+
+def resolve_beats_workspace(repo_root: Path, beats_workspace: Path) -> Path:
+    """Resolve the Beats workspace relative to the repository root when needed."""
+
+    if beats_workspace.is_absolute():
+        return beats_workspace
+    return repo_root / beats_workspace
+
+
+def validate_beats_workspace(beats_workspace: Path) -> None:
+    """Fail fast when the configured Beats workspace is not usable."""
+
+    package_json_path = beats_workspace / "package.json"
+    if package_json_path.is_file():
+        return
+    logger.error(
+        "Beats workspace %s does not contain package.json.",
+        beats_workspace,
+    )
+    raise typer.Exit(code=1)
+
+
+def beats_dependencies_installed(beats_workspace: Path) -> bool:
+    """Return True when the Beats workspace already has installed dependencies."""
+
+    return (beats_workspace / "node_modules").is_dir()
+
+
+def ensure_beats_dependencies(beats_workspace: Path) -> None:
+    """Install Beats dependencies when the workspace has not been bootstrapped yet."""
+
+    if beats_dependencies_installed(beats_workspace):
+        return
+
+    logger.info(
+        "Installing Beats dependencies with `npm install --package-lock=false` in %s",
+        beats_workspace,
+    )
+    try:
+        result = subprocess.run(
+            ["npm", "install", "--package-lock=false"],
+            cwd=beats_workspace,
+            check=False,
+        )
+    except OSError:
+        logger.exception("Failed to launch npm while installing Beats dependencies.")
+        raise typer.Exit(code=1) from None
+
+    if result.returncode == 0:
+        return
+
+    logger.error(
+        "Beats dependency installation failed with exit code %d.",
+        result.returncode,
+    )
+    raise typer.Exit(code=result.returncode)
+
+
+def build_beats_websocket_url() -> str:
+    """Build the websocket URL expected by the Beats UI."""
+
+    return f"ws://{WEBSOCKET_HOST}:{WEBSOCKET_PORT}"
+
+
+def build_totem_run_command(
+    *,
+    configuration: str,
+    add_low_power_mode: bool,
+    x11_forward: bool,
+) -> list[str]:
+    """Build the runtime command that forwards frames into Beats."""
+
+    command = ["uv", "run", "totem", "run", "--configuration", configuration]
+    if x11_forward:
+        command.append("--x11-forward")
+    if not add_low_power_mode:
+        command.append("--no-add-low-power-mode")
+    return command
+
+
+def build_beats_start_command() -> list[str]:
+    """Build the command that launches the Beats Electron app."""
+
+    return ["npm", "run", DEFAULT_BEATS_START_SCRIPT]
+
+
+def build_runtime_env(base_env: dict[str, str]) -> dict[str, str]:
+    """Prepare runtime environment variables for Beats forwarding."""
+
+    runtime_env = dict(base_env)
+    runtime_env[FORWARD_TO_BEATS_ENV_VAR] = "1"
+    return runtime_env
+
+
+def build_beats_env(
+    base_env: dict[str, str],
+    *,
+    websocket_url: str,
+) -> dict[str, str]:
+    """Prepare Beats environment variables for websocket connectivity."""
+
+    beats_env = dict(base_env)
+    beats_env[BEATS_WEBSOCKET_ENV_VAR] = websocket_url
+    return beats_env
+
+
+def run_supervised_processes(
+    *,
+    repo_root: Path,
+    runtime_command: list[str],
+    runtime_env: dict[str, str],
+    beats_workspace: Path,
+    beats_command: list[str],
+    beats_env: dict[str, str],
+) -> int:
+    """Launch the runtime and Beats UI together and stop both when either exits."""
+
+    logger.info("Starting totem runtime: %s", " ".join(runtime_command))
+    runtime_process = spawn_process(runtime_command, cwd=repo_root, env=runtime_env)
+
+    try:
+        logger.info("Starting Beats UI: %s", " ".join(beats_command))
+        beats_process = spawn_process(
+            beats_command,
+            cwd=beats_workspace,
+            env=beats_env,
+        )
+    except Exception:
+        terminate_process(runtime_process)
+        raise
+
+    try:
+        while True:
+            runtime_return_code = runtime_process.poll()
+            if runtime_return_code is not None:
+                logger.info("Totem runtime exited with code %d", runtime_return_code)
+                return runtime_return_code
+
+            beats_return_code = beats_process.poll()
+            if beats_return_code is not None:
+                logger.info("Beats UI exited with code %d", beats_return_code)
+                return beats_return_code
+
+            time.sleep(PROCESS_POLL_INTERVAL_SECONDS)
+    except KeyboardInterrupt:
+        logger.info("Stopping totem runtime and Beats UI.")
+        return 130
+    finally:
+        terminate_process(beats_process)
+        terminate_process(runtime_process)
+
+
+def spawn_process(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+) -> subprocess.Popen[bytes]:
+    """Spawn a long-running subprocess in its own process group."""
+
+    try:
+        return subprocess.Popen(
+            command,
+            cwd=cwd,
+            env=env,
+            start_new_session=True,
+        )
+    except OSError:
+        logger.exception("Failed to launch process: %s", " ".join(command))
+        raise typer.Exit(code=1) from None
+
+
+def terminate_process(process: subprocess.Popen[bytes]) -> None:
+    """Terminate a process tree without leaving child processes behind."""
+
+    if process.poll() is not None:
+        return
+
+    try:
+        if hasattr(os, "killpg"):
+            os.killpg(process.pid, signal.SIGTERM)
+        else:
+            process.terminate()
+        process.wait(timeout=PROCESS_SHUTDOWN_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        if hasattr(os, "killpg"):
+            os.killpg(process.pid, signal.SIGKILL)
+        else:
+            process.kill()
+        process.wait(timeout=PROCESS_SHUTDOWN_TIMEOUT_SECONDS)
+

--- a/src/heart/loop.py
+++ b/src/heart/loop.py
@@ -6,11 +6,13 @@ import typer
 
 from heart.cli.commands.bench_device import bench_device_command
 from heart.cli.commands.run import run_command
+from heart.cli.commands.run_beats import run_beats_command
 from heart.cli.commands.update_driver import update_driver_command
 
 app = typer.Typer()
 
 app.command(name="run")(run_command)
+app.command(name="run-beats")(run_beats_command)
 app.command(name="update-driver")(update_driver_command)
 app.command(name="bench-device")(bench_device_command)
 

--- a/tests/cli/test_run_beats.py
+++ b/tests/cli/test_run_beats.py
@@ -1,0 +1,126 @@
+"""Validate the combined totem-plus-Beats launcher so the single-command workflow stays reliable."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import typer
+
+from heart.cli.commands.run_beats import (BEATS_WEBSOCKET_ENV_VAR,
+                                          FORWARD_TO_BEATS_ENV_VAR,
+                                          build_beats_env,
+                                          build_beats_websocket_url,
+                                          build_totem_run_command,
+                                          ensure_beats_dependencies,
+                                          resolve_beats_workspace)
+
+
+class TestRunBeatsCommandBuilders:
+    """Exercise command and environment builders so the launcher keeps the runtime and UI in sync."""
+
+    def test_build_totem_run_command_includes_requested_flags(self) -> None:
+        """Verify runtime flags are preserved so the combined launcher does not silently change scene startup behaviour."""
+
+        command = build_totem_run_command(
+            configuration="lib_2025",
+            add_low_power_mode=False,
+            x11_forward=True,
+        )
+
+        assert command == [
+            "uv",
+            "run",
+            "totem",
+            "run",
+            "--configuration",
+            "lib_2025",
+            "--x11-forward",
+            "--no-add-low-power-mode",
+        ]
+
+    def test_build_beats_env_sets_websocket_url(self) -> None:
+        """Verify the Beats app receives a websocket URL so the UI can attach to the runtime stream immediately on boot."""
+
+        websocket_url = build_beats_websocket_url()
+        env = build_beats_env({"PATH": "/bin"}, websocket_url=websocket_url)
+
+        assert env[BEATS_WEBSOCKET_ENV_VAR] == websocket_url
+        assert env["PATH"] == "/bin"
+
+    def test_resolve_beats_workspace_uses_repo_root_for_relative_paths(self) -> None:
+        """Verify relative Beats paths resolve from the repository root so the launcher works from any shell location."""
+
+        repo_root = Path("/tmp/heart")
+
+        assert resolve_beats_workspace(repo_root, Path("experimental/beats")) == Path(
+            "/tmp/heart/experimental/beats"
+        )
+
+    def test_runtime_env_flag_name_remains_stable(self) -> None:
+        """Verify the runtime forwarding env var stays stable so the combined launcher continues selecting the streamed device path."""
+
+        assert FORWARD_TO_BEATS_ENV_VAR == "FORWARD_TO_BEATS_APP"
+
+
+class TestEnsureBeatsDependencies:
+    """Cover Beats dependency bootstrap behaviour so the one-command launcher is usable in a fresh worktree."""
+
+    def test_skips_install_when_node_modules_exists(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Verify bootstrap is skipped for installed workspaces so repeated launches avoid unnecessary npm churn."""
+
+        beats_workspace = tmp_path / "beats"
+        (beats_workspace / "node_modules").mkdir(parents=True)
+
+        def _unexpected_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+            raise AssertionError("npm install should not run when node_modules exists")
+
+        monkeypatch.setattr(subprocess, "run", _unexpected_run)
+
+        ensure_beats_dependencies(beats_workspace)
+
+    def test_installs_dependencies_when_node_modules_is_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Verify bootstrap runs npm install so first-time launcher use can start Beats without separate setup steps."""
+
+        beats_workspace = tmp_path / "beats"
+        beats_workspace.mkdir()
+        commands: list[tuple[list[str], Path]] = []
+
+        def _run(
+            command: list[str], *, cwd: Path, check: bool
+        ) -> subprocess.CompletedProcess[bytes]:
+            commands.append((command, cwd))
+            return subprocess.CompletedProcess(command, 0)
+
+        monkeypatch.setattr(subprocess, "run", _run)
+
+        ensure_beats_dependencies(beats_workspace)
+
+        assert commands == [
+            (["npm", "install", "--package-lock=false"], beats_workspace)
+        ]
+
+    def test_raises_exit_when_npm_install_fails(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Verify bootstrap fails loudly on npm errors so users do not end up debugging a half-started combined session."""
+
+        beats_workspace = tmp_path / "beats"
+        beats_workspace.mkdir()
+
+        def _run(
+            command: list[str], *, cwd: Path, check: bool
+        ) -> subprocess.CompletedProcess[bytes]:
+            return subprocess.CompletedProcess(command, 7)
+
+        monkeypatch.setattr(subprocess, "run", _run)
+
+        with pytest.raises(typer.Exit) as error:
+            ensure_beats_dependencies(beats_workspace)
+
+        assert error.value.exit_code == 7


### PR DESCRIPTION
## Summary
- add a `totem run-beats` CLI command that starts the totem runtime and Beats Electron app together
- wire the runtime and UI automatically with `FORWARD_TO_BEATS_APP=1` and `VITE_BEATS_WEBSOCKET_URL=ws://localhost:8765`
- bootstrap Beats dependencies with `npm install --package-lock=false` when `experimental/beats/node_modules` is missing
- document the new one-command workflow in `README.md`
- add focused CLI tests for command building, workspace resolution, and dependency bootstrap behavior

## Testing
- `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/0961/heart/.uv-cache make format`
- `UV_CACHE_DIR=/Users/lampe/.codex/worktrees/0961/heart/.uv-cache make test`