### PR TITLE
Move switch runtime into Manyfold graph

### DIFF
--- a/src/heart/peripheral/configurations/__init__.py
+++ b/src/heart/peripheral/configurations/__init__.py
@@ -48,6 +48,25 @@ def _detect_switches() -> Iterator[Peripheral[Any]]:
         logger.info("Adding switch - %s", switch)
         yield switch
 
+def _switch_detection_node(
+    *,
+    start_immediately: bool,
+    on_detect: Any | None,
+) -> Any:
+    return Switch.detection_node(
+        detector=_detect_switches,
+        spawn_sources=True,
+        on_detect=on_detect,
+        start_immediately=start_immediately,
+    )
+
+def _switch_graph_nodes() -> tuple[GraphNodeFactory, ...]:
+    if Configuration.use_mock_switch():
+        return ()
+    if Configuration.is_pi() and not Configuration.is_x11_forward():
+        return (_switch_detection_node,)
+    return ()
+
 def _detect_phone_text() -> Iterator[Peripheral[Any]]:
     if os.environ.get(DISABLE_PHONE_TEXT_ENV_VAR) == "1":
         logger.info("PhoneText detection disabled via %s", DISABLE_PHONE_TEXT_ENV_VAR)
@@ -161,6 +180,7 @@ def _radio_graph_nodes() -> tuple[GraphNodeFactory, ...]:
 
 def _manyfold_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     return (
+        *_switch_graph_nodes(),
         *_accelerometer_graph_nodes(),
         *_heart_rate_graph_nodes(),
         *_radio_graph_nodes(),

--- a/src/heart/peripheral/configurations/default.py
+++ b/src/heart/peripheral/configurations/default.py
@@ -6,20 +6,24 @@ from heart.peripheral.configuration import PeripheralConfiguration
 from heart.peripheral.configurations import (_detect_drawing_pads,
                                              _detect_gamepads,
                                              _detect_phone_text,
-                                             _detect_sensors, _detect_switches,
+                                             _detect_sensors,
                                              _detect_uwb_position,
-                                             _manyfold_graph_nodes)
+                                             _manyfold_graph_nodes,
+                                             _switch_graph_nodes)
 
 
 def configure() -> PeripheralConfiguration:
     """Return the default detection plan for ``manager``."""
 
-    detectors = (
-        _detect_switches,
+    detectors = [
         _detect_sensors,
         _detect_gamepads,
         _detect_phone_text,
         _detect_drawing_pads,
         _detect_uwb_position
-    )
-    return PeripheralConfiguration(detectors=detectors, graph_nodes=_manyfold_graph_nodes())
+    ]
+    if not _switch_graph_nodes():
+        from heart.peripheral.configurations import _detect_switches
+
+        detectors.insert(0, _detect_switches)
+    return PeripheralConfiguration(detectors=tuple(detectors), graph_nodes=_manyfold_graph_nodes())

--- a/src/heart/peripheral/switch.py
+++ b/src/heart/peripheral/switch.py
@@ -3,17 +3,21 @@ import json
 import time
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Any, Iterator, Mapping, Self
+from typing import Any, Callable, Iterable, Iterator, Mapping, Self
 
 import manyfold.rx as reactivex
 import serial
 from bleak.backends.device import BLEDevice
