### PR TITLE
Add tree vibe scene

### DIFF
--- a/src/heart/renderers/vibe/state.py
+++ b/src/heart/renderers/vibe/state.py
@@ -8,6 +8,7 @@ from heart.renderers.spritesheet import (BoundingBox, FrameDescription, Size,
 TUBE_SHEET_PATH = Path("vibe") / "tube_64x64_spritesheet.png"
 NO_LEGS_SHEET_PATH = Path("vibe") / "no_legs_128x128_spritesheet.png"
 SUNSLEEPER_SHEET_PATH = Path("vibe") / "sunsleeper_256x256_spritesheet.png"
+TREE_SHEET_PATH = Path("vibe") / "tree_384x384_spritesheet.png"
 TUBE_FRAME_SIZE = 64
 TUBE_FRAME_COUNT = 29
 TUBE_FRAME_DURATION_MS = 250
@@ -17,6 +18,9 @@ NO_LEGS_FRAME_DURATION_MS = 250
 SUNSLEEPER_FRAME_SIZE = 256
 SUNSLEEPER_FRAME_COUNT = 48
 SUNSLEEPER_FRAME_DURATION_MS = 274
+TREE_FRAME_SIZE = 384
+TREE_FRAME_COUNT = 19
+TREE_FRAME_DURATION_MS = 67
 
 
 @dataclass
@@ -79,6 +83,15 @@ class VibeState:
                     SUNSLEEPER_FRAME_SIZE,
                     SUNSLEEPER_FRAME_COUNT,
                     SUNSLEEPER_FRAME_DURATION_MS,
+                ),
+            ),
+            SpritesheetLoop(
+                sheet_file_path=str(TREE_SHEET_PATH),
+                disable_input=True,
+                frame_data=VibeState._frame_data(
+                    TREE_FRAME_SIZE,
+                    TREE_FRAME_COUNT,
+                    TREE_FRAME_DURATION_MS,
                 ),
             ),
         ]


### PR DESCRIPTION
## Summary
- add a new tree spritesheet scene under vibe
- build a high-resolution 19-frame tree spritesheet from the supplied GIF
- wire the new scene into lib_2026 vibe navigation

## Testing
- RUN_CONFIGURATION=lib_2026 make run