### PR TITLE
Move drawing pad discovery into Manyfold graph

### DIFF
--- a/src/heart/peripheral/configurations/__init__.py
+++ b/src/heart/peripheral/configurations/__init__.py
@@ -210,6 +210,22 @@ def _detect_drawing_pads() -> Iterator[Peripheral[Any]]:
     yield from itertools.chain(DrawingPad.detect())
 
 
+def _drawing_pad_detection_node(
+    *,
+    start_immediately: bool,
+    on_detect: Any | None,
+) -> Any:
+    return DrawingPad.detection_node(
+        spawn_sources=True,
+        on_detect=on_detect,
+        start_immediately=start_immediately,
+    )
+
+
+def _drawing_pad_graph_nodes() -> tuple[GraphNodeFactory, ...]:
+    return (_drawing_pad_detection_node,)
+
+
 def _detect_radios() -> Iterator[Peripheral[Any]]:
     from heart.peripheral.radio import RadioPeripheral
 
@@ -254,6 +270,7 @@ def _manyfold_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     return (
         *_switch_graph_nodes(),
         *_accelerometer_graph_nodes(),
+        *_drawing_pad_graph_nodes(),
         *_gamepad_graph_nodes(),
         *_heart_rate_graph_nodes(),
         *_phone_text_graph_nodes(),

--- a/src/heart/peripheral/configurations/default.py
+++ b/src/heart/peripheral/configurations/default.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from heart.peripheral.configuration import PeripheralConfiguration
-from heart.peripheral.configurations import (_detect_drawing_pads,
-                                             _detect_sensors,
+from heart.peripheral.configurations import (_detect_sensors,
                                              _manyfold_graph_nodes,
                                              _switch_graph_nodes)
 
@@ -14,7 +13,6 @@ def configure() -> PeripheralConfiguration:
 
     detectors = [
         _detect_sensors,
-        _detect_drawing_pads,
     ]
     if not _switch_graph_nodes():
         from heart.peripheral.configurations import _detect_switches

--- a/src/heart/peripheral/drawing_pad.py
+++ b/src/heart/peripheral/drawing_pad.py
@@ -16,11 +16,73 @@ underlying grid, while an erase event clears a circular region.
 from __future__ import annotations
 
 import threading
+import time
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Any, Iterator, Mapping, Self
 
-from heart.peripheral.core import Input, Peripheral
+from manyfold import (DetectionNode, Graph, Layer, ManagedGraphNode,
+                      ManagedGraphNodeHandle, OwnerName, Plane, Schema,
+                      StreamFamily, StreamName, TypedRoute, Variant, route)
+from manyfold.sensor_io import (BackoffPolicy, RetryPolicy, SensorEvent,
+                                StopToken, sensor_event_schema)
+
+from heart.peripheral.core import (Input, Peripheral, PeripheralInfo,
+                                   PeripheralTag)
+
+DRAWING_PAD_GRAPH_OWNER = OwnerName("heart.drawing_pad")
+DRAWING_PAD_GRAPH_FAMILY = StreamFamily("peripheral")
+
+
+def drawing_pad_sample_event_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=DRAWING_PAD_GRAPH_OWNER,
+        family=DRAWING_PAD_GRAPH_FAMILY,
+        stream=StreamName("samples"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartDrawingPadSampleEvent"),
+    )
+
+
+def drawing_pad_detection_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=DRAWING_PAD_GRAPH_OWNER,
+        family=DRAWING_PAD_GRAPH_FAMILY,
+        stream=StreamName("detected"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartDrawingPadDetectionEvent"),
+    )
+
+
+def drawing_pad_exception_schema() -> Schema[BaseException]:
+    def encode(exc: BaseException) -> bytes:
+        return f"{type(exc).__name__}:{exc}".encode("utf-8")
+
+    def decode(payload: bytes) -> BaseException:
+        return RuntimeError(payload.decode("utf-8"))
+
+    return Schema(
+        schema_id="PythonException",
+        version=1,
+        encode=encode,
+        decode=decode,
+    )
+
+
+def drawing_pad_error_route() -> TypedRoute[BaseException]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=DRAWING_PAD_GRAPH_OWNER,
+        family=DRAWING_PAD_GRAPH_FAMILY,
+        stream=StreamName("errors"),
+        variant=Variant.Meta,
+        schema=drawing_pad_exception_schema(),
+    )
 
 
 @dataclass(slots=True)
@@ -76,6 +138,7 @@ class DrawingPad(Peripheral[Any]):
             [0.0 for _ in range(self.resolution)] for _ in range(self.resolution)
         ]
         self._stylus_history: list[StylusSample] = []
