### PR TITLE
Move Rubiks cube runtime onto Manyfold graph

### DIFF
--- a/src/heart/peripheral/configurations/__init__.py
+++ b/src/heart/peripheral/configurations/__init__.py
@@ -4,8 +4,8 @@ import itertools
 import os
 from typing import Any, Iterator
 
-from heart.peripheral.configuration import GraphNodeFactory
 from heart.peripheral.compass import Compass
+from heart.peripheral.configuration import GraphNodeFactory
 from heart.peripheral.core import Peripheral
 from heart.peripheral.drawing_pad import DrawingPad
 from heart.peripheral.gamepad import Gamepad
@@ -60,6 +60,22 @@ def _detect_rubiks_connected_x() -> Iterator[Peripheral[Any]]:
     if not configured_address and not autodetect_enabled:
         return
     yield from itertools.chain(RubiksConnectedXPeripheral.detect())
+
+def _rubiks_connected_x_detection_node(
+    *,
+    start_immediately: bool,
+    on_detect: Any | None,
+) -> Any:
+    return RubiksConnectedXPeripheral.detection_node(
+        detector=_detect_rubiks_connected_x,
+        spawn_sources=True,
+        on_detect=on_detect,
+        start_immediately=start_immediately,
+    )
+
+def _rubiks_connected_x_graph_nodes() -> tuple[GraphNodeFactory, ...]:
+    return (_rubiks_connected_x_detection_node,)
+
 def _detect_sensors() -> Iterator[Peripheral[Any]]:
     if Configuration.is_pi() and not Configuration.is_x11_forward():
         yield from itertools.chain(Accelerometer.detect(), Compass.detect())
@@ -98,6 +114,9 @@ def _radio_detection_node(
 
 def _radio_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     return (_radio_detection_node,)
+
+def _manyfold_graph_nodes() -> tuple[GraphNodeFactory, ...]:
+    return (*_radio_graph_nodes(), *_rubiks_connected_x_graph_nodes())
 
 def _detect_uwb_position() -> Iterator[Peripheral[Any]]:
     yield from itertools.chain(FakeUWBPositioning.detect())

--- a/src/heart/peripheral/configurations/default.py
+++ b/src/heart/peripheral/configurations/default.py
@@ -8,10 +8,9 @@ from heart.peripheral.configurations import (_detect_drawing_pads,
                                              _detect_heart_rate_sensor,
                                              _detect_microphones,
                                              _detect_phone_text,
-                                             _radio_graph_nodes,
-                                             _detect_rubiks_connected_x,
                                              _detect_sensors, _detect_switches,
-                                             _detect_uwb_position)
+                                             _detect_uwb_position,
+                                             _manyfold_graph_nodes)
 
 
 def configure() -> PeripheralConfiguration:
@@ -23,9 +22,8 @@ def configure() -> PeripheralConfiguration:
         _detect_gamepads,
         _detect_heart_rate_sensor,
         _detect_phone_text,
-        _detect_rubiks_connected_x,
         _detect_microphones,
         _detect_drawing_pads,
         _detect_uwb_position
     )
-    return PeripheralConfiguration(detectors=detectors, graph_nodes=_radio_graph_nodes())
+    return PeripheralConfiguration(detectors=detectors, graph_nodes=_manyfold_graph_nodes())

--- a/src/heart/peripheral/configurations/rubiks_connected_x.py
+++ b/src/heart/peripheral/configurations/rubiks_connected_x.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from heart.peripheral.configuration import PeripheralConfiguration
-from heart.peripheral.configurations import (_detect_rubiks_connected_x,
-                                             _detect_sensors, _detect_switches)
+from heart.peripheral.configurations import (_detect_sensors, _detect_switches,
+                                             _rubiks_connected_x_graph_nodes)
 
 
 def configure() -> PeripheralConfiguration:
@@ -13,6 +13,8 @@ def configure() -> PeripheralConfiguration:
     detectors = (
         _detect_switches,
         _detect_sensors,
-        _detect_rubiks_connected_x,
     )
-    return PeripheralConfiguration(detectors=detectors)
+    return PeripheralConfiguration(
+        detectors=detectors,
+        graph_nodes=_rubiks_connected_x_graph_nodes(),
+    )

