### PR TITLE
Publish magnetometer samples through Manyfold

### DIFF
--- a/src/heart/peripheral/sensor.py
+++ b/src/heart/peripheral/sensor.py
@@ -15,8 +15,10 @@ from manyfold.sensor_io import (BackoffPolicy, ManagedRunLoop,
                                 StopToken, sensor_event_schema)
 
 import heart.utilities.reactive as reactive
-from heart.peripheral.core import Peripheral, PeripheralInfo, PeripheralTag
-from heart.peripheral.input_payloads.motion import AccelerometerVector
+from heart.peripheral.core import (Input, Peripheral, PeripheralInfo,
+                                   PeripheralTag)
+from heart.peripheral.input_payloads.motion import (AccelerometerVector,
+                                                    MagnetometerVector)
 from heart.utilities.env import get_device_ports
 from heart.utilities.logging import get_logger
 from heart.utilities.logging_control import get_logging_controller
@@ -28,6 +30,7 @@ logger = get_logger(__name__)
 RECONNECT_DELAY_SECONDS = 1.0
 ACCELEROMETER_THREAD_NAME = "peripheral-accelerometer"
 ACCELEROMETER_GRAPH_OWNER = OwnerName("heart.accelerometer")
+MAGNETOMETER_GRAPH_OWNER = OwnerName("heart.magnetometer")
 ACCELEROMETER_GRAPH_FAMILY = StreamFamily("peripheral")
 
 
@@ -40,6 +43,18 @@ def accelerometer_vector_event_route() -> TypedRoute[SensorEvent]:
         stream=StreamName("vectors"),
         variant=Variant.Meta,
         schema=sensor_event_schema("HeartAccelerometerVectorEvent"),
+    )
+
+
+def magnetometer_vector_event_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=MAGNETOMETER_GRAPH_OWNER,
+        family=ACCELEROMETER_GRAPH_FAMILY,
+        stream=StreamName("vectors"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartMagnetometerVectorEvent"),
     )
 
 
@@ -210,6 +225,7 @@ class Accelerometer(Peripheral[Acceleration | None]):
         graph: Graph,
         *,
         output_route: TypedRoute[SensorEvent] | None = None,
+        magnetometer_output_route: TypedRoute[SensorEvent] | None = None,
         error_route: TypedRoute[BaseException] | None = None,
         retry: RetryPolicy | None = None,
         backoff: BackoffPolicy | None = None,
@@ -218,6 +234,9 @@ class Accelerometer(Peripheral[Acceleration | None]):
         """Install this accelerometer as a self-running Manyfold graph source."""
 
         resolved_output_route = output_route or accelerometer_vector_event_route()
+        resolved_magnetometer_output_route = (
+            magnetometer_output_route or magnetometer_vector_event_route()
+        )
 
         def _body(stop: StopToken, graph: Graph) -> None:
             try:
@@ -226,12 +245,20 @@ class Accelerometer(Peripheral[Acceleration | None]):
                         datum = ser.readline()
                         if not datum:
                             continue
-                        acceleration = self._process_data(datum)
-                        if acceleration is None:
+                        sensor_input = self._process_data(datum)
+                        if sensor_input is None:
                             continue
+                        output = (
+                            resolved_magnetometer_output_route
+                            if sensor_input.event_type
+                            == MagnetometerVector.EVENT_TYPE
+                            else resolved_output_route
+                        )
                         graph.publish(
-                            resolved_output_route,
-                            self._acceleration_to_sensor_event(acceleration),
+                            output,
+                            sensor_input.to_sensor_event(
+                                identity=self.peripheral_info().to_sensor_identity()
+                            ),
                         )
             except KeyboardInterrupt:
                 stop.set()
@@ -240,7 +267,7 @@ class Accelerometer(Peripheral[Acceleration | None]):
         return ManagedGraphNode(
             name="heart-accelerometer-vectors",
             body=_body,
-            output_routes=(resolved_output_route,),
+            output_routes=(resolved_output_route, resolved_magnetometer_output_route),
             error_route=error_route or accelerometer_error_route(),
             retry=retry or RetryPolicy(max_attempts=1_000_000),
             backoff=backoff or BackoffPolicy.fixed(RECONNECT_DELAY_SECONDS),
@@ -248,7 +275,7 @@ class Accelerometer(Peripheral[Acceleration | None]):
             start_immediately=start_immediately,
         ).install(graph)
 
