### PR TITLE
Move heart rate runtime into Manyfold graph

### DIFF
--- a/src/heart/peripheral/configurations/__init__.py
+++ b/src/heart/peripheral/configurations/__init__.py
@@ -104,6 +104,20 @@ def _detect_gamepads() -> Iterator[Peripheral[Any]]:
 def _detect_heart_rate_sensor() -> Iterator[Peripheral[Any]]:
     yield from itertools.chain(HeartRateManager.detect())
 
+def _heart_rate_detection_node(
+    *,
+    start_immediately: bool,
+    on_detect: Any | None,
+) -> Any:
+    return HeartRateManager.detection_node(
+        spawn_sources=True,
+        on_detect=on_detect,
+        start_immediately=start_immediately,
+    )
+
+def _heart_rate_graph_nodes() -> tuple[GraphNodeFactory, ...]:
+    return (_heart_rate_detection_node,)
+
 def _detect_microphones() -> Iterator[Peripheral[Any]]:
     yield from itertools.chain(Microphone.detect())
 
@@ -148,6 +162,7 @@ def _radio_graph_nodes() -> tuple[GraphNodeFactory, ...]:
 def _manyfold_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     return (
         *_accelerometer_graph_nodes(),
+        *_heart_rate_graph_nodes(),
         *_radio_graph_nodes(),
         *_rubiks_connected_x_graph_nodes(),
         *_microphone_graph_nodes(),

--- a/src/heart/peripheral/configurations/default.py
+++ b/src/heart/peripheral/configurations/default.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from heart.peripheral.configuration import PeripheralConfiguration
 from heart.peripheral.configurations import (_detect_drawing_pads,
                                              _detect_gamepads,
-                                             _detect_heart_rate_sensor,
                                              _detect_phone_text,
                                              _detect_sensors, _detect_switches,
                                              _detect_uwb_position,
@@ -19,7 +18,6 @@ def configure() -> PeripheralConfiguration:
         _detect_switches,
         _detect_sensors,
         _detect_gamepads,
-        _detect_heart_rate_sensor,
         _detect_phone_text,
         _detect_drawing_pads,
         _detect_uwb_position

--- a/src/heart/peripheral/heart_rates.py
+++ b/src/heart/peripheral/heart_rates.py
@@ -1,9 +1,15 @@
 # ant_hr_manager.py
 import threading
 import time
-from typing import (Any, Callable, Dict, Iterator, List, Optional,
+from typing import (Any, Callable, ClassVar, Dict, Iterator, List, Optional,
                     SupportsIndex, Tuple, overload)
 
+from manyfold import (DetectionNode, Graph, Layer, ManagedGraphNode,
+                      ManagedGraphNodeHandle, OwnerName, Plane, Schema,
+                      StreamFamily, StreamName, TypedRoute, Variant, route)
+from manyfold.rx.subject import Subject
+from manyfold.sensor_io import (BackoffPolicy, RetryPolicy, SensorEvent,
+                                StopToken, sensor_event_schema)
 from openant.base.ant import usb
 from openant.base.driver import DriverNotFound
 from openant.devices import ANTPLUS_NETWORK_KEY
@@ -16,6 +22,8 @@ from openant.easy.node import Node
 from usb.core import NoBackendError
 
 from heart.peripheral.core import Peripheral
+from heart.peripheral.input_payloads import (HeartRateLifecycle,
+                                             HeartRateMeasurement)
 from heart.utilities.logging import get_logger
 
 RETRY_DELAY = 5
@@ -23,6 +31,8 @@ DEVICE_TIMEOUT = 30  # seconds of silence ⇒ forget the strap
 CLEANUP_INTERVAL = 5  # how often the janitor thread wakes up
 
 BATTERY_PERCENT_SCALE = 100 / 256
+HEART_RATE_GRAPH_OWNER = OwnerName("heart.heart_rate")
+HEART_RATE_GRAPH_FAMILY = StreamFamily("peripheral")
 
 
 class HeartRateStore:
@@ -67,6 +77,69 @@ last_seen = _STATE.last_seen
 
 logger = get_logger(__name__)
 
+
+def heart_rate_measurement_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=HEART_RATE_GRAPH_OWNER,
+        family=HEART_RATE_GRAPH_FAMILY,
+        stream=StreamName("measurements"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartRateMeasurementEvent"),
+    )
+
+
+def heart_rate_lifecycle_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=HEART_RATE_GRAPH_OWNER,
+        family=HEART_RATE_GRAPH_FAMILY,
+        stream=StreamName("lifecycle"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartRateLifecycleEvent"),
+    )
+
+
+def heart_rate_detection_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=HEART_RATE_GRAPH_OWNER,
+        family=HEART_RATE_GRAPH_FAMILY,
+        stream=StreamName("detected"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartRateDetectionEvent"),
+    )
+
+
+def heart_rate_exception_schema() -> Schema[BaseException]:
+    def encode(exc: BaseException) -> bytes:
+        return f"{type(exc).__name__}:{exc}".encode("utf-8")
+
+    def decode(payload: bytes) -> BaseException:
+        return RuntimeError(payload.decode("utf-8"))
+
+    return Schema(
+        schema_id="PythonException",
+        version=1,
+        encode=encode,
+        decode=decode,
+    )
+
+
+def heart_rate_error_route() -> TypedRoute[BaseException]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=HEART_RATE_GRAPH_OWNER,
+        family=HEART_RATE_GRAPH_FAMILY,
+        stream=StreamName("errors"),
+        variant=Variant.Meta,
+        schema=heart_rate_exception_schema(),
+    )
+
 # ---------------------------------------------------------------------------
 # OpenANT sometimes has race conditions where it receives broadcast data
 # before being initialized.  We wrap the list so __getitem__ never explodes.
@@ -108,6 +181,8 @@ class _SafeList(list[Any]):
 class HeartRateManager(Peripheral[Any]):
     """Continuously scans for ANT+ HR straps and publishes measurements."""
 
+    EVENT_DETECTED: ClassVar[str] = "peripheral.heart_rate.detected"
+
     def __init__(self) -> None:
         super().__init__()
         self._node: Optional[Node] = None
@@ -123,6 +198,9 @@ class HeartRateManager(Peripheral[Any]):
         self._janitor.start()
 
         self._lifecycle_status: Dict[str, str] = {}
+        self._event_subject: Subject[Any] = Subject()
+        self._measurement_sink: Callable[[SensorEvent], None] | None = None
+        self._lifecycle_sink: Callable[[SensorEvent], None] | None = None
 
     # ---------- Peripheral framework ----------
 
@@ -139,6 +217,59 @@ class HeartRateManager(Peripheral[Any]):
             return
         yield cls()
 
+    @classmethod
+    def detection_node(
+        cls,
+        *,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        measurement_output_route: TypedRoute[SensorEvent] | None = None,
+        lifecycle_output_route: TypedRoute[SensorEvent] | None = None,
+        source_error_route: TypedRoute[BaseException] | None = None,
+        spawn_sources: bool = False,
+        on_detect: Any | None = None,
+        start_immediately: bool = True,
+    ) -> DetectionNode:
+        resolved_output_route = output_route or heart_rate_detection_route()
+        resolved_measurement_route = (
+            measurement_output_route or heart_rate_measurement_route()
+        )
+        resolved_lifecycle_route = lifecycle_output_route or heart_rate_lifecycle_route()
+
+        def mapper(peripheral: "HeartRateManager") -> SensorEvent:
+            return SensorEvent(
+                event_type=cls.EVENT_DETECTED,
+                data={"source": "ant_plus"},
+                observed_at=time.time(),
+                identity=peripheral.peripheral_info().to_sensor_identity(),
+            )
+
+        def spawn(peripheral: "HeartRateManager", access: Any) -> None:
+            if not spawn_sources:
+                return
+            access.own(
+                peripheral.install_node(
+                    access.graph,
+                    measurement_output_route=resolved_measurement_route,
+                    lifecycle_output_route=resolved_lifecycle_route,
+                    error_route=source_error_route or heart_rate_error_route(),
+                )
+            )
+
+        return DetectionNode(
+            name="heart-rate-detection",
+            detector=cls.detect,
+            output_route=resolved_output_route,
+            mapper=mapper,
+            on_detect=on_detect,
+            spawn=spawn,
+            error_route=heart_rate_error_route(),
+            group="heart-rate-detection",
+            start_immediately=start_immediately,
+        )
+
+    def _event_stream(self) -> Subject[Any]:
+        return self._event_subject
+
     # ---------- Callbacks -----------------------------------------------------
 
     def _on_found(self, d: Tuple[int, int, int]) -> None:
@@ -148,6 +279,16 @@ class HeartRateManager(Peripheral[Any]):
             hrm = auto_create_device(self._node, dev_id, dev_type, tx_type)
             hrm.on_device_data = self._cb(hrm)
             self._devices.append(hrm)
+            self._emit_lifecycle(
+                HeartRateLifecycle(
+                    status="found",
+                    device_id=f"{dev_id:05X}",
+                    detail={
+                        "device_type": DeviceType(dev_type).name,
+                        "transmission_type": tx_type,
+                    },
+                )
+            )
         except Exception:
             logger.exception("Could not create HR device")
 
@@ -155,11 +296,38 @@ class HeartRateManager(Peripheral[Any]):
         def _inner(_pg: object, _name: object, data: object) -> None:
             if isinstance(data, HeartRateData):
                 device_id = f"{hrm.device_id:05X}"
-                self._store.update_from_data(device_id, data)
+                measurement = self._record_measurement(device_id, data)
+                event = measurement.to_input().to_sensor_event(
+                    identity=self.peripheral_info().to_sensor_identity()
+                )
+                self._event_subject.on_next(measurement)
+                if self._measurement_sink is not None:
+                    self._measurement_sink(event)
 
                 logger.debug("HR %s BPM (device %s)", data.heart_rate, device_id)
 
         return _inner
+
+    def _record_measurement(
+        self,
+        device_id: str,
+        data: HeartRateData,
+    ) -> HeartRateMeasurement:
+        self._store.update_from_data(device_id, data)
+        battery_level = self._store.battery_status.get(device_id)
+        return HeartRateMeasurement(
+            device_id=device_id,
+            bpm=data.heart_rate,
+            battery_level=battery_level,
+        )
+
+    def _emit_lifecycle(self, lifecycle: HeartRateLifecycle) -> None:
+        event = lifecycle.to_input().to_sensor_event(
+            identity=self.peripheral_info().to_sensor_identity()
+        )
+        self._event_subject.on_next(lifecycle)
+        if self._lifecycle_sink is not None:
+            self._lifecycle_sink(event)
 
     # ---------- Janitor thread ------------------------------------------------
 
@@ -170,6 +338,13 @@ class HeartRateManager(Peripheral[Any]):
             for dev_id in stale:
                 logger.info(
                     "Pruned silent HR strap %s (>%ds idle)", dev_id, DEVICE_TIMEOUT
+                )
+                self._emit_lifecycle(
+                    HeartRateLifecycle(
+                        status="stale",
+                        device_id=dev_id,
+                        detail={"timeout_seconds": DEVICE_TIMEOUT},
+                    )
                 )
 
     # ---------- ANT+ life-cycle ---------------------------------------------
@@ -232,3 +407,50 @@ class HeartRateManager(Peripheral[Any]):
                     time.sleep(RETRY_DELAY)
         finally:
             self._stop_evt.set()  # stop janitor when manager exits
+
+    def install_node(
+        self,
+        graph: Graph,
+        *,
+        measurement_output_route: TypedRoute[SensorEvent] | None = None,
+        lifecycle_output_route: TypedRoute[SensorEvent] | None = None,
+        error_route: TypedRoute[BaseException] | None = None,
+        retry: RetryPolicy | None = None,
+        backoff: BackoffPolicy | None = None,
+        start_immediately: bool = True,
+    ) -> ManagedGraphNodeHandle:
+        """Install this ANT+ manager as a self-running Manyfold graph source."""
+
+        resolved_measurement_route = (
+            measurement_output_route or heart_rate_measurement_route()
+        )
+        resolved_lifecycle_route = lifecycle_output_route or heart_rate_lifecycle_route()
+
+        def _body(stop: StopToken, graph: Graph) -> None:
+            self._measurement_sink = lambda event: graph.publish(
+                resolved_measurement_route,
+                event,
+            )
+            self._lifecycle_sink = lambda event: graph.publish(
+                resolved_lifecycle_route,
+                event,
+            )
+            try:
+                while not stop.is_set():
+                    self._ant_cycle()
+                    if not stop.is_set():
+                        stop.wait(RETRY_DELAY)
+            finally:
+                self._measurement_sink = None
+                self._lifecycle_sink = None
+
+        return ManagedGraphNode(
+            name="heart-rate-measurements",
+            body=_body,
+            output_routes=(resolved_measurement_route, resolved_lifecycle_route),
+            error_route=error_route or heart_rate_error_route(),
+            retry=retry or RetryPolicy(max_attempts=1_000_000),
+            backoff=backoff or BackoffPolicy.fixed(RETRY_DELAY),
+            group="heart-rate",
+            start_immediately=start_immediately,
+        ).install(graph)

--- a/tests/peripheral/test_heart_rates.py
+++ b/tests/peripheral/test_heart_rates.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+from manyfold import Graph
+
+from heart.peripheral import heart_rates
+from heart.peripheral.heart_rates import (HeartRateManager,
+                                          heart_rate_detection_route,
+                                          heart_rate_lifecycle_route,
+                                          heart_rate_measurement_route)
+
+
+@dataclass
+class _HeartRateDataStub:
+    heart_rate: int
+    battery_percentage: int | None = None
+
+
+class _HeartRateDeviceStub:
+    device_id = 0x1234
+
+
+class TestHeartRateManyfoldNode:
+    """Cover ANT+ heart-rate discovery and samples as Manyfold-owned graph nodes."""
+
+    def test_detection_node_publishes_heart_rate_manager_to_manyfold_route(
+        self,
+        monkeypatch,
+    ) -> None:
+        detected = HeartRateManager()
+
+        def _detect(cls) -> Iterator[HeartRateManager]:
+            yield detected
+
+        monkeypatch.setattr(HeartRateManager, "detect", classmethod(_detect))
+        graph = Graph()
+        registered: list[HeartRateManager] = []
+
+        handle = HeartRateManager.detection_node(
+            start_immediately=False,
+            on_detect=lambda peripheral, _access: registered.append(peripheral),
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest_detection = graph.latest(heart_rate_detection_route())
+        assert registered == [detected]
+        assert latest_detection is not None
+        assert latest_detection.value.event_type == HeartRateManager.EVENT_DETECTED
+        assert latest_detection.value.data == {"source": "ant_plus"}
+
+    def test_detection_node_can_spawn_measurement_source(
+        self,
+        monkeypatch,
+    ) -> None:
+        detected = HeartRateManager()
+
+        def _detect(cls) -> Iterator[HeartRateManager]:
+            yield detected
+
+        original_install_node = HeartRateManager.install_node
+
+        def _install_node(self: HeartRateManager, graph: Graph, **kwargs):
+            kwargs["start_immediately"] = False
+            return original_install_node(self, graph, **kwargs)
+
+        def _ant_cycle(self: HeartRateManager) -> None:
+            data = _HeartRateDataStub(heart_rate=142, battery_percentage=128)
+            self._cb(_HeartRateDeviceStub())(None, None, data)
+            self._emit_lifecycle(
+                heart_rates.HeartRateLifecycle(
+                    status="found",
+                    device_id="01234",
+                    detail={"device_type": "HeartRate"},
+                )
+            )
+            self._measurement_sink = None
+            self._lifecycle_sink = None
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(HeartRateManager, "detect", classmethod(_detect))
+        monkeypatch.setattr(HeartRateManager, "install_node", _install_node)
+        monkeypatch.setattr(heart_rates, "HeartRateData", _HeartRateDataStub)
+        monkeypatch.setattr(HeartRateManager, "_ant_cycle", _ant_cycle)
+        graph = Graph()
+
+        handle = HeartRateManager.detection_node(
+            start_immediately=False,
+            spawn_sources=True,
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+        assert len(handle.spawned_handles) == 1
+
+        spawned = handle.spawned_handles[0]
+        try:
+            spawned.loop_handle.loop.run(spawned.loop_handle.token)
+        except KeyboardInterrupt:
+            pass
+
+        latest_measurement = graph.latest(heart_rate_measurement_route())
+        latest_lifecycle = graph.latest(heart_rate_lifecycle_route())
+        assert latest_measurement is not None
+        assert latest_measurement.value.event_type == "peripheral.heart_rate.measurement"
+        assert latest_measurement.value.data["device_id"] == "01234"
+        assert latest_measurement.value.data["bpm"] == 142
+        assert latest_measurement.value.data["battery_level"] == 50.0
+        assert latest_lifecycle is not None
+        assert latest_lifecycle.value.event_type == "peripheral.heart_rate.lifecycle"
+        assert latest_lifecycle.value.data["status"] == "found"

--- a/tests/peripheral/test_peripheral_configurations.py
+++ b/tests/peripheral/test_peripheral_configurations.py
@@ -5,10 +5,13 @@ from collections.abc import Iterator
 from manyfold import Graph
 
 from heart.peripheral.configurations import (_accelerometer_detection_node,
+                                             _detect_heart_rate_sensor,
                                              _detect_radios,
+                                             _heart_rate_detection_node,
                                              _manyfold_graph_nodes,
                                              _microphone_detection_node,
                                              _radio_detection_node)
+from heart.peripheral.configurations.default import configure
 from heart.peripheral.input_payloads import MicrophoneLevel, RadioPacket
 from heart.peripheral.microphone import (Microphone,
                                          microphone_detection_route,
@@ -233,3 +236,13 @@ class TestManyfoldMicrophoneConfiguration:
         assert latest_level is not None
         assert latest_level.value.event_type == MicrophoneLevel.EVENT_TYPE
         assert latest_level.value.data["rms"] == 0.5
+
+
+class TestManyfoldHeartRateConfiguration:
+    """Cover default graph-node factories so ANT+ heart-rate streams stay Manyfold-owned."""
+
+    def test_default_configuration_moves_heart_rate_to_graph_node(self) -> None:
+        configuration = configure()
+
+        assert _heart_rate_detection_node in configuration.graph_nodes
+        assert _detect_heart_rate_sensor not in configuration.detectors


### PR DESCRIPTION
## Summary
- add Manyfold graph routes for ANT+ heart-rate detection, measurements, lifecycle, and errors
- add HeartRateManager detection/install nodes so discovered managers can spawn managed measurement sources
- move default heart-rate detection out of direct detectors and into Manyfold graph-node configuration
- add focused coverage for detection, spawned measurement/lifecycle publication, and default configuration ownership

## Verification
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools make format
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run pytest tests/peripheral/test_heart_rates.py tests/peripheral/test_peripheral_configurations.py tests/peripheral/test_peripheral_manager_graph.py
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run pytest tests/peripheral
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run ruff check src/heart/peripheral/heart_rates.py src/heart/peripheral/configurations tests/peripheral/test_heart_rates.py tests/peripheral/test_peripheral_configurations.py