### PR TITLE
Move compass runtime onto Manyfold graph

### DIFF
--- a/src/heart/peripheral/compass.py
+++ b/src/heart/peripheral/compass.py
@@ -4,13 +4,23 @@ from __future__ import annotations
 
 import math
 import threading
+import time
 from collections import deque
 from collections.abc import Iterator
 from datetime import timedelta
-from typing import Deque, Mapping, Self
+from typing import Any, Deque, Mapping, Self
+
+from manyfold import (DetectionNode, Graph, Layer, ManagedGraphNode,
+                      ManagedGraphNodeHandle, OwnerName, Plane, Schema,
+                      StreamFamily, StreamName, TypedRoute, Variant, route)
+from manyfold.sensor_io import (BackoffPolicy, RetryPolicy, SensorEvent,
+                                StopToken, sensor_event_schema)
 
 import heart.utilities.reactive as reactive
-from heart.peripheral.core import Input, Peripheral
+from heart.peripheral.core import (Input, Peripheral, PeripheralInfo,
+                                   PeripheralTag)
+from heart.peripheral.input_payloads.motion import MagnetometerVector
+from heart.peripheral.sensor import magnetometer_vector_event_route
 from heart.utilities.logging import get_logger
 from heart.utilities.reactive import operators as ops
 from heart.utilities.reactive_threads import (interval_in_background,
@@ -19,6 +29,72 @@ from heart.utilities.reactive_threads import (interval_in_background,
 logger = get_logger(__name__)
 
 Vector3 = tuple[float, float, float]
+COMPASS_GRAPH_OWNER = OwnerName("heart.compass")
+COMPASS_GRAPH_FAMILY = StreamFamily("peripheral")
+
+
+def compass_detection_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=COMPASS_GRAPH_OWNER,
+        family=COMPASS_GRAPH_FAMILY,
+        stream=StreamName("detected"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartCompassDetectionEvent"),
+    )
+
+
+def compass_vector_event_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=COMPASS_GRAPH_OWNER,
+        family=COMPASS_GRAPH_FAMILY,
+        stream=StreamName("vectors"),
+        variant=Variant.State,
+        schema=sensor_event_schema("HeartCompassVectorEvent"),
+    )
+
+
+def compass_heading_event_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=COMPASS_GRAPH_OWNER,
+        family=COMPASS_GRAPH_FAMILY,
+        stream=StreamName("headings"),
+        variant=Variant.State,
+        schema=sensor_event_schema("HeartCompassHeadingEvent"),
+    )
+
+
+def compass_exception_schema() -> Schema[BaseException]:
+    def encode(exc: BaseException) -> bytes:
+        return f"{type(exc).__name__}:{exc}".encode("utf-8")
+
+    def decode(payload: bytes) -> BaseException:
+        return RuntimeError(payload.decode("utf-8"))
+
+    return Schema(
+        schema_id="PythonException",
+        version=1,
+        encode=encode,
+        decode=decode,
+    )
+
+
+def compass_error_route() -> TypedRoute[BaseException]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=COMPASS_GRAPH_OWNER,
+        family=COMPASS_GRAPH_FAMILY,
+        stream=StreamName("errors"),
+        variant=Variant.Meta,
+        schema=compass_exception_schema(),
+    )
+
 
 class Compass(Peripheral[Vector3 | None]):
     """Maintain a smoothed magnetic heading derived from sensor bus events."""
@@ -49,6 +125,62 @@ class Compass(Peripheral[Vector3 | None]):
 
         yield cls()
 
