### PR TITLE
Fix Pi Beats runtime startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Provide an extensible runtime that drives an LED totem using pygame-based render
 The runtime packages two Typer CLIs: `totem` orchestrates configuration loading, render loops, and firmware updates, while `totem_debug` surfaces hardware diagnostics. Renderers run inside a pygame game loop, peripheral workers feed data through the `PeripheralManager`, and display services target either a local window or the LED matrix.
 
 ## Quick Start
+
 1. Create and activate a Python 3.11+ virtual environment.
 2. Install dependencies:
    ```bash
@@ -33,39 +34,43 @@ The runtime packages two Typer CLIs: `totem` orchestrates configuration loading,
    ```bash
    make run RUN_CONFIGURATION=your_configuration
    ```
-6. Review [docs/books/getting_started.md](docs/books/getting_started.md) for Raspberry Pi deployment, hardware wiring, and CLI options.
 
 ## Command-Line Interfaces
-| Command | Purpose |
-| --- | --- |
-| `totem` | Runs the runtime (`totem run`), updates firmware (`totem update-driver`), and manages renderer options. |
+
+| Command       | Purpose                                                                                                    |
+| ------------- | ---------------------------------------------------------------------------------------------------------- |
+| `totem`       | Runs the runtime (`totem run`), updates firmware (`totem update-driver`), and manages renderer options.    |
 | `totem_debug` | Provides hardware diagnostics, including Bluetooth scanning, UART inspection, and accelerometer streaming. |
 
 Key `totem run` flags:
+
 - `--configuration <name>` selects modules from `heart.programs.configurations`.
-- `--x11-forward` forces a pygame window even when the RGB matrix driver is active.
 - `--add-low-power-mode/--no-add-low-power-mode` toggles the standby mode that keeps LEDs dim when no scenes are active.
 - `totem run-beats --configuration <name>` launches the streamed totem runtime and the Beats Electron UI together, wiring `FORWARD_TO_BEATS_APP=1` and `VITE_BEATS_WEBSOCKET_URL=ws://localhost:8765` automatically.
 
 ## Architecture Summary
+
 - `heart/environment.py` defines the `GameLoop` responsible for frame pacing and peripheral coordination.
 - `heart.renderers` hosts animations, overlays, and HUDs that can be composed into playlists.
 - `heart.device` contains output adapters such as `LocalScreen` and `LEDMatrix`.
 - `heart.peripheral.core.manager.PeripheralManager` supervises switches, gamepads, heart-rate monitors, and other inputs.
 
 See the following references for deeper analysis:
+
 - [docs/library/runtime_systems.md](docs/library/runtime_systems.md) for loop orchestration details.
 - [docs/code_flow.md](docs/code_flow.md) for a diagram of launch and render paths.
 - [docs/library/tooling_and_configuration.md](docs/library/tooling_and_configuration.md) for playlist authoring guidance.
 - [docs/books/development_workflow.md](docs/books/development_workflow.md) for the devex snapshot workflow.
 
 ## Hardware Integration
+
 - `LEDMatrix` streams frames to the RGB matrix when `HEART_USE_ISOLATED_RENDERER=1`.
 - Bluetooth gamepads, switches, accelerometers, and heart-rate sensors publish data through the event bus managed by the peripheral subsystem.
 - `totem update-driver --name <driver>` flashes device firmware located in `drivers/`.
 - [docs/library/tooling_and_configuration.md](docs/library/tooling_and_configuration.md) documents debugging helpers for pairing controllers and inspecting UART traffic.
 
 ## Development Workflow
+
 - `make install` sets up the editable package and dev extras using `uv`.
 - `make run` starts `uv run totem run --configuration lib_2025`; override with `RUN_CONFIGURATION=<name>`.
 - `make format` applies Ruff, isort, Black, docformatter, and mdformat; run before committing.
@@ -75,6 +80,7 @@ See the following references for deeper analysis:
 - Keep collection and element variable names distinct (for example, `sensors` and `sensor`).
 
 The repository layout is summarised below:
+
 ```
 heart/
 ├── docs/                     # Architecture guides, dev logs, hardware notes
@@ -88,6 +94,7 @@ heart/
 ```
 
 ## Contributing
+
 1. Fork the repository and create a topic branch.
 2. Run `make format` and `make test` before pushing changes.
 3. Update documentation when introducing new renderers, configurations, or hardware capabilities. Re-render diagrams with `scripts/render_code_flow.py` when architecture changes.

--- a/drivers/totem/start-heart.sh
+++ b/drivers/totem/start-heart.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+REPO_DIR="${HEART_REPO_DIR:-/home/michael/Desktop/heart}"
 ADDRESS="${HEART_RUBIKS_CONNECTED_X_ADDRESS:-}"
 ATTEMPTS="${HEART_RUBIKS_CONNECTED_X_CONNECT_ATTEMPTS:-5}"
 SLEEP_SECONDS="${HEART_RUBIKS_CONNECTED_X_CONNECT_SLEEP_SECONDS:-2}"
@@ -16,4 +17,5 @@ if [[ -n "${ADDRESS}" ]] && command -v bluetoothctl >/dev/null 2>&1; then
   done
 fi
 
-exec /usr/bin/python3 /home/michael/Desktop/heart/src/heart/loop.py run --no-add-low-power-mode
+cd "${REPO_DIR}"
+exec make run

--- a/drivers/totem/totem.env.example
+++ b/drivers/totem/totem.env.example
@@ -1,3 +1,4 @@
-HEART_RUN_CONFIGURATION=lib_2025
-# Example temporary override while developing:
-# HEART_RUN_CONFIGURATION=rubiks_connected_x_visualizer
+HEART_REPO_DIR=/home/michael/Desktop/heart
+HEART_DEVICE_LAYOUT=rectangle
+HEART_LAYOUT_COLUMNS=1
+HEART_LAYOUT_ROWS=4

--- a/drivers/totem/totem.service
+++ b/drivers/totem/totem.service
@@ -6,28 +6,33 @@ After=multi-user.target
 Type=simple
 User=root
 Group=root
-WorkingDirectory=/home/michael/Desktop/heart
+WorkingDirectory=/
+Environment=HEART_REPO_DIR=/home/michael/Desktop/heart
+Environment=PATH=/root/.local/bin:/home/michael/.local/bin:/home/pi/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 Environment=DISPLAY=:1
-Environment=PYTHONPATH=/home/michael/Desktop/heart/src:/home/michael/Desktop/heart/packages/heart-firmware-io/src:/home/michael/Desktop/heart/packages/heart-device-manager/src
 Environment=MOCK_SWITCH=1
 Environment=PERIPHERAL_CONFIGURATION=default
+Environment=HEART_DEVICE_LAYOUT=rectangle
+Environment=HEART_LAYOUT_COLUMNS=1
+Environment=HEART_LAYOUT_ROWS=4
 Environment=PYTHONUNBUFFERED=1
 Environment=FORWARD_TO_BEATS_APP=0
-Environment=HEART_RUN_CONFIGURATION=lib_2025
 Environment=HEART_DISABLE_PHONE_TEXT=1
 Environment=HEART_RUBIKS_CONNECTED_X_AUTODETECT=1
 Environment=HEART_RUBIKS_CONNECTED_X_PREFERRED_NAME=RubiksX_CDCF6B
 EnvironmentFile=-/etc/default/totem
-ExecStartPre=-/usr/bin/pkill -f "/home/michael/Desktop/heart/src/heart/loop.py run"
+ExecStartPre=-/usr/bin/pkill -f "uv run totem run"
+ExecStartPre=-/usr/bin/pkill -f "totem run"
 ExecStartPre=-/usr/bin/pkill -f "src/heart/loop.py run"
 ExecStartPre=-/usr/bin/pkill -f "Xvfb.*:1"
 # Use the helper script to set up Xvfb
 ExecStartPre=/usr/local/bin/setup-xvfb.sh
-# Start the main app (no need for sudo as we're already running as root)
-ExecStart=/bin/bash /home/michael/Desktop/heart/drivers/totem/start-heart.sh
+# Start the main app through the same Makefile target used manually.
+ExecStart=/bin/bash /usr/local/bin/start-heart.sh
 # Kill Xvfb on shutdown
 ExecStop=-/usr/bin/pkill -f "Xvfb.*:1"
-ExecStopPost=-/usr/bin/pkill -f "/home/michael/Desktop/heart/src/heart/loop.py run"
+ExecStopPost=-/usr/bin/pkill -f "uv run totem run"
+ExecStopPost=-/usr/bin/pkill -f "totem run"
 ExecStopPost=-/usr/bin/pkill -f "src/heart/loop.py run"
 KillMode=control-group
 TimeoutStopSec=15s

--- a/src/heart/cli/commands/bench_device.py
+++ b/src/heart/cli/commands/bench_device.py
@@ -7,7 +7,7 @@ logger = get_logger(__name__)
 
 
 def bench_device_command() -> None:
-    device = select_device(x11_forward=False)
+    device = select_device()
 
     size = device.full_display_size()
     logger.info("Device full display size: %s", size)

--- a/src/heart/cli/commands/game_loop.py
+++ b/src/heart/cli/commands/game_loop.py
@@ -4,11 +4,11 @@ from heart.runtime.container.initialize import build_runtime_container
 from heart.runtime.game_loop import GameLoop
 
 
-def build_game_loop_container(*, x11_forward: bool) -> RuntimeContainer:
-    device = select_device(x11_forward=x11_forward)
+def build_game_loop_container() -> RuntimeContainer:
+    device = select_device()
     return build_runtime_container(device=device)
 
 
-def build_game_loop(*, x11_forward: bool) -> GameLoop:
-    resolver = build_game_loop_container(x11_forward=x11_forward)
+def build_game_loop() -> GameLoop:
+    resolver = build_game_loop_container()
     return resolver.resolve(GameLoop)

--- a/src/heart/cli/commands/run.py
+++ b/src/heart/cli/commands/run.py
@@ -1,38 +1,21 @@
-import os
 from pathlib import Path
 from typing import Annotated
 
 import typer
 
+import heart.cli.commands.run_beats as run_beats
 from heart.cli.commands.game_loop import build_game_loop_container
