### PR TITLE
Move UWB positioning into Manyfold graph

### DIFF
--- a/src/heart/peripheral/configurations/__init__.py
+++ b/src/heart/peripheral/configurations/__init__.py
@@ -191,6 +191,20 @@ def _radio_detection_node(
 def _radio_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     return (_radio_detection_node,)
 
+def _uwb_detection_node(
+    *,
+    start_immediately: bool,
+    on_detect: Any | None,
+) -> Any:
+    return FakeUWBPositioning.detection_node(
+        spawn_sources=True,
+        on_detect=on_detect,
+        start_immediately=start_immediately,
+    )
+
+def _uwb_graph_nodes() -> tuple[GraphNodeFactory, ...]:
+    return (_uwb_detection_node,)
+
 def _manyfold_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     return (
         *_switch_graph_nodes(),
@@ -200,6 +214,7 @@ def _manyfold_graph_nodes() -> tuple[GraphNodeFactory, ...]:
         *_radio_graph_nodes(),
         *_rubiks_connected_x_graph_nodes(),
         *_microphone_graph_nodes(),
+        *_uwb_graph_nodes(),
     )
 
 def _detect_uwb_position() -> Iterator[Peripheral[Any]]:

--- a/src/heart/peripheral/configurations/default.py
+++ b/src/heart/peripheral/configurations/default.py
@@ -6,7 +6,6 @@ from heart.peripheral.configuration import PeripheralConfiguration
 from heart.peripheral.configurations import (_detect_drawing_pads,
                                              _detect_phone_text,
                                              _detect_sensors,
-                                             _detect_uwb_position,
                                              _manyfold_graph_nodes,
                                              _switch_graph_nodes)
 
@@ -18,7 +17,6 @@ def configure() -> PeripheralConfiguration:
         _detect_sensors,
         _detect_phone_text,
         _detect_drawing_pads,
-        _detect_uwb_position
     ]
     if not _switch_graph_nodes():
         from heart.peripheral.configurations import _detect_switches

--- a/src/heart/peripheral/uwb.py
+++ b/src/heart/peripheral/uwb.py
@@ -2,13 +2,19 @@ from __future__ import annotations
 
 import math
 import random
+import time
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Iterator, List, Self
+from typing import Any, Iterator, List, Self
 
 import manyfold.rx as reactivex
 import numpy as np
+from manyfold import (DetectionNode, Graph, Layer, ManagedGraphNode,
+                      ManagedGraphNodeHandle, OwnerName, Plane, Schema,
+                      StreamFamily, StreamName, TypedRoute, Variant, route)
 from manyfold.rx import operators as ops
+from manyfold.sensor_io import (BackoffPolicy, RetryPolicy, SensorEvent,
+                                StopToken, sensor_event_schema)
 
 from heart.peripheral.core import Peripheral, PeripheralInfo, PeripheralTag
 from heart.utilities.reactivex_threads import (interval_in_background,
@@ -37,6 +43,61 @@ class LocalizedTarget:
     y: float
     z: float
     stations: List[BaseStationMeasurement]
+
+
+UWB_GRAPH_OWNER = OwnerName("heart.uwb")
+UWB_GRAPH_FAMILY = StreamFamily("peripheral")
+
+
+def uwb_position_event_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=UWB_GRAPH_OWNER,
+        family=UWB_GRAPH_FAMILY,
+        stream=StreamName("positions"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartUWBPositionEvent"),
+    )
+
+
+def uwb_detection_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=UWB_GRAPH_OWNER,
+        family=UWB_GRAPH_FAMILY,
+        stream=StreamName("detected"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartUWBDetectionEvent"),
+    )
+
+
+def uwb_exception_schema() -> Schema[BaseException]:
+    def encode(exc: BaseException) -> bytes:
+        return f"{type(exc).__name__}:{exc}".encode("utf-8")
+
+    def decode(payload: bytes) -> BaseException:
+        return RuntimeError(payload.decode("utf-8"))
+
+    return Schema(
+        schema_id="PythonException",
+        version=1,
+        encode=encode,
+        decode=decode,
+    )
+
+
+def uwb_error_route() -> TypedRoute[BaseException]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=UWB_GRAPH_OWNER,
+        family=UWB_GRAPH_FAMILY,
+        stream=StreamName("errors"),
+        variant=Variant.Meta,
+        schema=uwb_exception_schema(),
+    )
 
 
 # --- Position solver helper --------------------------------------------------