+from manyfold import (DetectionNode, Graph, Layer, ManagedGraphNode,
+                      ManagedGraphNodeHandle, OwnerName, Plane, Schema,
+                      StreamFamily, StreamName, TypedRoute, Variant, route)
 from manyfold.rx import create
 from manyfold.rx import operators as ops
 from manyfold.rx.abc import ObserverBase, SchedulerBase
 from manyfold.rx.disposable import Disposable
 from manyfold.sensor_io import (BackoffPolicy, ManagedRunLoop,
-                                ManagedRunLoopHandle, StopToken)
+                                ManagedRunLoopHandle, RetryPolicy, SensorEvent,
+                                StopToken, sensor_event_schema)
 
 from heart.peripheral.bluetooth import UartListener
 from heart.peripheral.core import (Peripheral, PeripheralInfo,
@@ -33,6 +37,62 @@ BLUETOOTH_RETRY_DELAY_SECONDS = 5
 BLUETOOTH_SLOW_RETRY_DELAY_SECONDS = 30
 BLUETOOTH_MAX_RETRY_ATTEMPTS = 5
 BLUETOOTH_SWITCH_THREAD_NAME = "peripheral-bluetooth-switch"
+BUTTON_PRESS_EVENT = "button.press"
+BUTTON_LONG_PRESS_EVENT = "button.long_press"
+SWITCH_ROTATION_EVENT = "switch.rotation"
+SWITCH_GRAPH_OWNER = OwnerName("heart.switch")
+SWITCH_GRAPH_FAMILY = StreamFamily("peripheral")
+
+
+def switch_state_event_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=SWITCH_GRAPH_OWNER,
+        family=SWITCH_GRAPH_FAMILY,
+        stream=StreamName("state"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartSwitchStateEvent"),
+    )
+
+
+def switch_detection_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=SWITCH_GRAPH_OWNER,
+        family=SWITCH_GRAPH_FAMILY,
+        stream=StreamName("detected"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartSwitchDetectionEvent"),
+    )
+
+
+def switch_exception_schema() -> Schema[BaseException]:
+    def encode(exc: BaseException) -> bytes:
+        return f"{type(exc).__name__}:{exc}".encode("utf-8")
+
+    def decode(payload: bytes) -> BaseException:
+        return RuntimeError(payload.decode("utf-8"))
+
+    return Schema(
+        schema_id="PythonException",
+        version=1,
+        encode=encode,
+        decode=decode,
+    )
+
+
+def switch_error_route() -> TypedRoute[BaseException]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=SWITCH_GRAPH_OWNER,
+        family=SWITCH_GRAPH_FAMILY,
+        stream=StreamName("errors"),
+        variant=Variant.Meta,
+        schema=switch_exception_schema(),
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -79,6 +139,97 @@ class BaseSwitch(Peripheral[SwitchState]):
 
     def get_rotation_since_last_long_button_press(self) -> int:
         return self.rotational_value - self.rotation_value_at_last_long_button_press
+
+    @classmethod
+    def detection_node(
+        cls,
+        *,
+        detector: Callable[[], Iterable[Peripheral[Any]]] | None = None,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        state_output_route: TypedRoute[SensorEvent] | None = None,
+        state_error_route: TypedRoute[BaseException] | None = None,
+        spawn_sources: bool = False,
+        on_detect: Any | None = None,
+        start_immediately: bool = True,
+    ) -> DetectionNode:
+        resolved_output_route = output_route or switch_detection_route()
+        resolved_state_output_route = state_output_route or switch_state_event_route()
+
+        def mapper(peripheral: "BaseSwitch") -> SensorEvent:
+            return SensorEvent(
+                event_type="peripheral.switch.detected",
+                data={"kind": type(peripheral).__name__},
+                observed_at=time.time(),
+                identity=peripheral.peripheral_info().to_sensor_identity(),
+            )
+
+        def spawn(peripheral: "BaseSwitch", access: Any) -> None:
+            if not spawn_sources:
+                return
+            install_node = getattr(peripheral, "install_node", None)
+            if install_node is None:
+                return
+            access.own(
+                install_node(
+                    access.graph,
+                    output_route=resolved_state_output_route,
+                    error_route=state_error_route or switch_error_route(),
+                )
+            )
+
+        return DetectionNode(
+            name="heart-switch-detection",
+            detector=detector or cls.detect,
+            output_route=resolved_output_route,
+            mapper=mapper,
+            on_detect=on_detect,
+            spawn=spawn,
+            error_route=switch_error_route(),
+            group="switch-detection",
+            start_immediately=start_immediately,
+        )
+
+    def update_due_to_data(self, data: Mapping[str, Any]) -> None:
+        event_type = data.get("event_type")
+        value = data.get("data")
+        if event_type == SWITCH_ROTATION_EVENT:
+            if value is None:
+                logger.debug("Ignoring malformed switch rotation payload: %s", data)
+                return
+            try:
+                self.rotational_value = int(value)
+            except (TypeError, ValueError):
+                logger.debug("Ignoring malformed switch rotation payload: %s", data)
+            return
+        if event_type == BUTTON_PRESS_EVENT:
+            if value:
+                self.button_value += 1
+                self.rotation_value_at_last_button_press = self.rotational_value
+            return
+        if event_type == BUTTON_LONG_PRESS_EVENT:
+            if value:
+                self.button_long_press_value += 1
+                self.rotation_value_at_last_long_button_press = self.rotational_value
+            return
+        super().update_due_to_data(data)
+
+    def _state_to_sensor_event(self, state: SwitchState) -> SensorEvent:
+        return SensorEvent(
+            event_type="peripheral.switch.state",
+            data={
+                "rotational_value": state.rotational_value,
+                "button_value": state.button_value,
+                "long_button_value": state.long_button_value,
+                "rotation_since_last_button_press": (
+                    state.rotation_since_last_button_press
+                ),
+                "rotation_since_last_long_button_press": (
+                    state.rotation_since_last_long_button_press
+                ),
+            },
+            observed_at=time.time(),
+            identity=self.peripheral_info().to_sensor_identity(),
+        )
 
 class FakeSwitch(BaseSwitch):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -214,6 +365,60 @@ class Switch(BaseSwitch):
             on_next=self.update_due_to_data,
         )
 
