### PR TITLE
Move fake accelerometer runtime onto Manyfold graph

### DIFF
--- a/src/heart/peripheral/configurations/__init__.py
+++ b/src/heart/peripheral/configurations/__init__.py
@@ -123,11 +123,16 @@ def _rubiks_connected_x_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     return (_rubiks_connected_x_detection_node,)
 
 
-def _detect_sensors() -> Iterator[Peripheral[Any]]:
-    if Configuration.is_pi() and not Configuration.is_x11_forward():
-        return
-    else:
-        yield from FakeAccelerometer.detect()
+def _fake_accelerometer_detection_node(
+    *,
+    start_immediately: bool,
+    on_detect: Any | None,
+) -> Any:
+    return FakeAccelerometer.detection_node(
+        spawn_sources=True,
+        on_detect=on_detect,
+        start_immediately=start_immediately,
+    )
 
 
 def _compass_detection_node(
@@ -163,7 +168,13 @@ def _accelerometer_detection_node(
 def _accelerometer_graph_nodes() -> tuple[GraphNodeFactory, ...]:
     if Configuration.is_pi() and not Configuration.is_x11_forward():
         return (_accelerometer_detection_node,)
-    return ()
+    return _fake_accelerometer_graph_nodes()
+
+
+def _fake_accelerometer_graph_nodes() -> tuple[GraphNodeFactory, ...]:
+    if Configuration.is_pi() and not Configuration.is_x11_forward():
+        return ()
+    return (_fake_accelerometer_detection_node,)
 
 
 def _detect_gamepads() -> Iterator[Peripheral[Any]]:

--- a/src/heart/peripheral/configurations/default.py
+++ b/src/heart/peripheral/configurations/default.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from heart.peripheral.configuration import PeripheralConfiguration
-from heart.peripheral.configurations import (_detect_sensors, _detect_switches,
+from heart.peripheral.configuration import (DetectorFactory,
+                                            PeripheralConfiguration)
+from heart.peripheral.configurations import (_detect_switches,
                                              _manyfold_graph_nodes,
                                              _switch_graph_nodes)
 
@@ -11,9 +12,7 @@ from heart.peripheral.configurations import (_detect_sensors, _detect_switches,
 def configure() -> PeripheralConfiguration:
     """Return the default detection plan for ``manager``."""
 
-    detectors = [
-        _detect_sensors,
-    ]
+    detectors: list[DetectorFactory] = []
     if not _switch_graph_nodes():
         detectors.insert(0, _detect_switches)
     return PeripheralConfiguration(

--- a/src/heart/peripheral/configurations/rubiks_connected_x.py
+++ b/src/heart/peripheral/configurations/rubiks_connected_x.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from heart.peripheral.configuration import PeripheralConfiguration
-from heart.peripheral.configurations import (_detect_sensors, _detect_switches,
+from heart.peripheral.configuration import (DetectorFactory,
+                                            PeripheralConfiguration)
+from heart.peripheral.configurations import (_detect_switches,
+                                             _fake_accelerometer_graph_nodes,
                                              _rubiks_connected_x_graph_nodes,
                                              _switch_graph_nodes)
 
@@ -11,10 +13,11 @@ from heart.peripheral.configurations import (_detect_sensors, _detect_switches,
 def configure() -> PeripheralConfiguration:
     """Return a minimal detection plan for Rubik's Connected X visualizer runs."""
 
-    detectors = [_detect_sensors]
+    detectors: list[DetectorFactory] = []
     switch_graph_nodes = _switch_graph_nodes()
     graph_nodes = (
         *switch_graph_nodes,
+        *_fake_accelerometer_graph_nodes(),
         *_rubiks_connected_x_graph_nodes(),
     )
     if not switch_graph_nodes:

--- a/src/heart/peripheral/sensor.py
+++ b/src/heart/peripheral/sensor.py
@@ -362,6 +362,53 @@ class FakeAccelerometer(Peripheral[Acceleration | None]):
     def detect(cls) -> Iterator[Self]:
         yield cls()
 
+    @classmethod
+    def detection_node(
+        cls,
+        *,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        vector_output_route: TypedRoute[SensorEvent] | None = None,
+        vector_error_route: TypedRoute[BaseException] | None = None,
+        spawn_sources: bool = False,
+        on_detect: Any | None = None,
+        start_immediately: bool = True,
+    ) -> DetectionNode:
+        resolved_output_route = output_route or accelerometer_detection_route()
+        resolved_vector_output_route = (
+            vector_output_route or accelerometer_vector_event_route()
+        )
+
+        def mapper(peripheral: "FakeAccelerometer") -> SensorEvent:
+            return SensorEvent(
+                event_type="peripheral.accelerometer.detected",
+                data={"mode": "fake"},
+                observed_at=time.time(),
+                identity=peripheral.peripheral_info().to_sensor_identity(),
+            )
+
+        def spawn(peripheral: "FakeAccelerometer", access: Any) -> None:
+            if not spawn_sources:
+                return
+            access.own(
+                peripheral.install_node(
+                    access.graph,
+                    output_route=resolved_vector_output_route,
+                    error_route=vector_error_route or accelerometer_error_route(),
+                )
+            )
+
+        return DetectionNode(
+            name="heart-fake-accelerometer-detection",
+            detector=cls.detect,
+            output_route=resolved_output_route,
+            mapper=mapper,
+            on_detect=on_detect,
+            spawn=spawn,
+            error_route=accelerometer_error_route(),
+            group="accelerometer-detection",
+            start_immediately=start_immediately,
+        )
+
     def peripheral_info(self) -> PeripheralInfo:
         return PeripheralInfo(
             id="fake_accelerometer",
@@ -373,13 +420,57 @@ class FakeAccelerometer(Peripheral[Acceleration | None]):
     def _event_stream(
         self
     ) -> reactive.Observable[Acceleration | None]:
-        def random_accel(_: int) -> Acceleration:
-            return Acceleration(
-                x=random.random(),
-                y=random.random(),
-                z=9.8,
-            )
         return pipe_in_background(
             interval_in_background(period=timedelta(milliseconds=500)),
-            ops.map(random_accel)
+            ops.map(lambda _: self._sample())
+        )
+
+    def install_node(
+        self,
+        graph: Graph,
+        *,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        error_route: TypedRoute[BaseException] | None = None,
+        retry: RetryPolicy | None = None,
+        backoff: BackoffPolicy | None = None,
+        sample_interval_seconds: float = 0.5,
+        start_immediately: bool = True,
+    ) -> ManagedGraphNodeHandle:
+        """Install this fake accelerometer as a Manyfold-managed graph source."""
+
+        resolved_output_route = output_route or accelerometer_vector_event_route()
+
+        def _body(stop: StopToken, graph: Graph) -> None:
+            while not stop.is_set():
+                graph.publish(
+                    resolved_output_route,
+                    self._sample_to_sensor_event(self._sample()),
+                )
+                if sample_interval_seconds <= 0:
+                    stop.set()
+                    continue
+                stop.wait(sample_interval_seconds)
+
+        return ManagedGraphNode(
+            name="heart-fake-accelerometer-vectors",
+            body=_body,
+            output_routes=(resolved_output_route,),
+            error_route=error_route or accelerometer_error_route(),
+            retry=retry or RetryPolicy(max_attempts=1_000_000),
+            backoff=backoff or BackoffPolicy.fixed(0.5),
+            group="accelerometer",
+            start_immediately=start_immediately,
+        ).install(graph)
+
+    def _sample(self) -> Acceleration:
+        return Acceleration(
+            x=random.random(),
+            y=random.random(),
+            z=9.8,
+        )
+
+    def _sample_to_sensor_event(self, sample: Acceleration) -> SensorEvent:
+        vector = AccelerometerVector(x=sample.x, y=sample.y, z=sample.z)
+        return vector.to_input().to_sensor_event(
+            identity=self.peripheral_info().to_sensor_identity()
         )

--- a/tests/peripheral/test_accelerometer.py
+++ b/tests/peripheral/test_accelerometer.py
@@ -5,7 +5,7 @@ from collections.abc import Iterator
 from manyfold import Graph
 from manyfold.sensor_io import BackoffPolicy, RetryPolicy
 
-from heart.peripheral.sensor import (Accelerometer,
+from heart.peripheral.sensor import (Accelerometer, FakeAccelerometer,
                                      accelerometer_detection_route,
                                      accelerometer_error_route,
                                      accelerometer_vector_event_route,
@@ -178,3 +178,48 @@ class TestAccelerometerManyfoldNode:
         latest = graph.latest(accelerometer_error_route())
         assert latest is not None
         assert isinstance(latest.value, RuntimeError)
+
+
+class TestFakeAccelerometerManyfoldNode:
+    """Cover graph-native fake accelerometer discovery and vector streaming."""
+
+    def test_detection_node_publishes_fake_accelerometer_to_manyfold_route(
+        self,
+    ) -> None:
+        graph = Graph()
+        registered: list[FakeAccelerometer] = []
+
+        handle = FakeAccelerometer.detection_node(
+            start_immediately=False,
+            on_detect=lambda peripheral, _access: registered.append(peripheral),
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest = graph.latest(accelerometer_detection_route())
+        assert len(registered) == 1
+        assert latest is not None
+        assert latest.value.event_type == "peripheral.accelerometer.detected"
+        assert latest.value.data == {"mode": "fake"}
+        assert latest.value.identity.id == "fake_accelerometer"
+
+    def test_install_node_publishes_fake_vectors_to_manyfold_route(self) -> None:
+        peripheral = FakeAccelerometer()
+        graph = Graph()
+
+        handle = peripheral.install_node(
+            graph,
+            start_immediately=False,
+            retry=RetryPolicy(max_attempts=1),
+            backoff=BackoffPolicy.none(),
+            sample_interval_seconds=0,
+        )
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest = graph.latest(accelerometer_vector_event_route())
+        assert latest is not None
+        assert latest.value.event_type == "peripheral.accelerometer.vector"
+        assert 0.0 <= latest.value.data["x"] <= 1.0
+        assert 0.0 <= latest.value.data["y"] <= 1.0
+        assert latest.value.data["z"] == 9.8
+        assert latest.value.identity.id == "fake_accelerometer"

--- a/tests/peripheral/test_peripheral_configurations.py
+++ b/tests/peripheral/test_peripheral_configurations.py
@@ -7,23 +7,14 @@ from manyfold import Graph
 from pytest import MonkeyPatch
 
 from heart.peripheral.compass import Compass, compass_detection_route
-from heart.peripheral.configurations import (_accelerometer_detection_node,
-                                             _compass_detection_node,
-                                             _detect_drawing_pads,
-                                             _detect_gamepads,
-                                             _detect_heart_rate_sensor,
-                                             _detect_phone_text,
-                                             _detect_radios, _detect_switches,
-                                             _detect_uwb_position,
-                                             _drawing_pad_detection_node,
-                                             _gamepad_detection_node,
-                                             _heart_rate_detection_node,
-                                             _manyfold_graph_nodes,
-                                             _microphone_detection_node,
-                                             _phone_text_detection_node,
-                                             _radio_detection_node,
-                                             _switch_detection_node,
-                                             _uwb_detection_node)
+from heart.peripheral.configurations import (
+    _accelerometer_detection_node, _compass_detection_node,
+    _detect_drawing_pads, _detect_gamepads, _detect_heart_rate_sensor,
+    _detect_phone_text, _detect_radios, _detect_switches, _detect_uwb_position,
+    _drawing_pad_detection_node, _fake_accelerometer_detection_node,
+    _gamepad_detection_node, _heart_rate_detection_node, _manyfold_graph_nodes,
+    _microphone_detection_node, _phone_text_detection_node,
+    _radio_detection_node, _switch_detection_node, _uwb_detection_node)
 from heart.peripheral.configurations.default import configure
 from heart.peripheral.configurations.pranay_pi import \
     configure as configure_pranay_pi
@@ -44,7 +35,7 @@ from heart.peripheral.radio import (RadioDriver, RadioPeripheral,
                                     RawRadioPacket, SerialRadioDriver,
                                     radio_detection_route,
                                     radio_packet_event_route)
-from heart.peripheral.sensor import (Accelerometer,
+from heart.peripheral.sensor import (Accelerometer, FakeAccelerometer,
                                      accelerometer_detection_route,
                                      accelerometer_vector_event_route,
                                      magnetometer_vector_event_route)
@@ -279,7 +270,7 @@ class TestManyfoldAccelerometerConfiguration:
 
         assert _compass_detection_node in nodes
 
-    def test_manyfold_graph_nodes_keep_fake_accelerometer_direct_off_pi(
+    def test_manyfold_graph_nodes_include_fake_accelerometer_off_pi(
         self,
         monkeypatch,
     ) -> None:
@@ -295,6 +286,83 @@ class TestManyfoldAccelerometerConfiguration:
         nodes = _manyfold_graph_nodes()
 
         assert _accelerometer_detection_node not in nodes
+        assert _fake_accelerometer_detection_node in nodes
+
+    def test_fake_accelerometer_detection_node_spawns_vector_source(
+        self,
+        monkeypatch,
+    ) -> None:
+        original_install_node = FakeAccelerometer.install_node
+
+        def _install_node(
+            self: FakeAccelerometer,
+            graph: Graph,
+            **kwargs: Any,
+        ) -> Any:
+            return original_install_node(
+                self,
+                graph,
+                **kwargs,
+                sample_interval_seconds=0,
+            )
+
+        monkeypatch.setattr(FakeAccelerometer, "install_node", _install_node)
+        graph = Graph()
+        registered: list[FakeAccelerometer] = []
+
+        handle = _fake_accelerometer_detection_node(
+            start_immediately=False,
+            on_detect=lambda peripheral, _access: registered.append(peripheral),
+        ).install(graph)
+
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+        assert len(registered) == 1
+        assert len(handle.spawned_handles) == 1
+
+        spawned = handle.spawned_handles[0]
+        spawned.loop_handle.loop.run(spawned.loop_handle.token)
+
+        latest_detection = graph.latest(accelerometer_detection_route())
+        latest_vector = graph.latest(accelerometer_vector_event_route())
+        assert latest_detection is not None
+        assert latest_detection.value.identity.id == "fake_accelerometer"
+        assert latest_vector is not None
+        assert latest_vector.value.event_type == "peripheral.accelerometer.vector"
+        assert latest_vector.value.identity.id == "fake_accelerometer"
+
+    def test_default_configuration_moves_fake_accelerometer_to_graph_node(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_pi",
+            lambda: False,
+        )
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_x11_forward",
+            lambda: False,
+        )
+
+        configuration = configure()
+
+        assert _fake_accelerometer_detection_node in configuration.graph_nodes
+
+    def test_rubiks_configuration_moves_fake_accelerometer_to_graph_node(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_pi",
+            lambda: False,
+        )
+        monkeypatch.setattr(
+            "heart.peripheral.configurations.Configuration.is_x11_forward",
+            lambda: False,
+        )
+
+        configuration = configure_rubiks_connected_x()
+
+        assert _fake_accelerometer_detection_node in configuration.graph_nodes
 
 
 class TestManyfoldGamepadConfiguration:


### PR DESCRIPTION
## Summary
- add Manyfold detection and managed vector source nodes for FakeAccelerometer
- move default off-Pi fake accelerometer discovery from direct detector wiring into graph nodes
- preserve Rubik's visualizer local fake accelerometer behavior through the graph path

## Validation
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools make format
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run ruff check src/heart/peripheral/sensor.py src/heart/peripheral/configurations tests/peripheral/test_accelerometer.py tests/peripheral/test_peripheral_configurations.py
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run mypy --config-file pyproject.toml src/heart/peripheral/sensor.py src/heart/peripheral/configurations
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run pytest tests/peripheral/test_accelerometer.py tests/peripheral/test_peripheral_configurations.py
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run pytest tests/peripheral