@@ -108,6 +169,56 @@ class FakeUWBPositioning(Peripheral[LocalizedTarget | None]):
     def detect(cls) -> Iterator[Self]:
         yield cls()
 
+    @classmethod
+    def detection_node(
+        cls,
+        *,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        position_output_route: TypedRoute[SensorEvent] | None = None,
+        position_error_route: TypedRoute[BaseException] | None = None,
+        spawn_sources: bool = False,
+        on_detect: Any | None = None,
+        start_immediately: bool = True,
+    ) -> DetectionNode:
+        resolved_output_route = output_route or uwb_detection_route()
+        resolved_position_output_route = (
+            position_output_route or uwb_position_event_route()
+        )
+
+        def mapper(peripheral: "FakeUWBPositioning") -> SensorEvent:
+            return SensorEvent(
+                event_type="peripheral.uwb.detected",
+                data={
+                    "base_station_count": len(peripheral.BASE_STATIONS),
+                    "mode": "fake",
+                },
+                observed_at=time.time(),
+                identity=peripheral.peripheral_info().to_sensor_identity(),
+            )
+
+        def spawn(peripheral: "FakeUWBPositioning", access: Any) -> None:
+            if not spawn_sources:
+                return
+            access.own(
+                peripheral.install_node(
+                    access.graph,
+                    output_route=resolved_position_output_route,
+                    error_route=position_error_route or uwb_error_route(),
+                )
+            )
+
+        return DetectionNode(
+            name="heart-uwb-detection",
+            detector=cls.detect,
+            output_route=resolved_output_route,
+            mapper=mapper,
+            on_detect=on_detect,
+            spawn=spawn,
+            error_route=uwb_error_route(),
+            group="uwb-detection",
+            start_immediately=start_immediately,
+        )
+
     def peripheral_info(self) -> PeripheralInfo:
         return PeripheralInfo(
             id="fake_uwb_positioning",
@@ -118,49 +229,110 @@ class FakeUWBPositioning(Peripheral[LocalizedTarget | None]):
         )
 
     def _event_stream(self) -> reactivex.Observable[LocalizedTarget | None]:
