### PR TITLE
Move fake switch fallback into Manyfold graph

### DIFF
--- a/src/heart/peripheral/configurations/__init__.py
+++ b/src/heart/peripheral/configurations/__init__.py
@@ -65,11 +65,7 @@ def _switch_detection_node(
 
 
 def _switch_graph_nodes() -> tuple[GraphNodeFactory, ...]:
-    if Configuration.use_mock_switch():
-        return ()
-    if Configuration.is_pi() and not Configuration.is_x11_forward():
-        return (_switch_detection_node,)
-    return ()
+    return (_switch_detection_node,)
 
 
 def _detect_phone_text() -> Iterator[Peripheral[Any]]:

--- a/src/heart/peripheral/configurations/default.py
+++ b/src/heart/peripheral/configurations/default.py
@@ -2,19 +2,13 @@
 
 from __future__ import annotations
 
-from heart.peripheral.configuration import (DetectorFactory,
-                                            PeripheralConfiguration)
-from heart.peripheral.configurations import (_detect_switches,
-                                             _manyfold_graph_nodes,
-                                             _switch_graph_nodes)
+from heart.peripheral.configuration import PeripheralConfiguration
+from heart.peripheral.configurations import _manyfold_graph_nodes
 
 
 def configure() -> PeripheralConfiguration:
     """Return the default detection plan for ``manager``."""
 
-    detectors: list[DetectorFactory] = []
-    if not _switch_graph_nodes():
-        detectors.insert(0, _detect_switches)
     return PeripheralConfiguration(
-        detectors=tuple(detectors), graph_nodes=_manyfold_graph_nodes()
+        detectors=(), graph_nodes=_manyfold_graph_nodes()
     )

--- a/src/heart/peripheral/configurations/pranay_pi.py
+++ b/src/heart/peripheral/configurations/pranay_pi.py
@@ -3,13 +3,10 @@
 from __future__ import annotations
 
 from heart.peripheral.configuration import PeripheralConfiguration
-from heart.peripheral.configurations import (_detect_switches,
-                                             _switch_graph_nodes)
+from heart.peripheral.configurations import _switch_graph_nodes
 
 
 def configure() -> PeripheralConfiguration:
     """Return the minimal peripheral plan needed to boot the Pranay scene."""
 
-    graph_nodes = _switch_graph_nodes()
-    detectors = () if graph_nodes else (_detect_switches,)
-    return PeripheralConfiguration(detectors=detectors, graph_nodes=graph_nodes)
+    return PeripheralConfiguration(detectors=(), graph_nodes=_switch_graph_nodes())

--- a/src/heart/peripheral/configurations/rubiks_connected_x.py
+++ b/src/heart/peripheral/configurations/rubiks_connected_x.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-from heart.peripheral.configuration import (DetectorFactory,
-                                            PeripheralConfiguration)
-from heart.peripheral.configurations import (_detect_switches,
-                                             _fake_accelerometer_graph_nodes,
+from heart.peripheral.configuration import PeripheralConfiguration
+from heart.peripheral.configurations import (_fake_accelerometer_graph_nodes,
                                              _rubiks_connected_x_graph_nodes,
                                              _switch_graph_nodes)
 
@@ -13,16 +11,12 @@ from heart.peripheral.configurations import (_detect_switches,
 def configure() -> PeripheralConfiguration:
     """Return a minimal detection plan for Rubik's Connected X visualizer runs."""
 
-    detectors: list[DetectorFactory] = []
-    switch_graph_nodes = _switch_graph_nodes()
     graph_nodes = (
-        *switch_graph_nodes,
+        *_switch_graph_nodes(),
         *_fake_accelerometer_graph_nodes(),
         *_rubiks_connected_x_graph_nodes(),
     )
-    if not switch_graph_nodes:
-        detectors.insert(0, _detect_switches)
     return PeripheralConfiguration(
-        detectors=tuple(detectors),
+        detectors=(),
         graph_nodes=graph_nodes,
     )

--- a/src/heart/peripheral/switch.py
+++ b/src/heart/peripheral/switch.py
@@ -292,6 +292,47 @@ class FakeSwitch(BaseSwitch):
         else:
             logger.warning("Not running FakeSwitch")
 
+    def install_node(
+        self,
+        graph: Graph,
+        *,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        error_route: TypedRoute[BaseException] | None = None,
+        retry: RetryPolicy | None = None,
+        backoff: BackoffPolicy | None = None,
+        poll_interval_seconds: float = 0.01,
+        start_immediately: bool = True,
+    ) -> ManagedGraphNodeHandle:
+        """Install this fake switch as a Manyfold-managed graph state source."""
+
+        resolved_output_route = output_route or switch_state_event_route()
+
+        def _body(stop: StopToken, graph: Graph) -> None:
+            previous_state: SwitchState | None = None
+            while not stop.is_set():
+                state = self._snapshot()
+                if state != previous_state:
+                    graph.publish(
+                        resolved_output_route,
+                        self._state_to_sensor_event(state),
+                    )
+                    previous_state = state
+                if poll_interval_seconds <= 0:
+                    stop.set()
+                    continue
+                stop.wait(poll_interval_seconds)
+
+        return ManagedGraphNode(
+            name="heart-fake-switch-state",
+            body=_body,
+            output_routes=(resolved_output_route,),
+            error_route=error_route or switch_error_route(),
+            retry=retry or RetryPolicy(max_attempts=1_000_000),
+            backoff=backoff or BackoffPolicy.fixed(0.5),
+            group="switch",
+            start_immediately=start_immediately,
+        ).install(graph)
+
     def _handle_alternate_activate(self, _: Any) -> None:
         self.button_long_press_value += 1
         self.rotation_value_at_last_long_button_press = self.rotational_value

--- a/tests/peripheral/test_peripheral_configurations.py
+++ b/tests/peripheral/test_peripheral_configurations.py
@@ -463,7 +463,7 @@ class TestManyfoldDrawingPadConfiguration:
 
 
 class TestManyfoldSwitchConfiguration:
-    """Cover default graph-node factories so physical switch streams stay Manyfold-owned."""
+    """Cover default graph-node factories so switch streams stay Manyfold-owned."""
 
     def test_manyfold_graph_nodes_include_physical_switch_on_pi(
         self,
@@ -508,7 +508,7 @@ class TestManyfoldSwitchConfiguration:
         assert _switch_detection_node in configuration.graph_nodes
         assert _detect_switches not in configuration.detectors
 
-    def test_default_configuration_keeps_switch_direct_for_local_fake(
+    def test_default_configuration_moves_local_fake_switch_to_graph_node(
         self,
         monkeypatch,
     ) -> None:
@@ -527,8 +527,8 @@ class TestManyfoldSwitchConfiguration:
 
         configuration = configure()
 
-        assert _switch_detection_node not in configuration.graph_nodes
-        assert configuration.detectors[0] is _detect_switches
+        assert _switch_detection_node in configuration.graph_nodes
+        assert _detect_switches not in configuration.detectors
 
     def test_rubiks_configuration_moves_physical_switch_to_graph_node(
         self,
@@ -552,7 +552,7 @@ class TestManyfoldSwitchConfiguration:
         assert _switch_detection_node in configuration.graph_nodes
         assert _detect_switches not in configuration.detectors
 
-    def test_rubiks_configuration_keeps_switch_direct_for_local_fake(
+    def test_rubiks_configuration_moves_local_fake_switch_to_graph_node(
         self,
         monkeypatch,
     ) -> None:
@@ -571,8 +571,8 @@ class TestManyfoldSwitchConfiguration:
 
         configuration = configure_rubiks_connected_x()
 
-        assert _switch_detection_node not in configuration.graph_nodes
-        assert configuration.detectors[0] is _detect_switches
+        assert _switch_detection_node in configuration.graph_nodes
+        assert _detect_switches not in configuration.detectors
 
     def test_pranay_configuration_moves_physical_switch_to_graph_node(
         self,
@@ -596,7 +596,7 @@ class TestManyfoldSwitchConfiguration:
         assert _switch_detection_node in configuration.graph_nodes
         assert _detect_switches not in configuration.detectors
 
-    def test_pranay_configuration_keeps_switch_direct_for_local_fake(
+    def test_pranay_configuration_moves_local_fake_switch_to_graph_node(
         self,
         monkeypatch,
     ) -> None:
@@ -615,8 +615,8 @@ class TestManyfoldSwitchConfiguration:
 
         configuration = configure_pranay_pi()
 
-        assert _switch_detection_node not in configuration.graph_nodes
-        assert configuration.detectors[0] is _detect_switches
+        assert _switch_detection_node in configuration.graph_nodes
+        assert _detect_switches not in configuration.detectors
 
 
 class TestManyfoldMicrophoneConfiguration:

--- a/tests/peripheral/test_switch.py
+++ b/tests/peripheral/test_switch.py
@@ -8,7 +8,8 @@ from collections.abc import Iterator
 import pytest
 from manyfold import Graph
 
-from heart.peripheral.switch import (Switch, switch_detection_route,
+from heart.peripheral.switch import (FakeSwitch, Switch,
+                                     switch_detection_route,
                                      switch_state_event_route)
 from heart.utilities.reactive import Disposable
 from heart.utilities.reactive_threads import \
@@ -137,3 +138,23 @@ class TestSwitchManyfoldRuntime:
         assert latest_state.value.event_type == "peripheral.switch.state"
         assert latest_state.value.data["rotational_value"] == 3
         assert latest_state.value.data["button_value"] == 1
+
+    def test_fake_switch_install_node_publishes_state_snapshot(self) -> None:
+        switch = FakeSwitch()
+        switch._handle_browse(2)
+        switch._handle_activate(object())
+        graph = Graph()
+
+        handle = switch.install_node(
+            graph,
+            poll_interval_seconds=0,
+            start_immediately=False,
+        )
+        handle.loop_handle.loop.run(handle.loop_handle.token)
+
+        latest_state = graph.latest(switch_state_event_route())
+        assert latest_state is not None
+        assert latest_state.value.event_type == "peripheral.switch.state"
+        assert latest_state.value.data["rotational_value"] == 2
+        assert latest_state.value.data["button_value"] == 1
+        assert latest_state.value.identity.id == "fake_switch"


### PR DESCRIPTION
## Summary
- add a Manyfold-managed state source for FakeSwitch so local/mock switch state can publish through the same switch route as physical switches
- make switch detection graph-owned for default, Rubik's Connected X, and Pranay Pi configurations instead of falling back to direct detector registration
- update configuration and switch runtime coverage for graph-owned local fake switches

## Validation
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run ruff check src/heart/peripheral/switch.py src/heart/peripheral/configurations tests/peripheral/test_switch.py tests/peripheral/test_peripheral_configurations.py
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run pytest tests/peripheral/test_switch.py tests/peripheral/test_peripheral_configurations.py
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools make format
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run mypy --config-file pyproject.toml src/heart/peripheral/switch.py src/heart/peripheral/configurations
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run pytest tests/peripheral