### PR TITLE
Route accelerometer runtime through Manyfold nodes

### DIFF
--- a/src/heart/peripheral/configurations/__init__.py
+++ b/src/heart/peripheral/configurations/__init__.py
@@ -78,9 +78,25 @@ def _rubiks_connected_x_graph_nodes() -> tuple[GraphNodeFactory, ...]:
 
 def _detect_sensors() -> Iterator[Peripheral[Any]]:
     if Configuration.is_pi() and not Configuration.is_x11_forward():
-        yield from itertools.chain(Accelerometer.detect(), Compass.detect())
+        yield from itertools.chain(Compass.detect())
     else:
         yield from FakeAccelerometer.detect()
+
+def _accelerometer_detection_node(
+    *,
+    start_immediately: bool,
+    on_detect: Any | None,
+) -> Any:
+    return Accelerometer.detection_node(
+        spawn_sources=True,
+        on_detect=on_detect,
+        start_immediately=start_immediately,
+    )
+
+def _accelerometer_graph_nodes() -> tuple[GraphNodeFactory, ...]:
+    if Configuration.is_pi() and not Configuration.is_x11_forward():
+        return (_accelerometer_detection_node,)
+    return ()
 
 def _detect_gamepads() -> Iterator[Peripheral[Any]]:
     yield from itertools.chain(Gamepad.detect())
@@ -131,6 +147,7 @@ def _radio_graph_nodes() -> tuple[GraphNodeFactory, ...]:
 
 def _manyfold_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     return (
+        *_accelerometer_graph_nodes(),
         *_radio_graph_nodes(),
         *_rubiks_connected_x_graph_nodes(),
         *_microphone_graph_nodes(),

--- a/src/heart/peripheral/sensor.py
+++ b/src/heart/peripheral/sensor.py
@@ -1,15 +1,20 @@
 import json
 import logging
 import random
+import time
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, Iterator, Mapping, Self, cast
 
 import manyfold.rx as reactivex
 import serial
+from manyfold import (DetectionNode, Graph, Layer, ManagedGraphNode,
+                      ManagedGraphNodeHandle, OwnerName, Plane, Schema,
+                      StreamFamily, StreamName, TypedRoute, Variant, route)
 from manyfold.rx import operators as ops
 from manyfold.sensor_io import (BackoffPolicy, ManagedRunLoop,
-                                ManagedRunLoopHandle, StopToken)
+                                ManagedRunLoopHandle, RetryPolicy, SensorEvent,
+                                StopToken, sensor_event_schema)
 
 from heart.peripheral.core import Peripheral, PeripheralInfo, PeripheralTag
 from heart.peripheral.input_payloads.motion import AccelerometerVector
@@ -22,6 +27,59 @@ from heart.utilities.reactivex_threads import (interval_in_background,
 logger = get_logger(__name__)
 RECONNECT_DELAY_SECONDS = 1.0
 ACCELEROMETER_THREAD_NAME = "peripheral-accelerometer"
+ACCELEROMETER_GRAPH_OWNER = OwnerName("heart.accelerometer")
+ACCELEROMETER_GRAPH_FAMILY = StreamFamily("peripheral")
+
+
+def accelerometer_vector_event_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=ACCELEROMETER_GRAPH_OWNER,
+        family=ACCELEROMETER_GRAPH_FAMILY,
+        stream=StreamName("vectors"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartAccelerometerVectorEvent"),
+    )
+
+
+def accelerometer_detection_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=ACCELEROMETER_GRAPH_OWNER,
+        family=ACCELEROMETER_GRAPH_FAMILY,
+        stream=StreamName("detected"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartAccelerometerDetectionEvent"),
+    )
+
+
+def accelerometer_exception_schema() -> Schema[BaseException]:
+    def encode(exc: BaseException) -> bytes:
+        return f"{type(exc).__name__}:{exc}".encode("utf-8")
+
+    def decode(payload: bytes) -> BaseException:
+        return RuntimeError(payload.decode("utf-8"))
+
+    return Schema(
+        schema_id="PythonException",
+        version=1,
+        encode=encode,
+        decode=decode,
+    )
+
+
+def accelerometer_error_route() -> TypedRoute[BaseException]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=ACCELEROMETER_GRAPH_OWNER,
+        family=ACCELEROMETER_GRAPH_FAMILY,
+        stream=StreamName("errors"),
+        variant=Variant.Meta,
+        schema=accelerometer_exception_schema(),
+    )
 
 
 @dataclass