--- a/src/heart/peripheral/core/manager.py
+++ b/src/heart/peripheral/core/manager.py
@@ -1,7 +1,7 @@
 from typing import Any, Iterable
 
-from manyfold import Graph
 import manyfold.rx as reactivex
+from manyfold import Graph
 
 from heart.peripheral.configuration import PeripheralConfiguration
 from heart.peripheral.configuration_loader import PeripheralConfigurationLoader

--- a/src/heart/peripheral/rubiks_connected_x.py
+++ b/src/heart/peripheral/rubiks_connected_x.py
@@ -16,7 +16,12 @@ from typing import Any, Iterable, Iterator, Sequence
 
 import manyfold.rx as reactivex
 from bleak import BleakClient, BleakScanner
+from manyfold import (DetectionNode, Graph, Layer, ManagedGraphNode,
+                      ManagedGraphNodeHandle, OwnerName, Plane, Schema,
+                      StreamFamily, StreamName, TypedRoute, Variant, route)
 from manyfold.rx.subject import Subject
+from manyfold.sensor_io import (BackoffPolicy, RetryPolicy, SensorEvent,
+                                StopToken, sensor_event_schema)
 
 from heart.peripheral.core import Peripheral, PeripheralInfo, PeripheralTag
 from heart.utilities.logging import get_logger
@@ -58,8 +63,14 @@ RUBIKS_CONNECTED_X_BASELINE_CAPTURE_GESTURE = (
     "U'",
 )
 RUBIKS_CONNECTED_X_THREAD_NAME = "peripheral-rubiks-connected-x"
+RUBIKS_CONNECTED_X_DETECTED_EVENT = "peripheral.rubiks_connected_x.detected"
+RUBIKS_CONNECTED_X_NOTIFICATION_EVENT = (
+    "peripheral.rubiks_connected_x.notification"
+)
 RUBIKS_CONNECTED_X_DISABLE_ORIENTATION_COMMAND = b"\x37"
 RUBIKS_CONNECTED_X_REQUEST_STATE_COMMAND = b"\x33"
+RUBIKS_CONNECTED_X_GRAPH_OWNER = OwnerName("heart.rubiks_connected_x")
+RUBIKS_CONNECTED_X_GRAPH_FAMILY = StreamFamily("peripheral")
 DEFAULT_RUBIKS_CONNECTED_X_ADDRESS = "E1:EE:92:6B:CF:CD"
 DEFAULT_RUBIKS_CONNECTED_X_PREFERRED_NAME = "RubiksX_CDCF6B"
 RUBIKS_CONNECTED_X_NAME_TOKENS = (
@@ -88,6 +99,57 @@ class RubiksConnectedXMessageType(StrEnum):
     BATTERY = "battery"
     OFFLINE_STATS = "offline_stats"
     CUBE_TYPE = "cube_type"
+
+
+def rubiks_connected_x_detection_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=RUBIKS_CONNECTED_X_GRAPH_OWNER,
+        family=RUBIKS_CONNECTED_X_GRAPH_FAMILY,
+        stream=StreamName("detected"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartRubiksConnectedXDetectionEvent"),
+    )
+
+
+def rubiks_connected_x_notification_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=RUBIKS_CONNECTED_X_GRAPH_OWNER,
+        family=RUBIKS_CONNECTED_X_GRAPH_FAMILY,
+        stream=StreamName("notifications"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartRubiksConnectedXNotificationEvent"),
+    )
+
+
+def rubiks_connected_x_exception_schema() -> Schema[BaseException]:
+    def encode(exc: BaseException) -> bytes:
+        return f"{type(exc).__name__}:{exc}".encode("utf-8")
+
+    def decode(payload: bytes) -> BaseException:
+        return RuntimeError(payload.decode("utf-8"))
+
+    return Schema(
+        schema_id="PythonException",
+        version=1,
+        encode=encode,
+        decode=decode,
+    )
+
+
+def rubiks_connected_x_error_route() -> TypedRoute[BaseException]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=RUBIKS_CONNECTED_X_GRAPH_OWNER,
+        family=RUBIKS_CONNECTED_X_GRAPH_FAMILY,
+        stream=StreamName("errors"),
+        variant=Variant.Meta,
+        schema=rubiks_connected_x_exception_schema(),
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -1022,6 +1084,7 @@ class RubiksConnectedXPeripheral(Peripheral[RubiksConnectedXNotification]):
         self._sequence = 0
         self._frame_buffers: dict[str, bytearray] = {}
         self._last_bluez_connect_attempt_monotonic = 0.0
+        self._managed_graph_node_installed = False
 
     def _event_stream(self) -> reactivex.Observable[RubiksConnectedXNotification]:
         return self._events
@@ -1050,7 +1113,62 @@ class RubiksConnectedXPeripheral(Peripheral[RubiksConnectedXNotification]):
         )
         return
 