+    def peripheral_info(self) -> PeripheralInfo:
+        return PeripheralInfo(
+            id=f"switch:{self.port}",
+            tags=[
+                PeripheralTag(
+                    name="input_variant",
+                    variant="button",
+                    metadata={"version": "v1"},
+                ),
+                PeripheralTag(name="mode", variant="main_rotary_button"),
+            ],
+        )
+
+    def install_node(
+        self,
+        graph: Graph,
+        *,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        error_route: TypedRoute[BaseException] | None = None,
+        retry: RetryPolicy | None = None,
+        backoff: BackoffPolicy | None = None,
+        start_immediately: bool = True,
+    ) -> ManagedGraphNodeHandle:
+        resolved_output_route = output_route or switch_state_event_route()
+
+        def _body(stop: StopToken, graph: Graph) -> None:
+            try:
+                with self._connect_to_ser() as ser:
+                    while not stop.is_set():
+                        if ser.in_waiting <= 0:
+                            stop.wait(SERIAL_RECONNECT_DELAY_SECONDS)
+                            continue
+                        bus_data = ser.readline().decode("utf-8").rstrip()
+                        data = json.loads(bus_data)
+                        self.update_due_to_data(data)
+                        graph.publish(
+                            resolved_output_route,
+                            self._state_to_sensor_event(self._snapshot()),
+                        )
+            except KeyboardInterrupt:
+                stop.set()
+                return
+
+        return ManagedGraphNode(
+            name="heart-switch-state",
+            body=_body,
+            output_routes=(resolved_output_route,),
+            error_route=error_route or switch_error_route(),
+            retry=retry or RetryPolicy(max_attempts=1_000_000),
+            backoff=backoff or BackoffPolicy.fixed(SERIAL_RECONNECT_DELAY_SECONDS),
+            group="switch",
+            start_immediately=start_immediately,
+        ).install(graph)
+
 class BluetoothSwitch(BaseSwitch):
     def __init__(self, device: BLEDevice, *args: Any, **kwargs: Any) -> None:
         self.listener = UartListener(device=device)
@@ -281,6 +486,20 @@ class BluetoothSwitch(BaseSwitch):
         for device in devices:
             yield cls(device=device)
 
+    def peripheral_info(self) -> PeripheralInfo:
+        return PeripheralInfo(
+            id=f"bluetooth_switch:{self.listener.device.address}",
+            tags=[
+                PeripheralTag(
+                    name="input_variant",
+                    variant="button",
+                    metadata={"version": "v1"},
+                ),
+                PeripheralTag(name="transport", variant="bluetooth"),
+                PeripheralTag(name="mode", variant="main_rotary_button"),
+            ],
+        )
+
     def _connect_to_ser(self) -> None:
         self.listener.start()
 
@@ -321,3 +540,47 @@ class BluetoothSwitch(BaseSwitch):
         finally:
             self.connected = False
             self.listener.close()
