### PR TITLE
Add Manyfold display frame route

### DIFF
--- a/src/heart/peripheral/led_matrix.py
+++ b/src/heart/peripheral/led_matrix.py
@@ -7,16 +7,62 @@ import threading
 from datetime import datetime
 from typing import Any, Mapping
 
+from manyfold import (Graph, Layer, ManagedGraphNode, ManagedGraphNodeHandle,
+                      OwnerName, Plane, Schema, StreamFamily, StreamName,
+                      TypedRoute, Variant, route)
+from manyfold.sensor_io import (BackoffPolicy, RetryPolicy, SensorEvent,
+                                StopToken, sensor_event_schema)
 from PIL import Image
 
 import heart.utilities.reactive as reactive
-from heart.peripheral.core import Peripheral
+from heart.peripheral.core import Peripheral, PeripheralInfo, PeripheralTag
 from heart.peripheral.input_payloads.display import DisplayFrame
 from heart.utilities.logging import get_logger
 from heart.utilities.logging_control import get_logging_controller
 from heart.utilities.reactive import Subject
 
 _LOGGER = get_logger(__name__)
+DISPLAY_GRAPH_OWNER = OwnerName("heart.display")
+DISPLAY_GRAPH_FAMILY = StreamFamily("peripheral")
+
+
+def display_frame_event_route() -> TypedRoute[SensorEvent]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=DISPLAY_GRAPH_OWNER,
+        family=DISPLAY_GRAPH_FAMILY,
+        stream=StreamName("frames"),
+        variant=Variant.Meta,
+        schema=sensor_event_schema("HeartDisplayFrameEvent"),
+    )
+
+
+def display_exception_schema() -> Schema[BaseException]:
+    def encode(exc: BaseException) -> bytes:
+        return f"{type(exc).__name__}:{exc}".encode("utf-8")
+
+    def decode(payload: bytes) -> BaseException:
+        return RuntimeError(payload.decode("utf-8"))
+
+    return Schema(
+        schema_id="PythonException",
+        version=1,
+        encode=encode,
+        decode=decode,
+    )
+
+
+def display_error_route() -> TypedRoute[BaseException]:
+    return route(
+        plane=Plane.Read,
+        layer=Layer.Logical,
+        owner=DISPLAY_GRAPH_OWNER,
+        family=DISPLAY_GRAPH_FAMILY,
+        stream=StreamName("errors"),
+        variant=Variant.Meta,
+        schema=display_exception_schema(),
+    )
 
 
 class LEDMatrixDisplay(Peripheral[DisplayFrame]):
@@ -40,6 +86,7 @@ class LEDMatrixDisplay(Peripheral[DisplayFrame]):
         self._sequence = 0
         self._stop = threading.Event()
         self._frame_subject: Subject[DisplayFrame] = Subject()
+        self._frame_publishers: list[tuple[Graph, TypedRoute[SensorEvent]]] = []
         self._log_controller = get_logging_controller()
         self._frame_count = 0
 
@@ -62,6 +109,58 @@ class LEDMatrixDisplay(Peripheral[DisplayFrame]):
 
     def _event_stream(self) -> reactive.Observable[DisplayFrame]:
         return self._frame_subject
