### PR TITLE
Move PhoneText runtime into Manyfold graph

### DIFF
--- a/src/heart/peripheral/configurations/__init__.py
+++ b/src/heart/peripheral/configurations/__init__.py
@@ -25,6 +25,7 @@ logger = get_logger(__name__)
 
 DISABLE_PHONE_TEXT_ENV_VAR = "HEART_DISABLE_PHONE_TEXT"
 
+
 def _detect_switches() -> Iterator[Peripheral[Any]]:
     switches: list[Peripheral[Any]]
     if Configuration.use_mock_switch():
@@ -48,6 +49,7 @@ def _detect_switches() -> Iterator[Peripheral[Any]]:
         logger.info("Adding switch - %s", switch)
         yield switch
 
+
 def _switch_detection_node(
     *,
     start_immediately: bool,
@@ -60,6 +62,7 @@ def _switch_detection_node(
         start_immediately=start_immediately,
     )
 
+
 def _switch_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     if Configuration.use_mock_switch():
         return ()
@@ -67,11 +70,32 @@ def _switch_graph_nodes() -> tuple[GraphNodeFactory, ...]:
         return (_switch_detection_node,)
     return ()
 
+
 def _detect_phone_text() -> Iterator[Peripheral[Any]]:
     if os.environ.get(DISABLE_PHONE_TEXT_ENV_VAR) == "1":
         logger.info("PhoneText detection disabled via %s", DISABLE_PHONE_TEXT_ENV_VAR)
         return
     yield from itertools.chain(PhoneText.detect())
+
+
+def _phone_text_detection_node(
+    *,
+    start_immediately: bool,
+    on_detect: Any | None,
+) -> Any:
+    return PhoneText.detection_node(
+        detector=_detect_phone_text,
+        spawn_sources=True,
+        on_detect=on_detect,
+        start_immediately=start_immediately,
+    )
+
+
+def _phone_text_graph_nodes() -> tuple[GraphNodeFactory, ...]:
+    if os.environ.get(DISABLE_PHONE_TEXT_ENV_VAR) == "1":
+        return ()
+    return (_phone_text_detection_node,)
+
 
 def _detect_rubiks_connected_x() -> Iterator[Peripheral[Any]]:
     configured_address = os.environ.get(RUBIKS_CONNECTED_X_ADDRESS_ENV_VAR)
@@ -79,6 +103,7 @@ def _detect_rubiks_connected_x() -> Iterator[Peripheral[Any]]:
     if not configured_address and not autodetect_enabled:
         return
     yield from itertools.chain(RubiksConnectedXPeripheral.detect())
+
 
 def _rubiks_connected_x_detection_node(
     *,
@@ -92,14 +117,17 @@ def _rubiks_connected_x_detection_node(
         start_immediately=start_immediately,
     )
 
+
 def _rubiks_connected_x_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     return (_rubiks_connected_x_detection_node,)
+
 
 def _detect_sensors() -> Iterator[Peripheral[Any]]:
     if Configuration.is_pi() and not Configuration.is_x11_forward():
         yield from itertools.chain(Compass.detect())
     else:
         yield from FakeAccelerometer.detect()
+
 
 def _accelerometer_detection_node(
     *,
@@ -112,13 +140,16 @@ def _accelerometer_detection_node(
         start_immediately=start_immediately,
     )
 
+
 def _accelerometer_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     if Configuration.is_pi() and not Configuration.is_x11_forward():
         return (_accelerometer_detection_node,)
     return ()
 
+
 def _detect_gamepads() -> Iterator[Peripheral[Any]]:
     yield from itertools.chain(Gamepad.detect())
+
 
 def _gamepad_detection_node(
     *,
@@ -130,11 +161,14 @@ def _gamepad_detection_node(
         start_immediately=start_immediately,
     )
 
+
 def _gamepad_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     return (_gamepad_detection_node,)
 
+
 def _detect_heart_rate_sensor() -> Iterator[Peripheral[Any]]:
     yield from itertools.chain(HeartRateManager.detect())
+
 
 def _heart_rate_detection_node(
     *,
@@ -147,11 +181,14 @@ def _heart_rate_detection_node(
         start_immediately=start_immediately,
     )
 
+
 def _heart_rate_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     return (_heart_rate_detection_node,)
 
+
 def _detect_microphones() -> Iterator[Peripheral[Any]]:
     yield from itertools.chain(Microphone.detect())
+
 
 def _microphone_detection_node(
     *,
@@ -164,16 +201,20 @@ def _microphone_detection_node(
         start_immediately=start_immediately,
     )
 
+
 def _microphone_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     return (_microphone_detection_node,)
 
+
 def _detect_drawing_pads() -> Iterator[Peripheral[Any]]:
     yield from itertools.chain(DrawingPad.detect())
+
 
 def _detect_radios() -> Iterator[Peripheral[Any]]:
     from heart.peripheral.radio import RadioPeripheral
 
     yield from itertools.chain(RadioPeripheral.detect())
+
 
 def _radio_detection_node(
     *,
@@ -188,8 +229,10 @@ def _radio_detection_node(
         start_immediately=start_immediately,
     )
 
+
 def _radio_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     return (_radio_detection_node,)
+
 
 def _uwb_detection_node(
     *,
@@ -202,8 +245,10 @@ def _uwb_detection_node(
         start_immediately=start_immediately,
     )
 
+
 def _uwb_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     return (_uwb_detection_node,)
+
 
 def _manyfold_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     return (
@@ -211,11 +256,13 @@ def _manyfold_graph_nodes() -> tuple[GraphNodeFactory, ...]:
         *_accelerometer_graph_nodes(),
         *_gamepad_graph_nodes(),
         *_heart_rate_graph_nodes(),
+        *_phone_text_graph_nodes(),
         *_radio_graph_nodes(),
         *_rubiks_connected_x_graph_nodes(),
         *_microphone_graph_nodes(),
         *_uwb_graph_nodes(),
     )
+
 
 def _detect_uwb_position() -> Iterator[Peripheral[Any]]:
     yield from itertools.chain(FakeUWBPositioning.detect())

--- a/src/heart/peripheral/configurations/default.py
+++ b/src/heart/peripheral/configurations/default.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from heart.peripheral.configuration import PeripheralConfiguration
 from heart.peripheral.configurations import (_detect_drawing_pads,
-                                             _detect_phone_text,
                                              _detect_sensors,
                                              _manyfold_graph_nodes,
                                              _switch_graph_nodes)
@@ -15,11 +14,12 @@ def configure() -> PeripheralConfiguration:
 
     detectors = [
         _detect_sensors,
-        _detect_phone_text,
         _detect_drawing_pads,
     ]
     if not _switch_graph_nodes():
         from heart.peripheral.configurations import _detect_switches
 
         detectors.insert(0, _detect_switches)
-    return PeripheralConfiguration(detectors=tuple(detectors), graph_nodes=_manyfold_graph_nodes())
+    return PeripheralConfiguration(
+        detectors=tuple(detectors), graph_nodes=_manyfold_graph_nodes()
+    )

--- a/src/heart/peripheral/phone_text.py
+++ b/src/heart/peripheral/phone_text.py
@@ -6,11 +6,19 @@ null terminator (`\0`).  The most-recent message is available via
 `PhoneText.get_last_text()` for inspection by other code/tests.
 """
 
+import time
 from collections.abc import Iterator
 from types import ModuleType
-from typing import Any, Self, cast
+from typing import Any, Callable, Self, cast
 
-from heart.peripheral.core import Peripheral
+from manyfold import (DetectionNode, Graph, Layer, ManagedGraphNode,
+                      ManagedGraphNodeHandle, OwnerName, Plane, Schema,
+                      StreamFamily, StreamName, TypedRoute, Variant, route)
+from manyfold.rx.subject import Subject
+from manyfold.sensor_io import (BackoffPolicy, RetryPolicy, SensorEvent,
+                                StopToken, sensor_event_schema)
+
+from heart.peripheral.core import Peripheral, PeripheralInfo, PeripheralTag
 from heart.utilities.logging import get_logger
 from heart.utilities.optional_imports import optional_import
 
@@ -27,6 +35,59 @@ bz_peripheral = cast(
 _SERVICE_UUID = "1235"
 _CHARACTERISTIC_UUID = "5679"
 _LOCAL_NAME = "PhoneText"
+PHONE_TEXT_GRAPH_OWNER = OwnerName("heart.phone_text")
+PHONE_TEXT_GRAPH_FAMILY = StreamFamily("peripheral")
+
+
+def phone_text_message_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=PHONE_TEXT_GRAPH_OWNER,
+        family=PHONE_TEXT_GRAPH_FAMILY,
+        stream=StreamName("messages"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartPhoneTextMessageEvent"),
+    )
+
+
+def phone_text_detection_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=PHONE_TEXT_GRAPH_OWNER,
+        family=PHONE_TEXT_GRAPH_FAMILY,
+        stream=StreamName("detected"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartPhoneTextDetectionEvent"),
+    )
+
+
+def phone_text_exception_schema() -> Schema[BaseException]:
+    def encode(exc: BaseException) -> bytes:
+        return f"{type(exc).__name__}:{exc}".encode("utf-8")
+
+    def decode(payload: bytes) -> BaseException:
+        return RuntimeError(payload.decode("utf-8"))
+
+    return Schema(
+        schema_id="PythonException",
+        version=1,
+        encode=encode,
+        decode=decode,
+    )
+
+
+def phone_text_error_route() -> TypedRoute[BaseException]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=PHONE_TEXT_GRAPH_OWNER,
+        family=PHONE_TEXT_GRAPH_FAMILY,
+        stream=StreamName("errors"),
+        variant=Variant.Meta,
+        schema=phone_text_exception_schema(),
+    )
 
 
 class PhoneText(Peripheral[str]):
@@ -38,6 +99,8 @@ class PhoneText(Peripheral[str]):
         self._last_text: str | None = None  # full text as received
         self.new_text = False
         self._buffer = bytearray()  # assembly buffer for chunks
+        self._text_subject: Subject[str] = Subject()
+        self._on_text: Callable[[str], None] | None = None
 
     # ---------------------------------------------------------------------
     # Peripheral API
@@ -56,6 +119,67 @@ class PhoneText(Peripheral[str]):
         logger.info("PhoneText peripheral advertising. (Ctrl-C to quit)")
         pi_ble.publish()
 
+    def peripheral_info(self) -> PeripheralInfo:
+        return PeripheralInfo(
+            id="phone_text",
+            tags=[
+                PeripheralTag(name="input_variant", variant="text"),
+                PeripheralTag(name="transport", variant="ble"),
+            ],
+        )
+
+    @classmethod
+    def detection_node(
+        cls,
+        *,
+        detector: Any | None = None,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        message_output_route: TypedRoute[SensorEvent] | None = None,
+        message_error_route: TypedRoute[BaseException] | None = None,
+        spawn_sources: bool = False,
+        on_detect: Any | None = None,
+        start_immediately: bool = True,
+    ) -> DetectionNode:
+        resolved_output_route = output_route or phone_text_detection_route()
+        resolved_message_output_route = (
+            message_output_route or phone_text_message_route()
+        )
+
+        def mapper(peripheral: "PhoneText") -> SensorEvent:
+            return SensorEvent(
+                event_type="peripheral.phone_text.detected",
+                data={
+                    "local_name": _LOCAL_NAME,
+                    "service_uuid": _SERVICE_UUID,
+                    "characteristic_uuid": _CHARACTERISTIC_UUID,
+                },
+                observed_at=time.time(),
+                identity=peripheral.peripheral_info().to_sensor_identity(),
+            )
+
+        def spawn(peripheral: "PhoneText", access: Any) -> None:
+            if not spawn_sources:
+                return
+            access.own(
+                peripheral.install_node(
+                    access.graph,
+                    output_route=resolved_message_output_route,
+                    error_route=message_error_route or phone_text_error_route(),
+                )
+            )
+
+        return DetectionNode(
+            name="heart-phone-text-detection",
+            detector=detector or cls.detect,
+            output_route=resolved_output_route,
+            mapper=mapper,
+            on_detect=on_detect,
+            spawn=spawn,
+            error_route=phone_text_error_route(),
+            group="phone-text-detection",
+            start_immediately=start_immediately,
+        )
+
     # ------------------------------------------------------------------
     # Public helpers
     # ------------------------------------------------------------------
@@ -72,12 +196,50 @@ class PhoneText(Peripheral[str]):
         self.new_text = False
         return text
 
+    def install_node(
+        self,
+        graph: Graph,
+        *,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        error_route: TypedRoute[BaseException] | None = None,
+        retry: RetryPolicy | None = None,
+        backoff: BackoffPolicy | None = None,
+        start_immediately: bool = True,
+    ) -> ManagedGraphNodeHandle:
+        """Install this BLE text service as a Manyfold graph message source."""
+
+        resolved_output_route = output_route or phone_text_message_route()
+
+        def _body(stop: StopToken, graph: Graph) -> None:
+            def publish_text(text: str) -> None:
+                graph.publish(
+                    resolved_output_route,
+                    self._text_to_sensor_event(text),
+                )
+
+            previous_callback = self._on_text
+            self._on_text = publish_text
+            try:
+                self.run()
+            finally:
+                self._on_text = previous_callback
+                stop.set()
+
+        return ManagedGraphNode(
+            name="heart-phone-text-messages",
+            body=_body,
+            output_routes=(resolved_output_route,),
+            error_route=error_route or phone_text_error_route(),
+            retry=retry or RetryPolicy(max_attempts=1_000_000),
+            backoff=backoff or BackoffPolicy.fixed(1.0),
+            group="phone-text",
+            start_immediately=start_immediately,
+        ).install(graph)
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
-    def _on_write(
-        self, value: bytes, _options: dict[str, Any] | None
-    ) -> None:  # noqa: D401
+    def _on_write(self, value: bytes, _options: dict[str, Any] | None) -> None:  # noqa: D401
         """Bluezero callback executed whenever a central writes new data."""
 
         logger.debug("Received value: %r", value)
@@ -138,7 +300,21 @@ class PhoneText(Peripheral[str]):
 
         self._last_text = text
         self.new_text = True
+        self._text_subject.on_next(text)
+        if self._on_text is not None:
+            self._on_text(text)
         logger.info("Processed text: %r", text)
+
+    def _event_stream(self) -> Subject[str]:
+        return self._text_subject
+
+    def _text_to_sensor_event(self, text: str) -> SensorEvent:
+        return SensorEvent(
+            event_type="peripheral.phone_text.message",
+            data={"text": text},
+            observed_at=time.time(),
+            identity=self.peripheral_info().to_sensor_identity(),
+        )
 
     @classmethod
     def detect(cls) -> Iterator[Self]:

--- a/tests/peripheral/test_peripheral_configurations.py
+++ b/tests/peripheral/test_peripheral_configurations.py
@@ -9,12 +9,14 @@ from pytest import MonkeyPatch
 from heart.peripheral.configurations import (_accelerometer_detection_node,
                                              _detect_gamepads,
                                              _detect_heart_rate_sensor,
+                                             _detect_phone_text,
                                              _detect_radios, _detect_switches,
                                              _detect_uwb_position,
                                              _gamepad_detection_node,
                                              _heart_rate_detection_node,
                                              _manyfold_graph_nodes,
                                              _microphone_detection_node,
+                                             _phone_text_detection_node,
                                              _radio_detection_node,
                                              _switch_detection_node,
                                              _uwb_detection_node)
@@ -25,6 +27,8 @@ from heart.peripheral.input_payloads import MicrophoneLevel, RadioPacket
 from heart.peripheral.microphone import (Microphone,
                                          microphone_detection_route,
                                          microphone_level_event_route)
+from heart.peripheral.phone_text import (PhoneText, phone_text_detection_route,
+                                         phone_text_message_route)
 from heart.peripheral.radio import (RadioDriver, RadioPeripheral,
                                     RawRadioPacket, SerialRadioDriver,
                                     radio_detection_route,
@@ -368,6 +372,57 @@ class TestManyfoldHeartRateConfiguration:
 
         assert _heart_rate_detection_node in configuration.graph_nodes
         assert _detect_heart_rate_sensor not in configuration.detectors
+
+
+class TestManyfoldPhoneTextConfiguration:
+    """Cover default graph-node factories so BLE text input stays Manyfold-owned."""
+
+    def test_phone_text_detection_node_spawns_message_source(
+        self,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        detected = PhoneText()
+
+        def _detect(cls) -> Iterator[PhoneText]:
+            yield detected
+
+        def _install_node(
+            self: PhoneText,
+            graph: Graph,
+            **kwargs: Any,
+        ) -> object:
+            graph.publish(
+                kwargs["output_route"],
+                self._text_to_sensor_event("hello"),
+            )
+            return object()
+
+        monkeypatch.setattr(PhoneText, "detect", classmethod(_detect))
+        monkeypatch.setattr(PhoneText, "install_node", _install_node)
+        graph = Graph()
+        registered: list[PhoneText] = []
+
+        handle = _phone_text_detection_node(
+            start_immediately=False,
+            on_detect=lambda peripheral, _access: registered.append(peripheral),
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest_detection = graph.latest(phone_text_detection_route())
+        latest_message = graph.latest(phone_text_message_route())
+        assert registered == [detected]
+        assert latest_detection is not None
+        assert latest_detection.value.event_type == "peripheral.phone_text.detected"
+        assert latest_message is not None
+        assert latest_message.value.event_type == "peripheral.phone_text.message"
+        assert latest_message.value.data == {"text": "hello"}
+
+    def test_default_configuration_moves_phone_text_to_graph_node(self) -> None:
+        configuration = configure()
+
+        assert _phone_text_detection_node in configuration.graph_nodes
+        assert _detect_phone_text not in configuration.detectors
 
 
 class TestManyfoldUWBConfiguration:

--- a/tests/peripheral/test_phone_text.py
+++ b/tests/peripheral/test_phone_text.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from manyfold import Graph
+
+from heart.peripheral.phone_text import (PhoneText, phone_text_detection_route,
+                                         phone_text_message_route)
+
+
+class TestManyfoldPhoneText:
+    """Cover graph-native BLE text detection and message publication."""
+
+    def test_detection_node_publishes_phone_text_to_manyfold_route(
+        self,
+        monkeypatch,
+    ) -> None:
+        detected = PhoneText()
+
+        def _detect(cls) -> Iterator[PhoneText]:
+            yield detected
+
+        monkeypatch.setattr(PhoneText, "detect", classmethod(_detect))
+        graph = Graph()
+        registered: list[PhoneText] = []
+
+        handle = PhoneText.detection_node(
+            on_detect=lambda peripheral, _access: registered.append(peripheral),
+            start_immediately=False,
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest = graph.latest(phone_text_detection_route())
+        assert registered == [detected]
+        assert latest is not None
+        assert latest.value.event_type == "peripheral.phone_text.detected"
+        assert latest.value.data == {
+            "local_name": "PhoneText",
+            "service_uuid": "1235",
+            "characteristic_uuid": "5679",
+        }
+        assert latest.value.identity.id == "phone_text"
+
+    def test_install_node_publishes_text_messages_to_manyfold_route(
+        self,
+        monkeypatch,
+    ) -> None:
+        phone_text = PhoneText()
+
+        def _run(self: PhoneText) -> None:
+            self._handle_message_bytes(b"hello")
+
+        monkeypatch.setattr(PhoneText, "run", _run)
+        graph = Graph()
+
+        handle = phone_text.install_node(graph, start_immediately=False)
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest = graph.latest(phone_text_message_route())
+        assert latest is not None
+        assert latest.value.event_type == "peripheral.phone_text.message"
+        assert latest.value.data == {"text": "hello"}
+        assert latest.value.identity.id == "phone_text"


### PR DESCRIPTION
## Summary
- add Manyfold detection, message, and error routes for PhoneText
- install PhoneText as a managed graph node that publishes BLE text writes as SensorEvent messages
- move default PhoneText registration out of direct detectors and into `_manyfold_graph_nodes()` while preserving `HEART_DISABLE_PHONE_TEXT`
- add focused coverage for PhoneText graph detection/source behavior and default configuration ownership

## Verification
- `UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tool uv run ruff check src/heart/peripheral/phone_text.py src/heart/peripheral/configurations/__init__.py src/heart/peripheral/configurations/default.py tests/peripheral/test_phone_text.py tests/peripheral/test_peripheral_configurations.py`
- `UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tool uv run mypy src/heart/peripheral/phone_text.py src/heart/peripheral/configurations/__init__.py src/heart/peripheral/configurations/default.py`
- `UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tool uv run pytest tests/peripheral/test_phone_text.py tests/peripheral/test_peripheral_configurations.py -q`
- `UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tool uv run pytest tests/peripheral -q`
- `UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tool make format`