### PR TITLE
Route microphone runtime through Manyfold nodes

### DIFF
--- a/src/heart/peripheral/configurations/__init__.py
+++ b/src/heart/peripheral/configurations/__init__.py
@@ -91,6 +91,20 @@ def _detect_heart_rate_sensor() -> Iterator[Peripheral[Any]]:
 def _detect_microphones() -> Iterator[Peripheral[Any]]:
     yield from itertools.chain(Microphone.detect())
 
+def _microphone_detection_node(
+    *,
+    start_immediately: bool,
+    on_detect: Any | None,
+) -> Any:
+    return Microphone.detection_node(
+        spawn_sources=True,
+        on_detect=on_detect,
+        start_immediately=start_immediately,
+    )
+
+def _microphone_graph_nodes() -> tuple[GraphNodeFactory, ...]:
+    return (_microphone_detection_node,)
+
 def _detect_drawing_pads() -> Iterator[Peripheral[Any]]:
     yield from itertools.chain(DrawingPad.detect())
 
@@ -116,7 +130,11 @@ def _radio_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     return (_radio_detection_node,)
 
 def _manyfold_graph_nodes() -> tuple[GraphNodeFactory, ...]:
-    return (*_radio_graph_nodes(), *_rubiks_connected_x_graph_nodes())
+    return (
+        *_radio_graph_nodes(),
+        *_rubiks_connected_x_graph_nodes(),
+        *_microphone_graph_nodes(),
+    )
 
 def _detect_uwb_position() -> Iterator[Peripheral[Any]]:
     yield from itertools.chain(FakeUWBPositioning.detect())

--- a/src/heart/peripheral/configurations/default.py
+++ b/src/heart/peripheral/configurations/default.py
@@ -6,7 +6,6 @@ from heart.peripheral.configuration import PeripheralConfiguration
 from heart.peripheral.configurations import (_detect_drawing_pads,
                                              _detect_gamepads,
                                              _detect_heart_rate_sensor,
-                                             _detect_microphones,
                                              _detect_phone_text,
                                              _detect_sensors, _detect_switches,
                                              _detect_uwb_position,
@@ -22,7 +21,6 @@ def configure() -> PeripheralConfiguration:
         _detect_gamepads,
         _detect_heart_rate_sensor,
         _detect_phone_text,
-        _detect_microphones,
         _detect_drawing_pads,
         _detect_uwb_position
     )

--- a/src/heart/peripheral/microphone.py
+++ b/src/heart/peripheral/microphone.py
@@ -11,8 +11,12 @@ from typing import Any, Self, cast
 
 import manyfold.rx as reactivex
 import numpy as np
+from manyfold import (DetectionNode, Graph, Layer, ManagedGraphNode,
+                      ManagedGraphNodeHandle, OwnerName, Plane, Schema,
+                      StreamFamily, StreamName, TypedRoute, Variant, route)
 from manyfold.rx.subject import Subject
-from manyfold.sensor_io import BackoffPolicy, ManagedRunLoop, StopToken
+from manyfold.sensor_io import (BackoffPolicy, ManagedRunLoop, RetryPolicy,
+                                SensorEvent, StopToken, sensor_event_schema)
 
 from heart.peripheral.core import Peripheral
 from heart.peripheral.input_payloads.audio import MicrophoneLevel
@@ -29,6 +33,59 @@ DEFAULT_SAMPLE_RATE = 16_000
 DEFAULT_BLOCK_DURATION_SECONDS = 0.1
 DEFAULT_CHANNELS = 1
 DEFAULT_RETRY_DELAY_SECONDS = 1.0
+MICROPHONE_GRAPH_OWNER = OwnerName("heart.microphone")
+MICROPHONE_GRAPH_FAMILY = StreamFamily("peripheral")
+
+
+def microphone_level_event_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=MICROPHONE_GRAPH_OWNER,
+        family=MICROPHONE_GRAPH_FAMILY,
+        stream=StreamName("levels"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartMicrophoneLevelEvent"),
+    )
+
+
+def microphone_detection_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=MICROPHONE_GRAPH_OWNER,
+        family=MICROPHONE_GRAPH_FAMILY,
+        stream=StreamName("detected"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartMicrophoneDetectionEvent"),
+    )
+
+
+def microphone_exception_schema() -> Schema[BaseException]:
+    def encode(exc: BaseException) -> bytes:
+        return f"{type(exc).__name__}:{exc}".encode("utf-8")
+
+    def decode(payload: bytes) -> BaseException:
+        return RuntimeError(payload.decode("utf-8"))
+
+    return Schema(
+        schema_id="PythonException",
+        version=1,
+        encode=encode,
+        decode=decode,
+    )
+
+
+def microphone_error_route() -> TypedRoute[BaseException]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=MICROPHONE_GRAPH_OWNER,
+        family=MICROPHONE_GRAPH_FAMILY,
+        stream=StreamName("errors"),
+        variant=Variant.Meta,
+        schema=microphone_exception_schema(),
+    )
 
 
 class Microphone(Peripheral[MicrophoneLevel]):