+
+    def peripheral_info(self) -> PeripheralInfo:
+        return PeripheralInfo(
+            id=f"led_matrix_{self._width}x{self._height}",
+            tags=(
+                PeripheralTag(
+                    name="input_variant",
+                    variant="display",
+                    metadata={
+                        "width": str(self._width),
+                        "height": str(self._height),
+                    },
+                ),
+            ),
+        )
+
+    def install_node(
+        self,
+        graph: Graph,
+        *,
+        output_route: TypedRoute[SensorEvent] | None = None,
+        error_route: TypedRoute[BaseException] | None = None,
+        retry: RetryPolicy | None = None,
+        backoff: BackoffPolicy | None = None,
+        start_immediately: bool = True,
+    ) -> ManagedGraphNodeHandle:
+        """Install this virtual display as a Manyfold-managed frame source."""
+
+        resolved_output_route = output_route or display_frame_event_route()
+
+        def _body(stop: StopToken, graph: Graph) -> None:
+            publisher = (graph, resolved_output_route)
+            self._frame_publishers.append(publisher)
+            try:
+                while not stop.wait(1.0):
+                    pass
+            finally:
+                try:
+                    self._frame_publishers.remove(publisher)
+                except ValueError:
+                    pass
+
+        return ManagedGraphNode(
+            name="heart-display-frames",
+            body=_body,
+            output_routes=(resolved_output_route,),
+            error_route=error_route or display_error_route(),
+            retry=retry or RetryPolicy(max_attempts=1_000_000),
+            backoff=backoff or BackoffPolicy.fixed(1.0),
+            group="display",
+            start_immediately=start_immediately,
+        ).install(graph)
 
     def publish_image(
         self,
@@ -88,6 +187,14 @@ class LEDMatrixDisplay(Peripheral[DisplayFrame]):
 
         self._frame_count += 1
         self._frame_subject.on_next(frame)
+        for graph, output_route in tuple(self._frame_publishers):
+            graph.publish(
+                output_route,
+                frame.to_input(timestamp=timestamp).to_sensor_event(
+                    identity=self.peripheral_info().to_sensor_identity(),
+                    sequence_number=frame.frame_id,
+                ),
+            )
         self._log_controller.log(
             key="peripheral.display.frame",
             logger=_LOGGER,

--- a/tests/peripheral/test_led_matrix_display.py
+++ b/tests/peripheral/test_led_matrix_display.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import time
+
 import numpy as np
+from manyfold import Graph
 from PIL import Image
 
-from heart.peripheral.led_matrix import LEDMatrixDisplay
+from heart.peripheral.led_matrix import (LEDMatrixDisplay,
+                                         display_frame_event_route)
 from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
@@ -41,3 +45,34 @@ class TestPeripheralLedMatrixDisplay:
         subscription.dispose()
 
         assert received == [frame]
+
+    def test_install_node_publishes_frames_to_manyfold_route(self) -> None:
+        """Verify that rendered matrix frames are available as graph events."""
+        peripheral = LEDMatrixDisplay(width=2, height=2)
+        image = _solid_image(2, 2, value=9)
+        graph = Graph()
+
+        handle = peripheral.install_node(graph)
+        try:
+            deadline = time.monotonic() + 1.0
+            latest = None
+            frame = None
+            while time.monotonic() < deadline:
+                frame = peripheral.publish_image(image)
+                latest = graph.latest(display_frame_event_route())
+                if latest is not None:
+                    break
+                time.sleep(0.01)
+        finally:
+            handle.dispose()
+
+        assert frame is not None
+        assert latest is not None
+        assert latest.value.event_type == "peripheral.display.frame"
+        assert latest.value.sequence_number == frame.frame_id
+        assert latest.value.identity.id == "led_matrix_2x2"
+        assert latest.value.data["frame_id"] == frame.frame_id
+        assert latest.value.data["width"] == frame.width
+        assert latest.value.data["height"] == frame.height
+        assert latest.value.data["mode"] == frame.mode
+        assert latest.value.data["data"] == frame.data


### PR DESCRIPTION
## Summary
- Add a Manyfold heart.display frame route and error route for LED matrix output
- Add LEDMatrixDisplay.install_node so rendered frames can publish as SensorEvents through a managed graph source
- Cover graph publication of display frames in the LED matrix peripheral tests

## Verification
- make format with writable UV_CACHE_DIR and UV_TOOL_DIR
- uv run pytest tests/peripheral
- uv run ruff check src/heart/peripheral/led_matrix.py tests/peripheral/test_led_matrix_display.py
- uv run mypy --config-file pyproject.toml src/heart/peripheral/led_matrix.py