### PR TITLE
Grow peripheral graph from detection nodes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "heart-firmware-io",
     "lagom",
     "moderngl",
-    "manyfold",
+    "manyfold>=0.1.4",
     "numba",
     "numpy",
     "openant",
@@ -77,7 +77,6 @@ build-backend = "uv_build"
 [tool.uv.sources]
 heart-device-manager = { path = "./packages/heart-device-manager" }
 heart-firmware-io = { path = "./packages/heart-firmware-io" }
-manyfold = { git = "https://github.com/Organization5762/manyfold.git", rev = "7e8d2164e911e770f315519d6f13a8e0f95da531" }
 heart-rgb-matrix-driver = { path = "./rust/heart_rgb_matrix_driver" }
 
 [tool.setuptools.package-data]

--- a/src/heart/peripheral/configuration.py
+++ b/src/heart/peripheral/configuration.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, Sequence
+from typing import Any, Callable, Iterable, Protocol, Sequence
 
 from heart.peripheral.core import Peripheral
 
 DetectorFactory = Callable[[], Iterable[Peripheral[Any]]]
+
+
+class GraphNodeFactory(Protocol):
+    def __call__(self, *, start_immediately: bool, on_detect: Any | None) -> Any: ...
 
 
 @dataclass(frozen=True)
@@ -15,6 +19,8 @@ class PeripheralConfiguration:
     """Declarative description of a peripheral detection plan."""
 
     detectors: Sequence[DetectorFactory]
+    graph_nodes: Sequence[GraphNodeFactory] = ()
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "detectors", tuple(self.detectors))
+        object.__setattr__(self, "graph_nodes", tuple(self.graph_nodes))

--- a/src/heart/peripheral/configurations/__init__.py
+++ b/src/heart/peripheral/configurations/__init__.py
@@ -4,6 +4,7 @@ import itertools
 import os
 from typing import Any, Iterator
 
+from heart.peripheral.configuration import GraphNodeFactory
 from heart.peripheral.compass import Compass
 from heart.peripheral.core import Peripheral
 from heart.peripheral.drawing_pad import DrawingPad
@@ -25,12 +26,13 @@ logger = get_logger(__name__)
 DISABLE_PHONE_TEXT_ENV_VAR = "HEART_DISABLE_PHONE_TEXT"
 
 def _detect_switches() -> Iterator[Peripheral[Any]]:
+    switches: list[Peripheral[Any]]
     if Configuration.use_mock_switch():
         logger.info("MOCK_SWITCH enabled; using fake switch")
         switches = list(FakeSwitch.detect())
     elif Configuration.is_pi() and not Configuration.is_x11_forward():
         logger.info("Detecting switches")
-        switches: list[Peripheral[Any]] = [
+        switches = [
             *Switch.detect(),
             *BluetoothSwitch.detect(),
         ]
@@ -80,6 +82,22 @@ def _detect_radios() -> Iterator[Peripheral[Any]]:
     from heart.peripheral.flowtoy import FlowToyPeripheral
 
     yield from itertools.chain(FlowToyPeripheral.detect())
+
+def _radio_detection_node(
+    *,
+    start_immediately: bool,
+    on_detect: Any | None,
+) -> Any:
+    from heart.peripheral.flowtoy import FlowToyPeripheral
+
+    return FlowToyPeripheral.detection_node(
+        spawn_sources=True,
+        on_detect=on_detect,
+        start_immediately=start_immediately,
+    )
+
+def _radio_graph_nodes() -> tuple[GraphNodeFactory, ...]:
+    return (_radio_detection_node,)
 
 def _detect_uwb_position() -> Iterator[Peripheral[Any]]:
     yield from itertools.chain(FakeUWBPositioning.detect())

--- a/src/heart/peripheral/configurations/default.py
+++ b/src/heart/peripheral/configurations/default.py
@@ -8,7 +8,7 @@ from heart.peripheral.configurations import (_detect_drawing_pads,
                                              _detect_heart_rate_sensor,
                                              _detect_microphones,
                                              _detect_phone_text,
-                                             _detect_radios,
+                                             _radio_graph_nodes,
                                              _detect_rubiks_connected_x,
                                              _detect_sensors, _detect_switches,
                                              _detect_uwb_position)
@@ -26,7 +26,6 @@ def configure() -> PeripheralConfiguration:
         _detect_rubiks_connected_x,
         _detect_microphones,
         _detect_drawing_pads,
-        _detect_radios,
         _detect_uwb_position
     )
-    return PeripheralConfiguration(detectors=detectors)
+    return PeripheralConfiguration(detectors=detectors, graph_nodes=_radio_graph_nodes())

--- a/src/heart/peripheral/core/manager.py
+++ b/src/heart/peripheral/core/manager.py
@@ -1,5 +1,6 @@
 from typing import Any, Iterable
 
+from manyfold import Graph
 import manyfold.rx as reactivex
 
 from heart.peripheral.configuration import PeripheralConfiguration