@@ -61,6 +119,61 @@ class Accelerometer(Peripheral[Acceleration | None]):
         for port in get_device_ports("usb-Adafruit_KB2040"):
             yield cls(port=port, baudrate=115200)
 
+    def peripheral_info(self) -> PeripheralInfo:
+        return PeripheralInfo(
+            id=f"accelerometer:{self.port}",
+            tags=[
+                PeripheralTag(name="input_variant", variant="accelerometer"),
+            ],
+        )
+
+    @classmethod
+    def detection_node(
+        cls,
+        *,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        vector_output_route: TypedRoute[SensorEvent] | None = None,
+        vector_error_route: TypedRoute[BaseException] | None = None,
+        spawn_sources: bool = False,
+        on_detect: Any | None = None,
+        start_immediately: bool = True,
+    ) -> DetectionNode:
+        resolved_output_route = output_route or accelerometer_detection_route()
+        resolved_vector_output_route = (
+            vector_output_route or accelerometer_vector_event_route()
+        )
+
+        def mapper(peripheral: "Accelerometer") -> SensorEvent:
+            return SensorEvent(
+                event_type="peripheral.accelerometer.detected",
+                data={"port": peripheral.port, "baudrate": peripheral.baudrate},
+                observed_at=time.time(),
+                identity=peripheral.peripheral_info().to_sensor_identity(),
+            )
+
+        def spawn(peripheral: "Accelerometer", access: Any) -> None:
+            if not spawn_sources:
+                return
+            access.own(
+                peripheral.install_node(
+                    access.graph,
+                    output_route=resolved_vector_output_route,
+                    error_route=vector_error_route or accelerometer_error_route(),
+                )
+            )
+
+        return DetectionNode(
+            name="heart-accelerometer-detection",
+            detector=cls.detect,
+            output_route=resolved_output_route,
+            mapper=mapper,
+            on_detect=on_detect,
+            spawn=spawn,
+            error_route=accelerometer_error_route(),
+            group="accelerometer-detection",
+            start_immediately=start_immediately,
+        )
+
     def _connect_to_ser(self) -> serial.Serial:
         return serial.Serial(self.port, self.baudrate, timeout=1.0)
 
@@ -92,12 +205,55 @@ class Accelerometer(Peripheral[Acceleration | None]):
                     continue
                 self._process_data(datum)
 
-    def _process_data(self, data: bytes) -> None:
+    def install_node(
+        self,
+        graph: Graph,
+        *,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        error_route: TypedRoute[BaseException] | None = None,
+        retry: RetryPolicy | None = None,
+        backoff: BackoffPolicy | None = None,
+        start_immediately: bool = True,
+    ) -> ManagedGraphNodeHandle:
+        """Install this accelerometer as a self-running Manyfold graph source."""
+
+        resolved_output_route = output_route or accelerometer_vector_event_route()
+
+        def _body(stop: StopToken, graph: Graph) -> None:
+            try:
+                with self._connect_to_ser() as ser:
+                    while not stop.is_set():
+                        datum = ser.readline()
+                        if not datum:
+                            continue
+                        acceleration = self._process_data(datum)
+                        if acceleration is None:
+                            continue
+                        graph.publish(
+                            resolved_output_route,
+                            self._acceleration_to_sensor_event(acceleration),
+                        )
+            except KeyboardInterrupt:
+                stop.set()
+                return
+
+        return ManagedGraphNode(
+            name="heart-accelerometer-vectors",
+            body=_body,
+            output_routes=(resolved_output_route,),
+            error_route=error_route or accelerometer_error_route(),
+            retry=retry or RetryPolicy(max_attempts=1_000_000),
+            backoff=backoff or BackoffPolicy.fixed(RECONNECT_DELAY_SECONDS),
+            group="accelerometer",
+            start_immediately=start_immediately,
+        ).install(graph)
+
+    def _process_data(self, data: bytes) -> Acceleration | None:
         bus_data = data.decode("utf-8").rstrip()
         if not bus_data:
-            return
+            return None
         if "{" not in bus_data:
-            return
+            return None
         if not bus_data.startswith("{"):
             bus_data = bus_data[bus_data.find("{") :]
 