+from heart.cli.commands.run_options import (DEFAULT_ADD_LOW_POWER_MODE,
+                                            DEFAULT_BEATS_WORKSPACE,
+                                            DEFAULT_CONFIGURATION,
+                                            DEFAULT_INSTALL_BEATS_DEPS,
+                                            DEFAULT_WITH_BEATS,
+                                            resolve_configuration_name)
 from heart.programs.registry import ConfigurationRegistry
 from heart.runtime.game_loop import GameLoop
 from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
-
-DEFAULT_CONFIGURATION = "lib_2025"
-CONFIGURATION_OVERRIDE_ENV_VAR = "HEART_RUN_CONFIGURATION"
-DEFAULT_ADD_LOW_POWER_MODE = True
-DEFAULT_X11_FORWARD = False
-DEFAULT_WITH_BEATS = False
-DEFAULT_INSTALL_BEATS_DEPS = True
-DEFAULT_BEATS_WORKSPACE = Path("experimental/beats")
-
-
-def resolve_configuration_name(configuration: str) -> str:
-    """Return the requested configuration after applying any environment override."""
-
-    override = os.environ.get(CONFIGURATION_OVERRIDE_ENV_VAR, "").strip()
-    if not override:
-        return configuration
-    if override != configuration:
-        logger.info(
-            "Using configuration override from %s: %s",
-            CONFIGURATION_OVERRIDE_ENV_VAR,
-            override,
-        )
-    return override
 
 
 def run_command(
@@ -46,10 +29,6 @@ def run_command(
             help="Add a low power mode",
         ),
     ] = DEFAULT_ADD_LOW_POWER_MODE,