-    def _process_data(self, data: bytes) -> Acceleration | None:
+    def _process_data(self, data: bytes) -> Input | None:
         bus_data = data.decode("utf-8").rstrip()
         if not bus_data:
             return None
@@ -288,8 +315,7 @@ class Accelerometer(Peripheral[Acceleration | None]):
             )
             return None
 
-
-    def _update_due_to_data(self, data: dict[str, Any]) -> Acceleration | None:
+    def _update_due_to_data(self, data: dict[str, Any]) -> Input | None:
         event_type = data.get("event_type")
         payload = data.get("data")
         if not isinstance(payload, dict):
@@ -299,12 +325,11 @@ class Accelerometer(Peripheral[Acceleration | None]):
         if event_type in {"acceleration", "sensor.acceleration"}:
             return self._handle_acceleration(payload)
         if event_type in {"magnetic", "sensor.magnetic"}:
-            self._handle_magnetic(payload)
-            return None
+            return self._handle_magnetic(payload)
         logger.debug("Ignoring unknown sensor payload type: %s", event_type)
         return None
 
-    def _handle_acceleration(self, payload: Mapping[str, Any]) -> Acceleration | None:
+    def _handle_acceleration(self, payload: Mapping[str, Any]) -> Input | None:
         try:
             vector = AccelerometerVector(
                 x=float(payload["x"]),
@@ -317,35 +342,20 @@ class Accelerometer(Peripheral[Acceleration | None]):
 
         input_event = vector.to_input()
         self.acceleration_value = cast(dict[str, float], input_event.data)
-        return Acceleration(
-            x=self.acceleration_value["x"],
-            y=self.acceleration_value["y"],
-            z=self.acceleration_value["z"],
-        )
+        return input_event
 
-    def _acceleration_to_sensor_event(self, acceleration: Acceleration) -> SensorEvent:
-        vector = AccelerometerVector(
-            x=acceleration.x,
-            y=acceleration.y,
-            z=acceleration.z,
-        )
-        return vector.to_input().to_sensor_event(
-            identity=self.peripheral_info().to_sensor_identity()
-        )
+    def _handle_magnetic(self, payload: Mapping[str, Any]) -> Input | None:
+        try:
+            vector = MagnetometerVector(
+                x=float(payload["x"]),
+                y=float(payload["y"]),
+                z=float(payload["z"]),
+            )
+        except (KeyError, TypeError, ValueError):
+            logger.debug("Magnetometer payload missing axis components: %s", payload)
+            return None
+        return vector.to_input()
 
-    def _handle_magnetic(self, payload: Mapping[str, Any]) -> None:
-        logger.debug("Ignoring magnetic payload: %s", payload)
-        # try:
-        #     vector = MagnetometerVector(
-        #         x=float(payload["x"]),
-        #         y=float(payload["y"]),
-        #         z=float(payload["z"]),
-        #     )
-        # except (KeyError, TypeError, ValueError):
-        #     logger.debug("Magnetometer payload missing axis components: %s", payload)
-        #     return
-
-        # raise NotImplementedError("")
 
 class FakeAccelerometer(Peripheral[Acceleration | None]):
     @classmethod

--- a/tests/peripheral/test_accelerometer.py
+++ b/tests/peripheral/test_accelerometer.py
@@ -8,7 +8,8 @@ from manyfold.sensor_io import BackoffPolicy, RetryPolicy
 from heart.peripheral.sensor import (Accelerometer,
                                      accelerometer_detection_route,
                                      accelerometer_error_route,
-                                     accelerometer_vector_event_route)
+                                     accelerometer_vector_event_route,
+                                     magnetometer_vector_event_route)
 
 
 class _SerialStub:
@@ -85,6 +86,34 @@ class TestAccelerometerManyfoldNode:
         assert latest.value.data == {"x": 1.0, "y": 2.0, "z": 3.0}
         assert latest.value.identity.id == "accelerometer:/dev/ttyUSB0"
         assert peripheral.get_acceleration() is not None