@@ -106,7 +262,7 @@ class Accelerometer(Peripheral[Acceleration | None]):
         except json.JSONDecodeError:
             self._decode_failures += 1
             logger.debug("Failed to decode JSON: %s", bus_data)
-            return
+            return None
         self._messages_received += 1
         self._log_controller.log(
             key="sensor.serial.poll",
@@ -115,7 +271,7 @@ class Accelerometer(Peripheral[Acceleration | None]):
             msg="Sensor stream stats messages=%s decode_failures=%s",
             args=(self._messages_received, self._decode_failures),
         )
-        self._update_due_to_data(parsed)
+        return self._update_due_to_data(parsed)
 
     def get_acceleration(self) -> Acceleration | None:
         if self.acceleration_value is None:
@@ -133,22 +289,22 @@ class Accelerometer(Peripheral[Acceleration | None]):
             return None
 
 
-    def _update_due_to_data(self, data: dict[str, Any]) -> None:
+    def _update_due_to_data(self, data: dict[str, Any]) -> Acceleration | None:
         event_type = data.get("event_type")
         payload = data.get("data")
         if not isinstance(payload, dict):
             logger.debug("Ignoring malformed sensor payload: %s", payload)
-            return
+            return None
 
         if event_type in {"acceleration", "sensor.acceleration"}:
-            self._handle_acceleration(payload)
-            return
+            return self._handle_acceleration(payload)
         if event_type in {"magnetic", "sensor.magnetic"}:
             self._handle_magnetic(payload)
-            return
+            return None
         logger.debug("Ignoring unknown sensor payload type: %s", event_type)
+        return None
 
-    def _handle_acceleration(self, payload: Mapping[str, Any]) -> None:
+    def _handle_acceleration(self, payload: Mapping[str, Any]) -> Acceleration | None:
         try:
             vector = AccelerometerVector(
                 x=float(payload["x"]),
@@ -157,10 +313,25 @@ class Accelerometer(Peripheral[Acceleration | None]):
             )
         except (KeyError, TypeError, ValueError):
             logger.debug("Accelerometer payload missing axis components: %s", payload)
-            return
+            return None
 
         input_event = vector.to_input()
         self.acceleration_value = cast(dict[str, float], input_event.data)
+        return Acceleration(
+            x=self.acceleration_value["x"],
+            y=self.acceleration_value["y"],
+            z=self.acceleration_value["z"],
+        )
+
+    def _acceleration_to_sensor_event(self, acceleration: Acceleration) -> SensorEvent:
+        vector = AccelerometerVector(
+            x=acceleration.x,
+            y=acceleration.y,
+            z=acceleration.z,
+        )
+        return vector.to_input().to_sensor_event(
+            identity=self.peripheral_info().to_sensor_identity()
+        )
 
     def _handle_magnetic(self, payload: Mapping[str, Any]) -> None:
         logger.debug("Ignoring magnetic payload: %s", payload)