-    x11_forward: Annotated[
-        bool,
-        typer.Option("--x11-forward", help="Use X11 forwarding for RGB display"),
-    ] = DEFAULT_X11_FORWARD,
     with_beats: Annotated[
         bool,
         typer.Option("--with-beats", help="Launch the Beats UI alongside the runtime."),
@@ -68,18 +47,15 @@ def run_command(
     resolved_configuration = resolve_configuration_name(configuration)
 
     if with_beats:
-        from heart.cli.commands.run_beats import run_beats_command
-
-        run_beats_command(
+        run_beats.run_beats_command(
             configuration=resolved_configuration,
             add_low_power_mode=add_low_power_mode,
-            x11_forward=x11_forward,
             install_beats_deps=install_beats_deps,
             beats_workspace=beats_workspace,
         )
         return
 
-    resolver = build_game_loop_container(x11_forward=x11_forward)
+    resolver = build_game_loop_container()
     registry = resolver.resolve(ConfigurationRegistry)
     configuration_fn = registry.get(resolved_configuration)
     if configuration_fn is None:

--- a/src/heart/cli/commands/run_beats.py
+++ b/src/heart/cli/commands/run_beats.py
@@ -9,12 +9,12 @@ from typing import Annotated
 
 import typer
 
-from heart.cli.commands.run import (DEFAULT_ADD_LOW_POWER_MODE,
-                                    DEFAULT_BEATS_WORKSPACE,
-                                    DEFAULT_CONFIGURATION,
-                                    DEFAULT_INSTALL_BEATS_DEPS,
-                                    DEFAULT_X11_FORWARD,
-                                    resolve_configuration_name)
+from heart.cli.commands.run_options import (DEFAULT_ADD_LOW_POWER_MODE,
+                                            DEFAULT_BEATS_WORKSPACE,
+                                            DEFAULT_CONFIGURATION,
+                                            DEFAULT_INSTALL_BEATS_DEPS,
+                                            resolve_configuration_name)
+from heart.device.beats.websocket import WEBSOCKET_HOST, WEBSOCKET_PORT
 from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
@@ -32,13 +32,8 @@ def run_beats_command(
     ] = DEFAULT_CONFIGURATION,
     add_low_power_mode: bool = typer.Option(
         DEFAULT_ADD_LOW_POWER_MODE,
-        "--add-low-power-mode",
+        "--add-low-power-mode/--no-add-low-power-mode",
         help="Add a low power mode",
-    ),
-    x11_forward: bool = typer.Option(
-        DEFAULT_X11_FORWARD,
-        "--x11-forward",
-        help="Use X11 forwarding for RGB display",
     ),
     install_beats_deps: bool = typer.Option(
         DEFAULT_INSTALL_BEATS_DEPS,
@@ -67,7 +62,6 @@ def run_beats_command(
     runtime_command = build_totem_run_command(
         configuration=configuration,
         add_low_power_mode=add_low_power_mode,
-        x11_forward=x11_forward,
     )
     beats_command = build_beats_start_command()
     runtime_env = build_runtime_env(os.environ.copy())
@@ -159,8 +153,6 @@ def ensure_beats_dependencies(beats_workspace: Path) -> None:
 def build_beats_websocket_url() -> str:
     """Build the websocket URL expected by the Beats UI."""
 
-    from heart.device.beats.websocket import WEBSOCKET_HOST, WEBSOCKET_PORT
-
     return f"ws://{WEBSOCKET_HOST}:{WEBSOCKET_PORT}"
 
 
@@ -168,13 +160,10 @@ def build_totem_run_command(
     *,
     configuration: str,
     add_low_power_mode: bool,
-    x11_forward: bool,
 ) -> list[str]:
     """Build the runtime command that forwards frames into Beats."""
 
     command = ["uv", "run", "totem", "run", "--configuration", configuration]
-    if x11_forward:
-        command.append("--x11-forward")
     if not add_low_power_mode:
         command.append("--no-add-low-power-mode")
     return command

--- a/src/heart/cli/commands/run_options.py
+++ b/src/heart/cli/commands/run_options.py
@@ -1,0 +1,28 @@
+import os
+from pathlib import Path
+
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+DEFAULT_CONFIGURATION = "lib_2025"
+CONFIGURATION_OVERRIDE_ENV_VAR = "HEART_RUN_CONFIGURATION"
+DEFAULT_ADD_LOW_POWER_MODE = True
+DEFAULT_WITH_BEATS = False
+DEFAULT_INSTALL_BEATS_DEPS = True
+DEFAULT_BEATS_WORKSPACE = Path("experimental/beats")
+
+
+def resolve_configuration_name(configuration: str) -> str:
+    """Return the requested configuration after applying any environment override."""
+
+    override = os.environ.get(CONFIGURATION_OVERRIDE_ENV_VAR, "").strip()
+    if not override:
+        return configuration
+    if override != configuration:
+        logger.info(
+            "Using configuration override from %s: %s",
+            CONFIGURATION_OVERRIDE_ENV_VAR,
+            override,
+        )
+    return override

--- a/src/heart/device/beats/device.py
+++ b/src/heart/device/beats/device.py
@@ -1,6 +1,7 @@
 import io
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
+from typing import Protocol
 
 import pygame
 from PIL import Image
@@ -12,17 +13,20 @@ from heart.runtime.rendering.constants import RGBA_IMAGE_FORMAT
 STREAMED_SCREEN_SCALE_FACTOR = 4
 
 
+class FrameWebSocket(Protocol):
+    def send(self, kind: str, payload: bytes) -> None: ...
+
+
 @dataclass
 class StreamedScreen(Device):
+    websocket: FrameWebSocket | None = field(default=None, repr=False)
+
     def individual_display_size(self) -> tuple[int, int]:
         return (64, 64)
 
     @cached_property
     def scale_factor(self) -> int:
         return STREAMED_SCREEN_SCALE_FACTOR
-
-    def __post_init__(self) -> None:
-        self.websocket = WebSocket()
 
     def set_screen(self, screen: pygame.Surface) -> None:
         image_bytes = pygame.image.tostring(screen, RGBA_IMAGE_FORMAT)
@@ -50,7 +54,12 @@ class StreamedScreen(Device):
         image.save(buf, format="PNG")
         frame_bytes = buf.getvalue()
 
-        self.websocket.send(
+        self._websocket().send(
             kind="frame",
             payload=frame_bytes,
         )
+
+    def _websocket(self) -> FrameWebSocket:
+        if self.websocket is None:
+            self.websocket = WebSocket()
+        return self.websocket

--- a/src/heart/device/beats/websocket.py
+++ b/src/heart/device/beats/websocket.py
@@ -308,6 +308,8 @@ class BeatsWebSocketNode:
         broadcast_queue: asyncio.Queue[bytes] = asyncio.Queue(
             maxsize=self.websocket._streaming_settings.queue_max_size
         )
+        self.websocket._broadcast_loop = loop
+        self.websocket._broadcast_queue = broadcast_queue
 
         def enqueue_frame(frame: bytes) -> None:
             loop.call_soon_threadsafe(
@@ -358,6 +360,8 @@ class BeatsWebSocketNode:
             )
             raise
         finally:
+            self.websocket._broadcast_loop = None
+            self.websocket._broadcast_queue = None
             self.websocket._server = None
             subscription.dispose()
             broadcast_task.cancel()
@@ -408,6 +412,8 @@ class WebSocket:
     _latest_peripheral_frames: dict[str, bytes] = field(
         default_factory=dict, init=False
     )
+    _broadcast_loop: Any | None = field(default=None, init=False)
+    _broadcast_queue: asyncio.Queue[bytes] | None = field(default=None, init=False)
     _control_handler: Callable[[ControlMessage], None] | None = field(
         default=None, init=False
     )
@@ -470,7 +476,17 @@ class WebSocket:
         if frame_bytes is None:
             return
         self._cache_replay_frame(kind=kind, payload=payload, frame_bytes=frame_bytes)
+        if self._enqueue_live_frame(frame_bytes):
+            return
         self._graph.publish(self._frame_route, frame_bytes)
+
+    def _enqueue_live_frame(self, frame_bytes: bytes) -> bool:
+        loop = getattr(self, "_broadcast_loop", None)
+        queue = getattr(self, "_broadcast_queue", None)
+        if loop is None or queue is None:
+            return False
+        loop.call_soon_threadsafe(self._enqueue_frame, frame_bytes, queue)
+        return True
 
     def _cache_replay_frame(
         self, *, kind: str, payload: object, frame_bytes: bytes

--- a/src/heart/device/rgb_display/runtime.py
+++ b/src/heart/device/rgb_display/runtime.py
@@ -85,6 +85,6 @@ def _load_matrix_runtime_module() -> ModuleType:
     if native_module is None:
         raise RuntimeError(
             "The clean-room HUB75 runtime is unavailable. Install the optional "
-            "`heart-rgb-matrix-driver` package or sync the project with `uv sync --extra native`."
+            "`heart-rgb-matrix-driver` package with `make install` or `make pi_install`."
         )
     return cast(ModuleType, native_module)

--- a/src/heart/device/selection.py
+++ b/src/heart/device/selection.py
@@ -1,14 +1,18 @@
 import os
+from pathlib import Path
 
 from heart.device import Cube, Device, Orientation, Rectangle
+from heart.device.beats.device import StreamedScreen
 from heart.device.local import LocalScreen
+from heart.device.rgb_display.device import LEDMatrix
 from heart.utilities.env import Configuration, DeviceLayoutMode
 from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
+RP1_HUB75_DEVICE_PATH = Path("/dev/rp1-hub75")
 
 
-def select_device(*, x11_forward: bool) -> Device:
+def select_device() -> Device:
     orientation = _select_orientation()
     panel_width = Configuration.panel_columns()
     panel_height = Configuration.panel_rows()
@@ -17,10 +21,7 @@ def select_device(*, x11_forward: bool) -> Device:
     if streamed_device is not None:
         return streamed_device
 
-    isolated_device = _select_isolated_renderer_device(
-        orientation=orientation,
-        x11_forward=x11_forward,
-    )
+    isolated_device = _select_isolated_renderer_device(orientation=orientation)
     if isolated_device is not None:
         return isolated_device
 
@@ -48,7 +49,6 @@ def _select_orientation() -> Orientation:
 def _select_streamed_device(orientation: Orientation) -> Device | None:
     if not Configuration.forward_to_beats_app():
         return None
-    from heart.device.beats import StreamedScreen
 
     if orientation.get_type() is not Cube:
         logger.info(
@@ -58,14 +58,9 @@ def _select_streamed_device(orientation: Orientation) -> Device | None:
     return StreamedScreen(orientation=Cube.sides())
 
 
-def _select_isolated_renderer_device(
-    *, orientation: Orientation, x11_forward: bool
-) -> Device | None:
+def _select_isolated_renderer_device(*, orientation: Orientation) -> Device | None:
     if not Configuration.use_isolated_renderer():
         return None
-    if x11_forward:
-        logger.warning("USE_ISOLATED_RENDERER enabled; ignoring x11_forward flag")
-    from heart.device.rgb_display import LEDMatrix
 
     return LEDMatrix(orientation=orientation)
 
@@ -86,13 +81,53 @@ def _select_pi_device(
     if Configuration.is_x11_forward():
         # This makes it work on Pi when no screens are connected.
         # You need to setup X11 forwarding with XQuartz to do that.
-        logger.warning("X11_FORWARD set, running with `LocalScreen`")
-        return LocalScreen(
-            width=panel_width,
-            height=panel_height,
+        return _select_pi_local_screen(
             orientation=orientation,
+            panel_width=panel_width,
+            panel_height=panel_height,
+            reason="X11_FORWARD set",
         )
 
-    from heart.device.rgb_display import LEDMatrix
+    if pi_info is not None and pi_info.version >= 5 and not _rp1_hub75_device_exists():
+        return _select_pi_local_screen(
+            orientation=orientation,
+            panel_width=panel_width,
+            panel_height=panel_height,
+            reason=f"{RP1_HUB75_DEVICE_PATH} is not present",
+        )
 
-    return LEDMatrix(orientation=orientation)
+    try:
+        return LEDMatrix(orientation=orientation)
+    except RuntimeError as exc:
+        if _is_missing_native_matrix_runtime(exc):
+            return _select_pi_local_screen(
+                orientation=orientation,
+                panel_width=panel_width,
+                panel_height=panel_height,
+                reason=str(exc),
+            )
+        raise
+
+
+def _rp1_hub75_device_exists() -> bool:
+    return RP1_HUB75_DEVICE_PATH.exists()
+
+
+def _is_missing_native_matrix_runtime(error: RuntimeError) -> bool:
+    return "heart-rgb-matrix-driver" in str(error)
+
+
+def _select_pi_local_screen(
+    *,
+    orientation: Orientation,
+    panel_width: int,
+    panel_height: int,
+    reason: str,
+) -> LocalScreen:
+    os.environ["X11_FORWARD"] = "1"
+    logger.warning("%s; running with LocalScreen.", reason)
+    return LocalScreen(
+        width=panel_width,
+        height=panel_height,
+        orientation=orientation,
+    )

--- a/src/heart/loop.py
+++ b/src/heart/loop.py
@@ -1,44 +1,25 @@
 import os
-import sys
 
 os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "1"
 
 import typer
 
-
-def _build_flowtoy_only_app() -> typer.Typer:
-    app = typer.Typer()
-
-    from heart.cli.commands.flowtoy import app as flowtoy_app
-
-    app.add_typer(flowtoy_app, name="flowtoy")
-    return app
+from heart.cli.commands.bench_device import bench_device_command
+from heart.cli.commands.flowtoy import app as flowtoy_app
+from heart.cli.commands.rubiks_connected_x import app as rubiks_connected_x_app
+from heart.cli.commands.run import run_command
+from heart.cli.commands.run_beats import run_beats_command
+from heart.cli.commands.update_driver import update_driver_command
 
 
 def _build_full_app() -> typer.Typer:
     app = typer.Typer()
 
-    from heart.cli.commands.bench_device import bench_device_command
-    from heart.cli.commands.flowtoy import app as flowtoy_app
-    from heart.cli.commands.rubiks_connected_x import \
-        app as rubiks_connected_x_app
-    from heart.cli.commands.run import run_command
-    from heart.cli.commands.update_driver import update_driver_command
-
     app.command(name="run")(run_command)
+    app.command(name="run-beats")(run_beats_command)
     app.command(name="update-driver")(update_driver_command)
     app.command(name="bench-device")(bench_device_command)
     app.add_typer(flowtoy_app, name="flowtoy")
-    app.add_typer(rubiks_connected_x_app, name="rubiks-connected-x")
-    return app
-
-
-def _build_rubiks_connected_x_only_app() -> typer.Typer:
-    app = typer.Typer()
-
-    from heart.cli.commands.rubiks_connected_x import \
-        app as rubiks_connected_x_app
-
     app.add_typer(rubiks_connected_x_app, name="rubiks-connected-x")
     return app
 
@@ -47,38 +28,6 @@ app = _build_full_app()
 
 
 def main() -> None:
-    if len(sys.argv) > 1 and sys.argv[1] == "flowtoy":
-        _build_flowtoy_only_app()()
-        return
-
-    if len(sys.argv) > 1 and sys.argv[1] == "rubiks-connected-x":
-        _build_rubiks_connected_x_only_app()()
-        return
-
-    if len(sys.argv) > 1 and sys.argv[1] == "update-driver":
-        app = typer.Typer()
-        from heart.cli.commands.update_driver import update_driver_command
-
-        app.command(name="update-driver")(update_driver_command)
-        app()
-        return
-
-    if len(sys.argv) > 1 and sys.argv[1] == "bench-device":
-        app = typer.Typer()
-        from heart.cli.commands.bench_device import bench_device_command
-
-        app.command(name="bench-device")(bench_device_command)
-        app()
-        return
-
-    if len(sys.argv) > 1 and sys.argv[1] == "run":
-        app = typer.Typer()
-        from heart.cli.commands.run import run_command
-
-        app.command(name="run")(run_command)
-        app()
-        return
-
     app()
 
 

--- a/src/heart/navigation/game_modes.py
+++ b/src/heart/navigation/game_modes.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 import pygame
 
+from heart import DeviceDisplayMode
 from heart.device import Orientation
 from heart.display.color import Color
 from heart.peripheral.core.manager import PeripheralManager
@@ -21,6 +22,7 @@ from heart.renderers.slide_transition import SlideTransitionMode
 from heart.renderers.spritesheet import SpritesheetLoop
 from heart.renderers.text import TextRendering
 from heart.runtime.display_context import DisplayContext
+from heart.utilities.env import Configuration
 from heart.utilities.logging import get_logger
 
 if TYPE_CHECKING:
@@ -292,15 +294,28 @@ class GameModes(StatefulBaseRenderer[GameModeState]):
 
         # Renderers may have different display modes, so we need to initialize them all.
         for completed, renderer in enumerate(initialization_renderers, start=1):
+            display_ready = False
             try:
                 with window.display_mode(renderer.device_display_mode):
+                    display_ready = True
                     renderer.initialize(window, peripheral_manager, orientation)
-            except Exception:
-                logger.exception(
-                    "Failed to initialize renderer %s",
-                    renderer.name,
-                )
-                raise
+            except Exception as exc:
+                if (
+                    not display_ready
+                    and renderer.device_display_mode == DeviceDisplayMode.OPENGL
+                    and not Configuration.render_crash_on_error()
+                ):
+                    logger.warning(
+                        "Skipping renderer %s; OpenGL display mode failed during initialization: %s",
+                        renderer.name,
+                        exc,
+                    )
+                else:
+                    logger.exception(
+                        "Failed to initialize renderer %s",
+                        renderer.name,
+                    )
+                    raise
             self._render_initialization_progress(
                 window,
                 completed=completed,

--- a/src/heart/peripheral/core/__init__.py
+++ b/src/heart/peripheral/core/__init__.py
@@ -10,8 +10,8 @@ from typing import (Any, Generic, Iterator, Mapping, Self, Sequence, TypeAlias,
                     TypeVar, cast)
 
 from manyfold import (EmptyNode, Graph, Layer, OwnerName, Plane, Schema,
-                      StreamFamily, StreamName, StreamNode, TypedRoute,
-                      Variant, route)
+                      StreamFamily, StreamName, StreamNode, TypedEnvelope,
+                      TypedRoute, Variant, route)
 from manyfold.sensor_io import (SensorEvent, SensorIdentity, SensorLocation,
                                 SensorTag)
 
@@ -182,9 +182,10 @@ class Peripheral(Generic[A]):
         map_subscription: Any | None = None
         source_subscription: Any | None = None
 
-        def wrap(a: A) -> PeripheralMessageEnvelope[A]:
+        def wrap(a: A | TypedEnvelope[A]) -> PeripheralMessageEnvelope[A]:
+            data = a.value if isinstance(a, TypedEnvelope) else a
             return PeripheralMessageEnvelope[A](
-                data=a, peripheral_info=self.peripheral_info()
+                data=data, peripheral_info=self.peripheral_info()
             )
 
         def subscribe(observer: Any, scheduler: Any = None) -> Any:

--- a/src/heart/peripheral/core/input/accelerometer.py
+++ b/src/heart/peripheral/core/input/accelerometer.py
@@ -6,14 +6,14 @@ from functools import cached_property
 from typing import TYPE_CHECKING, cast
 
 import pygame
-from manyfold import (CombineLatestNode, EmptyNode, Graph, MergeNode,
-                      StreamNode, TypedRoute)
+from manyfold import EmptyNode, Graph, MergeNode, StreamNode, TypedRoute
 
 from heart.peripheral.core import PeripheralMessageEnvelope
 from heart.peripheral.core.input.debug import (InputDebugNode, InputDebugStage,
                                                InputDebugTap)
 from heart.peripheral.core.input.external_sensors import ExternalSensorHub
-from heart.peripheral.core.streams import GraphRouteStream, runtime_route
+from heart.peripheral.core.streams import (GraphRouteStream, combine_latest,
+                                           runtime_route)
 from heart.peripheral.core.subscriptions import CompositeSubscription
 from heart.peripheral.sensor import (Acceleration, Accelerometer,
                                      FakeAccelerometer)
@@ -125,7 +125,7 @@ class AccelerometerDebugProfile:
         self._keyboard_controller.key_pressed(pygame.K_SPACE).subscribe(
             on_next=lambda _event: self._arm_space_impulse()
         )
-        key_states = CombineLatestNode().observable(
+        key_states = combine_latest(
             self._keyboard_controller.key_state(pygame.K_a),
             self._keyboard_controller.key_state(pygame.K_d),
             self._keyboard_controller.key_state(pygame.K_w),

--- a/src/heart/peripheral/core/input/gamepad.py
+++ b/src/heart/peripheral/core/input/gamepad.py
@@ -8,10 +8,11 @@ from functools import cache, cached_property
 from typing import TYPE_CHECKING
 
 import pygame
-from manyfold import CombineLatestNode, StreamNode, Timer
+from manyfold import StreamNode, Timer
 
 from heart.peripheral.core.input.debug import (InputDebugNode, InputDebugStage,
                                                InputDebugTap)
+from heart.peripheral.core.streams import combine_latest
 from heart.peripheral.gamepad import Gamepad, GamepadIdentifier
 from heart.peripheral.gamepad.peripheral_mappings import (BitDoLite2,
                                                           BitDoLite2Bluetooth,
@@ -179,9 +180,9 @@ class GamepadController:
         axis_x = GamepadAxis.LEFT_X if stick_name == "left" else GamepadAxis.RIGHT_X
         axis_y = GamepadAxis.LEFT_Y if stick_name == "left" else GamepadAxis.RIGHT_Y
         stream = (
-            CombineLatestNode()
-            .observable(
-                self.axis_value(axis_x, dead_zone), self.axis_value(axis_y, dead_zone)
+            combine_latest(
+                self.axis_value(axis_x, dead_zone),
+                self.axis_value(axis_y, dead_zone),
             )
             .map(lambda latest: GamepadStickValue(x=latest[0], y=latest[1]))
             .distinct_until_changed()

--- a/src/heart/peripheral/core/input/profiles/mandelbrot.py
+++ b/src/heart/peripheral/core/input/profiles/mandelbrot.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from functools import cached_property
 
 import pygame
-from manyfold import CombineLatestNode, MergeNode, StreamNode
+from manyfold import MergeNode, StreamNode
 
 from heart.peripheral.core.input.debug import (InputDebugNode, InputDebugStage,
                                                InputDebugTap)
@@ -13,6 +13,7 @@ from heart.peripheral.core.input.gamepad import (
     GamepadController)
 from heart.peripheral.core.input.keyboard import KeyboardController
 from heart.peripheral.core.input.streams import map_stream
+from heart.peripheral.core.streams import combine_latest
 
 MANDELBROT_RIGHT_STICK_DEAD_ZONE = 0.35
 
@@ -141,7 +142,7 @@ class MandelbrotControlProfile:
 
     @cached_property
     def motion_state(self) -> StreamNode[MandelbrotMotionState]:
-        keyboard_state = CombineLatestNode().observable(
+        keyboard_state = combine_latest(
             self._keyboard.key_state(pygame.K_w),
             self._keyboard.key_state(pygame.K_s),
             self._keyboard.key_state(pygame.K_a),
@@ -151,7 +152,7 @@ class MandelbrotControlProfile:
             self._keyboard.key_state(pygame.K_j),
             self._keyboard.key_state(pygame.K_k),
         )
-        gamepad_state = CombineLatestNode().observable(
+        gamepad_state = combine_latest(
             self._gamepad.button_held(GamepadButton.EAST),
             self._gamepad.button_held(GamepadButton.HOME),
             self._gamepad.button_held(GamepadButton.PLUS),
@@ -163,8 +164,7 @@ class MandelbrotControlProfile:
             self._gamepad.stick_value("right", MANDELBROT_RIGHT_STICK_DEAD_ZONE),
         )
         stream = (
-            CombineLatestNode()
-            .observable(keyboard_state, gamepad_state)
+            combine_latest(keyboard_state, gamepad_state)
             .map(lambda latest: self._to_motion_state(*latest))
             .distinct_until_changed()
 
@@ -201,8 +201,7 @@ class MandelbrotControlProfile:
     @cached_property
     def _observable(self) -> StreamNode[MandelbrotControlState]:
         stream = (
-            CombineLatestNode()
-            .observable(self.motion_state, self._edge_state)
+            combine_latest(self.motion_state, self._edge_state)
             .map(lambda latest: self._to_compatibility_state(*latest))
             .distinct_until_changed()
 
@@ -295,9 +294,9 @@ class MandelbrotControlProfile:
         command: MandelbrotCommand,
     ) -> StreamNode[MandelbrotCommand]:
         return (
-            CombineLatestNode()
-            .observable(
-                self._gamepad.button_held(modifier), self._gamepad.button_held(primary)
+            combine_latest(
+                self._gamepad.button_held(modifier),
+                self._gamepad.button_held(primary),
             )
             .map(lambda latest: bool(latest[0]) and bool(latest[1]))
             .distinct_until_changed()

--- a/src/heart/peripheral/core/streams.py
+++ b/src/heart/peripheral/core/streams.py
@@ -5,12 +5,13 @@ from threading import Lock
 from typing import Any, Callable, Generic, Iterable, TypeVar, cast
 
 from manyfold import (EmptyNode, Graph, Layer, MergeNode, OwnerName, Plane,
-                      Schema, StreamFamily, StreamName, StreamNode, TypedRoute,
-                      Variant, route)
+                      Schema, StreamFamily, StreamName, StreamNode,
+                      TypedEnvelope, TypedRoute, Variant, route)
 from manyfold.graph import RoutePipeline
 
 from heart.peripheral.core import Peripheral, PeripheralMessageEnvelope
-from heart.peripheral.core.subscriptions import CallbackObservable
+from heart.peripheral.core.subscriptions import (CallbackObservable,
+                                                 CompositeSubscription)
 from heart.peripheral.switch import BaseSwitch, FakeSwitch, SwitchState
 
 PeripheralSource = Callable[[], Iterable[Peripheral[Any]]]
@@ -19,9 +20,17 @@ RUNTIME_FAMILY = StreamFamily("runtime")
 T = TypeVar("T")
 
 
+def unwrap_stream_value(value: Any) -> Any:
+    return value.value if isinstance(value, TypedEnvelope) else value
+
+
+def _unwrap_stream_value(value: Any) -> Any:
+    return unwrap_stream_value(value)
+
+
 def _subscribe_source(source: Any, observer: Any) -> Any:
     def emit(value: Any) -> None:
-        observer.on_next(value.value if hasattr(value, "closed") else value)
+        observer.on_next(_unwrap_stream_value(value))
 
     return source.subscribe(emit, observer.on_error, observer.on_completed)
 
@@ -32,6 +41,41 @@ def _stream_from_source(source: Any) -> "_DerivedStream":
 
 def _materialize_stream(source: Any) -> StreamNode[Any]:
     return cast(StreamNode[Any], _MaterializedStream(source))
+
+
+def combine_latest(*sources: Any) -> StreamNode[tuple[Any, ...]]:
+    """Combine source streams without depending on reactivex source internals."""
+
+    def subscribe(observer: Any) -> Any:
+        source_count = len(sources)
+        values = [None] * source_count
+        has_value = [False] * source_count
+        is_done = [False] * source_count
+        lock = Lock()
+
+        def subscribe_source(index: int, source: Any) -> Any:
+            def on_next(value: Any) -> None:
+                with lock:
+                    values[index] = _unwrap_stream_value(value)
+                    has_value[index] = True
+                    if all(has_value):
+                        observer.on_next(tuple(values))
+
+            def on_completed() -> None:
+                with lock:
+                    is_done[index] = True
+                    if all(is_done):
+                        observer.on_completed()
+
+            return source.subscribe(on_next, observer.on_error, on_completed)
+
+        return CompositeSubscription(
+            subscribe_source(index, source) for index, source in enumerate(sources)
+        )
+
+    return cast(
+        StreamNode[tuple[Any, ...]], _materialize_stream(_DerivedStream(subscribe))
+    )
 
 
 class EventStream(Generic[T]):
@@ -417,13 +461,8 @@ def _route_pipeline_do_action(
     on_next: Callable[[Any], None] | None = None,
     *_args: Any,
     **_kwargs: Any,
-) -> RoutePipeline[Any]:
-    def emit(value: Any) -> Any:
-        if on_next is not None:
-            on_next(value)
-        return value
-
-    return self.map(emit)
+) -> StreamNode[Any]:
+    return _stream_from_source(self).do_action(on_next)
 
 
 def _route_pipeline_start_with(
@@ -595,9 +634,8 @@ class PeripheralStreams:
         observables = [peripheral.observe for peripheral in main_switches]
         if not observables:
             return EmptyNode().observable()
-        merged = (
-            MergeNode.merge(*observables)
-            .map(PeripheralMessageEnvelope[SwitchState].unwrap_peripheral)
+        merged = MergeNode.merge(*observables).map(
+            PeripheralMessageEnvelope[SwitchState].unwrap_peripheral
         )
         return merged
 

--- a/src/heart/renderers/random_pixel/provider.py
+++ b/src/heart/renderers/random_pixel/provider.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import random
 from dataclasses import replace
+from typing import Any
 
+import numpy as np
 from manyfold import BehaviorSubject, MergeNode, StreamNode
 
 from heart.display.color import Color
@@ -23,13 +25,17 @@ class RandomPixelStateProvider(ObservableProvider[RandomPixelState]):
         initial_color: Color | None = None,
         randomness: RandomnessProvider,
         rng: random.Random | None = None,
+        update_interval_ms: float = 100.0,
     ) -> None:
         self._width = width
         self._height = height
         self._num_pixels = num_pixels
         self._peripheral_manager = peripheral_manager
         self._color = BehaviorSubject(initial_color)
-        self._rng = rng or randomness.rng()
+        self._rng = rng
+        self._numpy_rng = randomness.numpy_rng()
+        self._update_interval_ms = update_interval_ms
+        self._elapsed_ms = 0.0
 
     def observable(
         self, peripheral_manager: PeripheralManager | None = None
@@ -41,7 +47,7 @@ class RandomPixelStateProvider(ObservableProvider[RandomPixelState]):
         color_updates = self._color.map(lambda color: ("color", color))
         tick_updates = (
             self._peripheral_manager.frame_tick_controller.observable()
-            .map(lambda _: ("tick", None))
+            .map(lambda frame_tick: ("tick", frame_tick))
 
         )
         return (
@@ -55,16 +61,29 @@ class RandomPixelStateProvider(ObservableProvider[RandomPixelState]):
         self._color.on_next(color)
 
     def _advance_state(
-        self, state: RandomPixelState, event: tuple[str, Color | None]
+        self, state: RandomPixelState, event: tuple[str, Color | Any]
     ) -> RandomPixelState:
         kind, value = event
         if kind == "color":
             next_color = value or Color.random()
+            self._elapsed_ms = 0.0
             return replace(state, color=next_color)
+        self._elapsed_ms += max(float(getattr(value, "delta_ms", 0.0)), 0.0)
+        if self._elapsed_ms < self._update_interval_ms:
+            return state
+        self._elapsed_ms %= self._update_interval_ms
         next_color = self._color.value or Color.random()
         return RandomPixelState(color=next_color, pixels=self._random_pixels())
 
     def _random_pixels(self) -> tuple[tuple[int, int], ...]:
+        if self._rng is None:
+            pixels = self._numpy_rng.integers(
+                low=(0, 0),
+                high=(self._width, self._height),
+                size=(self._num_pixels, 2),
+                dtype=np.int16,
+            )
+            return tuple(map(tuple, pixels.tolist()))
         return tuple(
             (
                 (self._rng.randrange(self._width), self._rng.randrange(self._height))

--- a/src/heart/renderers/three_fractal/renderer.py
+++ b/src/heart/renderers/three_fractal/renderer.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 import numpy as np
 import pygame
 from manyfold import StreamNode, shutdown
+from OpenGL.error import GLError
 from OpenGL.GL import (GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT, GL_FALSE,
                        GL_FLOAT, GL_LINEAR, GL_MODELVIEW, GL_NEAREST,
                        GL_PROJECTION, GL_QUADS, GL_RENDERER, GL_RGBA,
@@ -24,6 +25,7 @@ from pygame.math import lerp
 
 from heart import DeviceDisplayMode
 from heart.device import Cube, Orientation, Rectangle
+from heart.device.local import LocalScreen
 from heart.display.shaders.shader import Shader
 from heart.display.shaders.util import _UNIFORMS, get_global, set_global_float
 from heart.peripheral.core.input import (GamepadAxis, GamepadButton,
@@ -43,6 +45,17 @@ DEFAULT_DEBUG_HEIGHT = 800
 DEFAULT_DEBUG_FPS = 60
 DEFAULT_DEBUG_LAYOUT = "rectangle"
 TRIGGER_ACTIVE_THRESHOLD = 0.5
+
+
+def _opengl_string(name: int, label: str) -> str:
+    try:
+        value = glGetString(name)
+    except GLError as exc:
+        logger.warning("Unable to read OpenGL %s: %s", label, exc)
+        return "unavailable"
+    if value is None:
+        return "unavailable"
+    return value.decode("utf-8", errors="replace")
 
 
 @dataclass
@@ -203,19 +216,19 @@ class FractalRuntime(StatefulBaseRenderer[FractalRuntimeState]):
         """Initialize the fractal renderer with the given window size."""
         logger.info(
             "OpenGL Version: %s",
-            glGetString(GL_VERSION).decode("utf-8", errors="replace"),
+            _opengl_string(GL_VERSION, "version"),
         )
         logger.info(
             "OpenGL Vendor: %s",
-            glGetString(GL_VENDOR).decode("utf-8", errors="replace"),
+            _opengl_string(GL_VENDOR, "vendor"),
         )
         logger.info(
             "OpenGL Renderer: %s",
-            glGetString(GL_RENDERER).decode("utf-8", errors="replace"),
+            _opengl_string(GL_RENDERER, "renderer"),
         )
         logger.info(
             "OpenGL Shading Language Version: %s",
-            glGetString(GL_SHADING_LANGUAGE_VERSION).decode("utf-8", errors="replace"),
+            _opengl_string(GL_SHADING_LANGUAGE_VERSION, "shading language version"),
         )
 
         self.time_initialized = time.monotonic()
@@ -944,7 +957,10 @@ class FractalRuntime(StatefulBaseRenderer[FractalRuntimeState]):
         return min(d, dsphere) * 10.0 < 0
 
     def reset(self):
-        pygame.mouse.set_visible(True)
+        try:
+            pygame.mouse.set_visible(True)
+        except pygame.error:
+            logger.debug("Skipping fractal mouse reset; pygame video is not initialized")
         self.initialized = False
         self._auto_started = False
         self.mode = "auto"
@@ -978,6 +994,7 @@ class FractalScene(StatefulBaseRenderer[FractalSceneState]):
         super().__init__(builder=self.provider)
         self.device_display_mode = DeviceDisplayMode.OPENGL
         self._peripheral_manager: PeripheralManager | None = None
+        self._runtime_failed = False
 
     def initialize(
         self,
@@ -1007,12 +1024,22 @@ class FractalScene(StatefulBaseRenderer[FractalSceneState]):
     ) -> None:
         assert self._peripheral_manager is not None
         runtime = self.state.runtime
+        if self._runtime_failed:
+            return
         if not runtime.is_initialized():
-            runtime.initialize(
-                window=window,
-                peripheral_manager=self._peripheral_manager,
-                orientation=orientation,
-            )
+            try:
+                runtime.initialize(
+                    window=window,
+                    peripheral_manager=self._peripheral_manager,
+                    orientation=orientation,
+                )
+            except Exception as exc:
+                self._runtime_failed = True
+                logger.warning(
+                    "Disabling FractalScene; OpenGL runtime failed to initialize: %s",
+                    exc,
+                )
+                return
         runtime.real_process(
             window,
             orientation,
@@ -1023,6 +1050,7 @@ class FractalScene(StatefulBaseRenderer[FractalSceneState]):
             self.state.runtime.reset()
         self._initial_state = None
         self._peripheral_manager = None
+        self._runtime_failed = False
         super().reset()
 
 
@@ -1064,7 +1092,6 @@ def main() -> None:
         if args.layout == "cube"
         else Rectangle.with_layout(columns=1, rows=1)
     )
-    from heart.device.local import LocalScreen
 
     device = LocalScreen(width=args.width, height=args.height, orientation=orientation)
     container = build_runtime_container(device=device)

--- a/src/heart/renderers/water_cube/provider.py
+++ b/src/heart/renderers/water_cube/provider.py
@@ -28,12 +28,14 @@ class WaterCubeStateProvider(ObservableProvider[WaterCubeState]):
         else:
             accel = self._accelerometer_controller.observable()
 
-        def update_state(prev: WaterCubeState, acceleration: Acceleration):
-            return prev._step(
-                heights=prev.heights,
-                velocities=prev.velocities,
-                acceleration=acceleration,
-            )
-
         initial = WaterCubeState.initial_state(self.device)
-        return accel.start_with(initial).scan(update_state)
+        return accel.scan(self._advance_state, seed=initial).start_with(initial)
+
+    def _advance_state(
+        self, prev: WaterCubeState, acceleration: Acceleration | None
+    ) -> WaterCubeState:
+        return prev._step(
+            heights=prev.heights,
+            velocities=prev.velocities,
+            acceleration=acceleration,
+        )

--- a/src/heart/runtime/peripheral_runtime.py
+++ b/src/heart/runtime/peripheral_runtime.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from queue import Empty, SimpleQueue
 from typing import Any
 
 from manyfold import drain_frame_thread_queue
 
+from heart.device.beats.websocket import WebSocket
 from heart.peripheral.core import (PeripheralInfo, PeripheralMessageEnvelope,
                                    PeripheralTag)
 from heart.peripheral.core.input import InputDebugEnvelope
@@ -25,6 +27,7 @@ class PeripheralRuntime:
 
     def __init__(self, peripheral_manager: PeripheralManager) -> None:
         self._peripheral_manager = peripheral_manager
+        self._control_messages: SimpleQueue[Any] = SimpleQueue()
 
     def detect_and_start(self) -> None:
         logger.info("Attempting to detect attached peripherals")
@@ -45,6 +48,10 @@ class PeripheralRuntime:
 
         ws = websocket or _build_websocket()
         ws.set_control_handler(self._handle_control_message)
+        if not Configuration.stream_beats_input_debug():
+            logger.debug("Beats input debug streaming disabled")
+            return
+
         self._peripheral_manager.debug_tap.observable().subscribe(
             on_next=lambda envelope: ws.send(
                 kind="peripheral",
@@ -53,6 +60,17 @@ class PeripheralRuntime:
         )
 
     def _handle_control_message(self, control_message: Any) -> None:
+        self._control_messages.put(control_message)
+
+    def _drain_control_messages(self) -> None:
+        while True:
+            try:
+                control_message = self._control_messages.get_nowait()
+            except Empty:
+                return
+            self._apply_control_message(control_message)
+
+    def _apply_control_message(self, control_message: Any) -> None:
         navigation = self._peripheral_manager.navigation_profile
         if control_message.command == CONTROL_COMMAND_BROWSE:
             navigation.inject_browse(
@@ -106,6 +124,7 @@ class PeripheralRuntime:
 
     def tick(self) -> None:
         drain_frame_thread_queue()
+        self._drain_control_messages()
         if self._peripheral_manager.clock.value is None:
             return
         self._peripheral_manager.frame_tick_controller.advance(
@@ -116,7 +135,5 @@ class PeripheralRuntime:
 
 def _build_websocket() -> Any:
     """Construct the Beats websocket only when streaming is enabled."""
-
-    from heart.device.beats import WebSocket
 
     return WebSocket()

--- a/src/heart/utilities/color_conversion.py
+++ b/src/heart/utilities/color_conversion.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import os
 from collections import OrderedDict
 from types import ModuleType
 from typing import cast
@@ -10,21 +11,21 @@ import numpy as np
 
 from heart.utilities.env import Configuration
 
+OPENCV_COLOR_CONVERSION_ENV_VAR = "HEART_USE_OPENCV_COLOR_CONVERSION"
+TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
+
 
 def _load_cv2_module() -> ModuleType | None:
-    module: ModuleType | None = None
-    loader = importlib.util.find_spec("cv2")
-    if loader is None or loader.loader is None:
+    if importlib.util.find_spec("cv2") is None:
         return None
-    module = importlib.util.module_from_spec(loader)
     try:
-        loader.loader.exec_module(module)
+        return cast(ModuleType, importlib.import_module("cv2"))
     except Exception:  # pragma: no cover - runtime dependency issues
         return None
-    return module
 
 
-CV2_MODULE = _load_cv2_module()
+CV2_MODULE: ModuleType | None = None
+CV2_LOAD_ATTEMPTED = False
 
 HUE_SCALE = (6.0 / 179.0) - 6e-05
 CACHE_MAX_SIZE = Configuration.hsv_cache_max_size()
@@ -33,6 +34,24 @@ HSV_CALIBRATION_MODE = Configuration.hsv_calibration_mode()
 HSV_CALIBRATION_ENABLED = HSV_CALIBRATION_MODE != "off"
 HSV_CALIBRATION_STRICT = HSV_CALIBRATION_MODE == "strict"
 HSV_TO_BGR_CACHE: OrderedDict[tuple[int, int, int], np.ndarray] = OrderedDict()
+
+
+def _opencv_color_conversion_enabled() -> bool:
+    value = os.environ.get(OPENCV_COLOR_CONVERSION_ENV_VAR, "")
+    return value.strip().lower() in TRUTHY_ENV_VALUES
+
+
+def _cv2_module() -> ModuleType | None:
+    global CV2_LOAD_ATTEMPTED, CV2_MODULE
+
+    if CV2_MODULE is not None:
+        return CV2_MODULE
+    if CV2_LOAD_ATTEMPTED or not _opencv_color_conversion_enabled():
+        return None
+
+    CV2_LOAD_ATTEMPTED = True
+    CV2_MODULE = _load_cv2_module()
+    return CV2_MODULE
 
 
 def _numpy_hsv_from_bgr(image: np.ndarray) -> np.ndarray:
@@ -123,8 +142,9 @@ def _numpy_bgr_from_hsv(image: np.ndarray) -> np.ndarray:
 
 
 def _convert_bgr_to_hsv(image: np.ndarray) -> np.ndarray:
-    if CV2_MODULE is not None:
-        return cast(np.ndarray, CV2_MODULE.cvtColor(image, CV2_MODULE.COLOR_BGR2HSV))
+    cv2_module = _cv2_module()
+    if cv2_module is not None:
+        return cast(np.ndarray, cv2_module.cvtColor(image, cv2_module.COLOR_BGR2HSV))
 
     hsv = _numpy_hsv_from_bgr(image)
 
@@ -189,8 +209,9 @@ def _convert_bgr_to_hsv(image: np.ndarray) -> np.ndarray:
 
 
 def _convert_hsv_to_bgr(image: np.ndarray) -> np.ndarray:
-    if CV2_MODULE is not None:
-        return cast(np.ndarray, CV2_MODULE.cvtColor(image, CV2_MODULE.COLOR_HSV2BGR))
+    cv2_module = _cv2_module()
+    if cv2_module is not None:
+        return cast(np.ndarray, cv2_module.cvtColor(image, cv2_module.COLOR_HSV2BGR))
 
     result = _numpy_bgr_from_hsv(image)
 

--- a/src/heart/utilities/env/system.py
+++ b/src/heart/utilities/env/system.py
@@ -58,5 +58,9 @@ class SystemConfiguration:
         return _env_flag("FORWARD_TO_BEATS_APP", default=False)
 
     @classmethod
+    def stream_beats_input_debug(cls) -> bool:
+        return _env_flag("BEATS_STREAM_INPUT_DEBUG", default=False)
+
+    @classmethod
     def peripheral_configuration(cls) -> str:
         return os.environ.get("PERIPHERAL_CONFIGURATION", "default")

--- a/sync.sh
+++ b/sync.sh
@@ -19,6 +19,9 @@ DEFAULT_IGNORE_PATTERNS=(
   ".ruff_cache/"
   ".mypy_cache/"
   "node_modules/"
+  "target/"
+  ".vite/"
+  "dist/"
 )
 
 print_usage() {
@@ -217,7 +220,10 @@ fi
 RSYNC_FLAGS=(-az --delete)
 declare -a RSYNC_PREFIX=()
 if [[ -n "$SSH_KEY_PATH" && -f "$SSH_KEY_PATH" ]]; then
-  RSYNC_FLAGS+=(-e "ssh -i $SSH_KEY_PATH -o IdentitiesOnly=yes")
+  RSYNC_FLAGS+=(
+    -e
+    "ssh -i $SSH_KEY_PATH -o IdentitiesOnly=yes -o ConnectTimeout=10 -o ServerAliveInterval=5 -o ServerAliveCountMax=3"
+  )
 elif [[ -n "$REMOTE_PASS" ]]; then
   if command_exists sshpass; then
     RSYNC_PREFIX=(sshpass -p "$REMOTE_PASS")

--- a/tests/cli/test_run_beats.py
+++ b/tests/cli/test_run_beats.py
@@ -18,6 +18,7 @@ from heart.cli.commands.run_beats import (BEATS_WEBSOCKET_ENV_VAR,
                                           build_totem_run_command,
                                           ensure_beats_dependencies,
                                           resolve_beats_workspace)
+from heart.cli.commands.run_options import CONFIGURATION_OVERRIDE_ENV_VAR
 
 runner = CliRunner()
 
@@ -31,7 +32,6 @@ class TestRunBeatsCommandBuilders:
         command = build_totem_run_command(
             configuration="lib_2025",
             add_low_power_mode=False,
-            x11_forward=True,
         )
 
         assert command == [
@@ -41,7 +41,6 @@ class TestRunBeatsCommandBuilders:
             "run",
             "--configuration",
             "lib_2025",
-            "--x11-forward",
             "--no-add-low-power-mode",
         ]
 
@@ -147,7 +146,6 @@ class TestRunCommandWithBeats:
             *,
             configuration: str,
             add_low_power_mode: bool,
-            x11_forward: bool,
             install_beats_deps: bool,
             beats_workspace: Path,
         ) -> None:
@@ -155,7 +153,6 @@ class TestRunCommandWithBeats:
                 {
                     "configuration": configuration,
                     "add_low_power_mode": add_low_power_mode,
-                    "x11_forward": x11_forward,
                     "install_beats_deps": install_beats_deps,
                     "beats_workspace": beats_workspace,
                 }
@@ -174,7 +171,6 @@ class TestRunCommandWithBeats:
                 "--configuration",
                 "lib_2025",
                 "--no-add-low-power-mode",
-                "--x11-forward",
                 "--no-install-beats-deps",
                 "--beats-workspace",
                 "/tmp/beats",
@@ -185,18 +181,70 @@ class TestRunCommandWithBeats:
         assert recorded_call == {
             "configuration": "lib_2025",
             "add_low_power_mode": False,
-            "x11_forward": True,
             "install_beats_deps": False,
             "beats_workspace": Path("/tmp/beats"),
         }
 
-    def test_cli_hides_run_beats_subcommand(self) -> None:
-        """Verify the top-level CLI no longer advertises a separate Beats command so opt-in flows consistently use `run --with-beats`."""
+    def test_cli_exposes_run_beats_subcommand(self) -> None:
+        """Verify the top-level CLI advertises the documented Beats quick-start command."""
 
         result = runner.invoke(loop.app, ["--help"])
 
         assert result.exit_code == 0
-        assert "run-beats" not in result.stdout
+        assert "run-beats" in result.stdout
+
+    def test_run_beats_subcommand_dispatches_to_launcher(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify `totem run-beats` uses the supervised runtime-plus-UI launcher."""
+
+        recorded_call: dict[str, object] = {}
+
+        def _fake_run_supervised_processes(**kwargs: object) -> int:
+            recorded_call.update(kwargs)
+            return 0
+
+        monkeypatch.setattr(
+            "heart.cli.commands.run_beats.ensure_beats_dependencies",
+            lambda beats_workspace: None,
+        )
+        monkeypatch.setattr(
+            "heart.cli.commands.run_beats.validate_beats_workspace",
+            lambda beats_workspace: None,
+        )
+        monkeypatch.setattr(
+            "heart.cli.commands.run_beats.beats_dependencies_installed",
+            lambda beats_workspace: True,
+        )
+        monkeypatch.setattr(
+            "heart.cli.commands.run_beats.run_supervised_processes",
+            _fake_run_supervised_processes,
+        )
+
+        result = runner.invoke(
+            loop.app,
+            [
+                "run-beats",
+                "--configuration",
+                "lib_2025",
+                "--no-add-low-power-mode",
+                "--no-install-beats-deps",
+                "--beats-workspace",
+                "/tmp/beats",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert recorded_call["runtime_command"] == [
+            "uv",
+            "run",
+            "totem",
+            "run",
+            "--configuration",
+            "lib_2025",
+            "--no-add-low-power-mode",
+        ]
+        assert recorded_call["beats_workspace"] == Path("/tmp/beats")
 
     def test_run_command_skips_beats_launcher_by_default(
         self, monkeypatch: pytest.MonkeyPatch
@@ -206,7 +254,7 @@ class TestRunCommandWithBeats:
         monkeypatch.setattr(
             run_module,
             "build_game_loop_container",
-            lambda *, x11_forward: _FakeResolver(),
+            lambda: _FakeResolver(),
         )
 
         def _unexpected_run_beats_command(**kwargs: object) -> None:
@@ -230,10 +278,10 @@ class TestRunCommandWithBeats:
         monkeypatch.setattr(
             run_module,
             "build_game_loop_container",
-            lambda *, x11_forward: resolver,
+            lambda: resolver,
         )
         monkeypatch.setenv(
-            run_module.CONFIGURATION_OVERRIDE_ENV_VAR,
+            CONFIGURATION_OVERRIDE_ENV_VAR,
             "rubiks_connected_x_visualizer",
         )
 
@@ -254,7 +302,7 @@ class TestRunCommandWithBeats:
             recorded_call.update(kwargs)
 
         monkeypatch.setenv(
-            run_module.CONFIGURATION_OVERRIDE_ENV_VAR,
+            CONFIGURATION_OVERRIDE_ENV_VAR,
             "rubiks_connected_x_visualizer",
         )
         monkeypatch.setattr(

--- a/tests/device/test_beats_websocket.py
+++ b/tests/device/test_beats_websocket.py
@@ -4,6 +4,9 @@ import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
+from manyfold import Graph
+from websockets.exceptions import ConnectionClosedError
+
 from heart.device.beats.proto import beats_streaming_pb2
 from heart.device.beats.websocket import (WebSocket,
                                           _encode_peripheral_message,
@@ -321,8 +324,6 @@ class TestWebSocketReplayCache:
 
     def test_send_publishes_encoded_frames_to_manyfold_route(self) -> None:
         """Verify outbound websocket frames cross the Manyfold route boundary before node delivery."""
-        from manyfold import Graph
-
         websocket = object.__new__(WebSocket)
         websocket._graph = Graph()
         websocket._frame_route = beats_websocket_frame_route()
@@ -340,14 +341,39 @@ class TestWebSocketReplayCache:
         decoded = decode_stream_envelope(seen[0])
         assert decoded == ("frame", b"frame-bytes")
 
+    def test_send_enqueues_live_frames_when_broadcast_loop_is_running(self) -> None:
+        """Verify connected clients receive live frames without waiting for reconnect replay."""
+        class _Loop:
+            def __init__(self) -> None:
+                self.calls = []
+
+            def call_soon_threadsafe(self, callback, *args) -> None:
+                self.calls.append((callback, args))
+
+        websocket = object.__new__(WebSocket)
+        websocket._graph = Graph()
+        websocket._frame_route = beats_websocket_frame_route()
+        websocket._replay_lock = threading.Lock()
+        websocket._latest_frame = None
+        websocket._latest_peripheral_frames = {}
+        websocket._broadcast_loop = _Loop()
+        websocket._broadcast_queue = object()
+
+        websocket.send("frame", b"frame-bytes")
+
+        assert len(websocket._broadcast_loop.calls) == 1
+        callback, args = websocket._broadcast_loop.calls[0]
+        assert callback == websocket._enqueue_frame
+        decoded = decode_stream_envelope(args[0])
+        assert decoded == ("frame", b"frame-bytes")
+        assert args[1] is websocket._broadcast_queue
+
 
 class TestWebSocketDisconnectHandling:
     """Validate disconnect handling so expected client drops do not surface as server errors."""
 
     def test_handler_ignores_disconnect_during_replay_send(self) -> None:
         """Verify replay send disconnects are treated as normal closure so reconnect churn does not log handler failures."""
-        from websockets.exceptions import ConnectionClosedError
-
         websocket = object.__new__(WebSocket)
         websocket.clients = set()
         websocket._replay_lock = threading.Lock()

--- a/tests/experimental/test_shared_memory.py
+++ b/tests/experimental/test_shared_memory.py
@@ -14,7 +14,7 @@ def _load_experimental_classes():
     if str(EXPERIMENTAL_SRC) not in sys.path:
         sys.path.insert(0, str(EXPERIMENTAL_SRC))
 
-    if not EXPERIMENTAL_SRC.exists():
+    if not (EXPERIMENTAL_SRC / "isolated_rendering" / "buffer.py").exists():
         pytest.skip(
             "experimental isolated_rendering sources are not available",
             allow_module_level=True,

--- a/tests/navigation/test_game_modes.py
+++ b/tests/navigation/test_game_modes.py
@@ -10,10 +10,12 @@ from heart.navigation.game_modes import ModeEntry
 
 
 class DummyRenderer:
-    def __init__(self, name: str) -> None:
+    def __init__(
+        self, name: str, device_display_mode: DeviceDisplayMode = DeviceDisplayMode.FULL
+    ) -> None:
         self.name = name
         self.reset_calls = 0
-        self.device_display_mode = DeviceDisplayMode.FULL
+        self.device_display_mode = device_display_mode
         self.initialize_calls = 0
 
     def get_renderers(self, peripheral_manager):
@@ -340,6 +342,57 @@ class TestNavigationGameModes:
         logger.exception.assert_called_once_with(
             "Failed to initialize renderer %s",
             broken_renderer.name,
+        )
+
+    def test_initialize_registered_renderers_skips_opengl_display_mode_failure(
+        self,
+    ) -> None:
+        """Verify optional OpenGL scenes cannot abort startup when the display cannot enter OpenGL mode."""
+        game_modes = GameModes()
+        opengl_renderer = DummyRenderer(
+            "opengl-scene",
+            device_display_mode=DeviceDisplayMode.OPENGL,
+        )
+        game_modes.set_state(
+            GameModeState(
+                entries=[
+                    ModeEntry(
+                        title_renderer=opengl_renderer,
+                        renderer=DummyRenderer("mode"),
+                    )
+                ],
+                post_processors=[],
+            )
+        )
+        window = _make_window()
+        display_error = RuntimeError("no opengl")
+
+        def display_mode(mode: DeviceDisplayMode):
+            if mode == DeviceDisplayMode.OPENGL:
+                raise display_error
+            return nullcontext(window)
+
+        window.display_mode.side_effect = display_mode
+        peripheral_manager = Mock()
+        orientation = Mock()
+
+        with (
+            patch.object(game_modes_module.Configuration, "render_crash_on_error")
+            as render_crash_on_error,
+            patch.object(game_modes_module, "logger") as logger,
+        ):
+            render_crash_on_error.return_value = False
+            game_modes._initialize_registered_renderers(
+                window=window,
+                peripheral_manager=peripheral_manager,
+                orientation=orientation,
+            )
+
+        assert opengl_renderer.initialize_calls == 0
+        logger.warning.assert_called_once_with(
+            "Skipping renderer %s; OpenGL display mode failed during initialization: %s",
+            opengl_renderer.name,
+            display_error,
         )
 
     def test_render_initialization_progress_logs_terminal_bar(self) -> None:

--- a/tests/peripheral/test_event_streams.py
+++ b/tests/peripheral/test_event_streams.py
@@ -10,7 +10,8 @@ from manyfold import Graph, StreamNode
 from heart.peripheral.core import (Input, Peripheral, PeripheralInfo,
                                    PeripheralLocation,
                                    PeripheralMessageEnvelope, PeripheralTag)
-from heart.peripheral.core.streams import GraphRouteStream, runtime_route
+from heart.peripheral.core.streams import (EventStream, GraphRouteStream,
+                                           combine_latest, runtime_route)
 from heart.peripheral.core.subscriptions import (CallbackObservable,
                                                  NoopSubscription)
 
@@ -27,6 +28,16 @@ class CountingPeripheral(Peripheral[int]):
             return NoopSubscription()
 
         return CallbackObservable(on_subscribe)
+
+
+class EmittingPeripheral(Peripheral[int]):
+    """Peripheral backed by a controllable event stream for envelope tests."""
+
+    def __init__(self) -> None:
+        self.events: EventStream[int] = EventStream()
+
+    def _event_stream(self) -> StreamNode[int]:
+        return self.events
 
 
 class TestPeripheralObserveSharing:
@@ -48,8 +59,40 @@ class TestPeripheralObserveSharing:
             subscription_a.dispose()
             subscription_b.dispose()
 
+    def test_observe_unwraps_graph_pipeline_envelopes(self) -> None:
+        """Ensure peripheral observers receive domain payloads instead of Manyfold route envelopes."""
+        peripheral = EmittingPeripheral()
+        observed: list[PeripheralMessageEnvelope[int]] = []
+
+        subscription = peripheral.observe.subscribe(observed.append)
+        try:
+            peripheral.events.emit(7)
+
+            assert observed
+            assert observed[-1].data == 7
+        finally:
+            subscription.dispose()
+
 
 class TestGraphRouteStreamTransforms:
+    def test_combine_latest_accepts_graph_route_stream_sources(self) -> None:
+        graph = Graph()
+        route_a = runtime_route("test_event_stream_combine_a", "HeartCombineA")
+        route_b = runtime_route("test_event_stream_combine_b", "HeartCombineB")
+        stream_a = GraphRouteStream[int](graph, route_a)
+        stream_b = GraphRouteStream[int](graph, route_b)
+        observed: list[tuple[int, int]] = []
+
+        subscription = combine_latest(stream_a, stream_b).subscribe(observed.append)
+        try:
+            stream_a.on_next(1)
+            stream_b.on_next(2)
+            stream_a.on_next(3)
+
+            assert observed == [(1, 2), (3, 2)]
+        finally:
+            subscription.dispose()
+
     def test_callback_pipeline_connects_graph_route_to_python_sink(self) -> None:
         graph = Graph()
         route = runtime_route(

--- a/tests/peripheral/test_input_core.py
+++ b/tests/peripheral/test_input_core.py
@@ -27,7 +27,7 @@ from heart.peripheral.core.input.accelerometer import (
     ACCELERATION_ROUTE, DEBUG_ACCELERATION_ROUTE)
 from heart.peripheral.core.input.debug import InputDebugNode
 from heart.peripheral.core.manager import PeripheralManager
-from heart.peripheral.core.streams import EventStream
+from heart.peripheral.core.streams import EventStream, runtime_route
 from heart.peripheral.keyboard import (KeyboardEvent, KeyHeldEvent,
                                        KeyPressedEvent, KeyReleasedEvent,
                                        KeyState)
@@ -169,6 +169,31 @@ class TestInputDebugTap:
         assert history[0].source_id == "navigation"
         assert history[0].upstream_ids == ("keyboard.pressed.down",)
         assert history[0].payload == 7
+
+    def test_route_pipeline_instrumentation_preserves_payloads(self) -> None:
+        """Verify instrumented Manyfold route streams still emit raw payloads so renderer subscribers never receive TypedEnvelope wrappers."""
+        tap = InputDebugTap()
+        graph = Graph()
+        route_ref = runtime_route("keyboard.snapshot.test", "KeyboardSnapshot")
+        source = graph.observe(route_ref, replay_latest=False)
+        snapshot = KeyboardSnapshot(
+            pressed_keys=frozenset({pygame.K_y}),
+            timestamp_ms=123.0,
+        )
+        observed: list[KeyboardSnapshot] = []
+
+        InputDebugNode(
+            tap=tap,
+            stage=InputDebugStage.RAW,
+            stream_name="keyboard.snapshot",
+            source_id="keyboard",
+        ).connect(source).subscribe(observed.append)
+        graph.publish(route_ref, snapshot)
+
+        history = tap.snapshot()
+
+        assert observed == [snapshot]
+        assert history[-1].payload == snapshot
 
 
 class TestFrameTickController:
@@ -382,9 +407,7 @@ class TestKeyboardController:
         snapshots.emit(
             KeyboardSnapshot(pressed_keys=frozenset({pygame.K_a}), timestamp_ms=20.0)
         )
-        snapshots.emit(
-            KeyboardSnapshot(pressed_keys=frozenset(), timestamp_ms=100.0)
-        )
+        snapshots.emit(KeyboardSnapshot(pressed_keys=frozenset(), timestamp_ms=100.0))
 
         assert [type(event) for event in events] == [
             KeyPressedEvent,
@@ -487,13 +510,9 @@ class TestNavigationProfile:
         keyboard_snapshots.emit(_keyboard_snapshot(timestamp_ms=0.0))
         keyboard_snapshots.emit(_keyboard_snapshot(pygame.K_LEFT, timestamp_ms=10.0))
         keyboard_snapshots.emit(_keyboard_snapshot(timestamp_ms=100.0))
-        keyboard_snapshots.emit(
-            _keyboard_snapshot(pygame.K_RIGHT, timestamp_ms=110.0)
-        )
+        keyboard_snapshots.emit(_keyboard_snapshot(pygame.K_RIGHT, timestamp_ms=110.0))
         keyboard_snapshots.emit(_keyboard_snapshot(timestamp_ms=200.0))
-        keyboard_snapshots.emit(
-            _keyboard_snapshot(pygame.K_DOWN, timestamp_ms=210.0)
-        )
+        keyboard_snapshots.emit(_keyboard_snapshot(pygame.K_DOWN, timestamp_ms=210.0))
         keyboard_snapshots.emit(_keyboard_snapshot(timestamp_ms=300.0))
         keyboard_snapshots.emit(_keyboard_snapshot(pygame.K_UP, timestamp_ms=310.0))
 

--- a/tests/renderers/test_three_fractal_renderer.py
+++ b/tests/renderers/test_three_fractal_renderer.py
@@ -13,10 +13,11 @@ from heart.renderers.three_fractal.state import FractalSceneState
 
 
 class _StubRuntime:
-    def __init__(self) -> None:
+    def __init__(self, *, fail_initialize: bool = False) -> None:
         self.reset_calls = 0
         self.initialize_calls = 0
         self._initialized = True
+        self.fail_initialize = fail_initialize
 
     def reset(self) -> None:
         self.reset_calls += 1
@@ -26,6 +27,8 @@ class _StubRuntime:
 
     def initialize(self, *args, **kwargs) -> None:
         self.initialize_calls += 1
+        if self.fail_initialize:
+            raise RuntimeError("OpenGL unavailable")
         self._initialized = True
 
     def real_process(self, *args, **kwargs) -> None:
@@ -205,3 +208,17 @@ class TestFractalScene:
         scene.real_process(window=Mock(), orientation=Mock())
 
         assert runtime.initialize_calls == 1
+
+    def test_real_process_disables_runtime_after_initialization_failure(self) -> None:
+        """Verify unsupported OpenGL contexts do not throw every frame after fractal entry fails."""
+        scene = FractalScene(provider=Mock())
+        runtime = _StubRuntime(fail_initialize=True)
+        runtime._initialized = False
+        scene.set_state(FractalSceneState(runtime=runtime))
+        scene._peripheral_manager = Mock()
+
+        scene.real_process(window=Mock(), orientation=Mock())
+        scene.real_process(window=Mock(), orientation=Mock())
+
+        assert runtime.initialize_calls == 1
+        assert scene._runtime_failed is True

--- a/tests/renderers/test_water_cube_provider.py
+++ b/tests/renderers/test_water_cube_provider.py
@@ -1,0 +1,40 @@
+"""Validate WaterCube provider startup and accelerometer updates."""
+
+from __future__ import annotations
+
+from heart.device import Cube
+from heart.device.local import LocalScreen
+from heart.peripheral.core.manager import PeripheralManager
+from heart.peripheral.sensor import Acceleration
+from heart.renderers.water_cube.provider import WaterCubeStateProvider
+
+
+class TestWaterCubeStateProvider:
+    """Ensure the default playlist's water renderer initializes from a valid state."""
+
+    def test_observable_emits_initial_state_before_accelerometer_updates(
+        self,
+        monkeypatch,
+    ) -> None:
+        """Verify startup emits a WaterCubeState instead of feeding the initial state through the reducer as acceleration."""
+        peripheral_manager = PeripheralManager()
+        accelerometer_controller = peripheral_manager.accelerometer_controller
+        accelerometer_debug_profile = peripheral_manager.accelerometer_debug_profile
+        monkeypatch.setattr(
+            accelerometer_debug_profile,
+            "should_use_debug_input",
+            lambda: False,
+        )
+        provider = WaterCubeStateProvider(
+            accelerometer_controller=accelerometer_controller,
+            accelerometer_debug_profile=accelerometer_debug_profile,
+            device=LocalScreen(width=64, height=64, orientation=Cube.sides()),
+        )
+        observed_states = []
+
+        provider.observable(peripheral_manager).subscribe(observed_states.append)
+        accelerometer_controller.node().on_next(Acceleration(x=1.0, y=2.0, z=3.0))
+
+        assert len(observed_states) == 2
+        assert observed_states[0].gvec is None
+        assert observed_states[1].gvec == Acceleration(x=1.0, y=2.0, z=3.0)

--- a/tests/runtime/test_peripheral_runtime.py
+++ b/tests/runtime/test_peripheral_runtime.py
@@ -81,11 +81,16 @@ class TestPeripheralRuntimeStreaming:
 
         runtime.configure_streaming()
 
-    def test_configure_streaming_emits_peripheral_envelopes(self) -> None:
+    def test_configure_streaming_emits_peripheral_envelopes(self, monkeypatch) -> None:
         """Verify debug tap events are wrapped as peripheral payloads so the Beats websocket can replay and decode them after reconnects."""
         manager = _PeripheralManagerStub()
         runtime = PeripheralRuntime(manager)  # type: ignore[arg-type]
         websocket = _WebSocketStub()
+
+        monkeypatch.setattr(
+            "heart.runtime.peripheral_runtime.Configuration.stream_beats_input_debug",
+            classmethod(lambda cls: True),
+        )
 
         runtime.configure_streaming(websocket=websocket)  # type: ignore[arg-type]
         manager.debug_tap.publish(
@@ -109,6 +114,23 @@ class TestPeripheralRuntimeStreaming:
         assert envelope.data["stream_name"] == "switch.tick"
         assert envelope.data["source_id"] == "switch-1"
 
+    def test_configure_streaming_leaves_input_debug_off_by_default(self) -> None:
+        """Keep Beats frame/control streaming lightweight unless debug telemetry is explicitly requested."""
+        manager = _PeripheralManagerStub()
+        runtime = PeripheralRuntime(manager)  # type: ignore[arg-type]
+        websocket = _WebSocketStub()
+
+        runtime.configure_streaming(websocket=websocket)  # type: ignore[arg-type]
+        manager.debug_tap.publish(
+            stage=InputDebugStage.RAW,
+            stream_name="switch.tick",
+            source_id="switch-1",
+            payload={"rotation": 1},
+        )
+
+        assert websocket.control_handler is not None
+        assert websocket.sent == []
+
     def test_configure_streaming_maps_control_commands_into_navigation_injections(
         self,
     ) -> None:
@@ -123,6 +145,9 @@ class TestPeripheralRuntimeStreaming:
         websocket.control_handler(ControlMessage(command="browse", browse_step=2))
         websocket.control_handler(ControlMessage(command="activate"))
         websocket.control_handler(ControlMessage(command="alternate_activate"))
+
+        assert manager.navigation_profile.injected == []
+        runtime._drain_control_messages()
 
         assert manager.navigation_profile.injected == [
             ("browse", 2, "beats.control.browse"),
@@ -155,6 +180,9 @@ class TestPeripheralRuntimeStreaming:
                 clear=True,
             )
         )
+
+        assert manager.external_sensor_hub.updates == []
+        runtime._drain_control_messages()
 
         assert manager.external_sensor_hub.updates == [
             ("set", "accelerometer:debug:z", 12.5),


### PR DESCRIPTION
## Summary
Make the code work the way it's described in the README. Fix a bunch of bugs

- make `totem run` / `make run` own the default runtime path without `--x11-forward` or `--extra native` requirements
- make Beats streaming and control input stable by lazily starting the websocket, directly enqueueing live frames, and applying control messages on the runtime thread
- keep Pi startup on `make run`, improve RGB/native fallback behavior, skip OpenGL-only renderer initialization when the display cannot enter OpenGL, and avoid syncing heavyweight build output

## Verification
- `uvx ruff check $(git diff HEAD~1 --name-only -- "*.py")`
- `uvx isort --check-only $(git diff HEAD~1 --name-only -- "*.py")`
- `uv run pytest tests/cli/test_run_beats.py`
- `make test` -> 495 passed, 2 skipped
- `make check` currently reaches semgrep and fails on existing unrelated findings in `src/heart/cli/commands/flowtoy_fast_path.py`, `src/heart/device/rgb_display/debug.py`, and `src/heart/renderers/pranay_sketch/provider.py`

## Deep Review Notes
- fixed a review finding where OpenGL display-mode failure could still abort startup before `FractalScene` could disable itself
- removed the branch-owned semgrep `__all__` finding in `run.py`
- confirmed `docs/books/getting_started.md` remains absent

## Pi Runtime Smoke
- verified the Pi can run the default playlist with Beats connected from the Mac using the Pi local Wayland display path, not SSH X11 forwarding
- X11 forwarding still exposes an old XQuartz OpenGL stack, so this PR makes that failure non-fatal rather than depending on it