### PR TITLE
Add four-player Tetris mode

### DIFF
--- a/.codex/skills/tetris-vnc/SKILL.md
+++ b/.codex/skills/tetris-vnc/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: tetris-vnc
+description: Bring up the Heart Tetris TigerVNC display on a Raspberry Pi, configure it to autostart at boot, and open the VNC screen from the local Mac. Use when working on or debugging the Tetris display on totem3.local or another Heart Pi without X11 forwarding.
+---
+
+# Tetris VNC
+
+Use TigerVNC instead of X11 forwarding for the Heart Tetris renderer on a Pi.
+
+Default target:
+
+- Host: `totem3.local`
+- SSH user: `michael`
+- Service: `totem.service`
+- VNC display: `:1`
+- VNC port: `5901`
+- VNC geometry: `2304x576`
+- Pi repo path: `/home/michael/Desktop/heart`
+
+## Pi setup
+
+From the Pi checkout, run:
+
+```bash
+scripts/setup_tetris_vnc_autostart.sh --repo /home/michael/Desktop/heart
+```
+
+This installs TigerVNC if needed and configures the system `totem.service` as the default owner of both the VNC screen and the Tetris process. It writes:
+
+- `/etc/systemd/system/totem.service`
+- `/etc/default/totem`
+- `/usr/local/bin/setup-tetris-vnc.sh`, which starts TigerVNC on display `:1`
+- `/usr/local/bin/start-heart.sh`, which runs `uv run totem run --configuration tetris --no-add-low-power-mode`
+
+It also removes the older per-user `heart-tetris.service` and `heart-tetris-vnc.service` if they exist, enables `totem.service`, and starts it immediately. Use `--no-start` when you only want to install and enable the service.
+
+## Local open
+
+From the local checkout, run:
+
+```bash
+scripts/open_tetris_vnc_viewer.sh --host totem3.local --start-remote
+```
+
+This restarts the remote services over SSH, then opens TigerVNC Viewer locally. If the viewer is not at the default macOS path, pass:
+
+```bash
+scripts/open_tetris_vnc_viewer.sh --viewer "/path/to/TigerVNC Viewer" --host totem3.local
+```
+
+## Debugging
+
+Check remote services:
+
+```bash
+ssh michael@totem3.local 'sudo systemctl status totem.service'
+```
+
+Restart remote services:
+
+```bash
+ssh michael@totem3.local 'sudo systemctl restart totem.service'
+```
+
+Check VNC socket:
+
+```bash
+ssh michael@totem3.local 'ss -ltnp | grep :5901 || true'
+```