+        self._sample_publishers: list[tuple[Graph, TypedRoute[SensorEvent]]] = []
         self._polling_interval = polling_interval
         self._stop = threading.Event()
         super().__init__()
@@ -157,6 +220,104 @@ class DrawingPad(Peripheral[Any]):
         """Expose a single virtual drawing pad instance."""
         yield cls()
 
+    def peripheral_info(self) -> PeripheralInfo:
+        return PeripheralInfo(
+            id="drawing_pad",
+            tags=[
+                PeripheralTag(name="input_variant", variant="drawing_pad"),
+                PeripheralTag(name="input_mode", variant="stylus"),
+            ],
+        )
+
+    @classmethod
+    def detection_node(
+        cls,
+        *,
+        detector: Any | None = None,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        sample_output_route: TypedRoute[SensorEvent] | None = None,
+        sample_error_route: TypedRoute[BaseException] | None = None,
+        spawn_sources: bool = False,
+        on_detect: Any | None = None,
+        start_immediately: bool = True,
+    ) -> DetectionNode:
+        resolved_output_route = output_route or drawing_pad_detection_route()
+        resolved_sample_output_route = (
+            sample_output_route or drawing_pad_sample_event_route()
+        )
+
+        def mapper(peripheral: "DrawingPad") -> SensorEvent:
+            return SensorEvent(
+                event_type="peripheral.drawing_pad.detected",
+                data={
+                    "width_inches": peripheral.width_inches,
+                    "height_inches": peripheral.height_inches,
+                    "resolution": peripheral.resolution,
+                },
+                observed_at=time.time(),
+                identity=peripheral.peripheral_info().to_sensor_identity(),
+            )
+
+        def spawn(peripheral: "DrawingPad", access: Any) -> None:
+            if not spawn_sources:
+                return
+            access.own(
+                peripheral.install_node(
+                    access.graph,
+                    output_route=resolved_sample_output_route,
+                    error_route=sample_error_route or drawing_pad_error_route(),
+                )
+            )
+
+        return DetectionNode(
+            name="heart-drawing-pad-detection",
+            detector=detector or cls.detect,
+            output_route=resolved_output_route,
+            mapper=mapper,
+            on_detect=on_detect,
+            spawn=spawn,
+            error_route=drawing_pad_error_route(),
+            group="drawing-pad-detection",
+            start_immediately=start_immediately,
+        )
+
+    def install_node(
+        self,
+        graph: Graph,
+        *,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        error_route: TypedRoute[BaseException] | None = None,
+        retry: RetryPolicy | None = None,
+        backoff: BackoffPolicy | None = None,
+        start_immediately: bool = True,
+    ) -> ManagedGraphNodeHandle:
+        """Install this virtual pad as a Manyfold-managed stylus sample source."""
+
+        resolved_output_route = output_route or drawing_pad_sample_event_route()
+
+        def _body(stop: StopToken, _graph: Graph) -> None:
+            publisher = (graph, resolved_output_route)
+            self._sample_publishers.append(publisher)
+            try:
+                while not stop.wait(self._polling_interval):
+                    pass
+            finally:
+                try:
+                    self._sample_publishers.remove(publisher)
+                except ValueError:
+                    pass
+
+        return ManagedGraphNode(
+            name="heart-drawing-pad-samples",
+            body=_body,
+            output_routes=(resolved_output_route,),
+            error_route=error_route or drawing_pad_error_route(),
+            retry=retry or RetryPolicy(max_attempts=1_000_000),
+            backoff=backoff or BackoffPolicy.fixed(1.0),
+            group="drawing-pad",
+            start_immediately=start_immediately,
+        ).install(graph)
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
@@ -196,6 +357,22 @@ class DrawingPad(Peripheral[Any]):
                 )
 
         self._stylus_history.append(sample)
