### PR TITLE
Move gamepad discovery into Manyfold graph

### DIFF
--- a/src/heart/peripheral/configurations/__init__.py
+++ b/src/heart/peripheral/configurations/__init__.py
@@ -120,6 +120,19 @@ def _accelerometer_graph_nodes() -> tuple[GraphNodeFactory, ...]:
 def _detect_gamepads() -> Iterator[Peripheral[Any]]:
     yield from itertools.chain(Gamepad.detect())
 
+def _gamepad_detection_node(
+    *,
+    start_immediately: bool,
+    on_detect: Any | None,
+) -> Any:
+    return Gamepad.detection_node(
+        on_detect=on_detect,
+        start_immediately=start_immediately,
+    )
+
+def _gamepad_graph_nodes() -> tuple[GraphNodeFactory, ...]:
+    return (_gamepad_detection_node,)
+
 def _detect_heart_rate_sensor() -> Iterator[Peripheral[Any]]:
     yield from itertools.chain(HeartRateManager.detect())
 
@@ -182,6 +195,7 @@ def _manyfold_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     return (
         *_switch_graph_nodes(),
         *_accelerometer_graph_nodes(),
+        *_gamepad_graph_nodes(),
         *_heart_rate_graph_nodes(),
         *_radio_graph_nodes(),
         *_rubiks_connected_x_graph_nodes(),

--- a/src/heart/peripheral/configurations/default.py
+++ b/src/heart/peripheral/configurations/default.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from heart.peripheral.configuration import PeripheralConfiguration
 from heart.peripheral.configurations import (_detect_drawing_pads,
-                                             _detect_gamepads,
                                              _detect_phone_text,
                                              _detect_sensors,
                                              _detect_uwb_position,
@@ -17,7 +16,6 @@ def configure() -> PeripheralConfiguration:
 
     detectors = [
         _detect_sensors,
-        _detect_gamepads,
         _detect_phone_text,
         _detect_drawing_pads,
         _detect_uwb_position

--- a/src/heart/peripheral/gamepad/gamepad.py
+++ b/src/heart/peripheral/gamepad/gamepad.py
@@ -1,14 +1,19 @@
 import subprocess
 import time
 from collections import defaultdict
+from collections.abc import Callable, Iterable
 from datetime import timedelta
 from enum import StrEnum
 from typing import Any, Iterator, Self
 
 import pygame.joystick
+from manyfold import (DetectionNode, Layer, OwnerName, Plane, Schema,
+                      StreamFamily, StreamName, TypedRoute, Variant, route)
+from manyfold.sensor_io import SensorEvent, sensor_event_schema
 from pygame.event import Event
 
-from heart.peripheral.core import Peripheral, events
+from heart.peripheral.core import (Peripheral, PeripheralInfo, PeripheralTag,
+                                   events)
 from heart.utilities.env import Configuration
 from heart.utilities.logging import get_logger
 from heart.utilities.reactivex_threads import (interval_in_background,
@@ -19,6 +24,47 @@ INITIALIZATION_DELAY_SECONDS = 1.5
 DEFAULT_JOYSTICK_ID = 0
 DEFAULT_AXIS_DEAD_ZONE = 0.0
 DEFAULT_AXIS_THRESHOLD = 0.0
+GAMEPAD_GRAPH_OWNER = OwnerName("heart.gamepad")
+GAMEPAD_GRAPH_FAMILY = StreamFamily("peripheral")
+
+
+def gamepad_detection_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=GAMEPAD_GRAPH_OWNER,
+        family=GAMEPAD_GRAPH_FAMILY,
+        stream=StreamName("detected"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartGamepadDetectionEvent"),
+    )
+
+
+def gamepad_exception_schema() -> Schema[BaseException]:
+    def encode(exc: BaseException) -> bytes:
+        return f"{type(exc).__name__}:{exc}".encode("utf-8")
+
+    def decode(payload: bytes) -> BaseException:
+        return RuntimeError(payload.decode("utf-8"))
+
+    return Schema(
+        schema_id="PythonException",
+        version=1,
+        encode=encode,
+        decode=decode,
+    )
+
+
+def gamepad_error_route() -> TypedRoute[BaseException]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=GAMEPAD_GRAPH_OWNER,
+        family=GAMEPAD_GRAPH_FAMILY,
+        stream=StreamName("errors"),
+        variant=Variant.Meta,
+        schema=gamepad_exception_schema(),
+    )
 
 
 class GamepadIdentifier(StrEnum):
@@ -192,6 +238,56 @@ class Gamepad(Peripheral[Any]):
         except pygame.error:
             logger.exception("Error initializing joystick module")
             return
+
+    @classmethod
+    def detection_node(
+        cls,
+        *,
+        detector: Callable[[], Iterable["Gamepad"]] | None = None,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        on_detect: Any | None = None,
+        start_immediately: bool = True,
+    ) -> DetectionNode:
+        resolved_output_route = output_route or gamepad_detection_route()
+
+        def mapper(peripheral: "Gamepad") -> SensorEvent:
+            joystick_name = None
+            if peripheral.joystick is not None:
+                joystick_name = peripheral.joystick.get_name()
+            return SensorEvent(
+                event_type="peripheral.gamepad.detected",
+                data={
+                    "joystick_id": peripheral.joystick_id,
+                    "connected": peripheral.is_connected(),
+                    "name": joystick_name,
+                },
+                observed_at=time.time(),
+                identity=peripheral.peripheral_info().to_sensor_identity(),
+            )
+
+        return DetectionNode(
+            name="heart-gamepad-detection",
+            detector=detector or cls.detect,
+            output_route=resolved_output_route,
+            mapper=mapper,
+            on_detect=on_detect,
+            error_route=gamepad_error_route(),
+            group="gamepad-detection",
+            start_immediately=start_immediately,
+        )
+
+    def peripheral_info(self) -> PeripheralInfo:
+        tags = [
+            PeripheralTag(name="input_variant", variant="gamepad"),
+        ]
+        if self.joystick is not None:
+            tags.append(
+                PeripheralTag(name="gamepad_name", variant=self.joystick.get_name())
+            )
+        return PeripheralInfo(
+            id=f"gamepad:{self.joystick_id}",
+            tags=tags,
+        )
 
     def is_connected(self) -> bool:
         return self.joystick is not None

--- a/tests/peripheral/test_peripheral_configurations.py
+++ b/tests/peripheral/test_peripheral_configurations.py
@@ -5,14 +5,18 @@ from collections.abc import Iterator
 from manyfold import Graph
 
 from heart.peripheral.configurations import (_accelerometer_detection_node,
+                                             _detect_gamepads,
                                              _detect_heart_rate_sensor,
                                              _detect_radios, _detect_switches,
+                                             _gamepad_detection_node,
                                              _heart_rate_detection_node,
                                              _manyfold_graph_nodes,
                                              _microphone_detection_node,
                                              _radio_detection_node,
                                              _switch_detection_node)
 from heart.peripheral.configurations.default import configure
+from heart.peripheral.gamepad import Gamepad
+from heart.peripheral.gamepad.gamepad import gamepad_detection_route
 from heart.peripheral.input_payloads import MicrophoneLevel, RadioPacket
 from heart.peripheral.microphone import (Microphone,
                                          microphone_detection_route,
@@ -189,6 +193,47 @@ class TestManyfoldAccelerometerConfiguration:
         nodes = _manyfold_graph_nodes()
 
         assert _accelerometer_detection_node not in nodes
+
+
+class TestManyfoldGamepadConfiguration:
+    """Cover default graph-node factories so gamepad discovery stays Manyfold-owned."""
+
+    def test_gamepad_detection_node_publishes_detection_event(
+        self,
+        monkeypatch,
+    ) -> None:
+        detected = Gamepad(joystick_id=2)
+
+        def _detect(cls) -> Iterator[Gamepad]:
+            yield detected
+
+        monkeypatch.setattr(Gamepad, "detect", classmethod(_detect))
+        graph = Graph()
+        registered: list[Gamepad] = []
+
+        handle = _gamepad_detection_node(
+            start_immediately=False,
+            on_detect=lambda peripheral, _access: registered.append(peripheral),
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest_detection = graph.latest(gamepad_detection_route())
+        assert registered == [detected]
+        assert latest_detection is not None
+        assert latest_detection.value.event_type == "peripheral.gamepad.detected"
+        assert latest_detection.value.data == {
+            "joystick_id": 2,
+            "connected": False,
+            "name": None,
+        }
+        assert latest_detection.value.identity.id == "gamepad:2"
+
+    def test_default_configuration_moves_gamepad_to_graph_node(self) -> None:
+        configuration = configure()
+
+        assert _gamepad_detection_node in configuration.graph_nodes
+        assert _detect_gamepads not in configuration.detectors
 
 
 class TestManyfoldSwitchConfiguration:


### PR DESCRIPTION
## Summary
- add Manyfold detection/error routes and a DetectionNode factory for gamepads
- give gamepads stable sensor identity metadata for graph detection events
- move default gamepad registration from the direct detector list into the Manyfold graph-node plan
- cover graph-owned gamepad detection and default configuration behavior

## Verification
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools make format
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run pytest tests/peripheral/test_peripheral_configurations.py tests/peripheral/test_peripheral_manager_graph.py -q
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run ruff check src/heart/peripheral/gamepad/gamepad.py src/heart/peripheral/configurations tests/peripheral/test_peripheral_configurations.py
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run mypy --config-file pyproject.toml src/heart/peripheral/gamepad/gamepad.py src/heart/peripheral/configurations/__init__.py src/heart/peripheral/configurations/default.py
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run pytest tests/peripheral -q