--- a/scripts/open_tetris_vnc_viewer.sh
+++ b/scripts/open_tetris_vnc_viewer.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST="totem3.local"
+PORT=5901
+START_REMOTE=0
+SSH_USER="michael"
+SSH_KEY=""
+VIEWER_PATH="${VNC_VIEWER:-}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/open_tetris_vnc_viewer.sh [options] [host]
+
+Opens the TigerVNC viewer for a Tetris VNC display.
+
+Options:
+  --host HOST          Target host. Default: totem3.local.
+  --port N            VNC port. Default: 5901.
+  --start-remote      Restart totem.service over SSH before opening.
+  --user USER         SSH user for --start-remote. Default: michael.
+  --key PATH          SSH identity file for --start-remote.
+  --viewer PATH       TigerVNC Viewer executable path.
+  -h, --help          Show this help.
+
+If --viewer is omitted, the script tries the standard macOS TigerVNC app, then
+falls back to opening vnc://HOST:PORT.
+EOF
+}
+
+log() {
+  printf '[open-tetris-vnc] %s\n' "$*"
+}
+
+fail() {
+  printf '[open-tetris-vnc] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host)
+      [[ $# -ge 2 ]] || fail "--host requires a value"
+      HOST="$2"
+      shift 2
+      ;;
+    --port)
+      [[ $# -ge 2 ]] || fail "--port requires a value"
+      PORT="$2"
+      shift 2
+      ;;
+    --start-remote)
+      START_REMOTE=1
+      shift
+      ;;
+    --user)
+      [[ $# -ge 2 ]] || fail "--user requires a value"
+      SSH_USER="$2"
+      shift 2
+      ;;
+    --key)
+      [[ $# -ge 2 ]] || fail "--key requires a value"
+      SSH_KEY="$2"
+      shift 2
+      ;;
+    --viewer)
+      [[ $# -ge 2 ]] || fail "--viewer requires a value"
+      VIEWER_PATH="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      fail "unknown argument: $1"
+      ;;
+    *)
+      HOST="$1"
+      shift
+      ;;
+  esac
+done
+
+ssh_start_remote() {
+  local ssh_args=()
+  if [[ -n "$SSH_KEY" ]]; then
+    ssh_args+=("-i" "$SSH_KEY" "-o" "IdentitiesOnly=yes")
+  fi
+  log "Restarting totem.service on ${SSH_USER}@${HOST}."
+  ssh "${ssh_args[@]}" "${SSH_USER}@${HOST}" \
+    'sudo systemctl restart totem.service'
+}
+
+wait_for_vnc() {
+  if ! command -v nc >/dev/null 2>&1; then
+    return
+  fi
+  log "Waiting for ${HOST}:${PORT}."
+  for _ in {1..30}; do
+    if nc -z "$HOST" "$PORT" >/dev/null 2>&1; then
+      return
+    fi
+    sleep 1
+  done
+  fail "timed out waiting for ${HOST}:${PORT}"
+}
+
+open_viewer() {
+  local mac_app="/Applications/TigerVNC viewer 1.15.0.app"
+  local mac_viewer="/Applications/TigerVNC viewer 1.15.0.app/Contents/MacOS/TigerVNC viewer"
+
+  if [[ -n "$VIEWER_PATH" ]]; then
+    [[ -x "$VIEWER_PATH" ]] || fail "viewer is not executable: $VIEWER_PATH"
+    log "Opening $HOST:$PORT with $VIEWER_PATH."
+    "$VIEWER_PATH" "${HOST}:${PORT}" >/tmp/tetris-vnc-viewer.log 2>&1 &
+    return
+  fi
+
+  if [[ -d "$mac_app" ]] && command -v open >/dev/null 2>&1; then
+    log "Opening $HOST:$PORT with TigerVNC Viewer."
+    open -na "$mac_app" --args "${HOST}:${PORT}"
+    return
+  fi
+
+  if [[ -x "$mac_viewer" ]]; then
+    log "Opening $HOST:$PORT with TigerVNC Viewer."
+    "$mac_viewer" "${HOST}:${PORT}" >/tmp/tetris-vnc-viewer.log 2>&1 &
+    return
+  fi
+
+  if command -v open >/dev/null 2>&1; then
+    log "Opening vnc://$HOST:$PORT."
+    open "vnc://${HOST}:${PORT}"
+    return
+  fi
+
+  if command -v xdg-open >/dev/null 2>&1; then
+    log "Opening vnc://$HOST:$PORT."
+    xdg-open "vnc://${HOST}:${PORT}" >/tmp/tetris-vnc-viewer.log 2>&1 &
+    return
+  fi
+
+  fail "could not find a VNC viewer launcher"
+}
+
+if [[ "$START_REMOTE" -eq 1 ]]; then
+  ssh_start_remote
+  wait_for_vnc
+fi
+
+open_viewer

--- a/scripts/pair_tetris_controllers.sh
+++ b/scripts/pair_tetris_controllers.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCAN_SECONDS=15
+CONNECT_RETRIES=4
+RESET_PAIRINGS=0
+
+SLOT_IDS=(0 1 2 3)
+CONTROLLER_MACS=(
+  "E4:17:D8:E9:76:C8"
+  "E4:17:D8:43:5C:48"
+  "E4:17:D8:58:22:8A"
+  "E4:17:D8:91:15:35"
+)
+CONTROLLER_NAMES=(
+  "8BitDo Lite 2"
+  "8BitDo Lite 2"
+  "8BitDo Lite 2"
+  "8BitDo Lite 2"
+)
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/pair_tetris_controllers.sh [--reset] [--scan-seconds N] [--connect-retries N]
+
+Pairs, trusts, and connects the four hardcoded Tetris controllers on a Pi.
+
+Options:
+  --reset              Remove existing pairing records for these MACs first.
+  --scan-seconds N     Seconds to wait for each controller to appear. Default: 15.
+  --connect-retries N  Connection attempts after pairing/trust. Default: 4.
+  -h, --help           Show this help.
+
+Put each controller in pairing mode before running, or run the script again after
+putting missing controllers back into pairing mode.
+EOF
+}
+
+log() {
+  printf '[pair-tetris] %s\n' "$*"
+}
+
+warn() {
+  printf '[pair-tetris] WARNING: %s\n' "$*" >&2
+}
+
+fail() {
+  printf '[pair-tetris] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --reset)
+      RESET_PAIRINGS=1
+      shift
+      ;;
+    --scan-seconds)
+      [[ $# -ge 2 ]] || fail "--scan-seconds requires a value"
+      SCAN_SECONDS="$2"
+      shift 2
+      ;;
+    --connect-retries)
+      [[ $# -ge 2 ]] || fail "--connect-retries requires a value"
+      CONNECT_RETRIES="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing command: $1"
+}
+
+run_sudo() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+bt_info() {
+  bluetoothctl info "$1" 2>/dev/null || true
+}
+
+bt_has_flag() {
+  local mac="$1"
+  local flag="$2"
+  bt_info "$mac" | grep -q "$flag: yes"
+}
+
+bt_known() {
+  local mac="$1"
+  bluetoothctl devices 2>/dev/null | grep -qi "Device $mac "
+}
+
+load_input_modules() {
+  log "Loading Bluetooth/input kernel modules."
+  run_sudo modprobe uinput || warn "could not load uinput"
+  run_sudo modprobe joydev || warn "could not load joydev"
+  run_sudo modprobe hidp || warn "could not load hidp"
+}
+
+prepare_bluetooth() {
+  log "Preparing bluetoothd."
+  if command -v systemctl >/dev/null 2>&1; then
+    run_sudo systemctl start bluetooth || warn "could not start bluetooth service"
+  fi
+  bluetoothctl power on >/dev/null
+  bluetoothctl agent on >/dev/null || true
+  bluetoothctl default-agent >/dev/null || true
+}
+
+scan_for_controller() {
+  local mac="$1"
+  local deadline=$((SECONDS + SCAN_SECONDS))
+
+  if bt_known "$mac"; then
+    return 0
+  fi
+
+  log "Scanning for $mac for up to ${SCAN_SECONDS}s."
+  bluetoothctl scan on >/dev/null 2>&1 || true
+  while [[ "$SECONDS" -lt "$deadline" ]]; do
+    if bt_known "$mac"; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+pair_controller() {
+  local slot="$1"
+  local mac="$2"
+  local name="$3"
+
+  log "Slot $slot: setting up $name ($mac)."
+
+  if [[ "$RESET_PAIRINGS" -eq 1 ]]; then
+    bluetoothctl remove "$mac" >/dev/null 2>&1 || true
+    sleep 1
+  fi
+
+  if ! scan_for_controller "$mac"; then
+    warn "Slot $slot: $mac not visible. Put this controller in pairing mode and rerun."
+    return 1
+  fi
+
+  if ! bt_has_flag "$mac" "Paired"; then
+    log "Slot $slot: pairing $mac."
+    bluetoothctl pair "$mac" || true
+    sleep 2
+  fi
+
+  if ! bt_has_flag "$mac" "Paired"; then
+    warn "Slot $slot: pairing did not complete for $mac."
+    return 1
+  fi
+
+  bluetoothctl trust "$mac" >/dev/null || true
+
+  for attempt in $(seq 1 "$CONNECT_RETRIES"); do
+    if bt_has_flag "$mac" "Connected"; then
+      log "Slot $slot: connected."
+      return 0
+    fi
+    log "Slot $slot: connect attempt $attempt/$CONNECT_RETRIES."
+    bluetoothctl connect "$mac" || true
+    sleep 3
+  done
+
+  if bt_has_flag "$mac" "Connected"; then
+    log "Slot $slot: connected."
+    return 0
+  fi
+
+  warn "Slot $slot: paired/trusted but not connected."
+  return 1
+}
+
+print_verification() {
+  log "Connected Bluetooth controllers:"
+  bluetoothctl devices Connected 2>/dev/null || true
+
+  log "Linux joystick devices:"
+  if compgen -G "/sys/class/input/js*" >/dev/null; then
+    for joystick_path in /sys/class/input/js*; do
+      local name=""
+      local uniq=""
+      name="$(cat "$joystick_path/device/name" 2>/dev/null || true)"
+      uniq="$(cat "$joystick_path/device/uniq" 2>/dev/null || true)"
+      printf '  %s name="%s" uniq="%s"\n' "$joystick_path" "$name" "$uniq"
+    done
+  else
+    printf '  none\n'
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - <<'PY' || true
+try:
+    import pygame
+except Exception:
+    raise SystemExit(0)
+
+pygame.init()
+pygame.joystick.init()
+print("[pair-tetris] pygame joysticks:")
+print(f"  count={pygame.joystick.get_count()}")
+for index in range(pygame.joystick.get_count()):
+    joystick = pygame.joystick.Joystick(index)
+    joystick.init()
+    print(
+        f"  {index}: name={joystick.get_name()!r} axes={joystick.get_numaxes()} "
+        f"buttons={joystick.get_numbuttons()} hats={joystick.get_numhats()}"
+    )
+PY
+  fi
+}
+
+main() {
+  require_command bluetoothctl
+  require_command grep
+  require_command sed
+
+  load_input_modules
+  prepare_bluetooth
+
+  local failures=0
+  for index in "${!CONTROLLER_MACS[@]}"; do
+    if ! pair_controller "${SLOT_IDS[$index]}" "${CONTROLLER_MACS[$index]}" "${CONTROLLER_NAMES[$index]}"; then
+      failures=$((failures + 1))
+    fi
+  done
+
+  bluetoothctl scan off >/dev/null 2>&1 || true
+  print_verification
+
+  if [[ "$failures" -gt 0 ]]; then
+    fail "$failures controller(s) did not finish setup"
+  fi
+  log "All hardcoded Tetris controllers are paired/trusted/connected."
+}
+
+main "$@"

--- a/scripts/setup_tetris_vnc_autostart.sh
+++ b/scripts/setup_tetris_vnc_autostart.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DISPLAY_NUMBER=1
+GEOMETRY="2304x576"
+VNC_PORT=5901
+REPO_DIR="$(pwd)"
+CONFIGURATION="tetris"
+VNC_HELPER_PATH="/usr/local/bin/setup-tetris-vnc.sh"
+START_HELPER_PATH="/usr/local/bin/start-heart.sh"
+START_SERVICES=1
+INSTALL_PACKAGES=1
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/setup_tetris_vnc_autostart.sh [options]
+
+Installs TigerVNC and configures the system totem.service to start:
+  - native TigerVNC display :1
+  - the Heart Tetris configuration on that display
+
+Run this on the Pi from the Heart checkout.
+
+Options:
+  --repo DIR          Heart checkout path. Default: current directory.
+  --configuration N   Heart run configuration. Default: tetris.
+  --display N         X display number. Default: 1.
+  --geometry WxH      VNC framebuffer size. Default: 2304x576.
+  --port N            VNC TCP port. Default: 5901.
+  --no-install        Do not install TigerVNC packages.
+  --no-start          Create/enable services but do not start them now.
+  -h, --help          Show this help.
+EOF
+}
+
+log() {
+  printf '[tetris-vnc-setup] %s\n' "$*"
+}
+
+fail() {
+  printf '[tetris-vnc-setup] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      [[ $# -ge 2 ]] || fail "--repo requires a value"
+      REPO_DIR="$2"
+      shift 2
+      ;;
+    --display)
+      [[ $# -ge 2 ]] || fail "--display requires a value"
+      DISPLAY_NUMBER="$2"
+      shift 2
+      ;;
+    --configuration)
+      [[ $# -ge 2 ]] || fail "--configuration requires a value"
+      CONFIGURATION="$2"
+      shift 2
+      ;;
+    --geometry)
+      [[ $# -ge 2 ]] || fail "--geometry requires a value"
+      GEOMETRY="$2"
+      shift 2
+      ;;
+    --port)
+      [[ $# -ge 2 ]] || fail "--port requires a value"
+      VNC_PORT="$2"
+      shift 2
+      ;;
+    --no-install)
+      INSTALL_PACKAGES=0
+      shift
+      ;;
+    --no-start)
+      START_SERVICES=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+run_sudo() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing command: $1"
+}
+
+install_packages() {
+  if [[ "$INSTALL_PACKAGES" -eq 0 ]]; then
+    return
+  fi
+  if command -v Xtigervnc >/dev/null 2>&1; then
+    log "TigerVNC is already installed."
+    return
+  fi
+  require_command apt-get
+  log "Installing TigerVNC server."
+  run_sudo apt-get update
+  run_sudo apt-get install -y tigervnc-standalone-server
+}
+
+write_totem_files() {
+  local display_name
+  local x_socket
+  local x_lock
+
+  REPO_DIR="$(cd "$REPO_DIR" && pwd)"
+  display_name=":${DISPLAY_NUMBER}"
+  x_socket="/tmp/.X11-unix/X${DISPLAY_NUMBER}"
+  x_lock="/tmp/.X${DISPLAY_NUMBER}-lock"
+
+  log "Writing /etc/default/totem."
+  run_sudo tee /etc/default/totem >/dev/null <<EOF
+HEART_REPO_DIR=${REPO_DIR}
+DISPLAY=${display_name}
+X11_FORWARD=1
+SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS=1
+PERIPHERAL_CONFIGURATION=default
+FORWARD_TO_BEATS_APP=0
+HEART_DEVICE_LAYOUT=cube
+PYTHONUNBUFFERED=1
+HEART_RUN_CONFIGURATION=${CONFIGURATION}
+RUN_CONFIGURATION=${CONFIGURATION}
+HEART_TOTEM_EXTRA_ARGS=--no-add-low-power-mode
+EOF
+
+  log "Writing ${VNC_HELPER_PATH}."
+  run_sudo tee "$VNC_HELPER_PATH" >/dev/null <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+pkill -f "Xtigervnc ${display_name}" || true
+pkill -f "Xvfb ${display_name}" || true
+rm -f ${x_lock} ${x_socket}
+
+Xtigervnc ${display_name} -geometry ${GEOMETRY} -depth 24 -rfbport ${VNC_PORT} -SecurityTypes None -localhost no -AlwaysShared=1 &
+
+for _ in {1..30}; do
+  if [[ -S ${x_socket} ]]; then
+    exit 0
+  fi
+  sleep 1
+done
+
+exit 1
+EOF
+  run_sudo chmod 755 "$VNC_HELPER_PATH"
+
+  log "Writing ${START_HELPER_PATH}."
+  run_sudo tee "$START_HELPER_PATH" >/dev/null <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="${HEART_REPO_DIR:-/home/michael/Desktop/heart}"
+CONFIGURATION="${HEART_RUN_CONFIGURATION:-${RUN_CONFIGURATION:-tetris}}"
+EXTRA_ARGS="${HEART_TOTEM_EXTRA_ARGS:---no-add-low-power-mode}"
+
+/usr/local/bin/setup-tetris-vnc.sh
+
+cd "${REPO_DIR}"
+
+# shellcheck disable=SC2086
+exec uv run totem run --configuration "${CONFIGURATION}" ${EXTRA_ARGS}
+EOF
+  run_sudo chmod 755 "$START_HELPER_PATH"
+
+  log "Writing /etc/systemd/system/totem.service."
+  run_sudo tee /etc/systemd/system/totem.service >/dev/null <<EOF
+[Unit]
+Description=Totem Service
+After=multi-user.target
+
+[Service]
+Type=simple
+User=root
+Group=root
+WorkingDirectory=/
+Environment=HEART_REPO_DIR=${REPO_DIR}
+Environment=PATH=/root/.local/bin:/home/michael/.local/bin:/home/pi/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=DISPLAY=${display_name}
+Environment=MOCK_SWITCH=1
+Environment=PERIPHERAL_CONFIGURATION=default
+Environment=FORWARD_TO_BEATS_APP=0
+Environment=HEART_DEVICE_LAYOUT=cube
+Environment=PYTHONUNBUFFERED=1
+EnvironmentFile=-/etc/default/totem
+ExecStartPre=-/usr/bin/pkill -f "uv run totem run"
+ExecStartPre=-/usr/bin/pkill -f "totem run"
+ExecStartPre=-/usr/bin/pkill -f "src/heart/loop.py run"
+ExecStartPre=-/usr/bin/pkill -f "Xtigervnc ${display_name}"
+ExecStartPre=-/usr/bin/pkill -f "Xvfb ${display_name}"
+ExecStart=/bin/bash ${START_HELPER_PATH}
+ExecStop=-/usr/bin/pkill -f "Xtigervnc ${display_name}"
+ExecStop=-/usr/bin/pkill -f "Xvfb ${display_name}"
+ExecStopPost=-/usr/bin/pkill -f "uv run totem run"
+ExecStopPost=-/usr/bin/pkill -f "totem run"
+ExecStopPost=-/usr/bin/pkill -f "src/heart/loop.py run"
+KillMode=control-group
+TimeoutStopSec=15s
+SendSIGKILL=yes
+Restart=always
+RestartSec=3s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+stop_legacy_user_services() {
+  if ! command -v systemctl >/dev/null 2>&1; then
+    return
+  fi
+
+  log "Stopping legacy per-user Tetris services if present."
+  XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}" \
+    systemctl --user disable --now heart-tetris.service heart-tetris-vnc.service >/dev/null 2>&1 || true
+  rm -f \
+    "$HOME/.config/systemd/user/heart-tetris.service" \
+    "$HOME/.config/systemd/user/heart-tetris-vnc.service"
+  XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}" \
+    systemctl --user daemon-reload >/dev/null 2>&1 || true
+}
+
+clear_display_files() {
+  local x_socket="/tmp/.X11-unix/X${DISPLAY_NUMBER}"
+  local x_lock="/tmp/.X${DISPLAY_NUMBER}-lock"
+
+  log "Clearing stale display files for :${DISPLAY_NUMBER}."
+  run_sudo pkill -f "Xtigervnc :${DISPLAY_NUMBER}" || true
+  run_sudo pkill -f "Xvfb :${DISPLAY_NUMBER}" || true
+  run_sudo rm -f "$x_lock" "$x_socket"
+}
+
+enable_service() {
+  require_command systemctl
+
+  log "Reloading systemd and enabling totem.service."
+  run_sudo systemctl daemon-reload
+  run_sudo systemctl enable totem.service
+
+  if [[ "$START_SERVICES" -eq 1 ]]; then
+    log "Starting totem.service now."
+    clear_display_files
+    run_sudo systemctl restart totem.service
+  fi
+}
+
+print_status() {
+  log "Service status:"
+  run_sudo systemctl --no-pager --full status totem.service || true
+
+  log "Listening VNC sockets:"
+  ss -ltnp 2>/dev/null | grep ":${VNC_PORT}" || true
+
+  log "Current display/app processes:"
+  pgrep -af "[X]tigervnc|[X]vfb|[u]v run totem run|[t]otem run" || true
+}
+
+main() {
+  [[ -d "$REPO_DIR" ]] || fail "repo path does not exist: $REPO_DIR"
+  install_packages
+  require_command Xtigervnc
+  stop_legacy_user_services
+  write_totem_files
+  enable_service
+  print_status
+  log "TigerVNC target: $(hostname -I | awk '{print $1}'):${VNC_PORT}"
+}
+
+main "$@"

--- a/src/heart/programs/configurations/lib_2026.py
+++ b/src/heart/programs/configurations/lib_2026.py
@@ -26,6 +26,7 @@ from heart.renderers.tixyland import Tixyland, TixylandFactory
 from heart.renderers.vibe import VibeScene
 from heart.renderers.water_cube.renderer import WaterCube
 from heart.renderers.water_title_screen import WaterTitleScreen
+from heart.renderers.tetris import TetrisRenderer
 from heart.runtime.game_loop import GameLoop
 
 TITLE_TILE_HEIGHT_PX = 64
@@ -192,6 +193,9 @@ def configure(loop: GameLoop) -> None:
         )
     )
     water_mode.add_renderer(WaterCube)
+
+    tetris_mode = loop.add_mode("tetris")
+    tetris_mode.add_renderer(TetrisRenderer)
 
     pranay_mode = loop.add_mode(friend_beacon_text(text=PRANAY_SKETCH_MODE_TITLE))
     pranay_mode.add_renderer(PranaySketchRenderer())

--- a/src/heart/programs/configurations/tetris.py
+++ b/src/heart/programs/configurations/tetris.py
@@ -1,0 +1,9 @@
+from heart.renderers.tetris import TetrisRenderer
+from heart.runtime.game_loop import GameLoop
+
+
+def configure(loop: GameLoop) -> None:
+    mode = loop.add_mode("tetris")
+    mode.add_renderer(TetrisRenderer())
+    loop.components.game_modes.state.in_select_mode = False
+    loop.components.game_modes.state.post_processors.clear()

--- a/src/heart/renderers/tetris/__init__.py
+++ b/src/heart/renderers/tetris/__init__.py
@@ -1,0 +1,3 @@
+from heart.renderers.tetris.renderer import TetrisRenderer as TetrisRenderer
+from heart.renderers.tetris.state import TetrisGameState as TetrisGameState
+from heart.renderers.tetris.state import TetrisPlayerState as TetrisPlayerState

--- a/src/heart/renderers/tetris/direct_gamepad.py
+++ b/src/heart/renderers/tetris/direct_gamepad.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pygame
+
+from heart.peripheral.core.input import (GamepadAxis, GamepadButton,
+                                         GamepadDpadValue)
+from heart.peripheral.core.input.gamepad import DEFAULT_GAMEPAD_AXIS_DEAD_ZONE
+from heart.peripheral.gamepad.gamepad import GamepadIdentifier
+from heart.peripheral.gamepad.peripheral_mappings import (
+    BitDoLite2, BitDoLite2Bluetooth, DpadType, SwitchLikeMapping,
+    SwitchProMapping)
+from heart.utilities.env import Configuration
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+LINUX_JOYSTICK_SYSFS = Path("/sys/class/input")
+STICK_LOG_THRESHOLD = 0.35
+TETRIS_SLOT_BLUETOOTH_MACS: tuple[str | None, ...] = (
+    "E4:17:D8:E9:76:C8",  # 8BitDo Lite 2
+    "E4:17:D8:43:5C:48",  # 8BitDo Lite 2
+    "E4:17:D8:58:22:8A",  # 8BitDo Lite 2
+    "E4:17:D8:91:15:35",  # 8BitDo Lite 2
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DirectGamepadSnapshot:
+    connected: bool
+    identifier: str | None
+    buttons: dict[GamepadButton, bool] = field(default_factory=dict)
+    tapped_buttons: frozenset[GamepadButton] = frozenset()
+    axes: dict[GamepadAxis, float] = field(default_factory=dict)
+    dpad: GamepadDpadValue = GamepadDpadValue()
+    timestamp_monotonic: float = 0.0
+    slot: int = 0
+
+    def button_held(self, button: GamepadButton) -> bool:
+        return self.buttons.get(button, False)
+
+    def button_tapped(self, button: GamepadButton) -> bool:
+        return button in self.tapped_buttons
+
+    def axis_value(
+        self,
+        axis: GamepadAxis,
+        *,
+        dead_zone: float = DEFAULT_GAMEPAD_AXIS_DEAD_ZONE,
+    ) -> float:
+        value = self.axes.get(axis, 0.0)
+        if abs(value) < dead_zone:
+            return 0.0
+        return value
+
+
+class DirectTetrisGamepads:
+    def __init__(self) -> None:
+        self._joysticks_by_slot: dict[int, pygame.joystick.JoystickType] = {}
+        self._previous_buttons_by_slot: dict[int, dict[GamepadButton, bool]] = {}
+        self._snapshots_by_slot: dict[int, DirectGamepadSnapshot] = {}
+        self._last_logged_signature_by_slot: dict[int, tuple[object, ...]] = {}
+        self._joystick_initialized = False
+
+    def refresh(self, player_count: int) -> None:
+        self._ensure_initialized()
+        pygame.event.pump()
+        for slot in range(player_count):
+            self._snapshots_by_slot[slot] = self._read_slot(slot)
+
+    def snapshot_for_slot(self, slot: int) -> DirectGamepadSnapshot:
+        snapshot = self._snapshots_by_slot.get(slot)
+        if snapshot is not None:
+            return snapshot
+        return DirectGamepadSnapshot(
+            connected=False,
+            identifier=None,
+            timestamp_monotonic=time.monotonic(),
+            slot=slot,
+        )
+
+    def _ensure_initialized(self) -> None:
+        if self._joystick_initialized:
+            return
+        pygame.joystick.init()
+        self._joystick_initialized = True
+
+    def _read_slot(self, slot: int) -> DirectGamepadSnapshot:
+        joystick = self._joystick_for_slot(slot)
+        if joystick is None:
+            return DirectGamepadSnapshot(
+                connected=False,
+                identifier=None,
+                timestamp_monotonic=time.monotonic(),
+                slot=slot,
+            )
+        mapping = _mapping_for_joystick(joystick)
+        buttons = _read_buttons(joystick, mapping)
+        previous = self._previous_buttons_by_slot.get(slot, {})
+        tapped_buttons = frozenset(
+            button for button, held in buttons.items() if held and not previous.get(button)
+        )
+        self._previous_buttons_by_slot[slot] = buttons
+        snapshot = DirectGamepadSnapshot(
+            connected=True,
+            identifier=joystick.get_name(),
+            buttons=buttons,
+            tapped_buttons=tapped_buttons,
+            axes=_read_axes(joystick, mapping),
+            dpad=_read_dpad(joystick, mapping),
+            timestamp_monotonic=time.monotonic(),
+            slot=slot,
+        )
+        self._log_snapshot(snapshot)
+        return snapshot
+
+    def _joystick_for_slot(
+        self,
+        slot: int,
+    ) -> pygame.joystick.JoystickType | None:
+        joystick = self._joysticks_by_slot.get(slot)
+        if joystick is not None and _slot_detected(slot):
+            return joystick
+        if joystick is not None:
+            _safe_quit(joystick)
+            self._joysticks_by_slot.pop(slot, None)
+            self._previous_buttons_by_slot.pop(slot, None)
+            logger.info("tetris.direct_gamepad.disconnected slot=%s", slot)
+
+        physical_index = _physical_joystick_index(slot)
+        if physical_index is None:
+            return None
+        try:
+            joystick = pygame.joystick.Joystick(physical_index)
+            joystick.init()
+        except pygame.error as exc:
+            logger.warning(
+                "tetris.direct_gamepad.connect_failed slot=%s physical_index=%s error=%s",
+                slot,
+                physical_index,
+                exc,
+            )
+            return None
+        self._joysticks_by_slot[slot] = joystick
+        logger.info(
+            "tetris.direct_gamepad.ready slot=%s physical_index=%s name=%s",
+            slot,
+            physical_index,
+            joystick.get_name(),
+        )
+        return joystick
+
+    def _log_snapshot(self, snapshot: DirectGamepadSnapshot) -> None:
+        signature = _snapshot_signature(snapshot)
+        if signature == self._last_logged_signature_by_slot.get(snapshot.slot):
+            return
+        self._last_logged_signature_by_slot[snapshot.slot] = signature
+        if not signature:
+            return
+        logger.info(
+            "tetris.direct_gamepad.input slot=%s id=%s dpad=(%s,%s) left=(%.2f,%.2f) tapped=%s held=%s",
+            snapshot.slot,
+            snapshot.identifier,
+            snapshot.dpad.x,
+            snapshot.dpad.y,
+            snapshot.axes.get(GamepadAxis.LEFT_X, 0.0),
+            snapshot.axes.get(GamepadAxis.LEFT_Y, 0.0),
+            ",".join(
+                button.value
+                for button in sorted(snapshot.tapped_buttons, key=lambda item: item.value)
+            ),
+            ",".join(
+                button.value
+                for button, held in sorted(
+                    snapshot.buttons.items(),
+                    key=lambda item: item[0].value,
+                )
+                if held
+            ),
+        )
+
+
+def _slot_detected(slot: int) -> bool:
+    if Configuration.is_pi():
+        if _target_bluetooth_mac(slot) is None:
+            return False
+        return _mapped_joystick_index(slot) is not None
+    return pygame.joystick.get_count() > slot
+
+
+def _physical_joystick_index(slot: int) -> int | None:
+    if Configuration.is_pi():
+        return _mapped_joystick_index(slot)
+    if pygame.joystick.get_count() <= slot:
+        return None
+    return slot
+
+
+def _mapped_joystick_index(slot: int) -> int | None:
+    target_mac = _target_bluetooth_mac(slot)
+    if target_mac is None:
+        return None
+    normalized_target = _normalize_bluetooth_mac(target_mac)
+    for pygame_index, joystick_path in enumerate(sorted(LINUX_JOYSTICK_SYSFS.glob("js*"))):
+        uniq_path = joystick_path / "device" / "uniq"
+        try:
+            controller_mac = uniq_path.read_text().strip()
+        except OSError:
+            continue
+        if _normalize_bluetooth_mac(controller_mac) != normalized_target:
+            continue
+        return pygame_index
+    return None
+
+
+def _target_bluetooth_mac(slot: int) -> str | None:
+    if slot >= len(TETRIS_SLOT_BLUETOOTH_MACS):
+        return None
+    return TETRIS_SLOT_BLUETOOTH_MACS[slot]
+
+
+def _normalize_bluetooth_mac(mac_address: str) -> str:
+    return mac_address.replace(":", "").lower()
+
+
+def _mapping_for_joystick(joystick: pygame.joystick.JoystickType) -> SwitchLikeMapping:
+    try:
+        identifier = GamepadIdentifier(joystick.get_name())
+    except ValueError:
+        identifier = GamepadIdentifier.BIT_DO_LITE_2
+    if identifier is GamepadIdentifier.SWITCH_PRO:
+        return SwitchProMapping()
+    if Configuration.is_pi():
+        return BitDoLite2Bluetooth()
+    return BitDoLite2()
+
+
+def _read_buttons(
+    joystick: pygame.joystick.JoystickType,
+    mapping: SwitchLikeMapping,
+) -> dict[GamepadButton, bool]:
+    return {
+        GamepadButton.SOUTH: _button_held(joystick, mapping.BUTTON_B),
+        GamepadButton.EAST: _button_held(joystick, mapping.BUTTON_A),
+        GamepadButton.WEST: _button_held(joystick, mapping.BUTTON_Y),
+        GamepadButton.NORTH: _button_held(joystick, mapping.BUTTON_X),
+        GamepadButton.PLUS: _button_held(joystick, mapping.BUTTON_PLUS),
+        GamepadButton.MINUS: _button_held(joystick, mapping.BUTTON_MINUS),
+        GamepadButton.HOME: _button_held(joystick, mapping.BUTTON_HOME),
+        GamepadButton.CAPTURE: _button_held(joystick, mapping.BUTTON_CAPTURE),
+        GamepadButton.ZL: _button_held(joystick, mapping.BUTTON_ZL),
+        GamepadButton.ZR: _button_held(joystick, mapping.BUTTON_ZR),
+        GamepadButton.L3: _button_held(joystick, mapping.BUTTON_L3),
+        GamepadButton.R3: _button_held(joystick, mapping.BUTTON_R3),
+    }
+
+
+def _read_axes(
+    joystick: pygame.joystick.JoystickType,
+    mapping: SwitchLikeMapping,
+) -> dict[GamepadAxis, float]:
+    return {
+        GamepadAxis.LEFT_X: _axis_value(joystick, mapping.AXIS_LEFT_X),
+        GamepadAxis.LEFT_Y: _axis_value(joystick, mapping.AXIS_LEFT_Y),
+        GamepadAxis.RIGHT_X: _axis_value(joystick, mapping.AXIS_RIGHT_X),
+        GamepadAxis.RIGHT_Y: _axis_value(joystick, mapping.AXIS_RIGHT_Y),
+        GamepadAxis.TRIGGER_LEFT: _axis_value(joystick, mapping.AXIS_L),
+        GamepadAxis.TRIGGER_RIGHT: _axis_value(joystick, mapping.AXIS_R),
+    }
+
+
+def _read_dpad(
+    joystick: pygame.joystick.JoystickType,
+    mapping: SwitchLikeMapping,
+) -> GamepadDpadValue:
+    if mapping.get_dpad_type() is DpadType.HAT:
+        hat_index = mapping.DPAD_HAT
+        if hat_index is None or hat_index < 0:
+            return GamepadDpadValue()
+        try:
+            x_dir, y_dir = joystick.get_hat(hat_index)
+        except pygame.error:
+            return GamepadDpadValue()
+        return GamepadDpadValue(x=int(x_dir), y=int(y_dir))
+    if mapping.get_dpad_type() is DpadType.BUTTONS:
+        x_dir = int(_button_held(joystick, mapping.DPAD_RIGHT)) - int(
+            _button_held(joystick, mapping.DPAD_LEFT)
+        )
+        y_dir = int(_button_held(joystick, mapping.DPAD_UP)) - int(
+            _button_held(joystick, mapping.DPAD_DOWN)
+        )
+        return GamepadDpadValue(x=x_dir, y=y_dir)
+    return GamepadDpadValue()
+
+
+def _button_held(
+    joystick: pygame.joystick.JoystickType,
+    button_id: int | None,
+) -> bool:
+    if button_id is None or button_id < 0 or button_id >= joystick.get_numbuttons():
+        return False
+    return bool(joystick.get_button(button_id))
+
+
+def _axis_value(
+    joystick: pygame.joystick.JoystickType,
+    axis_id: int | None,
+) -> float:
+    if axis_id is None or axis_id < 0 or axis_id >= joystick.get_numaxes():
+        return 0.0
+    return float(joystick.get_axis(axis_id))
+
+
+def _safe_quit(joystick: pygame.joystick.JoystickType) -> None:
+    try:
+        joystick.quit()
+    except pygame.error:
+        return
+
+
+def _snapshot_signature(snapshot: DirectGamepadSnapshot) -> tuple[object, ...]:
+    left_x = snapshot.axes.get(GamepadAxis.LEFT_X, 0.0)
+    left_y = snapshot.axes.get(GamepadAxis.LEFT_Y, 0.0)
+    axis_x = round(left_x, 2) if abs(left_x) >= STICK_LOG_THRESHOLD else 0.0
+    axis_y = round(left_y, 2) if abs(left_y) >= STICK_LOG_THRESHOLD else 0.0
+    held_buttons = tuple(
+        sorted(button.value for button, held in snapshot.buttons.items() if held)
+    )
+    tapped_buttons = tuple(sorted(button.value for button in snapshot.tapped_buttons))
+    if (
+        snapshot.dpad.x == 0
+        and snapshot.dpad.y == 0
+        and axis_x == 0.0
+        and axis_y == 0.0
+        and not held_buttons
+        and not tapped_buttons
+    ):
+        return ()
+    return (
+        snapshot.dpad.x,
+        snapshot.dpad.y,
+        axis_x,
+        axis_y,
+        held_buttons,
+        tapped_buttons,
+    )

--- a/src/heart/renderers/tetris/renderer.py
+++ b/src/heart/renderers/tetris/renderer.py
@@ -1,0 +1,661 @@
+from __future__ import annotations
+
+import random
+import time
+from dataclasses import replace
+
+import pygame
+
+from heart import DeviceDisplayMode
+from heart.device import Orientation
+from heart.peripheral.core.input import GamepadButton
+from heart.peripheral.core.manager import PeripheralManager
+from heart.peripheral.providers.randomness import RandomnessProvider
+from heart.renderers import StatefulBaseRenderer
+from heart.runtime.display_context import DisplayContext
+from heart.utilities.logging import get_logger
+
+from .direct_gamepad import DirectGamepadSnapshot, DirectTetrisGamepads
+from .state import (BOARD_HEIGHT, BOARD_WIDTH, CELL_SIZE_PX,
+                    MOVE_REPEAT_DELAY_MS, MOVE_REPEAT_INTERVAL_MS,
+                    PIECE_ROTATIONS, TetrisColor, TetrisControls,
+                    TetrisGameState, TetrisInputMemory, TetrisPiece,
+                    TetrisPieceKind, TetrisPlayerState, advance_player,
+                    queue_garbage_for_opponents, restart_match,
+                    update_match_end_state)
+
+BACKGROUND_COLOR = pygame.Color(0, 8, 20)
+PANEL_BACKGROUND_COLOR = pygame.Color(0, 18, 40)
+HUD_PANEL_COLOR = pygame.Color(0, 3, 7)
+BOARD_BACKGROUND_COLOR = pygame.Color(0, 0, 0)
+BOARD_BORDER_COLOR = pygame.Color(40, 255, 226)
+BOARD_BORDER_SHADOW_COLOR = pygame.Color(0, 78, 148)
+GRID_COLOR = pygame.Color(24, 35, 45)
+GHOST_COLOR = pygame.Color(88, 96, 118)
+GARBAGE_WARNING_COLOR = pygame.Color(255, 70, 80)
+GAME_OVER_COLOR = pygame.Color(255, 35, 60)
+WIN_OVERLAY_COLOR = pygame.Color(255, 228, 68)
+LOSE_OVERLAY_COLOR = pygame.Color(255, 58, 86)
+RESTART_BUTTON_COLOR = pygame.Color(40, 255, 226)
+PLAYER_ACCENT_COLORS = (
+    pygame.Color(0, 220, 255),
+    pygame.Color(255, 211, 64),
+    pygame.Color(185, 112, 255),
+    pygame.Color(74, 222, 128),
+)
+TETRIS_PALETTE: dict[TetrisColor, pygame.Color] = {
+    TetrisColor.CYAN: pygame.Color(0, 238, 255),
+    TetrisColor.YELLOW: pygame.Color(255, 225, 58),
+    TetrisColor.PURPLE: pygame.Color(190, 104, 255),
+    TetrisColor.GREEN: pygame.Color(72, 224, 119),
+    TetrisColor.RED: pygame.Color(255, 75, 96),
+    TetrisColor.BLUE: pygame.Color(83, 132, 255),
+    TetrisColor.ORANGE: pygame.Color(255, 154, 56),
+    TetrisColor.GARBAGE: pygame.Color(82, 88, 103),
+}
+RNG_NAMESPACE = "tetris"
+PREVIEW_CELL_SIZE_PX = 2
+NEXT_PREVIEW_COUNT = 6
+logger = get_logger(__name__)
+
+
+def _blend_color(
+    color: pygame.Color,
+    target: pygame.Color,
+    amount: float,
+) -> pygame.Color:
+    return pygame.Color(
+        int(color.r + ((target.r - color.r) * amount)),
+        int(color.g + ((target.g - color.g) * amount)),
+        int(color.b + ((target.b - color.b) * amount)),
+    )
+
+
+class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
+    def __init__(
+        self,
+        *,
+        randomness: RandomnessProvider | None = None,
+        rng: random.Random | None = None,
+    ) -> None:
+        self._rng = rng or (randomness or RandomnessProvider()).rng(RNG_NAMESPACE)
+        super().__init__()
+        self.device_display_mode = DeviceDisplayMode.FULL
+        self._fonts: dict[int, pygame.font.Font] = {}
+        self._last_logged_controls_by_player: dict[int, tuple[object, ...]] = {}
+        self._gamepads = DirectTetrisGamepads()
+
+    def _create_initial_state(
+        self,
+        window: DisplayContext,
+        peripheral_manager: PeripheralManager,
+        orientation: Orientation,
+    ) -> TetrisGameState:
+        del window, peripheral_manager, orientation
+        return TetrisGameState.create(self._rng)
+
+    def real_process(
+        self,
+        window: DisplayContext,
+        orientation: Orientation,
+    ) -> None:
+        if window.screen is None:
+            raise RuntimeError("TetrisRenderer requires an initialized display surface")
+        elapsed_ms = self._elapsed_ms(window)
+        self._gamepads.refresh(player_count=len(self.state.players))
+        controls_by_player: list[TetrisControls] = []
+        for player_index, player in enumerate(self.state.players):
+            snapshot = self._snapshot_for_player(player_index)
+            controls = self._controls_for_snapshot(
+                player.input_memory,
+                snapshot,
+                elapsed_ms,
+            )
+            self._log_renderer_command(player_index, snapshot, controls)
+            controls_by_player.append(controls)
+        if self.state.match_finished:
+            if any(controls.restart for controls in controls_by_player):
+                restart_match(self.state, self._rng)
+        else:
+            for player_index, player in enumerate(self.state.players):
+                controls = replace(controls_by_player[player_index], restart=False)
+                cleared = advance_player(player, controls, elapsed_ms, self._rng)
+                queue_garbage_for_opponents(self.state, player_index, cleared)
+            update_match_end_state(self.state)
+
+        window.fill(BACKGROUND_COLOR)
+        self._render_players(window.screen, orientation)
+
+    def _elapsed_ms(self, window: DisplayContext) -> float:
+        if window.clock is None:
+            return 16.0
+        elapsed = float(window.clock.get_time())
+        if elapsed <= 0:
+            return 16.0
+        return min(elapsed, 100.0)
+
+    def _snapshot_for_player(self, player_index: int) -> DirectGamepadSnapshot:
+        return self._latest_snapshot(player_index)
+
+    def _latest_snapshot(self, player_index: int) -> DirectGamepadSnapshot:
+        return self._gamepads.snapshot_for_slot(player_index)
+
+    def _internal_process(
+        self,
+        window: DisplayContext,
+        peripheral_manager: PeripheralManager,
+        orientation: Orientation,
+    ) -> None:
+        self._active_peripheral_manager = peripheral_manager
+        super()._internal_process(window, peripheral_manager, orientation)
+
+    def _controls_for_snapshot(
+        self,
+        memory: TetrisInputMemory,
+        snapshot: DirectGamepadSnapshot,
+        elapsed_ms: float,
+    ) -> TetrisControls:
+        move_direction = self._move_direction(snapshot)
+        move_x = self._repeat_move(memory, move_direction, elapsed_ms)
+        dpad_up = snapshot.dpad.y > 0 and memory.previous_dpad_y <= 0
+        memory.previous_dpad_y = snapshot.dpad.y
+        return TetrisControls(
+            move_x=move_x,
+            soft_drop=self._soft_drop(snapshot),
+            hard_drop=snapshot.button_tapped(GamepadButton.SOUTH),
+            rotate_cw=snapshot.button_tapped(GamepadButton.EAST),
+            rotate_ccw=False,
+            hold=dpad_up,
+            restart=snapshot.button_tapped(GamepadButton.MINUS),
+        )
+
+    def _log_renderer_command(
+        self,
+        player_index: int,
+        snapshot: DirectGamepadSnapshot,
+        controls: TetrisControls,
+    ) -> None:
+        signature = self._control_signature(controls)
+        previous = self._last_logged_controls_by_player.get(player_index)
+        if signature == previous and controls.move_x == 0:
+            return
+        self._last_logged_controls_by_player[player_index] = signature
+        if not signature:
+            return
+        logger.info(
+            "tetris.command player=%s slot=%s age_ms=%.2f move_x=%s soft=%s hard=%s rotate_cw=%s rotate_ccw=%s hold=%s restart=%s",
+            player_index,
+            snapshot.slot,
+            (time.monotonic() - snapshot.timestamp_monotonic) * 1000,
+            controls.move_x,
+            controls.soft_drop,
+            controls.hard_drop,
+            controls.rotate_cw,
+            controls.rotate_ccw,
+            controls.hold,
+            controls.restart,
+        )
+
+    def _control_signature(self, controls: TetrisControls) -> tuple[object, ...]:
+        if not (
+            controls.move_x
+            or controls.soft_drop
+            or controls.hard_drop
+            or controls.rotate_cw
+            or controls.rotate_ccw
+            or controls.hold
+            or controls.restart
+        ):
+            return ()
+        return (
+            controls.move_x,
+            controls.soft_drop,
+            controls.hard_drop,
+            controls.rotate_cw,
+            controls.rotate_ccw,
+            controls.hold,
+            controls.restart,
+        )
+
+    def _move_direction(self, snapshot: DirectGamepadSnapshot) -> int:
+        if snapshot.dpad.x != 0:
+            return 1 if snapshot.dpad.x > 0 else -1
+        return 0
+
+    def _soft_drop(self, snapshot: DirectGamepadSnapshot) -> bool:
+        return snapshot.dpad.y < 0
+
+    def _repeat_move(
+        self,
+        memory: TetrisInputMemory,
+        direction: int,
+        elapsed_ms: float,
+    ) -> int:
+        if direction == 0:
+            memory.previous_move_x = 0
+            memory.held_move_x = 0
+            memory.move_repeat_elapsed_ms = 0.0
+            memory.move_repeat_primed = False
+            return 0
+        if direction != memory.held_move_x:
+            memory.previous_move_x = direction
+            memory.held_move_x = direction
+            memory.move_repeat_elapsed_ms = 0.0
+            memory.move_repeat_primed = False
+            return direction
+        memory.move_repeat_elapsed_ms += elapsed_ms
+        threshold = (
+            MOVE_REPEAT_INTERVAL_MS
+            if memory.move_repeat_primed
+            else MOVE_REPEAT_DELAY_MS
+        )
+        if memory.move_repeat_elapsed_ms < threshold:
+            return 0
+        memory.move_repeat_elapsed_ms = 0.0
+        memory.move_repeat_primed = True
+        return direction
+
+    def _render_players(
+        self,
+        screen: pygame.Surface,
+        orientation: Orientation,
+    ) -> None:
+        panel_width = screen.get_width() // orientation.layout.columns
+        panel_height = screen.get_height() // orientation.layout.rows
+        render_scale = max(1, min(panel_width // 64, panel_height // 64))
+        for player_index, player in enumerate(self.state.players):
+            col = player_index % orientation.layout.columns
+            row = player_index // orientation.layout.columns
+            panel = pygame.Rect(
+                col * panel_width,
+                row * panel_height,
+                panel_width,
+                panel_height,
+            )
+            self._render_player_panel(
+                screen,
+                panel,
+                player,
+                player_index,
+                render_scale,
+            )
+
+    def _render_player_panel(
+        self,
+        screen: pygame.Surface,
+        panel: pygame.Rect,
+        player: TetrisPlayerState,
+        player_index: int,
+        render_scale: int,
+    ) -> None:
+        pygame.draw.rect(screen, PANEL_BACKGROUND_COLOR, panel)
+        accent = PLAYER_ACCENT_COLORS[player_index % len(PLAYER_ACCENT_COLORS)]
+        cell_size = CELL_SIZE_PX * render_scale
+        preview_cell_size = PREVIEW_CELL_SIZE_PX * render_scale
+        board_width_px = BOARD_WIDTH * cell_size
+        board_height_px = BOARD_HEIGHT * cell_size
+        board_total_width = board_width_px + (2 * render_scale)
+        board_total_height = board_height_px + (2 * render_scale)
+        board_left = panel.left + ((panel.width - board_total_width) // 2) + render_scale
+        board_top = (
+            panel.top
+            + max(render_scale, (panel.height - board_total_height) // 2)
+            + render_scale
+        )
+        board_rect = pygame.Rect(
+            board_left - render_scale,
+            board_top - render_scale,
+            board_width_px + (2 * render_scale),
+            board_height_px + (2 * render_scale),
+        )
+        hold_rect = pygame.Rect(
+            panel.left + render_scale,
+            panel.top + render_scale,
+            max(1, board_rect.left - panel.left - (3 * render_scale)),
+            19 * render_scale,
+        )
+        garbage_rect = pygame.Rect(
+            hold_rect.left,
+            hold_rect.bottom + (2 * render_scale),
+            hold_rect.width,
+            max(1, panel.bottom - hold_rect.bottom - (3 * render_scale)),
+        )
+        next_rect = pygame.Rect(
+            board_rect.right + (2 * render_scale),
+            panel.top + render_scale,
+            max(1, panel.right - board_rect.right - (3 * render_scale)),
+            panel.height - (2 * render_scale),
+        )
+        self._draw_hud_frame(screen, hold_rect, accent, render_scale)
+        self._draw_hud_frame(screen, garbage_rect, accent, render_scale)
+        self._draw_hud_frame(screen, board_rect, accent, render_scale)
+        self._draw_hud_frame(screen, next_rect, accent, render_scale)
+        board_inner = board_rect.inflate(-2 * render_scale, -2 * render_scale)
+        pygame.draw.rect(screen, BOARD_BACKGROUND_COLOR, board_inner)
+        self._render_board(screen, board_left, board_top, player, cell_size)
+        self._render_ghost(screen, board_left, board_top, player, cell_size)
+        self._render_active_piece(screen, board_left, board_top, player, cell_size)
+        self._render_hold_panel(
+            screen,
+            hold_rect,
+            player,
+            accent,
+            render_scale,
+            preview_cell_size,
+        )
+        self._render_next_panel(
+            screen,
+            next_rect,
+            player,
+            accent,
+            render_scale,
+            preview_cell_size,
+        )
+        self._render_garbage_meter(
+            screen,
+            garbage_rect,
+            player,
+            render_scale,
+        )
+        if player.game_over:
+            self._render_game_over(screen, board_rect)
+        if self.state.match_finished:
+            self._render_match_result(screen, panel, board_rect, player_index, render_scale)
+
+    def _draw_hud_frame(
+        self,
+        screen: pygame.Surface,
+        rect: pygame.Rect,
+        accent: pygame.Color,
+        render_scale: int,
+    ) -> None:
+        pygame.draw.rect(screen, BOARD_BORDER_SHADOW_COLOR, rect)
+        pygame.draw.rect(screen, BOARD_BORDER_COLOR, rect, render_scale)
+        inner = rect.inflate(-2 * render_scale, -2 * render_scale)
+        if inner.width <= 0 or inner.height <= 0:
+            return
+        pygame.draw.rect(screen, BOARD_BORDER_COLOR, inner, render_scale)
+        content = inner.inflate(-2 * render_scale, -2 * render_scale)
+        if content.width > 0 and content.height > 0:
+            pygame.draw.rect(screen, HUD_PANEL_COLOR, content)
+        pygame.draw.line(screen, accent, rect.topleft, rect.topright, render_scale)
+
+    def _render_board(
+        self,
+        screen: pygame.Surface,
+        board_left: int,
+        board_top: int,
+        player: TetrisPlayerState,
+        cell_size: int,
+    ) -> None:
+        for y, row in enumerate(player.board):
+            for x, color in enumerate(row):
+                rect = self._cell_rect(board_left, board_top, x, y, cell_size)
+                if color is None:
+                    pygame.draw.rect(screen, GRID_COLOR, rect, 1)
+                else:
+                    self._draw_block(screen, rect, TETRIS_PALETTE[color])
+
+    def _render_ghost(
+        self,
+        screen: pygame.Surface,
+        board_left: int,
+        board_top: int,
+        player: TetrisPlayerState,
+        cell_size: int,
+    ) -> None:
+        if player.active is None or player.game_over:
+            return
+        ghost = player.active
+        while not self._piece_collides(player, ghost.moved(0, 1)):
+            ghost = ghost.moved(0, 1)
+        if ghost == player.active:
+            return
+        for x, y in ghost.cells():
+            if y >= 0:
+                pygame.draw.rect(
+                    screen,
+                    GHOST_COLOR,
+                    self._cell_rect(board_left, board_top, x, y, cell_size),
+                    max(1, cell_size // 3),
+                )
+
+    def _render_active_piece(
+        self,
+        screen: pygame.Surface,
+        board_left: int,
+        board_top: int,
+        player: TetrisPlayerState,
+        cell_size: int,
+    ) -> None:
+        if player.active is None:
+            return
+        color = TETRIS_PALETTE[player.active.color]
+        for x, y in player.active.cells():
+            if y >= 0:
+                rect = self._cell_rect(board_left, board_top, x, y, cell_size)
+                self._draw_block(screen, rect, color)
+
+    def _render_hold_panel(
+        self,
+        screen: pygame.Surface,
+        panel: pygame.Rect,
+        player: TetrisPlayerState,
+        accent: pygame.Color,
+        render_scale: int,
+        preview_cell_size: int,
+    ) -> None:
+        self._render_mini_label(screen, "H", panel.centerx, panel.top, accent, render_scale)
+        if player.hold_piece is not None:
+            self._render_preview_piece(
+                screen,
+                player.hold_piece,
+                panel.left + (2 * render_scale),
+                panel.top + (7 * render_scale),
+                cell_size=preview_cell_size,
+                dim=player.hold_used,
+            )
+
+    def _render_next_panel(
+        self,
+        screen: pygame.Surface,
+        panel: pygame.Rect,
+        player: TetrisPlayerState,
+        accent: pygame.Color,
+        render_scale: int,
+        preview_cell_size: int,
+    ) -> None:
+        self._render_mini_label(screen, "N", panel.centerx, panel.top, accent, render_scale)
+        preview_x = panel.left + (2 * render_scale)
+        for index, kind in enumerate(list(player.next_queue)[:NEXT_PREVIEW_COUNT]):
+            self._render_preview_piece(
+                screen,
+                kind,
+                preview_x,
+                panel.top + ((6 + (index * 9)) * render_scale),
+                cell_size=preview_cell_size,
+            )
+
+    def _render_mini_label(
+        self,
+        screen: pygame.Surface,
+        label: str,
+        x: int,
+        y: int,
+        color: pygame.Color,
+        render_scale: int,
+    ) -> None:
+        font = self._tiny_font(render_scale)
+        surface = font.render(label, False, color)
+        rect = surface.get_rect()
+        rect.midtop = (x, y)
+        screen.blit(surface, rect)
+
+    def _render_preview_piece(
+        self,
+        screen: pygame.Surface,
+        kind: TetrisPieceKind,
+        x: int,
+        y: int,
+        *,
+        cell_size: int,
+        dim: bool = False,
+    ) -> None:
+        color = TETRIS_PALETTE[TetrisPiece(kind=kind).color]
+        if dim:
+            color = pygame.Color(color.r // 3, color.g // 3, color.b // 3)
+        for cell_x, cell_y in PIECE_ROTATIONS[kind][0]:
+            rect = pygame.Rect(
+                x + (cell_x * cell_size),
+                y + (cell_y * cell_size),
+                cell_size,
+                cell_size,
+            )
+            self._draw_block(screen, rect, color)
+
+    def _render_garbage_meter(
+        self,
+        screen: pygame.Surface,
+        panel: pygame.Rect,
+        player: TetrisPlayerState,
+        render_scale: int,
+    ) -> None:
+        fill_bottom = panel.bottom - (2 * render_scale)
+        bar_height = 4 * render_scale
+        for index in range(min(player.pending_garbage, 9)):
+            rect = pygame.Rect(
+                panel.left + (2 * render_scale),
+                fill_bottom - ((index + 1) * bar_height),
+                max(1, panel.width - (4 * render_scale)),
+                max(1, bar_height - render_scale),
+            )
+            pygame.draw.rect(screen, GARBAGE_WARNING_COLOR, rect)
+
+    def _draw_block(
+        self,
+        screen: pygame.Surface,
+        rect: pygame.Rect,
+        color: pygame.Color,
+    ) -> None:
+        pygame.draw.rect(screen, color, rect)
+        if rect.width <= 1 or rect.height <= 1:
+            return
+        highlight = _blend_color(color, pygame.Color("white"), 0.44)
+        lowlight = _blend_color(color, pygame.Color("black"), 0.38)
+        bevel = max(1, min(rect.width, rect.height) // 3)
+        pygame.draw.rect(screen, highlight, pygame.Rect(rect.left, rect.top, rect.width, bevel))
+        pygame.draw.rect(screen, highlight, pygame.Rect(rect.left, rect.top, bevel, rect.height))
+        pygame.draw.rect(
+            screen,
+            lowlight,
+            pygame.Rect(rect.left, rect.bottom - bevel, rect.width, bevel),
+        )
+        pygame.draw.rect(
+            screen,
+            lowlight,
+            pygame.Rect(rect.right - bevel, rect.top, bevel, rect.height),
+        )
+        inset = max(1, bevel)
+        inner = rect.inflate(-2 * inset, -2 * inset)
+        if inner.width > 0 and inner.height > 0:
+            pygame.draw.rect(screen, _blend_color(color, pygame.Color("white"), 0.12), inner)
+
+    def _render_game_over(
+        self,
+        screen: pygame.Surface,
+        board_rect: pygame.Rect,
+    ) -> None:
+        overlay = pygame.Surface(board_rect.size, pygame.SRCALPHA)
+        overlay.fill((30, 0, 8, 180))
+        screen.blit(overlay, board_rect.topleft)
+        pygame.draw.line(
+            screen,
+            GAME_OVER_COLOR,
+            board_rect.topleft,
+            board_rect.bottomright,
+            2,
+        )
+        pygame.draw.line(
+            screen,
+            GAME_OVER_COLOR,
+            board_rect.topright,
+            board_rect.bottomleft,
+            2,
+        )
+
+    def _render_match_result(
+        self,
+        screen: pygame.Surface,
+        panel: pygame.Rect,
+        board_rect: pygame.Rect,
+        player_index: int,
+        render_scale: int,
+    ) -> None:
+        won = self.state.winner_index == player_index
+        overlay = pygame.Surface(panel.size, pygame.SRCALPHA)
+        overlay.fill((0, 0, 0, 150))
+        screen.blit(overlay, panel.topleft)
+
+        card_width = min(panel.width - (6 * render_scale), board_rect.width + (12 * render_scale))
+        card_height = min(panel.height - (8 * render_scale), 28 * render_scale)
+        card = pygame.Rect(0, 0, max(1, card_width), max(1, card_height))
+        card.center = board_rect.center
+        pygame.draw.rect(screen, pygame.Color(0, 5, 12), card)
+        pygame.draw.rect(screen, BOARD_BORDER_SHADOW_COLOR, card, max(1, render_scale))
+        pygame.draw.rect(screen, RESTART_BUTTON_COLOR, card.inflate(-2 * render_scale, -2 * render_scale), max(1, render_scale))
+
+        label = "WIN" if won else "LOSE"
+        label_color = WIN_OVERLAY_COLOR if won else LOSE_OVERLAY_COLOR
+        label_font = self._font(max(13, 9 * render_scale))
+        label_surface = label_font.render(label, False, label_color)
+        label_rect = label_surface.get_rect()
+        label_rect.midtop = (card.centerx, card.top + (4 * render_scale))
+        screen.blit(label_surface, label_rect)
+
+        restart_font = self._font(max(8, 5 * render_scale))
+        restart_surface = restart_font.render("PRESS -", False, RESTART_BUTTON_COLOR)
+        restart_rect = restart_surface.get_rect()
+        restart_rect.midtop = (card.centerx, label_rect.bottom + (2 * render_scale))
+        screen.blit(restart_surface, restart_rect)
+
+        reset_surface = restart_font.render("RESTART", False, pygame.Color("white"))
+        reset_rect = reset_surface.get_rect()
+        reset_rect.midtop = (card.centerx, restart_rect.bottom)
+        screen.blit(reset_surface, reset_rect)
+
+    def _cell_rect(
+        self,
+        board_left: int,
+        board_top: int,
+        x: int,
+        y: int,
+        cell_size: int,
+    ) -> pygame.Rect:
+        return pygame.Rect(
+            board_left + x * cell_size,
+            board_top + y * cell_size,
+            cell_size,
+            cell_size,
+        )
+
+    def _piece_collides(
+        self,
+        player: TetrisPlayerState,
+        piece: TetrisPiece,
+    ) -> bool:
+        for x, y in piece.cells():
+            if x < 0 or x >= BOARD_WIDTH or y >= BOARD_HEIGHT:
+                return True
+            if y >= 0 and player.board[y][x] is not None:
+                return True
+        return False
+
+    def _tiny_font(self, render_scale: int) -> pygame.font.Font:
+        return self._font(max(8, 6 * render_scale))
+
+    def _font(self, font_size: int) -> pygame.font.Font:
+        if font_size not in self._fonts:
+            if not pygame.font.get_init():
+                pygame.font.init()
+            self._fonts[font_size] = pygame.font.Font(None, font_size)
+        return self._fonts[font_size]

--- a/src/heart/renderers/tetris/state.py
+++ b/src/heart/renderers/tetris/state.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+import random
+from collections import deque
+from dataclasses import dataclass, field
+from enum import IntEnum, StrEnum
+from typing import Deque
+
+BOARD_WIDTH = 10
+BOARD_HEIGHT = 20
+CELL_SIZE_PX = 3
+PLAYER_COUNT = 4
+QUEUE_PREVIEW_LENGTH = 6
+FALL_INTERVAL_MS = 700
+SOFT_DROP_INTERVAL_MS = 120
+LOCK_DELAY_MS = 450
+MOVE_REPEAT_DELAY_MS = 80
+MOVE_REPEAT_INTERVAL_MS = 35
+
+
+class TetrisPieceKind(StrEnum):
+    I_PIECE = "I"
+    O_PIECE = "O"
+    T_PIECE = "T"
+    S_PIECE = "S"
+    Z_PIECE = "Z"
+    J_PIECE = "J"
+    L_PIECE = "L"
+
+
+class TetrisColor(IntEnum):
+    CYAN = 1
+    YELLOW = 2
+    PURPLE = 3
+    GREEN = 4
+    RED = 5
+    BLUE = 6
+    ORANGE = 7
+    GARBAGE = 8
+
+
+PIECE_COLORS: dict[TetrisPieceKind, TetrisColor] = {
+    TetrisPieceKind.I_PIECE: TetrisColor.CYAN,
+    TetrisPieceKind.O_PIECE: TetrisColor.YELLOW,
+    TetrisPieceKind.T_PIECE: TetrisColor.PURPLE,
+    TetrisPieceKind.S_PIECE: TetrisColor.GREEN,
+    TetrisPieceKind.Z_PIECE: TetrisColor.RED,
+    TetrisPieceKind.J_PIECE: TetrisColor.BLUE,
+    TetrisPieceKind.L_PIECE: TetrisColor.ORANGE,
+}
+
+PIECE_ROTATIONS: dict[TetrisPieceKind, tuple[tuple[tuple[int, int], ...], ...]] = {
+    TetrisPieceKind.I_PIECE: (
+        ((0, 1), (1, 1), (2, 1), (3, 1)),
+        ((2, 0), (2, 1), (2, 2), (2, 3)),
+        ((0, 2), (1, 2), (2, 2), (3, 2)),
+        ((1, 0), (1, 1), (1, 2), (1, 3)),
+    ),
+    TetrisPieceKind.O_PIECE: (
+        ((1, 0), (2, 0), (1, 1), (2, 1)),
+        ((1, 0), (2, 0), (1, 1), (2, 1)),
+        ((1, 0), (2, 0), (1, 1), (2, 1)),
+        ((1, 0), (2, 0), (1, 1), (2, 1)),
+    ),
+    TetrisPieceKind.T_PIECE: (
+        ((1, 0), (0, 1), (1, 1), (2, 1)),
+        ((1, 0), (1, 1), (2, 1), (1, 2)),
+        ((0, 1), (1, 1), (2, 1), (1, 2)),
+        ((1, 0), (0, 1), (1, 1), (1, 2)),
+    ),
+    TetrisPieceKind.S_PIECE: (
+        ((1, 0), (2, 0), (0, 1), (1, 1)),
+        ((1, 0), (1, 1), (2, 1), (2, 2)),
+        ((1, 1), (2, 1), (0, 2), (1, 2)),
+        ((0, 0), (0, 1), (1, 1), (1, 2)),
+    ),
+    TetrisPieceKind.Z_PIECE: (
+        ((0, 0), (1, 0), (1, 1), (2, 1)),
+        ((2, 0), (1, 1), (2, 1), (1, 2)),
+        ((0, 1), (1, 1), (1, 2), (2, 2)),
+        ((1, 0), (0, 1), (1, 1), (0, 2)),
+    ),
+    TetrisPieceKind.J_PIECE: (
+        ((0, 0), (0, 1), (1, 1), (2, 1)),
+        ((1, 0), (2, 0), (1, 1), (1, 2)),
+        ((0, 1), (1, 1), (2, 1), (2, 2)),
+        ((1, 0), (1, 1), (0, 2), (1, 2)),
+    ),
+    TetrisPieceKind.L_PIECE: (
+        ((2, 0), (0, 1), (1, 1), (2, 1)),
+        ((1, 0), (1, 1), (1, 2), (2, 2)),
+        ((0, 1), (1, 1), (2, 1), (0, 2)),
+        ((0, 0), (1, 0), (1, 1), (1, 2)),
+    ),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class TetrisPiece:
+    kind: TetrisPieceKind
+    rotation: int = 0
+    x: int = 3
+    y: int = 0
+
+    @property
+    def color(self) -> TetrisColor:
+        return PIECE_COLORS[self.kind]
+
+    def cells(self) -> tuple[tuple[int, int], ...]:
+        return tuple(
+            (self.x + dx, self.y + dy)
+            for dx, dy in PIECE_ROTATIONS[self.kind][self.rotation % 4]
+        )
+
+    def moved(self, dx: int, dy: int) -> "TetrisPiece":
+        return TetrisPiece(
+            kind=self.kind,
+            rotation=self.rotation,
+            x=self.x + dx,
+            y=self.y + dy,
+        )
+
+    def rotated(self, steps: int = 1) -> "TetrisPiece":
+        return TetrisPiece(
+            kind=self.kind,
+            rotation=(self.rotation + steps) % 4,
+            x=self.x,
+            y=self.y,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TetrisControls:
+    move_x: int = 0
+    soft_drop: bool = False
+    hard_drop: bool = False
+    rotate_cw: bool = False
+    rotate_ccw: bool = False
+    hold: bool = False
+    restart: bool = False
+
+
+@dataclass(slots=True)
+class TetrisInputMemory:
+    previous_move_x: int = 0
+    held_move_x: int = 0
+    move_repeat_elapsed_ms: float = 0.0
+    move_repeat_primed: bool = False
+    previous_dpad_y: int = 0
+    soft_drop_elapsed_ms: float = 0.0
+
+
+@dataclass(slots=True)
+class TetrisPlayerState:
+    board: list[list[TetrisColor | None]]
+    active: TetrisPiece | None
+    next_queue: Deque[TetrisPieceKind]
+    hold_piece: TetrisPieceKind | None = None
+    hold_used: bool = False
+    fall_elapsed_ms: float = 0.0
+    lock_elapsed_ms: float = 0.0
+    pending_garbage: int = 0
+    score: int = 0
+    lines_cleared: int = 0
+    game_over: bool = False
+    input_memory: TetrisInputMemory = field(default_factory=TetrisInputMemory)
+
+    @classmethod
+    def create(cls, rng: random.Random) -> "TetrisPlayerState":
+        player = cls(
+            board=empty_board(),
+            active=None,
+            next_queue=deque(),
+        )
+        fill_queue(player.next_queue, rng)
+        spawn_next_piece(player, rng)
+        return player
+
+
+@dataclass(slots=True)
+class TetrisGameState:
+    players: list[TetrisPlayerState]
+    match_finished: bool = False
+    winner_index: int | None = None
+
+    @classmethod
+    def create(cls, rng: random.Random, player_count: int = PLAYER_COUNT) -> "TetrisGameState":
+        return cls(players=[TetrisPlayerState.create(rng) for _ in range(player_count)])
+
+
+def empty_board() -> list[list[TetrisColor | None]]:
+    return [[None for _ in range(BOARD_WIDTH)] for _ in range(BOARD_HEIGHT)]
+
+
+def fill_queue(queue: Deque[TetrisPieceKind], rng: random.Random) -> None:
+    while len(queue) < QUEUE_PREVIEW_LENGTH + 1:
+        bag = list(TetrisPieceKind)
+        rng.shuffle(bag)
+        queue.extend(bag)
+
+
+def spawn_next_piece(player: TetrisPlayerState, rng: random.Random) -> None:
+    fill_queue(player.next_queue, rng)
+    kind = player.next_queue.popleft()
+    player.active = TetrisPiece(kind=kind)
+    player.hold_used = False
+    player.lock_elapsed_ms = 0.0
+    player.fall_elapsed_ms = 0.0
+    fill_queue(player.next_queue, rng)
+    if collides(player.board, player.active):
+        player.game_over = True
+
+
+def collides(board: list[list[TetrisColor | None]], piece: TetrisPiece) -> bool:
+    for x, y in piece.cells():
+        if x < 0 or x >= BOARD_WIDTH or y >= BOARD_HEIGHT:
+            return True
+        if y >= 0 and board[y][x] is not None:
+            return True
+    return False
+
+
+def try_move(player: TetrisPlayerState, dx: int, dy: int) -> bool:
+    if player.active is None:
+        return False
+    candidate = player.active.moved(dx, dy)
+    if collides(player.board, candidate):
+        return False
+    player.active = candidate
+    if dy == 0:
+        player.lock_elapsed_ms = 0.0
+    return True
+
+
+def try_rotate(player: TetrisPlayerState, steps: int) -> bool:
+    if player.active is None:
+        return False
+    candidate = player.active.rotated(steps)
+    for kick_x in (0, -1, 1, -2, 2):
+        kicked = TetrisPiece(
+            kind=candidate.kind,
+            rotation=candidate.rotation,
+            x=candidate.x + kick_x,
+            y=candidate.y,
+        )
+        if not collides(player.board, kicked):
+            player.active = kicked
+            player.lock_elapsed_ms = 0.0
+            return True
+    return False
+
+
+def hold_piece(player: TetrisPlayerState, rng: random.Random) -> None:
+    if player.active is None or player.hold_used:
+        return
+    active_kind = player.active.kind
+    if player.hold_piece is None:
+        player.hold_piece = active_kind
+        spawn_next_piece(player, rng)
+    else:
+        player.active = TetrisPiece(kind=player.hold_piece)
+        player.hold_piece = active_kind
+        if collides(player.board, player.active):
+            player.game_over = True
+    player.hold_used = True
+
+
+def hard_drop(player: TetrisPlayerState, rng: random.Random) -> int:
+    if player.active is None:
+        return 0
+    distance = 0
+    while try_move(player, 0, 1):
+        distance += 1
+    player.score += distance * 2
+    return lock_piece(player, rng)
+
+
+def lock_piece(player: TetrisPlayerState, rng: random.Random) -> int:
+    if player.active is None:
+        return 0
+    for x, y in player.active.cells():
+        if y < 0:
+            player.game_over = True
+            player.active = None
+            return 0
+        player.board[y][x] = player.active.color
+    player.active = None
+    cleared = clear_lines(player)
+    if player.pending_garbage > 0:
+        apply_garbage(player, player.pending_garbage, rng)
+        player.pending_garbage = 0
+    spawn_next_piece(player, rng)
+    return cleared
+
+
+def clear_lines(player: TetrisPlayerState) -> int:
+    remaining = [row for row in player.board if any(cell is None for cell in row)]
+    cleared = BOARD_HEIGHT - len(remaining)
+    if cleared == 0:
+        return 0
+    player.board[:] = [
+        [None for _ in range(BOARD_WIDTH)] for _ in range(cleared)
+    ] + remaining
+    player.lines_cleared += cleared
+    player.score += (100, 300, 500, 800)[min(cleared, 4) - 1]
+    return cleared
+
+
+def apply_garbage(
+    player: TetrisPlayerState,
+    line_count: int,
+    rng: random.Random,
+) -> None:
+    for _ in range(line_count):
+        hole = rng.randrange(BOARD_WIDTH)
+        player.board.pop(0)
+        player.board.append(
+            [
+                None if x == hole else TetrisColor.GARBAGE
+                for x in range(BOARD_WIDTH)
+            ]
+        )
+    if player.active is not None and collides(player.board, player.active):
+        while player.active is not None and collides(player.board, player.active):
+            player.active = player.active.moved(0, -1)
+            if any(y < 0 for _, y in player.active.cells()):
+                player.game_over = True
+                return
+
+
+def queue_garbage_for_opponents(
+    state: TetrisGameState,
+    sender_index: int,
+    line_count: int,
+) -> None:
+    if line_count <= 0:
+        return
+    for index, player in enumerate(state.players):
+        if index == sender_index or player.game_over:
+            continue
+        player.pending_garbage += line_count
+
+
+def update_match_end_state(state: TetrisGameState) -> None:
+    if state.match_finished:
+        return
+    alive_indices = [
+        index for index, player in enumerate(state.players) if not player.game_over
+    ]
+    if len(alive_indices) > 1:
+        return
+    state.match_finished = True
+    state.winner_index = alive_indices[0] if alive_indices else None
+
+
+def restart_match(state: TetrisGameState, rng: random.Random) -> None:
+    replacement = TetrisGameState.create(rng, player_count=len(state.players))
+    state.players = replacement.players
+    state.match_finished = False
+    state.winner_index = None
+
+
+def restart_player(player: TetrisPlayerState, rng: random.Random) -> None:
+    replacement = TetrisPlayerState.create(rng)
+    player.board = replacement.board
+    player.active = replacement.active
+    player.next_queue = replacement.next_queue
+    player.hold_piece = replacement.hold_piece
+    player.hold_used = replacement.hold_used
+    player.fall_elapsed_ms = replacement.fall_elapsed_ms
+    player.lock_elapsed_ms = replacement.lock_elapsed_ms
+    player.pending_garbage = replacement.pending_garbage
+    player.score = replacement.score
+    player.lines_cleared = replacement.lines_cleared
+    player.game_over = replacement.game_over
+    player.input_memory = replacement.input_memory
+
+
+def advance_player(
+    player: TetrisPlayerState,
+    controls: TetrisControls,
+    elapsed_ms: float,
+    rng: random.Random,
+) -> int:
+    if controls.restart:
+        restart_player(player, rng)
+        return 0
+    if player.game_over:
+        return 0
+
+    if controls.hold:
+        hold_piece(player, rng)
+    if controls.rotate_cw:
+        try_rotate(player, 1)
+    if controls.rotate_ccw:
+        try_rotate(player, -1)
+
+    move_x = controls.move_x
+    if move_x != 0:
+        try_move(player, move_x, 0)
+
+    if controls.hard_drop:
+        return hard_drop(player, rng)
+
+    if controls.soft_drop:
+        player.fall_elapsed_ms = 0.0
+        player.input_memory.soft_drop_elapsed_ms += elapsed_ms
+        if player.input_memory.soft_drop_elapsed_ms < SOFT_DROP_INTERVAL_MS:
+            return 0
+        player.input_memory.soft_drop_elapsed_ms = 0.0
+        if try_move(player, 0, 1):
+            player.score += 1
+            player.lock_elapsed_ms = 0.0
+            return 0
+        player.lock_elapsed_ms += SOFT_DROP_INTERVAL_MS
+        if player.lock_elapsed_ms >= LOCK_DELAY_MS:
+            return lock_piece(player, rng)
+        return 0
+
+    player.input_memory.soft_drop_elapsed_ms = 0.0
+    fall_interval = FALL_INTERVAL_MS
+    player.fall_elapsed_ms += elapsed_ms
+    cleared = 0
+    while player.fall_elapsed_ms >= fall_interval and not player.game_over:
+        player.fall_elapsed_ms -= fall_interval
+        if try_move(player, 0, 1):
+            if controls.soft_drop:
+                player.score += 1
+            player.lock_elapsed_ms = 0.0
+            continue
+        player.lock_elapsed_ms += fall_interval
+        if player.lock_elapsed_ms >= LOCK_DELAY_MS:
+            cleared += lock_piece(player, rng)
+            break
+    return cleared


### PR DESCRIPTION
## Summary
- add a standalone four-player competitive Tetris configuration with hold/next previews, garbage lines, restart/end states, and direct controller input
- make Tetris self-contained: no `GameLoop` runtime switch and no changes to shared renderer/main-loop code
- register Tetris as a mode in `lib_2026`
- hardcode the four 8BitDo controller MACs to Tetris player slots
- add a Pi setup script to pair/trust/connect the Tetris controllers
- add TigerVNC setup/open scripts plus a repo-local Codex skill for running Tetris on `totem3.local` without X11 forwarding
- configure the VNC Tetris setup through the normal system `totem.service`, with TigerVNC on display `:1` and Tetris as the service process

## Validation
- `uv run python -m compileall -q src/heart/programs/configurations/lib_2026.py src/heart/programs/configurations/tetris.py src/heart/renderers/tetris`
- `uv run ruff check src/heart/programs/configurations/lib_2026.py src/heart/programs/configurations/tetris.py src/heart/renderers/tetris`
- `uv run pytest -q tests/runtime/test_game_loop.py tests/navigation/test_game_modes.py`
- `uv run python - <<'PY' ... PY` assertion that `lib_2026` registers `TetrisRenderer`
- Ran locally with `uv run totem run --configuration tetris --no-add-low-power-mode`; macOS pygame detected `8BitDo Lite 2` and Tetris received D-pad, rotate, hard-drop, and restart input.
- Earlier Pi/VNC validation: installed and started the cleaned setup on `totem3.local`; `totem.service` was enabled and active, old per-user Tetris services were inactive, `Xtigervnc :1` listened on VNC port `5901`, and Tetris ran as the service process.