+        self._publish_sample(sample)
+
+    def _publish_sample(self, sample: StylusSample) -> None:
+        if not self._sample_publishers:
+            return
+        event = self._sample_to_sensor_event(sample)
+        for graph, output_route in tuple(self._sample_publishers):
+            graph.publish(output_route, event)
+
+    def _sample_to_sensor_event(self, sample: StylusSample) -> SensorEvent:
+        return SensorEvent(
+            event_type="peripheral.drawing_pad.sample",
+            data=asdict(sample),
+            observed_at=time.time(),
+            identity=self.peripheral_info().to_sensor_identity(),
+        )
 
     def _normalize_coordinate(self, value: float, units: str, *, axis: str) -> float:
         if units == "relative":

--- a/tests/peripheral/test_drawing_pad.py
+++ b/tests/peripheral/test_drawing_pad.py
@@ -1,7 +1,12 @@
+import time
+
 import pytest
+from manyfold import Graph
 
 from heart.peripheral.core import Input
-from heart.peripheral.drawing_pad import DrawingPad, StylusSample
+from heart.peripheral.drawing_pad import (DrawingPad, StylusSample,
+                                          drawing_pad_detection_route,
+                                          drawing_pad_sample_event_route)
 
 
 class TestPeripheralDrawingPad:
@@ -70,3 +75,70 @@ class TestPeripheralDrawingPad:
         x_idx = round(sample.x * (pad.resolution - 1))
         y_idx = round(sample.y * (pad.resolution - 1))
         assert grid[y_idx][x_idx] == pytest.approx(1.0)