-        def simulate_sample(n: int) -> LocalizedTarget:
-            # "True" target path: a slow circle in the x-y plane with fixed height
-            t = n / 20.0  # time-ish index
-            true_x = 2.5 + 1.0 * math.cos(t)
-            true_y = 2.5 + 1.0 * math.sin(t)
-            true_z = 1.0
-
-            true_pos = np.array([true_x, true_y, true_z], dtype=float)
-
-            # Simulate distances with some noise
-            distances: list[float] = []
-            station_measurements: list[BaseStationMeasurement] = []
-
-            for idx, (sx, sy, sz) in enumerate(self.BASE_STATIONS):
-                station_pos = np.array([sx, sy, sz], dtype=float)
-                ideal_d = float(np.linalg.norm(true_pos - station_pos))
-                noisy_d = ideal_d + random.gauss(0.0, 0.05)
-
-                distances.append(noisy_d)
-                station_measurements.append(
-                    BaseStationMeasurement(
-                        station_id=f"bs_{idx}",
-                        x=sx,
-                        y=sy,
-                        z=sz,
-                        distance=noisy_d,
-                    )
-                )
-
-            # Solve for estimated target position from the noisy distances
-            est_x, est_y, est_z = solve_target_position(
-                self.BASE_STATIONS, distances
-            )
-
-            return LocalizedTarget(
-                x=est_x,
-                y=est_y,
-                z=est_z,
-                stations=station_measurements,
-            )
-
         # Emit a new multilateration solution every 500 ms
         return pipe_in_background(
             interval_in_background(period=timedelta(milliseconds=500)),
-            ops.map(simulate_sample),
+            ops.map(self._sample_at_index),
+        )
+
+    def install_node(
+        self,
+        graph: Graph,
+        *,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        error_route: TypedRoute[BaseException] | None = None,
+        retry: RetryPolicy | None = None,
+        backoff: BackoffPolicy | None = None,
+        sample_interval_seconds: float = 0.5,
+        start_immediately: bool = True,
+    ) -> ManagedGraphNodeHandle:
+        """Install this positioning source as a Manyfold-managed graph node."""
+
+        resolved_output_route = output_route or uwb_position_event_route()
+
+        def _body(stop: StopToken, graph: Graph) -> None:
+            sample_index = 0
+            while not stop.is_set():
+                graph.publish(
+                    resolved_output_route,
+                    self._target_to_sensor_event(self._sample_at_index(sample_index)),
+                )
+                sample_index += 1
+                if sample_interval_seconds <= 0:
+                    stop.set()
+                    continue
+                stop.wait(sample_interval_seconds)
+
+        return ManagedGraphNode(
+            name="heart-uwb-positioning",
+            body=_body,
+            output_routes=(resolved_output_route,),
+            error_route=error_route or uwb_error_route(),
+            retry=retry or RetryPolicy(max_attempts=1_000_000),
+            backoff=backoff or BackoffPolicy.fixed(0.5),
+            group="uwb-positioning",
+            start_immediately=start_immediately,
+        ).install(graph)
+
+    def _sample_at_index(self, n: int) -> LocalizedTarget:
+        # "True" target path: a slow circle in the x-y plane with fixed height
+        t = n / 20.0  # time-ish index
+        true_x = 2.5 + 1.0 * math.cos(t)
+        true_y = 2.5 + 1.0 * math.sin(t)
+        true_z = 1.0
+
+        true_pos = np.array([true_x, true_y, true_z], dtype=float)
+
+        # Simulate distances with some noise
+        distances: list[float] = []
+        station_measurements: list[BaseStationMeasurement] = []
+
+        for idx, (sx, sy, sz) in enumerate(self.BASE_STATIONS):
+            station_pos = np.array([sx, sy, sz], dtype=float)
+            ideal_d = float(np.linalg.norm(true_pos - station_pos))
+            noisy_d = ideal_d + random.gauss(0.0, 0.05)
+
+            distances.append(noisy_d)
+            station_measurements.append(
+                BaseStationMeasurement(
+                    station_id=f"bs_{idx}",
+                    x=sx,
+                    y=sy,
+                    z=sz,
+                    distance=noisy_d,
+                )
+            )
+
+        # Solve for estimated target position from the noisy distances
+        est_x, est_y, est_z = solve_target_position(
+            self.BASE_STATIONS, distances
+        )
+
+        return LocalizedTarget(
+            x=est_x,
+            y=est_y,
+            z=est_z,
+            stations=station_measurements,
+        )
+
+    def _target_to_sensor_event(self, target: LocalizedTarget) -> SensorEvent:
+        return SensorEvent(
+            event_type="peripheral.uwb.position",
+            data={
+                "x": target.x,
+                "y": target.y,
+                "z": target.z,
+                "stations": [
+                    {
+                        "station_id": station.station_id,
+                        "x": station.x,
+                        "y": station.y,
+                        "z": station.z,
+                        "distance": station.distance,
+                    }
+                    for station in target.stations
+                ],
+            },
+            observed_at=time.time(),
+            identity=self.peripheral_info().to_sensor_identity(),
         )

--- a/tests/peripheral/test_peripheral_configurations.py
+++ b/tests/peripheral/test_peripheral_configurations.py
@@ -1,19 +1,23 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from typing import Any
 
 from manyfold import Graph
+from pytest import MonkeyPatch
 
 from heart.peripheral.configurations import (_accelerometer_detection_node,
                                              _detect_gamepads,
                                              _detect_heart_rate_sensor,
                                              _detect_radios, _detect_switches,
+                                             _detect_uwb_position,
                                              _gamepad_detection_node,
                                              _heart_rate_detection_node,
                                              _manyfold_graph_nodes,
                                              _microphone_detection_node,
                                              _radio_detection_node,
-                                             _switch_detection_node)
+                                             _switch_detection_node,
+                                             _uwb_detection_node)
 from heart.peripheral.configurations.default import configure
 from heart.peripheral.gamepad import Gamepad
 from heart.peripheral.gamepad.gamepad import gamepad_detection_route