+
+    def install_node(
+        self,
+        graph: Graph,
+        *,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        error_route: TypedRoute[BaseException] | None = None,
+        retry: RetryPolicy | None = None,
+        backoff: BackoffPolicy | None = None,
+        start_immediately: bool = True,
+    ) -> ManagedGraphNodeHandle:
+        resolved_output_route = output_route or switch_state_event_route()
+
+        def _body(stop: StopToken, graph: Graph) -> None:
+            self._connect_to_ser()
+            self.connected = True
+            try:
+                while not stop.is_set():
+                    for event in self.listener.consume_events():
+                        self.update_due_to_data(event)
+                        graph.publish(
+                            resolved_output_route,
+                            self._state_to_sensor_event(self._snapshot()),
+                        )
+                    stop.wait(BLUETOOTH_EVENT_POLL_DELAY_SECONDS)
+            finally:
+                self.connected = False
+                self.listener.close()
+
+        return ManagedGraphNode(
+            name="heart-bluetooth-switch-state",
+            body=_body,
+            output_routes=(resolved_output_route,),
+            error_route=error_route or switch_error_route(),
+            retry=retry or RetryPolicy(max_attempts=BLUETOOTH_MAX_RETRY_ATTEMPTS),
+            backoff=backoff
+            or BackoffPolicy(
+                initial_delay=BLUETOOTH_RETRY_DELAY_SECONDS,
+                multiplier=2.0,
+                max_delay=BLUETOOTH_SLOW_RETRY_DELAY_SECONDS,
+            ),
+            group="bluetooth-switch",
+            start_immediately=start_immediately,
+        ).install(graph)

--- a/tests/peripheral/test_peripheral_configurations.py
+++ b/tests/peripheral/test_peripheral_configurations.py
@@ -6,11 +6,12 @@ from manyfold import Graph
 
 from heart.peripheral.configurations import (_accelerometer_detection_node,
                                              _detect_heart_rate_sensor,
-                                             _detect_radios,
+                                             _detect_radios, _detect_switches,
                                              _heart_rate_detection_node,
                                              _manyfold_graph_nodes,
                                              _microphone_detection_node,
-                                             _radio_detection_node)
+                                             _radio_detection_node,
+                                             _switch_detection_node)
 from heart.peripheral.configurations.default import configure
 from heart.peripheral.input_payloads import MicrophoneLevel, RadioPacket
 from heart.peripheral.microphone import (Microphone,
@@ -170,7 +171,7 @@ class TestManyfoldAccelerometerConfiguration:
 
         nodes = _manyfold_graph_nodes()
 
-        assert nodes[0] is _accelerometer_detection_node
+        assert _accelerometer_detection_node in nodes
 
     def test_manyfold_graph_nodes_keep_fake_accelerometer_direct_off_pi(
         self,
@@ -188,6 +189,75 @@ class TestManyfoldAccelerometerConfiguration:
         nodes = _manyfold_graph_nodes()
 
         assert _accelerometer_detection_node not in nodes
+
+
+class TestManyfoldSwitchConfiguration:
+    """Cover default graph-node factories so physical switch streams stay Manyfold-owned."""
+
+    def test_manyfold_graph_nodes_include_physical_switch_on_pi(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.use_mock_switch",
+            lambda: False,
+        )
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_pi",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_x11_forward",
+            lambda: False,
+        )
+
+        nodes = _manyfold_graph_nodes()
+
+        assert nodes[0] is _switch_detection_node
+
+    def test_default_configuration_moves_physical_switch_to_graph_node(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.use_mock_switch",
+            lambda: False,
+        )
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_pi",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_x11_forward",
+            lambda: False,
+        )
+
+        configuration = configure()
+
+        assert _switch_detection_node in configuration.graph_nodes
+        assert _detect_switches not in configuration.detectors
+
+    def test_default_configuration_keeps_switch_direct_for_local_fake(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.use_mock_switch",
+            lambda: False,
+        )
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_pi",
+            lambda: False,
+        )
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_x11_forward",
+            lambda: False,
+        )
+
+        configuration = configure()
+
+        assert _switch_detection_node not in configuration.graph_nodes
+        assert configuration.detectors[0] is _detect_switches
 
 
 class TestManyfoldMicrophoneConfiguration:

--- a/tests/peripheral/test_switch.py
+++ b/tests/peripheral/test_switch.py
@@ -3,17 +3,24 @@
 from __future__ import annotations
 
 import threading
+from collections.abc import Iterator
 
 import pytest
+from manyfold import Graph
 from manyfold.rx.disposable import Disposable
 
-from heart.peripheral.switch import Switch
+from heart.peripheral.switch import (Switch, switch_detection_route,
+                                     switch_state_event_route)
 from heart.utilities.reactivex_threads import \
     reset_reactivex_threading_state_for_tests
 
