### PR TITLE
Route frame ticks through Manyfold graph

### DIFF
--- a/src/heart/peripheral/core/input/frame.py
+++ b/src/heart/peripheral/core/input/frame.py
@@ -5,10 +5,11 @@ from dataclasses import dataclass
 from typing import cast
 
 import pygame
+from manyfold import Graph, TypedRoute
 
 import heart.utilities.reactive as reactive
 from heart.peripheral.core.input.debug import InputDebugStage, InputDebugTap
-from heart.utilities.reactive import Subject
+from heart.peripheral.core.streams import GraphRouteStream, runtime_route
 from heart.utilities.reactive_threads import pipe_in_background
 
 
@@ -21,11 +22,18 @@ class FrameTick:
     fps: float | None = None
 
 
+FRAME_TICK_ROUTE: TypedRoute[FrameTick] = runtime_route(
+    "frame.tick",
+    "HeartFrameTick",
+)
+
+
 class FrameTickController:
-    def __init__(self, debug_tap: InputDebugTap) -> None:
+    def __init__(self, debug_tap: InputDebugTap, graph: Graph | None = None) -> None:
         self._debug_tap = debug_tap
         self._frame_index = 0
-        self._subject: Subject[FrameTick] = Subject()
+        self._graph = graph or Graph()
+        self._stream = GraphRouteStream[FrameTick](self._graph, FRAME_TICK_ROUTE)
 
     def advance(self, clock: pygame.time.Clock) -> FrameTick:
         fps = float(clock.get_fps())
@@ -44,8 +52,8 @@ class FrameTickController:
             source_id="frame",
             payload=frame,
         )
-        self._subject.on_next(frame)
+        self._stream.on_next(frame)
         return frame
 
     def observable(self) -> reactive.Observable[FrameTick]:
-        return pipe_in_background(cast(reactive.Observable[FrameTick], self._subject))
+        return pipe_in_background(cast(reactive.Observable[FrameTick], self._stream))

--- a/src/heart/peripheral/core/manager.py
+++ b/src/heart/peripheral/core/manager.py
@@ -46,7 +46,10 @@ class PeripheralManager:
         )
         self._streams = PeripheralStreams(self._graph, self._iter_peripherals)
         self._debug_tap = InputDebugTap()
-        self._frame_tick_controller = FrameTickController(self._debug_tap)
+        self._frame_tick_controller = FrameTickController(
+            self._debug_tap,
+            graph=self._graph,
+        )
         self._keyboard_controller = KeyboardController(self._debug_tap)
         self._gamepad_controller = GamepadController(self, self._debug_tap)
         self._external_sensor_hub = ExternalSensorHub(self._debug_tap, graph=self._graph)

--- a/tests/peripheral/test_input_core.py
+++ b/tests/peripheral/test_input_core.py
@@ -26,6 +26,7 @@ from heart.peripheral.core.input import (AccelerometerController,
 from heart.peripheral.core.input.accelerometer import (
     ACCELERATION_ROUTE, DEBUG_ACCELERATION_ROUTE)
 from heart.peripheral.core.input.debug import instrument_input_stream
+from heart.peripheral.core.input.frame import FRAME_TICK_ROUTE
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.keyboard import (KeyboardEvent, KeyHeldEvent,
                                        KeyPressedEvent, KeyReleasedEvent,
@@ -132,7 +133,8 @@ class TestFrameTickController:
     ) -> None:
         """Verify frame ticks emit delta and monotonic timing once per advance so renderer providers can stop joining clock and tick streams."""
         tap = InputDebugTap()
-        controller = FrameTickController(tap)
+        graph = Graph()
+        controller = FrameTickController(tap, graph=graph)
         emitted: list[FrameTick] = []
         monkeypatch.setattr(
             "heart.peripheral.core.input.frame.time.monotonic",
@@ -150,6 +152,9 @@ class TestFrameTickController:
             fps=60.0,
         )
         assert emitted == [frame]
+        latest = graph.latest(FRAME_TICK_ROUTE)
+        assert latest is not None
+        assert latest.value == frame
         assert tap.snapshot()[-1].stage is InputDebugStage.FRAME
         assert tap.snapshot()[-1].stream_name == "frame.tick"
         assert tap.latency_snapshot()["frame.tick"].count == 1


### PR DESCRIPTION
## Summary
- replace the frame tick controller's private reactive Subject with a Manyfold-backed GraphRouteStream
- share the PeripheralManager graph with frame ticks so runtime frame timing is observable on a generic Manyfold route
- add coverage that frame advance publishes the latest tick to the graph route while preserving existing observable/debug behavior

## Validation
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run pytest tests/peripheral/test_input_core.py::TestFrameTickController tests/peripheral/test_input_core.py::TestAccelerometerDebugProfile -q
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run pytest tests/peripheral/test_input_core.py -q
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run pytest tests/peripheral/test_event_streams.py tests/runtime/test_peripheral_runtime.py -q
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run ruff check src/heart/peripheral/core/input/frame.py src/heart/peripheral/core/manager.py tests/peripheral/test_input_core.py
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run isort --check-only src/heart/peripheral/core/input/frame.py src/heart/peripheral/core/manager.py tests/peripheral/test_input_core.py
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools uv run mypy --config-file pyproject.toml src/heart/peripheral/core/input/frame.py src/heart/peripheral/core/manager.py
- UV_CACHE_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-cache UV_TOOL_DIR=/var/folders/tn/kwqxs_lx66z0xq7y589tjb940000gn/T/uv-tools make format