+
+
+class TestDrawingPadManyfoldRuntime:
+    """Cover graph-native drawing pad discovery and stylus sample publication."""
+
+    def test_detection_node_publishes_drawing_pad_to_manyfold_route(
+        self,
+        monkeypatch,
+    ) -> None:
+        detected = DrawingPad(resolution=12)
+
+        def _detect(cls):
+            yield detected
+
+        monkeypatch.setattr(DrawingPad, "detect", classmethod(_detect))
+        graph = Graph()
+        registered: list[DrawingPad] = []
+
+        handle = DrawingPad.detection_node(
+            start_immediately=False,
+            on_detect=lambda peripheral, _access: registered.append(peripheral),
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest = graph.latest(drawing_pad_detection_route())
+        assert registered == [detected]
+        assert latest is not None
+        assert latest.value.event_type == "peripheral.drawing_pad.detected"
+        assert latest.value.data == {
+            "width_inches": 6.0,
+            "height_inches": 6.0,
+            "resolution": 12,
+        }
+        assert latest.value.identity.id == "drawing_pad"
+
+    def test_install_node_publishes_stylus_samples_to_manyfold_route(self) -> None:
+        pad = DrawingPad(resolution=8, polling_interval=0.01)
+        graph = Graph()
+
+        handle = pad.install_node(graph)
+        try:
+            deadline = time.monotonic() + 1.0
+            while not pad._sample_publishers and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert pad._sample_publishers
+
+            pad.handle_input(
+                Input(
+                    event_type="drawing_pad.stroke",
+                    data={"x": 0.25, "y": 0.5, "pressure": 0.7, "radius": 0.1},
+                )
+            )
+        finally:
+            handle.dispose(timeout=1.0)
+
+        latest = graph.latest(drawing_pad_sample_event_route())
+        assert latest is not None
+        assert latest.value.event_type == "peripheral.drawing_pad.sample"
+        assert latest.value.data == {
+            "x": 0.25,
+            "y": 0.5,
+            "pressure": 0.7,
+            "radius": 0.1,
+            "is_erase": False,
+        }
+        assert latest.value.identity.id == "drawing_pad"

--- a/tests/peripheral/test_peripheral_configurations.py
+++ b/tests/peripheral/test_peripheral_configurations.py
@@ -7,11 +7,13 @@ from manyfold import Graph
 from pytest import MonkeyPatch
 
 from heart.peripheral.configurations import (_accelerometer_detection_node,
+                                             _detect_drawing_pads,
                                              _detect_gamepads,
                                              _detect_heart_rate_sensor,
                                              _detect_phone_text,
                                              _detect_radios, _detect_switches,
                                              _detect_uwb_position,
+                                             _drawing_pad_detection_node,
                                              _gamepad_detection_node,
                                              _heart_rate_detection_node,
                                              _manyfold_graph_nodes,
@@ -21,6 +23,9 @@ from heart.peripheral.configurations import (_accelerometer_detection_node,
                                              _switch_detection_node,
                                              _uwb_detection_node)
 from heart.peripheral.configurations.default import configure
+from heart.peripheral.drawing_pad import (DrawingPad,
+                                          drawing_pad_detection_route,
+                                          drawing_pad_sample_event_route)
 from heart.peripheral.gamepad import Gamepad
 from heart.peripheral.gamepad.gamepad import gamepad_detection_route
 from heart.peripheral.input_payloads import MicrophoneLevel, RadioPacket
@@ -245,6 +250,62 @@ class TestManyfoldGamepadConfiguration:
 
         assert _gamepad_detection_node in configuration.graph_nodes
         assert _detect_gamepads not in configuration.detectors
+
+
+class TestManyfoldDrawingPadConfiguration:
+    """Cover default graph-node factories so virtual drawing pads stay Manyfold-owned."""
+
+    def test_drawing_pad_detection_node_spawns_sample_source(
+        self,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        detected = DrawingPad()
+
+        def _detect(cls) -> Iterator[DrawingPad]:
+            yield detected
+
+        def _install_node(
+            self: DrawingPad,
+            graph: Graph,
+            **kwargs: Any,
+        ) -> object:
+            graph.publish(
+                kwargs["output_route"],
+                self._sample_to_sensor_event(
+                    self._parse_payload(
+                        {"x": 0.5, "y": 0.25, "pressure": 0.6},
+                        is_erase=False,
+                    )["sample"]
+                ),
+            )
+            return object()
+
+        monkeypatch.setattr(DrawingPad, "detect", classmethod(_detect))
+        monkeypatch.setattr(DrawingPad, "install_node", _install_node)
+        graph = Graph()
+        registered: list[DrawingPad] = []
+
+        handle = _drawing_pad_detection_node(
+            start_immediately=False,
+            on_detect=lambda peripheral, _access: registered.append(peripheral),
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest_detection = graph.latest(drawing_pad_detection_route())
+        latest_sample = graph.latest(drawing_pad_sample_event_route())
+        assert registered == [detected]
+        assert latest_detection is not None
+        assert latest_detection.value.event_type == "peripheral.drawing_pad.detected"
+        assert latest_sample is not None
+        assert latest_sample.value.event_type == "peripheral.drawing_pad.sample"
+        assert latest_sample.value.data["pressure"] == 0.6
+
+    def test_default_configuration_moves_drawing_pad_to_graph_node(self) -> None:
+        configuration = configure()
+
+        assert _drawing_pad_detection_node in configuration.graph_nodes
+        assert _detect_drawing_pads not in configuration.detectors
 
 
 class TestManyfoldSwitchConfiguration:


### PR DESCRIPTION
## Summary
- add Manyfold detection, sample, and error routes for DrawingPad
- install DrawingPad as a managed graph sample source that publishes stylus events
- move the default drawing pad detector into `_manyfold_graph_nodes()` instead of direct detection

## Verification
- `UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools make format`
- `UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run mypy src/heart/peripheral/drawing_pad.py src/heart/peripheral/configurations/__init__.py src/heart/peripheral/configurations/default.py`
- `UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run pytest tests/peripheral -q`
