### PR TITLE
Trim vibe scene list

### DIFF
--- a/src/heart/renderers/vibe/state.py
+++ b/src/heart/renderers/vibe/state.py
@@ -5,21 +5,9 @@ from heart.renderers import StatefulBaseRenderer
 from heart.renderers.spritesheet import (BoundingBox, FrameDescription, Size,
                                          SpritesheetLoop)
 
-TUBE_SHEET_PATH = Path("vibe") / "tube_64x64_spritesheet.png"
-NO_LEGS_SHEET_PATH = Path("vibe") / "no_legs_128x128_spritesheet.png"
-SUNSLEEPER_SHEET_PATH = Path("vibe") / "sunsleeper_256x256_spritesheet.png"
 SUNSLEEPER2_SHEET_PATH = Path("vibe") / "sunsleeper_64x64_spritesheet.png"
 TREE_SHEET_PATH = Path("vibe") / "tree_384x384_spritesheet.png"
 HEART_SHEET_PATH = Path("vibe") / "heart_64x64_spritesheet.png"
-TUBE_FRAME_SIZE = 64
-TUBE_FRAME_COUNT = 29
-TUBE_FRAME_DURATION_MS = 250
-NO_LEGS_FRAME_SIZE = 128
-NO_LEGS_FRAME_COUNT = 14
-NO_LEGS_FRAME_DURATION_MS = 250
-SUNSLEEPER_FRAME_SIZE = 256
-SUNSLEEPER_FRAME_COUNT = 48
-SUNSLEEPER_FRAME_DURATION_MS = 274
 SUNSLEEPER2_FRAME_SIZE = 64
 SUNSLEEPER2_FRAME_COUNT = 48
 SUNSLEEPER2_FRAME_DURATION_MS = 274
@@ -66,33 +54,6 @@ class VibeState:
     @staticmethod
     def build() -> "VibeState":
         scenes: list[StatefulBaseRenderer] = [
-            SpritesheetLoop(
-                sheet_file_path=str(TUBE_SHEET_PATH),
-                disable_input=True,
-                frame_data=VibeState._frame_data(
-                    TUBE_FRAME_SIZE,
-                    TUBE_FRAME_COUNT,
-                    TUBE_FRAME_DURATION_MS,
-                ),
-            ),
-            SpritesheetLoop(
-                sheet_file_path=str(NO_LEGS_SHEET_PATH),
-                disable_input=True,
-                frame_data=VibeState._frame_data(
-                    NO_LEGS_FRAME_SIZE,
-                    NO_LEGS_FRAME_COUNT,
-                    NO_LEGS_FRAME_DURATION_MS,
-                ),
-            ),
-            SpritesheetLoop(
-                sheet_file_path=str(SUNSLEEPER_SHEET_PATH),
-                disable_input=True,
-                frame_data=VibeState._frame_data(
-                    SUNSLEEPER_FRAME_SIZE,
-                    SUNSLEEPER_FRAME_COUNT,
-                    SUNSLEEPER_FRAME_DURATION_MS,
-                ),
-            ),
             SpritesheetLoop(
                 sheet_file_path=str(SUNSLEEPER2_SHEET_PATH),
                 disable_input=True,


### PR DESCRIPTION
## Summary
- remove tube, no legs, and the original sunsleeper from the vibe scene list
- keep the remaining vibe scenes focused on sunsleeper2, tree, and heart
- preserve the underlying assets while simplifying navigation

## Testing
- RUN_CONFIGURATION=lib_2026 make run