+
+    def test_install_node_publishes_magnetometer_vectors_to_manyfold_route(
+        self,
+        monkeypatch,
+    ) -> None:
+        peripheral = Accelerometer(port="/dev/ttyUSB0", baudrate=115200)
+        payload = b'{"event_type":"sensor.magnetic","data":{"x":7,"y":8,"z":9}}\n'
+        monkeypatch.setattr(
+            peripheral,
+            "_connect_to_ser",
+            lambda: _SerialStub(iter((payload,))),
+        )
+        graph = Graph()
+
+        handle = peripheral.install_node(
+            graph,
+            start_immediately=False,
+            retry=RetryPolicy(max_attempts=1),
+            backoff=BackoffPolicy.none(),
+        )
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest = graph.latest(magnetometer_vector_event_route())
+        assert latest is not None
+        assert latest.value.event_type == "peripheral.magnetometer.vector"
+        assert latest.value.data == {"x": 7.0, "y": 8.0, "z": 9.0}
+        assert latest.value.identity.id == "accelerometer:/dev/ttyUSB0"
+        assert peripheral.get_acceleration() is None
 
     def test_detection_node_can_spawn_vector_source(self, monkeypatch) -> None:
         detected = Accelerometer(port="/dev/ttyUSB0", baudrate=115200)

--- a/tests/peripheral/test_peripheral_configurations.py
+++ b/tests/peripheral/test_peripheral_configurations.py
@@ -40,7 +40,8 @@ from heart.peripheral.radio import (RadioDriver, RadioPeripheral,
                                     radio_packet_event_route)
 from heart.peripheral.sensor import (Accelerometer,
                                      accelerometer_detection_route,
-                                     accelerometer_vector_event_route)
+                                     accelerometer_vector_event_route,
+                                     magnetometer_vector_event_route)
 from heart.peripheral.uwb import (BaseStationMeasurement, FakeUWBPositioning,
                                   LocalizedTarget, uwb_detection_route,
                                   uwb_position_event_route)
@@ -175,6 +176,42 @@ class TestManyfoldAccelerometerConfiguration:
         assert latest_vector is not None
         assert latest_vector.value.event_type == "peripheral.accelerometer.vector"
         assert latest_vector.value.data == {"x": 1.0, "y": 2.0, "z": 3.0}
+
+    def test_accelerometer_detection_node_spawns_magnetometer_source(
+        self,
+        monkeypatch,
+    ) -> None:
+        payload = b'{"event_type":"sensor.magnetic","data":{"x":7,"y":8,"z":9}}\n'
+        detected = Accelerometer(port="/dev/ttyUSB0", baudrate=115200)
+
+        def _detect(cls) -> Iterator[Accelerometer]:
+            yield detected
+
+        monkeypatch.setattr(Accelerometer, "detect", classmethod(_detect))
+        monkeypatch.setattr(
+            detected,
+            "_connect_to_ser",
+            lambda: _SerialStub(iter((payload,))),
+        )
+        graph = Graph()
+
+        handle = _accelerometer_detection_node(
+            start_immediately=False,
+            on_detect=None,
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+        assert len(handle.spawned_handles) == 1
+
+        spawned = handle.spawned_handles[0]
+        spawned.loop_handle.loop.run(spawned.loop_handle.token)
+
+        latest_detection = graph.latest(accelerometer_detection_route())
+        latest_vector = graph.latest(magnetometer_vector_event_route())
+        assert latest_detection is not None
+        assert latest_vector is not None
+        assert latest_vector.value.event_type == "peripheral.magnetometer.vector"
+        assert latest_vector.value.data == {"x": 7.0, "y": 8.0, "z": 9.0}
 
     def test_manyfold_graph_nodes_include_accelerometer_on_pi(
         self,


### PR DESCRIPTION
## Summary
- add a Manyfold route for magnetometer vector SensorEvents emitted by the IMU serial source
- publish sensor.magnetic payloads from the managed accelerometer graph node instead of dropping them
- cover direct install-node and default graph-node spawned-source paths for magnetometer samples

## Validation
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools make format
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run pytest tests/peripheral/test_accelerometer.py tests/peripheral/test_peripheral_configurations.py
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run mypy --config-file pyproject.toml src/heart/peripheral/sensor.py

Note: an explicit mypy run including the existing test modules still reports their preexisting missing test annotations; changed source type-checks cleanly.