@@ -28,6 +32,9 @@ from heart.peripheral.radio import (RadioDriver, RadioPeripheral,
 from heart.peripheral.sensor import (Accelerometer,
                                      accelerometer_detection_route,
                                      accelerometer_vector_event_route)
+from heart.peripheral.uwb import (BaseStationMeasurement, FakeUWBPositioning,
+                                  LocalizedTarget, uwb_detection_route,
+                                  uwb_position_event_route)
 
 
 class _SerialStub:
@@ -361,3 +368,68 @@ class TestManyfoldHeartRateConfiguration:
 
         assert _heart_rate_detection_node in configuration.graph_nodes
         assert _detect_heart_rate_sensor not in configuration.detectors
+
+
+class TestManyfoldUWBConfiguration:
+    """Cover default graph-node factories so UWB positioning stays Manyfold-owned."""
+
+    def test_uwb_detection_node_spawns_position_source(
+        self,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        detected = FakeUWBPositioning()
+        target = LocalizedTarget(
+            x=1.0,
+            y=2.0,
+            z=3.0,
+            stations=[
+                BaseStationMeasurement(
+                    station_id="bs_0",
+                    x=0.0,
+                    y=0.0,
+                    z=2.5,
+                    distance=3.5,
+                )
+            ],
+        )
+
+        def _detect(cls) -> Iterator[FakeUWBPositioning]:
+            yield detected
+
+        def _install_node(
+            self: FakeUWBPositioning,
+            graph: Graph,
+            **kwargs: Any,
+        ) -> object:
+            graph.publish(
+                kwargs["output_route"],
+                self._target_to_sensor_event(target),
+            )
+            return object()
+
+        monkeypatch.setattr(FakeUWBPositioning, "detect", classmethod(_detect))
+        monkeypatch.setattr(FakeUWBPositioning, "install_node", _install_node)
+        graph = Graph()
+        registered: list[FakeUWBPositioning] = []
+
+        handle = _uwb_detection_node(
+            start_immediately=False,
+            on_detect=lambda peripheral, _access: registered.append(peripheral),
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest_detection = graph.latest(uwb_detection_route())
+        latest_position = graph.latest(uwb_position_event_route())
+        assert registered == [detected]
+        assert latest_detection is not None
+        assert latest_detection.value.event_type == "peripheral.uwb.detected"
+        assert latest_position is not None
+        assert latest_position.value.event_type == "peripheral.uwb.position"
+        assert latest_position.value.data["stations"][0]["station_id"] == "bs_0"
+
+    def test_default_configuration_moves_uwb_to_graph_node(self) -> None:
+        configuration = configure()
+
+        assert _uwb_detection_node in configuration.graph_nodes
+        assert _detect_uwb_position not in configuration.detectors

--- a/tests/peripheral/test_uwb.py
+++ b/tests/peripheral/test_uwb.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+from manyfold import Graph
+from manyfold.sensor_io import BackoffPolicy, RetryPolicy
+from pytest import MonkeyPatch
+
+from heart.peripheral.uwb import (BaseStationMeasurement, FakeUWBPositioning,
+                                  LocalizedTarget, uwb_detection_route,
+                                  uwb_error_route, uwb_position_event_route)
+
+
+def _target() -> LocalizedTarget:
+    return LocalizedTarget(
+        x=1.0,
+        y=2.0,
+        z=3.0,
+        stations=[
+            BaseStationMeasurement(
+                station_id="bs_0",
+                x=0.0,
+                y=0.0,
+                z=2.5,
+                distance=3.5,
+            )
+        ],
+    )
+
+
+class TestUWBManyfoldNode:
+    """Cover graph-native UWB positioning discovery and sample publication."""
+
+    def test_detection_node_publishes_uwb_to_manyfold_route(
+        self,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        detected = FakeUWBPositioning()
+
+        def _detect(cls) -> Iterator[FakeUWBPositioning]:
+            yield detected
+
+        monkeypatch.setattr(FakeUWBPositioning, "detect", classmethod(_detect))
+        graph = Graph()
+        registered: list[FakeUWBPositioning] = []
+
+        handle = FakeUWBPositioning.detection_node(
+            start_immediately=False,
+            on_detect=lambda peripheral, _access: registered.append(peripheral),
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest = graph.latest(uwb_detection_route())
+        assert registered == [detected]
+        assert latest is not None
+        assert latest.value.event_type == "peripheral.uwb.detected"
+        assert latest.value.data == {
+            "base_station_count": len(FakeUWBPositioning.BASE_STATIONS),
+            "mode": "fake",
+        }
+        assert latest.value.identity.id == "fake_uwb_positioning"
+
+    def test_install_node_publishes_positions_to_manyfold_route(
+        self,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        peripheral = FakeUWBPositioning()
+        monkeypatch.setattr(peripheral, "_sample_at_index", lambda _n: _target())
+        graph = Graph()
+
+        handle = peripheral.install_node(
+            graph,
+            start_immediately=False,
+            retry=RetryPolicy(max_attempts=1),
+            backoff=BackoffPolicy.none(),
+            sample_interval_seconds=0,
+        )
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest = graph.latest(uwb_position_event_route())
+        assert latest is not None
+        assert latest.value.event_type == "peripheral.uwb.position"
+        assert latest.value.data == {
+            "x": 1.0,
+            "y": 2.0,
+            "z": 3.0,
+            "stations": [
+                {
+                    "station_id": "bs_0",
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 2.5,
+                    "distance": 3.5,
+                }
+            ],
+        }
+        assert latest.value.identity.id == "fake_uwb_positioning"
+
+    def test_detection_node_can_spawn_position_source(
+        self,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        detected = FakeUWBPositioning()
+
+        def _detect(cls) -> Iterator[FakeUWBPositioning]:
+            yield detected
+
+        def _install_node(
+            self: FakeUWBPositioning,
+            graph: Graph,
+            **kwargs: Any,
+        ) -> object:
+            graph.publish(
+                kwargs["output_route"],
+                self._target_to_sensor_event(_target()),
+            )
+            return object()
+
+        monkeypatch.setattr(FakeUWBPositioning, "detect", classmethod(_detect))
+        monkeypatch.setattr(FakeUWBPositioning, "install_node", _install_node)
+        graph = Graph()
+
+        handle = FakeUWBPositioning.detection_node(
+            start_immediately=False,
+            spawn_sources=True,
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest_detection = graph.latest(uwb_detection_route())
+        latest_position = graph.latest(uwb_position_event_route())
+        assert latest_detection is not None
+        assert latest_detection.value.event_type == "peripheral.uwb.detected"
+        assert latest_position is not None
+        assert latest_position.value.data["stations"][0]["station_id"] == "bs_0"
+
+    def test_install_node_publishes_exceptions_to_error_route(
+        self,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        peripheral = FakeUWBPositioning()
+
+        def _sample_at_index(_n: int) -> LocalizedTarget:
+            raise RuntimeError("uwb unavailable")
+
+        monkeypatch.setattr(peripheral, "_sample_at_index", _sample_at_index)
+        graph = Graph()
+
+        handle = peripheral.install_node(
+            graph,
+            error_route=uwb_error_route(),
+            start_immediately=False,
+            retry=RetryPolicy(max_attempts=1),
+            backoff=BackoffPolicy.none(),
+            sample_interval_seconds=0,
+        )
+
+        try:
+            handle.loop_handle.loop.run(handle.loop_handle.token)
+        except RuntimeError as exc:
+            assert "uwb unavailable" in str(exc)
+        else:
+            raise AssertionError("expected UWB source failure")
+
+        latest = graph.latest(uwb_error_route())
+        assert latest is not None
+        assert isinstance(latest.value, RuntimeError)


### PR DESCRIPTION
## Summary
- add Manyfold routes for fake UWB detection, position samples, and errors
- install fake UWB positioning as a managed graph source that publishes SensorEvent position payloads
- move default UWB discovery out of direct detectors and into graph-node configuration

## Verification
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools make format
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run pytest tests/peripheral/test_uwb.py tests/peripheral/test_peripheral_configurations.py tests/peripheral/test_peripheral_manager_graph.py -q
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run ruff check src/heart/peripheral/uwb.py src/heart/peripheral/configurations/__init__.py src/heart/peripheral/configurations/default.py tests/peripheral/test_uwb.py tests/peripheral/test_peripheral_configurations.py
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run mypy --config-file pyproject.toml src/heart/peripheral/uwb.py src/heart/peripheral/configurations/__init__.py src/heart/peripheral/configurations/default.py