### PR TITLE
Move specialized switch configs onto Manyfold graph

### DIFF
--- a/src/heart/peripheral/configurations/__init__.py
+++ b/src/heart/peripheral/configurations/__init__.py
@@ -12,6 +12,7 @@ from heart.peripheral.gamepad import Gamepad
 from heart.peripheral.heart_rates import HeartRateManager
 from heart.peripheral.microphone import Microphone
 from heart.peripheral.phone_text import PhoneText
+from heart.peripheral.radio import RadioPeripheral
 from heart.peripheral.rubiks_connected_x import (
     RUBIKS_CONNECTED_X_ADDRESS_ENV_VAR, RUBIKS_CONNECTED_X_AUTODETECT_ENV_VAR,
     RubiksConnectedXPeripheral)
@@ -245,8 +246,6 @@ def _drawing_pad_graph_nodes() -> tuple[GraphNodeFactory, ...]:
 
 
 def _detect_radios() -> Iterator[Peripheral[Any]]:
-    from heart.peripheral.radio import RadioPeripheral
-
     yield from itertools.chain(RadioPeripheral.detect())
 
 
@@ -255,8 +254,6 @@ def _radio_detection_node(
     start_immediately: bool,
     on_detect: Any | None,
 ) -> Any:
-    from heart.peripheral.radio import RadioPeripheral
-
     return RadioPeripheral.detection_node(
         spawn_sources=True,
         on_detect=on_detect,

--- a/src/heart/peripheral/configurations/default.py
+++ b/src/heart/peripheral/configurations/default.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from heart.peripheral.configuration import PeripheralConfiguration
-from heart.peripheral.configurations import (_detect_sensors,
+from heart.peripheral.configurations import (_detect_sensors, _detect_switches,
                                              _manyfold_graph_nodes,
                                              _switch_graph_nodes)
 
@@ -15,8 +15,6 @@ def configure() -> PeripheralConfiguration:
         _detect_sensors,
     ]
     if not _switch_graph_nodes():
-        from heart.peripheral.configurations import _detect_switches
-
         detectors.insert(0, _detect_switches)
     return PeripheralConfiguration(
         detectors=tuple(detectors), graph_nodes=_manyfold_graph_nodes()

--- a/src/heart/peripheral/configurations/pranay_pi.py
+++ b/src/heart/peripheral/configurations/pranay_pi.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from heart.peripheral.configuration import PeripheralConfiguration
-from heart.peripheral.configurations import _detect_switches
+from heart.peripheral.configurations import (_detect_switches,
+                                             _switch_graph_nodes)
 
 
 def configure() -> PeripheralConfiguration:
     """Return the minimal peripheral plan needed to boot the Pranay scene."""
 
-    return PeripheralConfiguration(detectors=(_detect_switches,))
+    graph_nodes = _switch_graph_nodes()
+    detectors = () if graph_nodes else (_detect_switches,)
+    return PeripheralConfiguration(detectors=detectors, graph_nodes=graph_nodes)

--- a/src/heart/peripheral/configurations/rubiks_connected_x.py
+++ b/src/heart/peripheral/configurations/rubiks_connected_x.py
@@ -4,17 +4,22 @@ from __future__ import annotations
 
 from heart.peripheral.configuration import PeripheralConfiguration
 from heart.peripheral.configurations import (_detect_sensors, _detect_switches,
-                                             _rubiks_connected_x_graph_nodes)
+                                             _rubiks_connected_x_graph_nodes,
+                                             _switch_graph_nodes)
 
 
 def configure() -> PeripheralConfiguration:
     """Return a minimal detection plan for Rubik's Connected X visualizer runs."""
 
-    detectors = (
-        _detect_switches,
-        _detect_sensors,
+    detectors = [_detect_sensors]
+    switch_graph_nodes = _switch_graph_nodes()
+    graph_nodes = (
+        *switch_graph_nodes,
+        *_rubiks_connected_x_graph_nodes(),
     )
+    if not switch_graph_nodes:
+        detectors.insert(0, _detect_switches)
     return PeripheralConfiguration(
-        detectors=detectors,
-        graph_nodes=_rubiks_connected_x_graph_nodes(),
+        detectors=tuple(detectors),
+        graph_nodes=graph_nodes,
     )

--- a/tests/peripheral/test_peripheral_configurations.py
+++ b/tests/peripheral/test_peripheral_configurations.py
@@ -25,6 +25,10 @@ from heart.peripheral.configurations import (_accelerometer_detection_node,
                                              _switch_detection_node,
                                              _uwb_detection_node)
 from heart.peripheral.configurations.default import configure
+from heart.peripheral.configurations.pranay_pi import \
+    configure as configure_pranay_pi
+from heart.peripheral.configurations.rubiks_connected_x import \
+    configure as configure_rubiks_connected_x
 from heart.peripheral.drawing_pad import (DrawingPad,
                                           drawing_pad_detection_route,
                                           drawing_pad_sample_event_route)
@@ -454,6 +458,94 @@ class TestManyfoldSwitchConfiguration:
         )
 
         configuration = configure()
+
+        assert _switch_detection_node not in configuration.graph_nodes
+        assert configuration.detectors[0] is _detect_switches
+
+    def test_rubiks_configuration_moves_physical_switch_to_graph_node(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.use_mock_switch",
+            lambda: False,
+        )
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_pi",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_x11_forward",
+            lambda: False,
+        )
+
+        configuration = configure_rubiks_connected_x()
+
+        assert _switch_detection_node in configuration.graph_nodes
+        assert _detect_switches not in configuration.detectors
+
+    def test_rubiks_configuration_keeps_switch_direct_for_local_fake(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.use_mock_switch",
+            lambda: False,
+        )
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_pi",
+            lambda: False,
+        )
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_x11_forward",
+            lambda: False,
+        )
+
+        configuration = configure_rubiks_connected_x()
+
+        assert _switch_detection_node not in configuration.graph_nodes
+        assert configuration.detectors[0] is _detect_switches
+
+    def test_pranay_configuration_moves_physical_switch_to_graph_node(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.use_mock_switch",
+            lambda: False,
+        )
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_pi",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_x11_forward",
+            lambda: False,
+        )
+
+        configuration = configure_pranay_pi()
+
+        assert _switch_detection_node in configuration.graph_nodes
+        assert _detect_switches not in configuration.detectors
+
+    def test_pranay_configuration_keeps_switch_direct_for_local_fake(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.use_mock_switch",
+            lambda: False,
+        )
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_pi",
+            lambda: False,
+        )
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_x11_forward",
+            lambda: False,
+        )
+
+        configuration = configure_pranay_pi()
 
         assert _switch_detection_node not in configuration.graph_nodes
         assert configuration.detectors[0] is _detect_switches


### PR DESCRIPTION
## Summary
- move Rubik's Connected X and Pranay Pi configurations to use switch detection graph nodes when physical switch graph ownership is available
- preserve direct fake-switch detection fallback for local/mock environments
- lift remaining configuration imports to module scope for the repo import contract

## Validation
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tool make format
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tool uv run ruff check src/heart/peripheral/configurations tests/peripheral/test_peripheral_configurations.py
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tool uv run mypy --config-file pyproject.toml src/heart/peripheral/configurations
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tool uv run pytest tests/peripheral/test_peripheral_configurations.py -q
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tool uv run pytest tests/peripheral -q