@@ -77,6 +134,55 @@ class Microphone(Peripheral[MicrophoneLevel]):
             return
 
         yield cls()
+
+    @classmethod
+    def detection_node(
+        cls,
+        *,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        level_output_route: TypedRoute[SensorEvent] | None = None,
+        level_error_route: TypedRoute[BaseException] | None = None,
+        spawn_sources: bool = False,
+        on_detect: Any | None = None,
+        start_immediately: bool = True,
+    ) -> DetectionNode:
+        resolved_output_route = output_route or microphone_detection_route()
+        resolved_level_output_route = level_output_route or microphone_level_event_route()
+
+        def mapper(peripheral: "Microphone") -> SensorEvent:
+            return SensorEvent(
+                event_type="peripheral.microphone.detected",
+                data={
+                    "samplerate": peripheral.samplerate,
+                    "block_duration": peripheral.block_duration,
+                    "channels": peripheral.channels,
+                },
+                observed_at=time.time(),
+                identity=peripheral.peripheral_info().to_sensor_identity(),
+            )
+
+        def spawn(peripheral: "Microphone", access: Any) -> None:
+            if not spawn_sources:
+                return
+            access.own(
+                peripheral.install_node(
+                    access.graph,
+                    output_route=resolved_level_output_route,
+                    error_route=level_error_route or microphone_error_route(),
+                )
+            )
+
+        return DetectionNode(
+            name="heart-microphone-detection",
+            detector=cls.detect,
+            output_route=resolved_output_route,
+            mapper=mapper,
+            on_detect=on_detect,
+            spawn=spawn,
+            error_route=microphone_error_route(),
+            group="microphone-detection",
+            start_immediately=start_immediately,
+        )
 
     # ------------------------------------------------------------------
     # Public helpers
@@ -133,17 +239,81 @@ class Microphone(Peripheral[MicrophoneLevel]):
         finally:
             self._stop_token = StopToken(group="microphone")
 
+    def install_node(
+        self,
+        graph: Graph,
+        *,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        error_route: TypedRoute[BaseException] | None = None,
+        retry: RetryPolicy | None = None,
+        backoff: BackoffPolicy | None = None,
+        start_immediately: bool = True,
+    ) -> ManagedGraphNodeHandle:
+        """Install this microphone as a self-running Manyfold graph level source."""
+
+        resolved_output_route = output_route or microphone_level_event_route()
+        blocksize = max(1, int(self.samplerate * self.block_duration))
+
+        def _body(stop: StopToken, graph: Graph) -> None:
+            if sd is None:
+                logger.info("sounddevice not available; microphone graph node idle")
+                stop.set()
+                return
+
+            def _publish_audio_block(
+                indata: Any,
+                frames: int,
+                time_info: Any,
+                status: Any,
+            ) -> None:
+                level = self._handle_audio_block(indata, frames, time_info, status)
+                if level is None:
+                    return
+                graph.publish(
+                    resolved_output_route,
+                    self._level_to_sensor_event(level),
+                )
+
+            try:
+                with self._open_stream(blocksize, callback=_publish_audio_block):
+                    logger.info(
+                        "Microphone graph node started (samplerate=%dHz, block=%d samples)",
+                        self.samplerate,
+                        blocksize,
+                    )
+                    self._wait_forever(stop)
+            except KeyboardInterrupt:
+                logger.info("Microphone graph node interrupted; stopping stream")
+                stop.set()
+                return
+
+        return ManagedGraphNode(
+            name="heart-microphone-levels",
+            body=_body,
+            output_routes=(resolved_output_route,),
+            error_route=error_route or microphone_error_route(),
+            retry=retry or RetryPolicy(max_attempts=1_000_000),
+            backoff=backoff or BackoffPolicy.fixed(self._retry_delay),
+            group="microphone",
+            start_immediately=start_immediately,
+        ).install(graph)
+
     def _wait_forever(self, stop: StopToken) -> None:
         while not stop.wait(self.block_duration):
             pass
 