@@ -33,6 +34,8 @@ class PeripheralManager:
         configuration_loader: PeripheralConfigurationLoader | None = None,
     ) -> None:
         self._peripherals: list[Peripheral[Any]] = []
+        self._graph = Graph()
+        self._graph_node_handles: list[Any] = []
         self._started = False
         if configuration_loader and (configuration or configuration_registry):
             raise ValueError(
@@ -82,19 +85,42 @@ class PeripheralManager:
     def configuration_registry(self) -> PeripheralConfigurationRegistry:
         return self._configuration_loader.registry
 
+    @property
+    def graph(self) -> Graph:
+        return self._graph
+
+    @property
+    def graph_node_handles(self) -> tuple[Any, ...]:
+        return tuple(self._graph_node_handles)
+
     def detect(self) -> None:
-        for peripheral in self._iter_detected_peripherals():
+        configuration = self._ensure_configuration()
+        for peripheral in self._iter_detected_peripherals(configuration):
             self._register_peripheral(peripheral)
 
-        self._ensure_configuration()
+        for graph_node_factory in configuration.graph_nodes:
+            graph_node = graph_node_factory(
+                start_immediately=True,
+                on_detect=lambda peripheral, _access: self._register_peripheral(
+                    peripheral
+                ),
+            )
+            handle = graph_node.install(self._graph)
+            self._graph_node_handles.append(handle)
+            node_handle = getattr(handle, "node_handle", None)
+            if node_handle is not None:
+                node_handle.join()
 
     def register(self, peripheral: Peripheral[Any]) -> None:
         """Manually register ``peripheral`` with the manager."""
 
         self._register_peripheral(peripheral)
 
-    def _iter_detected_peripherals(self) -> Iterable[Peripheral[Any]]:
-        for detector in self._ensure_configuration().detectors:
+    def _iter_detected_peripherals(
+        self,
+        configuration: PeripheralConfiguration,
+    ) -> Iterable[Peripheral[Any]]:
+        for detector in configuration.detectors:
             yield from detector()
 
     def _ensure_configuration(self) -> PeripheralConfiguration:
@@ -111,6 +137,12 @@ class PeripheralManager:
         for peripheral in self._peripherals:
             logger.info(f"Attempting to start peripheral '{peripheral}'")
             peripheral.run()
+
+    def stop(self) -> None:
+        for handle in reversed(self._graph_node_handles):
+            dispose = getattr(handle, "dispose", None)
+            if dispose is not None:
+                dispose(timeout=1.0)
 
     def _register_peripheral(self, peripheral: Peripheral[Any]) -> None:
         self._peripherals.append(peripheral)

--- a/tests/peripheral/test_peripheral_manager_graph.py
+++ b/tests/peripheral/test_peripheral_manager_graph.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from manyfold import DetectionNode, Layer, OwnerName, Plane, StreamFamily
+from manyfold import StreamName, TypedEnvelope, TypedRoute, Variant, route
+from manyfold.sensor_io import (ManagedGraphNode, SensorEvent, StopToken,
+                                sensor_event_schema)
+
+from heart.peripheral.configuration import PeripheralConfiguration
+from heart.peripheral.core import Peripheral
+from heart.peripheral.core.manager import PeripheralManager
+
+
+def _sensor_event(event_type: str) -> SensorEvent:
+    return SensorEvent(event_type=event_type, data={}, observed_at=0.0)
+
+
+def _event_route(name: str) -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=OwnerName("heart.test"),
+        family=StreamFamily("peripheral"),
+        stream=StreamName(name),
+        variant=Variant.Meta,
+        schema=sensor_event_schema(f"HeartTest{name}"),
+    )
+
+
+class _LoaderStub:
+    registry: object = object()
+
+    def __init__(self, configuration: PeripheralConfiguration) -> None:
+        self._configuration = configuration
+
+    def load(self) -> PeripheralConfiguration:
+        return self._configuration
+
+
+class _DetectedPeripheral(Peripheral[str]):
+    def run(self) -> None:
+        return None
+
+
+class TestPeripheralManagerGraph:
+    def test_detect_installs_detection_nodes_that_register_peripherals(self) -> None:
+        detected = _DetectedPeripheral()
+        detection_route = _event_route("detected")
+        seen: list[TypedEnvelope[SensorEvent]] = []
+
+        def graph_node(*, start_immediately: bool, on_detect: Any | None) -> Any:
+            return DetectionNode(
+                name="test-detection",
+                detector=lambda: (item for item in (detected,)),
+                output_route=detection_route,
+                mapper=lambda _item: _sensor_event("test.detected"),
+                on_detect=on_detect,
+                start_immediately=start_immediately,
+            )
+
+        manager = PeripheralManager(
+            configuration_loader=cast(Any, _LoaderStub(
+                PeripheralConfiguration(detectors=(), graph_nodes=(graph_node,))
+            ))
+        )
+        manager.graph.observe(detection_route).subscribe(seen.append)
+
+        manager.detect()
+
+        assert manager.peripherals == (detected,)
+        assert len(manager.graph_node_handles) == 1
+        assert [envelope.value.event_type for envelope in seen] == ["test.detected"]
+
+    def test_detection_nodes_can_spawn_downstream_sources(self) -> None:
+        detected = _DetectedPeripheral()
+        detection_route = _event_route("detected")
+        source_route = _event_route("source")
+        source_events: list[TypedEnvelope[SensorEvent]] = []
+
+        def graph_node(*, start_immediately: bool, on_detect: Any | None) -> Any:
+            def spawn(_item: object, access: Any) -> None:
+                def body(stop: StopToken, graph: Any) -> None:
+                    graph.publish(source_route, _sensor_event("test.source"))
+                    stop.set()
+
+                access.own(
+                    ManagedGraphNode(
+                        name="test-source",
+                        body=body,
+                        output_routes=(source_route,),
+                    ).install(access.graph)
+                )
+
+            return DetectionNode(
+                name="test-detection",
+                detector=lambda: (item for item in (detected,)),
+                output_route=detection_route,
+                mapper=lambda _item: _sensor_event("test.detected"),
+                on_detect=on_detect,
+                spawn=spawn,
+                start_immediately=start_immediately,
+            )
+
+        manager = PeripheralManager(
+            configuration_loader=cast(Any, _LoaderStub(
+                PeripheralConfiguration(detectors=(), graph_nodes=(graph_node,))
+            ))
+        )
+        manager.graph.observe(source_route).subscribe(source_events.append)
+
+        manager.detect()
+
+        assert manager.peripherals == (detected,)
+        assert [envelope.value.event_type for envelope in source_events] == [
+            "test.source"
+        ]

