### PR TITLE
Fix main branch CI regressions

### DIFF
--- a/src/heart/loop.py
+++ b/src/heart/loop.py
@@ -5,6 +5,8 @@ os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "1"
 
 import typer
 
+_app: typer.Typer | None = None
+
 
 def _build_flowtoy_only_app() -> typer.Typer:
     app = typer.Typer()
@@ -20,7 +22,8 @@ def _build_full_app() -> typer.Typer:
 
     from heart.cli.commands.bench_device import bench_device_command
     from heart.cli.commands.flowtoy import app as flowtoy_app
-    from heart.cli.commands.rubiks_connected_x import app as rubiks_connected_x_app
+    from heart.cli.commands.rubiks_connected_x import \
+        app as rubiks_connected_x_app
     from heart.cli.commands.run import run_command
     from heart.cli.commands.update_driver import update_driver_command
 
@@ -35,10 +38,24 @@ def _build_full_app() -> typer.Typer:
 def _build_rubiks_connected_x_only_app() -> typer.Typer:
     app = typer.Typer()
 
-    from heart.cli.commands.rubiks_connected_x import app as rubiks_connected_x_app
+    from heart.cli.commands.rubiks_connected_x import \
+        app as rubiks_connected_x_app
 
     app.add_typer(rubiks_connected_x_app, name="rubiks-connected-x")
     return app
+
+
+def _get_app() -> typer.Typer:
+    global _app
+    if _app is None:
+        _app = _build_full_app()
+    return _app
+
+
+def __getattr__(name: str) -> object:
+    if name == "app":
+        return _get_app()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def main() -> None:
@@ -74,7 +91,7 @@ def main() -> None:
         app()
         return
 
-    _build_full_app()()
+    _get_app()()
 
 
 if __name__ == "__main__":

--- a/tests/drivers/test_flowtoy_bridge_driver.py
+++ b/tests/drivers/test_flowtoy_bridge_driver.py
@@ -94,6 +94,28 @@ class TestDriversFlowtoyBridgeDriver:
                     "page": 2,
                     "mode": 7,
                     "mode_name": "flowtoy-page-2-mode-7",
+                    "mode_documentation": {
+                        "page": 2,
+                        "mode": 7,
+                        "key": "flowtoy-page-2-mode-7",
+                        "display_name": "unicorn",
+                        "adjust": ["rainbow_brightness"],
+                        "kinetic_trigger": ["low_force"],
+                        "kinetic_response": ["activate_effect"],
+                        "runtime": {
+                            "static_hours": 9,
+                            "kinetic_hours": 5,
+                            "qualifier": "approx_plus",
+                        },
+                        "color_spectrum": [
+                            {"t": 0.0, "hex": "#ffd6f6"},
+                            {"t": 0.25, "hex": "#d9c2ff"},
+                            {"t": 0.5, "hex": "#9be7ff"},
+                            {"t": 0.75, "hex": "#b8ffd6"},
+                            {"t": 1.0, "hex": "#fffdf7"},
+                        ],
+                        "source_url": "https://flowtoys2.freshdesk.com/support/solutions/articles/6000229509-capsule-v2-modes-adjust-kinetic-and-runtimes",
+                    },
                     "command_flags": {
                         "adjust_active": False,
                         "wakeup": True,

--- a/tests/renderers/test_rubiks_connected_x_visualizer_provider.py
+++ b/tests/renderers/test_rubiks_connected_x_visualizer_provider.py
@@ -8,21 +8,15 @@ from heart.peripheral.rubiks_connected_x import (
     RUBIKS_CONNECTED_X_BASELINE_FACELETS_ENV_VAR,
     RUBIKS_CONNECTED_X_BASELINE_PATH_ENV_VAR,
     RUBIKS_CONNECTED_X_IGNORE_STATE_SYNC_ENV_VAR,
-    RUBIKS_CONNECTED_X_SOLVED_FACELETS,
-    load_rubiks_connected_x_baseline_facelets,
-    RubiksConnectedXMessageType,
-    RubiksConnectedXMove,
-    RubiksConnectedXNotification,
-    RubiksConnectedXParsedMessage,
-)
-from heart.renderers.rubiks_connected_x_visualizer.provider import (
-    RubiksConnectedXVisualizerStateProvider,
-)
-from heart.renderers.rubiks_connected_x_visualizer.state import (
-    RubiksConnectedXVisualizerState,
-)
-from heart.peripheral.rubiks_connected_x_state import apply_rubiks_connected_x_move
-
+    RUBIKS_CONNECTED_X_SOLVED_FACELETS, RubiksConnectedXMessageType,
+    RubiksConnectedXMove, RubiksConnectedXNotification,
+    RubiksConnectedXParsedMessage, load_rubiks_connected_x_baseline_facelets)
+from heart.peripheral.rubiks_connected_x_state import \
+    apply_rubiks_connected_x_move
+from heart.renderers.rubiks_connected_x_visualizer.provider import \
+    RubiksConnectedXVisualizerStateProvider
+from heart.renderers.rubiks_connected_x_visualizer.state import \
+    RubiksConnectedXVisualizerState
 
 SCRAMBLED_BASELINE = apply_rubiks_connected_x_move(
     RUBIKS_CONNECTED_X_SOLVED_FACELETS,
@@ -33,9 +27,25 @@ SCRAMBLED_BASELINE = apply_rubiks_connected_x_move(
 class TestRubiksConnectedXVisualizerStateProvider:
     """Exercise provider recovery paths so cube sync issues can be worked around without the phone app."""
 
-    def test_state_sync_updates_visualizer_when_not_overridden(self) -> None:
+    def test_state_sync_updates_visualizer_when_not_overridden(
+        self,
+        monkeypatch,
+        tmp_path: Path,
+    ) -> None:
         """Verify a full state sync replaces the fallback solved cube so normal BLE sync continues to reflect the cube's reported state."""
 
+        monkeypatch.delenv(
+            RUBIKS_CONNECTED_X_IGNORE_STATE_SYNC_ENV_VAR,
+            raising=False,
+        )
+        monkeypatch.delenv(
+            RUBIKS_CONNECTED_X_BASELINE_FACELETS_ENV_VAR,
+            raising=False,
+        )
+        monkeypatch.setenv(
+            RUBIKS_CONNECTED_X_BASELINE_PATH_ENV_VAR,
+            str(tmp_path / "missing-baseline.txt"),
+        )
         provider = RubiksConnectedXVisualizerStateProvider()
         notification = RubiksConnectedXNotification(
             characteristic_uuid="test",


### PR DESCRIPTION
## Summary
- restore the lazy `heart.loop.app` compatibility entry point used by CLI tests
- update the FlowToy bridge test to match the current decoded packet schema
- isolate the Rubik's visualizer state-sync test from local baseline files so it behaves consistently in CI

## Verification
- `make test`