-    def _open_stream(self, blocksize: int) -> Any:  # pragma: no cover - thin wrapper
+    def _open_stream(
+        self,
+        blocksize: int,
+        *,
+        callback: Any | None = None,
+    ) -> Any:  # pragma: no cover - thin wrapper
         assert sd is not None
         return sd.InputStream(
             samplerate=self.samplerate,
             channels=self.channels,
             blocksize=blocksize,
-            callback=self._on_audio_block,
+            callback=callback or self._on_audio_block,
         )
 
     # ------------------------------------------------------------------
@@ -152,18 +322,23 @@ class Microphone(Peripheral[MicrophoneLevel]):
     def _on_audio_block(
         self, indata: Any, frames: int, _time: Any, status: Any
     ) -> None:
+        self._handle_audio_block(indata, frames, _time, status)
+
+    def _handle_audio_block(
+        self, indata: Any, frames: int, _time: Any, status: Any
+    ) -> MicrophoneLevel | None:
         if status:  # pragma: no cover - requires real hardware conditions
             logger.warning("Microphone stream status: %s", status)
         try:
             audio = np.asarray(indata)
         except Exception:
             logger.exception("Failed to convert audio buffer to numpy array")
-            return
+            return None
         if audio.size == 0:
-            return
-        self._process_audio_chunk(audio, frames)
+            return None
+        return self._process_audio_chunk(audio, frames)
 
-    def _process_audio_chunk(self, audio: np.ndarray, frames: int) -> None:
+    def _process_audio_chunk(self, audio: np.ndarray, frames: int) -> MicrophoneLevel:
         """Compute loudness metrics and publish an event."""
 
         flattened = audio.reshape(-1)
@@ -181,6 +356,15 @@ class Microphone(Peripheral[MicrophoneLevel]):
         payload = level.to_input()
         self._latest_level = cast(dict[str, Any], payload.data)
         self._level_subject.on_next(level)
+        return level
+
+    def _level_to_sensor_event(self, level: MicrophoneLevel) -> SensorEvent:
+        return SensorEvent(
+            event_type=level.event_type,
+            data=level.to_input().data,
+            observed_at=level.timestamp,
+            identity=self.peripheral_info().to_sensor_identity(),
+        )
 
     # ------------------------------------------------------------------
     # Context manager helpers

--- a/tests/peripheral/test_microphone.py
+++ b/tests/peripheral/test_microphone.py
@@ -1,6 +1,43 @@
 
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from manyfold import Graph
+
 from heart.peripheral import microphone
-from heart.peripheral.microphone import Microphone
+from heart.peripheral.microphone import (Microphone,
+                                         microphone_detection_route,
+                                         microphone_level_event_route)
+
+
+class _InputStreamStub:
+    def __init__(self, *, callback: Any, blocks: tuple[np.ndarray, ...]) -> None:
+        self._callback = callback
+        self._blocks = blocks
+
+    def __enter__(self) -> "_InputStreamStub":
+        for block in self._blocks:
+            self._callback(block, len(block), None, None)
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        return None
+
+
+class _SoundDeviceStub:
+    def __init__(self, *, blocks: tuple[np.ndarray, ...] = ()) -> None:
+        self._blocks = blocks
+
+    def query_devices(self) -> list[dict[str, int]]:
+        return [{"max_input_channels": 1}]
+
+    def InputStream(self, **kwargs: Any) -> _InputStreamStub:
+        return _InputStreamStub(
+            callback=kwargs["callback"],
+            blocks=self._blocks,
+        )
 
 
 class TestPeripheralMicrophone:
@@ -11,3 +48,47 @@ class TestPeripheralMicrophone:
 
         monkeypatch.setattr(microphone, "sd", None)
         assert list(Microphone.detect()) == []