--- a/uv.lock
+++ b/uv.lock
@@ -708,7 +708,7 @@ requires-dist = [
     { name = "heart-firmware-io", directory = "packages/heart-firmware-io" },
     { name = "heart-rgb-matrix-driver", marker = "extra == 'native'", directory = "rust/heart_rgb_matrix_driver" },
     { name = "lagom" },
-    { name = "manyfold", git = "https://github.com/Organization5762/manyfold.git?rev=7e8d2164e911e770f315519d6f13a8e0f95da531" },
+    { name = "manyfold", specifier = ">=0.1.4" },
     { name = "moderngl" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "numba" },
@@ -1057,10 +1057,16 @@ wheels = [
 
 [[package]]
 name = "manyfold"
-version = "0.1.3"
-source = { git = "https://github.com/Organization5762/manyfold.git?rev=7e8d2164e911e770f315519d6f13a8e0f95da531#7e8d2164e911e770f315519d6f13a8e0f95da531" }
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "reactivex" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/0e/477c8e29ce74168a1d7d19ac6c6b6ae93b95de8241845e207861d2c5ed4d/manyfold-0.1.4-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:da71f7c1c99b063de3466d58b5af9d74ee9b9d5b6dc25e551ed452a2e274806e", size = 509784, upload-time = "2026-05-03T05:25:59.222Z" },
+    { url = "https://files.pythonhosted.org/packages/36/23/17bacad50b865fa7946453b47025decac4dabf219a77d7384eb1bdcb691d/manyfold-0.1.4-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a85aa5f6d854c7c15f5e5f921fbb4b866725a9926f32babca41bdb1bc3c94684", size = 502802, upload-time = "2026-05-03T05:26:01.162Z" },
+    { url = "https://files.pythonhosted.org/packages/62/73/9ee6c8719aefc0a7a5f466ffc151a9d3d391c85f57e5d7bf433c1159a09b/manyfold-0.1.4-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e395b312f4059c0f4495b2b49962b06f16df912fe0eb248834ea1a5b38cc415e", size = 548935, upload-time = "2026-05-03T05:26:03.09Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/5e/b73280e6db5aaf6631c8625ada152775414dee076323c682439ae338dae1/manyfold-0.1.4-cp310-abi3-win_amd64.whl", hash = "sha256:c2f9ce9a1415d0bfb21d7a90e05e9eba52ff9d85c10fa4c70e997e479fa1fcbf", size = 387360, upload-time = "2026-05-03T05:26:04.771Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary\n- consume the published manyfold 0.1.4 release from PyPI instead of a git SHA pin\n- add graph-node factories to peripheral configurations and give PeripheralManager an owned Manyfold graph\n- move default radio/FlowToy detection to a DetectionNode that registers detected peripherals and spawns downstream packet source nodes\n\n## Validation\n- uv run pytest tests/peripheral/test_peripheral_manager_graph.py tests/peripheral/test_radio_peripheral.py tests/runtime/test_container.py -q\n- uv run mypy src/heart/peripheral/core/manager.py src/heart/peripheral/configuration.py src/heart/peripheral/configurations/__init__.py src/heart/peripheral/configurations/default.py tests/peripheral/test_peripheral_manager_graph.py\n- uv run ruff check src/heart/peripheral/core/manager.py src/heart/peripheral/configuration.py src/heart/peripheral/configurations/__init__.py src/heart/peripheral/configurations/default.py tests/peripheral/test_peripheral_manager_graph.py