+BUTTON_PRESS_EVENT = "button.press"
+BUTTON_LONG_PRESS_EVENT = "button.long_press"
+SWITCH_ROTATION_EVENT = "switch.rotation"
+
 
 @pytest.fixture(autouse=True)
-def _reset_reactivex_threads() -> None:
+def _reset_reactivex_threads() -> Iterator[None]:
     reset_reactivex_threading_state_for_tests()
     yield
     reset_reactivex_threading_state_for_tests()
@@ -47,3 +54,86 @@ class TestSwitchRunLoopIsolation:
         assert switch._subscription is not None
 
         release.set()
+
+
+class _SerialStub:
+    def __init__(self, packets: Iterator[bytes]) -> None:
+        self._packets = packets
+
+    def __enter__(self) -> "_SerialStub":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    @property
+    def in_waiting(self) -> int:
+        return 1
+
+    def readline(self) -> bytes:
+        try:
+            return next(self._packets)
+        except StopIteration:
+            raise KeyboardInterrupt
+
+
+class TestSwitchManyfoldRuntime:
+    def test_update_due_to_data_tracks_rotation_and_button_edges(self) -> None:
+        switch = Switch(port="/dev/null", baudrate=115200)
+
+        switch.update_due_to_data({"event_type": SWITCH_ROTATION_EVENT, "data": 4})
+        switch.update_due_to_data({"event_type": BUTTON_PRESS_EVENT, "data": 1})
+        switch.update_due_to_data({"event_type": SWITCH_ROTATION_EVENT, "data": 9})
+        switch.update_due_to_data({"event_type": BUTTON_LONG_PRESS_EVENT, "data": 1})
+
+        assert switch._snapshot().rotational_value == 9
+        assert switch._snapshot().button_value == 1
+        assert switch._snapshot().long_button_value == 1
+        assert switch._snapshot().rotation_since_last_button_press == 5
+        assert switch._snapshot().rotation_since_last_long_button_press == 0
+
+    def test_detection_node_spawns_serial_state_source(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        detected = Switch(port="/dev/ttyUSB0", baudrate=115200)
+        payloads = iter(
+            (
+                b'{"event_type":"switch.rotation","data":3,"producer_id":0}\n',
+                b'{"event_type":"button.press","data":1,"producer_id":0}\n',
+            )
+        )
+
+        def _detect(cls) -> Iterator[Switch]:
+            yield detected
+
+        monkeypatch.setattr(Switch, "detect", classmethod(_detect))
+        monkeypatch.setattr(
+            detected,
+            "_connect_to_ser",
+            lambda: _SerialStub(payloads),
+        )
+        graph = Graph()
+        registered: list[Switch] = []
+
+        handle = Switch.detection_node(
+            spawn_sources=True,
+            start_immediately=False,
+            on_detect=lambda peripheral, _access: registered.append(peripheral),
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+        assert registered == [detected]
+        assert len(handle.spawned_handles) == 1
+
+        spawned = handle.spawned_handles[0]
+        spawned.loop_handle.loop.run(spawned.loop_handle.token)
+
+        latest_detection = graph.latest(switch_detection_route())
+        latest_state = graph.latest(switch_state_event_route())
+        assert latest_detection is not None
+        assert latest_detection.value.event_type == "peripheral.switch.detected"
+        assert latest_state is not None
+        assert latest_state.value.event_type == "peripheral.switch.state"
+        assert latest_state.value.data["rotational_value"] == 3
+        assert latest_state.value.data["button_value"] == 1


### PR DESCRIPTION
## Summary
- add Manyfold switch detection/state/error routes and graph-node installation for serial and Bluetooth switches
- move physical switch discovery into default graph nodes on Pi while preserving fake switch direct detection locally/mock mode
- add coverage for switch payload state updates, spawned state publication, and default configuration routing

## Verification
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools make format
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run ruff check src/heart/peripheral/switch.py src/heart/peripheral/configurations/__init__.py src/heart/peripheral/configurations/default.py tests/peripheral/test_switch.py tests/peripheral/test_peripheral_configurations.py
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run mypy --config-file pyproject.toml src/heart/peripheral/switch.py src/heart/peripheral/configurations/__init__.py src/heart/peripheral/configurations/default.py
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run pytest tests/peripheral -q