+
+    def test_detection_node_publishes_microphone_to_manyfold_route(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(microphone, "sd", _SoundDeviceStub())
+        graph = Graph()
+        registered: list[Microphone] = []
+
+        handle = Microphone.detection_node(
+            start_immediately=False,
+            on_detect=lambda peripheral, _access: registered.append(peripheral),
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest_detection = graph.latest(microphone_detection_route())
+        assert len(registered) == 1
+        assert latest_detection is not None
+        assert latest_detection.value.event_type == "peripheral.microphone.detected"
+        assert latest_detection.value.data["samplerate"] == 16_000
+
+    def test_detection_node_can_spawn_level_source(self, monkeypatch) -> None:
+        block = np.array([[0.0], [0.5], [-1.0]], dtype=float)
+        monkeypatch.setattr(microphone, "sd", _SoundDeviceStub(blocks=(block,)))
+        graph = Graph()
+
+        handle = Microphone.detection_node(
+            start_immediately=False,
+            spawn_sources=True,
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+        assert len(handle.spawned_handles) == 1
+
+        spawned = handle.spawned_handles[0]
+        spawned.loop_handle.token.set()
+        spawned.loop_handle.loop.run(spawned.loop_handle.token)
+
+        latest_level = graph.latest(microphone_level_event_route())
+        assert latest_level is not None
+        assert latest_level.value.event_type == "peripheral.microphone.level"
+        assert latest_level.value.data["frames"] == 3
+        assert latest_level.value.data["samplerate"] == 16_000

--- a/tests/peripheral/test_peripheral_configurations.py
+++ b/tests/peripheral/test_peripheral_configurations.py
@@ -5,8 +5,12 @@ from collections.abc import Iterator
 from manyfold import Graph
 
 from heart.peripheral.configurations import (_detect_radios,
+                                             _microphone_detection_node,
                                              _radio_detection_node)
-from heart.peripheral.input_payloads import RadioPacket
+from heart.peripheral.input_payloads import MicrophoneLevel, RadioPacket
+from heart.peripheral.microphone import (Microphone,
+                                         microphone_detection_route,
+                                         microphone_level_event_route)
 from heart.peripheral.radio import (RadioDriver, RadioPeripheral,
                                     RawRadioPacket, SerialRadioDriver,
                                     radio_detection_route,
@@ -82,3 +86,51 @@ class TestManyfoldRadioConfiguration:
         assert latest_packet is not None
         assert latest_packet.value.event_type == RadioPacket.EVENT_TYPE
         assert latest_packet.value.data["payload"] == [16]
+
+
+class TestManyfoldMicrophoneConfiguration:
+    """Cover default graph-node factories so microphone streams stay Manyfold-owned."""
+
+    def test_microphone_detection_node_spawns_level_source(
+        self,
+        monkeypatch,
+    ) -> None:
+        detected = Microphone()
+        level = MicrophoneLevel(
+            rms=0.5,
+            peak=1.0,
+            frames=16,
+            samplerate=16_000,
+            timestamp=123.0,
+        )
+
+        def _detect(cls) -> Iterator[Microphone]:
+            yield detected
+
+        def _install_node(self, graph: Graph, **kwargs):
+            graph.publish(
+                kwargs["output_route"],
+                self._level_to_sensor_event(level),
+            )
+            return object()
+
+        monkeypatch.setattr(Microphone, "detect", classmethod(_detect))
+        monkeypatch.setattr(Microphone, "install_node", _install_node)
+        graph = Graph()
+        registered: list[Microphone] = []
+
+        handle = _microphone_detection_node(
+            start_immediately=False,
+            on_detect=lambda peripheral, _access: registered.append(peripheral),
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest_detection = graph.latest(microphone_detection_route())
+        latest_level = graph.latest(microphone_level_event_route())
+        assert registered == [detected]
+        assert latest_detection is not None
+        assert latest_detection.value.event_type == "peripheral.microphone.detected"
+        assert latest_level is not None
+        assert latest_level.value.event_type == MicrophoneLevel.EVENT_TYPE
+        assert latest_level.value.data["rms"] == 0.5


### PR DESCRIPTION
## Summary
- add Manyfold routes, detection node, and managed level source for microphone peripherals
- route default microphone discovery through graph-node runtime management instead of the legacy detector list
- cover microphone detection/source spawning in focused peripheral configuration tests

## Verification
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools make format
- uv run pytest tests/peripheral/test_microphone.py tests/peripheral/test_peripheral_configurations.py tests/peripheral/test_peripheral_manager_graph.py tests/peripheral/test_radio_peripheral.py tests/peripheral/test_rubiks_connected_x.py

## Notes
- Full make check still reports pre-existing semgrep findings in src/heart/cli/commands/flowtoy_fast_path.py, src/heart/device/rgb_display/debug.py, and src/heart/renderers/pranay_sketch/provider.py.