+    @classmethod
+    def detection_node(
+        cls,
+        *,
+        detector: Any | None = None,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        notification_output_route: TypedRoute[SensorEvent] | None = None,
+        notification_error_route: TypedRoute[BaseException] | None = None,
+        spawn_sources: bool = False,
+        on_detect: Any | None = None,
+        start_immediately: bool = True,
+    ) -> DetectionNode:
+        resolved_output_route = output_route or rubiks_connected_x_detection_route()
+        resolved_notification_output_route = (
+            notification_output_route or rubiks_connected_x_notification_route()
+        )
+
+        def mapper(peripheral: "RubiksConnectedXPeripheral") -> SensorEvent:
+            return SensorEvent(
+                event_type=RUBIKS_CONNECTED_X_DETECTED_EVENT,
+                data={
+                    "address": peripheral.address,
+                    "name": peripheral.name,
+                    "characteristic_uuids": list(peripheral.characteristic_uuids),
+                },
+                observed_at=time.time(),
+                identity=peripheral.peripheral_info().to_sensor_identity(),
+            )
+
+        def spawn(peripheral: "RubiksConnectedXPeripheral", access: Any) -> None:
+            if not spawn_sources:
+                return
+            access.own(
+                peripheral.install_node(
+                    access.graph,
+                    output_route=resolved_notification_output_route,
+                    error_route=notification_error_route
+                    or rubiks_connected_x_error_route(),
+                )
+            )
+
+        return DetectionNode(
+            name="heart-rubiks-connected-x-detection",
+            detector=detector or cls.detect,
+            output_route=resolved_output_route,
+            mapper=mapper,
+            on_detect=on_detect,
+            spawn=spawn,
+            error_route=rubiks_connected_x_error_route(),
+            group="rubiks-connected-x-detection",
+            start_immediately=start_immediately,
+        )
+
     def run(self) -> None:
+        if self._managed_graph_node_installed:
+            return
         if self._thread is not None and self._thread.is_alive():
             return
         self._stop_event.clear()
@@ -1063,6 +1181,57 @@ class RubiksConnectedXPeripheral(Peripheral[RubiksConnectedXNotification]):
 
     def stop(self) -> None:
         self._stop_event.set()
+
+    def install_node(
+        self,
+        graph: Graph,
+        *,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        error_route: TypedRoute[BaseException] | None = None,
+        retry: RetryPolicy | None = None,
+        backoff: BackoffPolicy | None = None,
+        start_immediately: bool = True,
+    ) -> ManagedGraphNodeHandle:
+        """Install this cube as a self-running Manyfold graph notification source."""
+
+        resolved_output_route = output_route or rubiks_connected_x_notification_route()
+        self._managed_graph_node_installed = True
+
+        def _publish(notification: RubiksConnectedXNotification) -> None:
+            graph.publish(
+                resolved_output_route,
+                self._notification_to_sensor_event(notification),
+            )
+
+        def _body(stop: StopToken, _graph: Graph) -> None:
+            subscription = self._events.subscribe(_publish)
+            try:
+                asyncio.run(self._monitor_until_stopped(stop))
+            finally:
+                subscription.dispose()
+
+        return ManagedGraphNode(
+            name="heart-rubiks-connected-x",
+            body=_body,
+            output_routes=(resolved_output_route,),
+            error_route=error_route or rubiks_connected_x_error_route(),
+            retry=retry or RetryPolicy(max_attempts=1_000_000),
+            backoff=backoff or BackoffPolicy.fixed(DEFAULT_RECONNECT_DELAY_SECONDS),
+            group="rubiks-connected-x",
+            start_immediately=start_immediately,
+        ).install(graph)
+
+    async def _monitor_until_stopped(self, stop: StopToken) -> None:
+        self._stop_event.clear()
+        monitor_task = asyncio.create_task(self._monitor_forever())
+        try:
+            while not stop.is_set() and not monitor_task.done():
+                await asyncio.sleep(DEFAULT_IDLE_POLL_INTERVAL_SECONDS)
+            if stop.is_set():
+                self.stop()
+            await monitor_task
+        finally:
+            self.stop()
 
     def _run_thread(self) -> None:
         try:
@@ -1273,7 +1442,7 @@ class RubiksConnectedXPeripheral(Peripheral[RubiksConnectedXNotification]):
                     and parsed_message.message_type is RubiksConnectedXMessageType.STATE
                 ):
                     logger.info("Observed Rubik's Connected X full state sync.")
-                self._events.on_next(
+                self._emit_notification(
                     RubiksConnectedXNotification(
                         characteristic_uuid=characteristic_uuid,
                         payload_hex=payload.hex(" "),
@@ -1286,3 +1455,18 @@ class RubiksConnectedXPeripheral(Peripheral[RubiksConnectedXNotification]):
                 )
 
         return _callback
+
+    def _emit_notification(self, notification: RubiksConnectedXNotification) -> None:
+        self._events.on_next(notification)
+
+    def _notification_to_sensor_event(
+        self,
+        notification: RubiksConnectedXNotification,
+    ) -> SensorEvent:
+        return SensorEvent(
+            event_type=RUBIKS_CONNECTED_X_NOTIFICATION_EVENT,
+            data=serialize_rubiks_connected_x_notification(notification),
+            observed_at=time.time(),
+            identity=self.peripheral_info().to_sensor_identity(),
+            sequence_number=notification.sequence,
+        )

--- a/tests/peripheral/test_peripheral_manager_graph.py
+++ b/tests/peripheral/test_peripheral_manager_graph.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from manyfold import DetectionNode, Layer, OwnerName, Plane, StreamFamily
-from manyfold import StreamName, TypedEnvelope, TypedRoute, Variant, route
+from manyfold import (DetectionNode, Layer, OwnerName, Plane, StreamFamily,
+                      StreamName, TypedEnvelope, TypedRoute, Variant, route)
 from manyfold.sensor_io import (ManagedGraphNode, SensorEvent, StopToken,
                                 sensor_event_schema)
 

--- a/tests/peripheral/test_rubiks_connected_x.py
+++ b/tests/peripheral/test_rubiks_connected_x.py
@@ -4,20 +4,26 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
+from typing import Any
+
+from manyfold import Graph
 
 import heart.peripheral.rubiks_connected_x as rubiks_connected_x_module
 from heart.peripheral.rubiks_connected_x import (
     DEFAULT_RUBIKS_CONNECTED_X_ADDRESS,
     DEFAULT_RUBIKS_CONNECTED_X_PREFERRED_NAME,
-    RUBIKS_CONNECTED_X_ADDRESS_ENV_VAR, RUBIKS_CONNECTED_X_SOLVED_FACELETS,
+    RUBIKS_CONNECTED_X_ADDRESS_ENV_VAR, RUBIKS_CONNECTED_X_DETECTED_EVENT,
+    RUBIKS_CONNECTED_X_NOTIFICATION_EVENT, RUBIKS_CONNECTED_X_SOLVED_FACELETS,
     RubiksConnectedXMessageType, RubiksConnectedXNotification,
     RubiksConnectedXPeripheral, candidate_from_scan_result,
     extract_rubiks_connected_x_frames, normalize_candidate_name,
     parse_rubiks_connected_x_facelets, parse_rubiks_connected_x_message,
     parse_rubiks_connected_x_packet, render_candidate_line,
     render_notification_line, rubiks_connected_x_candidate_score,
-    rubiks_connected_x_face_slice, serialize_rubiks_connected_x_notification,
-    snapshot_services, summarize_rubiks_connected_x_notifications)
+    rubiks_connected_x_detection_route, rubiks_connected_x_face_slice,
+    rubiks_connected_x_notification_route,
+    serialize_rubiks_connected_x_notification, snapshot_services,
+    summarize_rubiks_connected_x_notifications)
 
 
 class TestRubiksConnectedXHelpers:
@@ -357,6 +363,74 @@ class TestRubiksConnectedXHelpers:
         assert len(peripherals) == 1
         assert peripherals[0].address == DEFAULT_RUBIKS_CONNECTED_X_ADDRESS
         assert peripherals[0].name == DEFAULT_RUBIKS_CONNECTED_X_PREFERRED_NAME
+
+    def test_detection_node_publishes_detected_cube_to_manyfold_route(self) -> None:
+        """Verify cube discovery can be represented as a Manyfold graph source instead of a manager-only detector."""
+
+        detected = RubiksConnectedXPeripheral(address="AA:BB:CC:DD", name="Cube")
+        graph = Graph()
+        detection_route = rubiks_connected_x_detection_route()
+        registered: list[RubiksConnectedXPeripheral] = []
+
+        handle = RubiksConnectedXPeripheral.detection_node(
+            detector=lambda: iter((detected,)),
+            output_route=detection_route,
+            on_detect=lambda peripheral, _graph: registered.append(peripheral),
+            start_immediately=False,
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest = graph.latest(detection_route)
+        assert latest is not None
+        assert latest.value.event_type == RUBIKS_CONNECTED_X_DETECTED_EVENT
+        assert latest.value.data["address"] == "AA:BB:CC:DD"
+        assert latest.value.identity.id == "rubiks-connected-x:AA:BB:CC:DD"
+        assert registered == [detected]
+
+    def test_detection_node_can_spawn_notification_source(self, monkeypatch) -> None:
+        """Verify detected cubes can install their runtime notification source through graph access."""
+
+        notification = RubiksConnectedXNotification(
+            characteristic_uuid="6e400003-b5a3-f393-e0a9-e50e24dcca9e",
+            payload_hex="2a 06 01 02 00 33 0d 0a",
+            payload_utf8=None,
+            byte_count=8,
+            sequence=7,
+        )
+        detected = RubiksConnectedXPeripheral(address="AA:BB:CC:DD", name="Cube")
+
+        async def fake_monitor_until_stopped(self: Any, stop: Any) -> None:
+            self._emit_notification(notification)
+            stop.set()
+
+        monkeypatch.setattr(
+            RubiksConnectedXPeripheral,
+            "_monitor_until_stopped",
+            fake_monitor_until_stopped,
+        )
+        graph = Graph()
+        detection_route = rubiks_connected_x_detection_route()
+        notification_route = rubiks_connected_x_notification_route()
+
+        handle = RubiksConnectedXPeripheral.detection_node(
+            detector=lambda: iter((detected,)),
+            output_route=detection_route,
+            notification_output_route=notification_route,
+            spawn_sources=True,
+            start_immediately=False,
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+        assert len(handle.spawned_handles) == 1
+        spawned = handle.spawned_handles[0]
+        spawned.loop_handle.loop.run(spawned.loop_handle.token)
+
+        latest = graph.latest(notification_route)
+        assert latest is not None
+        assert latest.value.event_type == RUBIKS_CONNECTED_X_NOTIFICATION_EVENT
+        assert latest.value.sequence_number == 7
+        assert latest.value.data["payload_hex"] == "2a 06 01 02 00 33 0d 0a"
 
     def test_resolve_runtime_device_attempts_bluez_connect_for_known_address(
         self,


### PR DESCRIPTION
## Summary
- add Manyfold routes plus detection/runtime graph nodes for Rubik's Connected X cubes
- publish cube detection and notifications as typed SensorEvent routes
- wire default and Rubik's-specific peripheral configurations through graph-node discovery so runtime sources can be spawned by Manyfold

## Verification
- uv run pytest tests/peripheral/test_rubiks_connected_x.py tests/peripheral/test_peripheral_manager_graph.py tests/peripheral/test_radio_peripheral.py
- uv run ruff check src/heart/peripheral/rubiks_connected_x.py src/heart/peripheral/configurations/__init__.py src/heart/peripheral/configurations/default.py src/heart/peripheral/configurations/rubiks_connected_x.py src/heart/peripheral/core/manager.py tests/peripheral/test_rubiks_connected_x.py tests/peripheral/test_peripheral_manager_graph.py