+    def peripheral_info(self) -> PeripheralInfo:
+        return PeripheralInfo(
+            id="compass:magnetometer",
+            tags=[
+                PeripheralTag(name="input_variant", variant="compass"),
+            ],
+        )
+
+    @classmethod
+    def detection_node(
+        cls,
+        *,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        spawn_sources: bool = False,
+        on_detect: Any | None = None,
+        start_immediately: bool = True,
+    ) -> DetectionNode:
+        resolved_output_route = output_route or compass_detection_route()
+
+        def mapper(peripheral: "Compass") -> SensorEvent:
+            return SensorEvent(
+                event_type="peripheral.compass.detected",
+                data={"window_size": peripheral.window_size},
+                observed_at=time.time(),
+                identity=peripheral.peripheral_info().to_sensor_identity(),
+            )
+
+        def spawn(peripheral: "Compass", access: Any) -> None:
+            if not spawn_sources:
+                return
+            access.own(
+                peripheral.install_node(
+                    access.graph,
+                    start_immediately=start_immediately,
+                )
+            )
+
+        return DetectionNode(
+            name="heart-compass-detection",
+            detector=cls.detect,
+            output_route=resolved_output_route,
+            mapper=mapper,
+            on_detect=on_detect,
+            spawn=spawn,
+            error_route=compass_error_route(),
+            group="compass-detection",
+            start_immediately=start_immediately,
+        )
+
+    def handle_input(self, input: Input) -> None:
+        if input.event_type in {
+            "magnetic",
+            "sensor.magnetic",
+            MagnetometerVector.EVENT_TYPE,
+        }:
+            self._handle_magnetometer(input)
 
     def _handle_magnetometer(self, event: Input) -> None:
         payload = event.data
@@ -79,6 +211,79 @@ class Compass(Peripheral[Vector3 | None]):
             ops.map(lambda _: self.get_latest_vector()),
             ops.distinct_until_changed(lambda x: x)
         )
+
+    def install_node(
+        self,
+        graph: Graph,
+        *,
+        input_route: TypedRoute[SensorEvent] | None = None,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        heading_output_route: TypedRoute[SensorEvent] | None = None,
+        error_route: TypedRoute[BaseException] | None = None,
+        retry: RetryPolicy | None = None,
+        backoff: BackoffPolicy | None = None,
+        start_immediately: bool = True,
+    ) -> ManagedGraphNodeHandle:
+        """Install this compass as a Manyfold transform over magnetometer vectors."""
+
+        resolved_input_route = input_route or magnetometer_vector_event_route()
+        resolved_output_route = output_route or compass_vector_event_route()
+        resolved_heading_output_route = heading_output_route or compass_heading_event_route()
+
+        def _body(stop: StopToken, graph: Graph) -> None:
+            def publish_compass_state(event: SensorEvent) -> None:
+                self.handle_input(
+                    Input(
+                        event_type=event.event_type,
+                        data=event.data,
+                    )
+                )
+                vector = self.get_latest_vector()
+                if vector is None:
+                    return
+                identity = self.peripheral_info().to_sensor_identity()
+                observed_at = time.time()
+                graph.publish(
+                    resolved_output_route,
+                    SensorEvent(
+                        event_type="peripheral.compass.vector",
+                        data={"x": vector[0], "y": vector[1], "z": vector[2]},
+                        observed_at=observed_at,
+                        identity=identity,
+                    ),
+                )
+                heading = self.get_heading_degrees()
+                if heading is None:
+                    return
+                graph.publish(
+                    resolved_heading_output_route,
+                    SensorEvent(
+                        event_type="peripheral.compass.heading",
+                        data={"degrees": heading},
+                        observed_at=observed_at,
+                        identity=identity,
+                    ),
+                )
+
+            subscription = graph.observe(resolved_input_route).subscribe(
+                lambda envelope: publish_compass_state(envelope.value)
+            )
+            try:
+                stop.wait()
+            finally:
+                subscription.dispose()
+
+        return ManagedGraphNode(
+            name="heart-compass",
+            body=_body,
+            output_routes=(resolved_output_route, resolved_heading_output_route),
+            error_route=error_route or compass_error_route(),
+            retry=retry or RetryPolicy(max_attempts=1),
+            backoff=backoff or BackoffPolicy.none(),
+            group="compass",
+            start_immediately=start_immediately,
+        ).install(graph)
+
     # ------------------------------------------------------------------
     # Public helpers
     # ------------------------------------------------------------------