--- a/tests/peripheral/test_accelerometer.py
+++ b/tests/peripheral/test_accelerometer.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from manyfold import Graph
+from manyfold.sensor_io import BackoffPolicy, RetryPolicy
+
+from heart.peripheral.sensor import (Accelerometer,
+                                     accelerometer_detection_route,
+                                     accelerometer_error_route,
+                                     accelerometer_vector_event_route)
+
+
+class _SerialStub:
+    def __init__(self, chunks: Iterator[bytes]) -> None:
+        self._chunks = chunks
+
+    def __enter__(self) -> "_SerialStub":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def readline(self) -> bytes:
+        try:
+            return next(self._chunks)
+        except StopIteration:
+            raise KeyboardInterrupt
+
+
+class TestAccelerometerManyfoldNode:
+    """Cover graph-native accelerometer discovery and vector streaming."""
+
+    def test_detection_node_publishes_accelerometer_to_manyfold_route(
+        self,
+        monkeypatch,
+    ) -> None:
+        detected = Accelerometer(port="/dev/ttyUSB0", baudrate=115200)
+
+        def _detect(cls) -> Iterator[Accelerometer]:
+            yield detected
+
+        monkeypatch.setattr(Accelerometer, "detect", classmethod(_detect))
+        graph = Graph()
+        registered: list[Accelerometer] = []
+
+        handle = Accelerometer.detection_node(
+            start_immediately=False,
+            on_detect=lambda peripheral, _access: registered.append(peripheral),
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest = graph.latest(accelerometer_detection_route())
+        assert registered == [detected]
+        assert latest is not None
+        assert latest.value.event_type == "peripheral.accelerometer.detected"
+        assert latest.value.data == {"port": "/dev/ttyUSB0", "baudrate": 115200}
+        assert latest.value.identity.id == "accelerometer:/dev/ttyUSB0"
+
+    def test_install_node_publishes_vectors_to_manyfold_route(
+        self,
+        monkeypatch,
+    ) -> None:
+        peripheral = Accelerometer(port="/dev/ttyUSB0", baudrate=115200)
+        payload = b'{"event_type":"sensor.acceleration","data":{"x":1,"y":2,"z":3}}\n'
+        monkeypatch.setattr(
+            peripheral,
+            "_connect_to_ser",
+            lambda: _SerialStub(iter((payload,))),
+        )
+        graph = Graph()
+
+        handle = peripheral.install_node(
+            graph,
+            start_immediately=False,
+            retry=RetryPolicy(max_attempts=1),
+            backoff=BackoffPolicy.none(),
+        )
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest = graph.latest(accelerometer_vector_event_route())
+        assert latest is not None
+        assert latest.value.event_type == "peripheral.accelerometer.vector"
+        assert latest.value.data == {"x": 1.0, "y": 2.0, "z": 3.0}
+        assert latest.value.identity.id == "accelerometer:/dev/ttyUSB0"
+        assert peripheral.get_acceleration() is not None
+
+    def test_detection_node_can_spawn_vector_source(self, monkeypatch) -> None:
+        detected = Accelerometer(port="/dev/ttyUSB0", baudrate=115200)
+        payload = b'{"event_type":"sensor.acceleration","data":{"x":4,"y":5,"z":6}}\n'
+
+        def _detect(cls) -> Iterator[Accelerometer]:
+            yield detected
+
+        monkeypatch.setattr(Accelerometer, "detect", classmethod(_detect))
+        monkeypatch.setattr(
+            detected,
+            "_connect_to_ser",
+            lambda: _SerialStub(iter((payload,))),
+        )
+        graph = Graph()
+
+        handle = Accelerometer.detection_node(
+            start_immediately=False,
+            spawn_sources=True,
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+        assert len(handle.spawned_handles) == 1
+
+        spawned = handle.spawned_handles[0]
+        spawned.loop_handle.loop.run(spawned.loop_handle.token)
+
+        latest_detection = graph.latest(accelerometer_detection_route())
+        latest_vector = graph.latest(accelerometer_vector_event_route())
+        assert latest_detection is not None
+        assert latest_vector is not None
+        assert latest_detection.value.event_type == "peripheral.accelerometer.detected"
+        assert latest_vector.value.data == {"x": 4.0, "y": 5.0, "z": 6.0}
+
+    def test_install_node_publishes_exceptions_to_error_route(
+        self,
+        monkeypatch,
+    ) -> None:
+        peripheral = Accelerometer(port="/dev/ttyUSB0", baudrate=115200)
+
+        def _connect_to_ser() -> object:
+            raise RuntimeError("sensor unavailable")
+
+        monkeypatch.setattr(peripheral, "_connect_to_ser", _connect_to_ser)
+        graph = Graph()
+
+        handle = peripheral.install_node(
+            graph,
+            error_route=accelerometer_error_route(),
+            start_immediately=False,
+            retry=RetryPolicy(max_attempts=1),
+            backoff=BackoffPolicy.none(),
+        )
+
+        try:
+            handle.loop_handle.loop.run(handle.loop_handle.token)
+        except RuntimeError as exc:
+            assert "sensor unavailable" in str(exc)
+        else:
+            raise AssertionError("expected accelerometer source failure")
+
+        latest = graph.latest(accelerometer_error_route())
+        assert latest is not None
+        assert isinstance(latest.value, RuntimeError)

--- a/tests/peripheral/test_peripheral_configurations.py
+++ b/tests/peripheral/test_peripheral_configurations.py
@@ -4,7 +4,9 @@ from collections.abc import Iterator
 
 from manyfold import Graph
 
-from heart.peripheral.configurations import (_detect_radios,
+from heart.peripheral.configurations import (_accelerometer_detection_node,
+                                             _detect_radios,
+                                             _manyfold_graph_nodes,
                                              _microphone_detection_node,
                                              _radio_detection_node)
 from heart.peripheral.input_payloads import MicrophoneLevel, RadioPacket
@@ -15,6 +17,26 @@ from heart.peripheral.radio import (RadioDriver, RadioPeripheral,
                                     RawRadioPacket, SerialRadioDriver,
                                     radio_detection_route,
                                     radio_packet_event_route)
+from heart.peripheral.sensor import (Accelerometer,
+                                     accelerometer_detection_route,
+                                     accelerometer_vector_event_route)
+
+
+class _SerialStub:
+    def __init__(self, packets: Iterator[bytes]) -> None:
+        self._packets = packets
+
+    def __enter__(self) -> "_SerialStub":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def readline(self) -> bytes:
+        try:
+            return next(self._packets)
+        except StopIteration:
+            raise KeyboardInterrupt
 
 
 class _DriverStub(RadioDriver):
@@ -86,6 +108,83 @@ class TestManyfoldRadioConfiguration:
         assert latest_packet is not None
         assert latest_packet.value.event_type == RadioPacket.EVENT_TYPE
         assert latest_packet.value.data["payload"] == [16]
+
+
+class TestManyfoldAccelerometerConfiguration:
+    """Cover default graph-node factories so connected IMU streams stay Manyfold-owned."""
+
+    def test_accelerometer_detection_node_spawns_vector_source(
+        self,
+        monkeypatch,
+    ) -> None:
+        payload = b'{"event_type":"sensor.acceleration","data":{"x":1,"y":2,"z":3}}\n'
+        detected = Accelerometer(port="/dev/ttyUSB0", baudrate=115200)
+
+        def _detect(cls) -> Iterator[Accelerometer]:
+            yield detected
+
+        monkeypatch.setattr(Accelerometer, "detect", classmethod(_detect))
+        monkeypatch.setattr(
+            detected,
+            "_connect_to_ser",
+            lambda: _SerialStub(iter((payload,))),
+        )
+        graph = Graph()
+        registered: list[Accelerometer] = []
+
+        handle = _accelerometer_detection_node(
+            start_immediately=False,
+            on_detect=lambda peripheral, _access: registered.append(peripheral),
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+        assert registered == [detected]
+        assert len(handle.spawned_handles) == 1
+
+        spawned = handle.spawned_handles[0]
+        spawned.loop_handle.loop.run(spawned.loop_handle.token)
+
+        latest_detection = graph.latest(accelerometer_detection_route())
+        latest_vector = graph.latest(accelerometer_vector_event_route())
+        assert latest_detection is not None
+        assert latest_detection.value.event_type == "peripheral.accelerometer.detected"
+        assert latest_vector is not None
+        assert latest_vector.value.event_type == "peripheral.accelerometer.vector"
+        assert latest_vector.value.data == {"x": 1.0, "y": 2.0, "z": 3.0}
+
+    def test_manyfold_graph_nodes_include_accelerometer_on_pi(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_pi",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_x11_forward",
+            lambda: False,
+        )
+
+        nodes = _manyfold_graph_nodes()
+
+        assert nodes[0] is _accelerometer_detection_node
+
+    def test_manyfold_graph_nodes_keep_fake_accelerometer_direct_off_pi(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_pi",
+            lambda: False,
+        )
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_x11_forward",
+            lambda: False,
+        )
+
+        nodes = _manyfold_graph_nodes()
+
+        assert _accelerometer_detection_node not in nodes
 
 
 class TestManyfoldMicrophoneConfiguration:


### PR DESCRIPTION
## Summary
- add graph-native accelerometer detection, vector, and error routes
- install real accelerometers as Manyfold managed graph sources that publish vector SensorEvents
- move Pi accelerometer discovery into the default Manyfold graph-node path while keeping fake debug accelerometers direct off-Pi

## Verification
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache-heart UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tool-heart make format
- uv run pytest tests/peripheral/test_accelerometer.py tests/peripheral/test_peripheral_configurations.py tests/peripheral/test_peripheral_manager_graph.py tests/peripheral/test_microphone.py tests/peripheral/test_radio_peripheral.py tests/peripheral/test_rubiks_connected_x.py
- uv run ruff check src/heart/peripheral/sensor.py src/heart/peripheral/configurations/__init__.py tests/peripheral/test_accelerometer.py tests/peripheral/test_peripheral_configurations.py