--- a/src/heart/peripheral/configurations/__init__.py
+++ b/src/heart/peripheral/configurations/__init__.py
@@ -124,9 +124,27 @@ def _rubiks_connected_x_graph_nodes() -> tuple[GraphNodeFactory, ...]:
 
 def _detect_sensors() -> Iterator[Peripheral[Any]]:
     if Configuration.is_pi() and not Configuration.is_x11_forward():
-        yield from itertools.chain(Compass.detect())
+        return
     else:
         yield from FakeAccelerometer.detect()
+
+
+def _compass_detection_node(
+    *,
+    start_immediately: bool,
+    on_detect: Any | None,
+) -> Any:
+    return Compass.detection_node(
+        spawn_sources=True,
+        on_detect=on_detect,
+        start_immediately=start_immediately,
+    )
+
+
+def _compass_graph_nodes() -> tuple[GraphNodeFactory, ...]:
+    if Configuration.is_pi() and not Configuration.is_x11_forward():
+        return (_compass_detection_node,)
+    return ()
 
 
 def _accelerometer_detection_node(
@@ -270,6 +288,7 @@ def _manyfold_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     return (
         *_switch_graph_nodes(),
         *_accelerometer_graph_nodes(),
+        *_compass_graph_nodes(),
         *_drawing_pad_graph_nodes(),
         *_gamepad_graph_nodes(),
         *_heart_rate_graph_nodes(),

--- a/tests/peripheral/test_compass.py
+++ b/tests/peripheral/test_compass.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+
+from manyfold import Graph
+from manyfold.sensor_io import BackoffPolicy, RetryPolicy, SensorEvent
+
+from heart.peripheral.compass import (Compass, compass_detection_route,
+                                      compass_heading_event_route,
+                                      compass_vector_event_route)
+from heart.peripheral.sensor import magnetometer_vector_event_route
+
+
+class TestCompassManyfoldNode:
+    """Cover graph-native compass detection and magnetometer transforms."""
+
+    def test_handle_input_updates_vector_and_heading(self) -> None:
+        compass = Compass()
+
+        compass.update_due_to_data(
+            {
+                "event_type": "peripheral.magnetometer.vector",
+                "data": {"x": 1, "y": 0, "z": 0},
+            }
+        )
+
+        assert compass.get_latest_vector() == (1.0, 0.0, 0.0)
+        assert compass.get_heading_degrees() == 90.0
+
+    def test_detection_node_publishes_compass_to_manyfold_route(
+        self,
+        monkeypatch,
+    ) -> None:
+        detected = Compass(window_size=3)
+
+        def _detect(cls) -> Iterator[Compass]:
+            yield detected
+
+        monkeypatch.setattr(Compass, "detect", classmethod(_detect))
+        graph = Graph()
+        registered: list[Compass] = []
+
+        handle = Compass.detection_node(
+            start_immediately=False,
+            on_detect=lambda peripheral, _access: registered.append(peripheral),
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest = graph.latest(compass_detection_route())
+        assert registered == [detected]
+        assert latest is not None
+        assert latest.value.event_type == "peripheral.compass.detected"
+        assert latest.value.data == {"window_size": 3}
+        assert latest.value.identity.id == "compass:magnetometer"
+
+    def test_install_node_publishes_compass_state_from_magnetometer_route(
+        self,
+    ) -> None:
+        compass = Compass()
+        graph = Graph()
+
+        handle = compass.install_node(
+            graph,
+            retry=RetryPolicy(max_attempts=1),
+            backoff=BackoffPolicy.none(),
+        )
+        try:
+            graph.publish(
+                magnetometer_vector_event_route(),
+                SensorEvent(
+                    event_type="peripheral.magnetometer.vector",
+                    data={"x": 0.0, "y": 1.0, "z": 2.0},
+                    observed_at=1.0,
+                ),
+            )
+
+            latest_vector = graph.latest(compass_vector_event_route())
+            latest_heading = graph.latest(compass_heading_event_route())
+            assert latest_vector is not None
+            assert latest_vector.value.event_type == "peripheral.compass.vector"
+            assert latest_vector.value.data == {"x": 0.0, "y": 1.0, "z": 2.0}
+            assert latest_vector.value.identity.id == "compass:magnetometer"
+            assert latest_heading is not None
+            assert latest_heading.value.event_type == "peripheral.compass.heading"
+            assert latest_heading.value.data == {"degrees": 0.0}
+        finally:
+            handle.dispose(timeout=1.0)
+
+    def test_detection_node_can_spawn_compass_source(self, monkeypatch) -> None:
+        detected = Compass()
+
+        def _detect(cls) -> Iterator[Compass]:
+            yield detected
+
+        monkeypatch.setattr(Compass, "detect", classmethod(_detect))
+        graph = Graph()
+
+        handle = Compass.detection_node(spawn_sources=True).install(graph)
+        try:
+            handle.node_handle.join()
+            assert len(handle.spawned_handles) == 1
+
+            graph.publish(
+                magnetometer_vector_event_route(),
+                SensorEvent(
+                    event_type="peripheral.magnetometer.vector",
+                    data={"x": 1.0, "y": 0.0, "z": 0.0},
+                    observed_at=1.0,
+                ),
+            )
+
+            latest_vector = None
+            for _ in range(20):
+                latest_vector = graph.latest(compass_vector_event_route())
+                if latest_vector is not None:
+                    break
+                time.sleep(0.01)
+
+            assert latest_vector is not None
+            assert latest_vector.value.data == {"x": 1.0, "y": 0.0, "z": 0.0}
+        finally:
+            handle.dispose(timeout=1.0)

--- a/tests/peripheral/test_peripheral_configurations.py
+++ b/tests/peripheral/test_peripheral_configurations.py
@@ -6,7 +6,9 @@ from typing import Any
 from manyfold import Graph
 from pytest import MonkeyPatch
 
+from heart.peripheral.compass import Compass, compass_detection_route
 from heart.peripheral.configurations import (_accelerometer_detection_node,
+                                             _compass_detection_node,
                                              _detect_drawing_pads,
                                              _detect_gamepads,
                                              _detect_heart_rate_sensor,
@@ -229,6 +231,49 @@ class TestManyfoldAccelerometerConfiguration:
         nodes = _manyfold_graph_nodes()
 
         assert _accelerometer_detection_node in nodes
+
+    def test_compass_detection_node_spawns_compass_source(
+        self,
+        monkeypatch,
+    ) -> None:
+        detected = Compass()
+
+        def _detect(cls) -> Iterator[Compass]:
+            yield detected
+
+        monkeypatch.setattr(Compass, "detect", classmethod(_detect))
+        graph = Graph()
+        registered: list[Compass] = []
+
+        handle = _compass_detection_node(
+            start_immediately=False,
+            on_detect=lambda peripheral, _access: registered.append(peripheral),
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest_detection = graph.latest(compass_detection_route())
+        assert registered == [detected]
+        assert len(handle.spawned_handles) == 1
+        assert latest_detection is not None
+        assert latest_detection.value.event_type == "peripheral.compass.detected"
+
+    def test_manyfold_graph_nodes_include_compass_on_pi(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_pi",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_x11_forward",
+            lambda: False,
+        )
+
+        nodes = _manyfold_graph_nodes()
+
+        assert _compass_detection_node in nodes
 
     def test_manyfold_graph_nodes_keep_fake_accelerometer_direct_off_pi(
         self,


### PR DESCRIPTION
## Summary
- add graph-native compass detection, vector, heading, and error routes
- install Compass as a Manyfold-managed transform subscribed to magnetometer vector events
- move Pi compass discovery into default graph nodes while preserving off-Pi fake accelerometer fallback

## Validation
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools make format
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run ruff check src/heart/peripheral/compass.py src/heart/peripheral/configurations/__init__.py tests/peripheral/test_compass.py tests/peripheral/test_peripheral_configurations.py
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run mypy --config-file pyproject.toml src/heart/peripheral/compass.py src/heart/peripheral/configurations/__init__.py
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run pytest tests/peripheral/test_compass.py tests/peripheral/test_peripheral_configurations.py -q
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run pytest tests/peripheral -q