### PR TITLE
[codex] Fix Mandelbrot gamepad Y motion

### DIFF
--- a/src/heart/peripheral/core/input/profiles/mandelbrot.py
+++ b/src/heart/peripheral/core/input/profiles/mandelbrot.py
@@ -11,7 +11,8 @@ from heart.peripheral.core.input.debug import (InputDebugNode, InputDebugStage,
 from heart.peripheral.core.input.gamepad import (
     DEFAULT_GAMEPAD_AXIS_DEAD_ZONE, GamepadAxis, GamepadButton,
     GamepadController, GamepadSnapshot)
-from heart.peripheral.core.input.keyboard import KeyboardController, KeyboardSnapshot
+from heart.peripheral.core.input.keyboard import (KeyboardController,
+                                                  KeyboardSnapshot)
 from heart.peripheral.core.input.streams import map_stream
 from heart.peripheral.core.streams import combine_latest
 
@@ -423,7 +424,7 @@ class MandelbrotControlProfile:
         move_multiplier = 2.0 if button_b_held else 1.0
         return MandelbrotMotionState(
             move_x=keyboard_move_x + dpad.x + left_stick_x,
-            move_y=keyboard_move_y - dpad.y + left_stick_y,
+            move_y=keyboard_move_y - dpad.y - left_stick_y,
             pan_x=right_stick_x,
             pan_y=-right_stick_y,
             move_multiplier=move_multiplier,

--- a/src/heart/renderers/palette_tunnel/renderer.py
+++ b/src/heart/renderers/palette_tunnel/renderer.py
@@ -8,51 +8,24 @@ import numpy as np
 import pygame
 from manyfold.graph import SubscriptionLike
 from OpenGL.error import GLError
-from OpenGL.GL import (
-    GL_COLOR_BUFFER_BIT,
-    GL_DEPTH_BUFFER_BIT,
-    GL_MODELVIEW,
-    GL_NEAREST,
-    GL_PROJECTION,
-    GL_QUADS,
-    GL_RGBA,
-    GL_TEXTURE_2D,
-    GL_TEXTURE_MAG_FILTER,
-    GL_TEXTURE_MIN_FILTER,
-    GL_UNSIGNED_BYTE,
-    glBegin,
-    glBindTexture,
-    glClear,
-    glDeleteTextures,
-    glDisable,
-    glEnable,
-    glEnd,
-    glGenTextures,
-    glLoadIdentity,
-    glMatrixMode,
-    glOrtho,
-    glReadPixels,
-    glTexCoord2f,
-    glTexImage2D,
-    glTexParameteri,
-    glTexSubImage2D,
-    glUseProgram,
-    glVertex2f,
-    glViewport,
-)
+from OpenGL.GL import (GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT, GL_MODELVIEW,
+                       GL_NEAREST, GL_PROJECTION, GL_QUADS, GL_RGBA,
+                       GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
+                       GL_TEXTURE_MIN_FILTER, GL_UNSIGNED_BYTE, glBegin,
+                       glBindTexture, glClear, glDeleteTextures, glDisable,
+                       glEnable, glEnd, glGenTextures, glLoadIdentity,
+                       glMatrixMode, glOrtho, glReadPixels, glTexCoord2f,
+                       glTexImage2D, glTexParameteri, glTexSubImage2D,
+                       glUseProgram, glVertex2f, glViewport)
 
 from heart import DeviceDisplayMode
 from heart.device import Cube, Orientation
-from heart.display.shaders.fullscreen import FullscreenShaderRuntime, UniformValue
-from heart.display.shaders.shader_templates.palette_tunnel import (
-    __file__ as shader_template_location,
-)
-from heart.peripheral.core.input import (
-    GamepadAxis,
-    GamepadButton,
-    GamepadSnapshot,
-    KeyboardSnapshot,
-)
+from heart.display.shaders.fullscreen import (FullscreenShaderRuntime,
+                                              UniformValue)
+from heart.display.shaders.shader_templates.palette_tunnel import \
+    __file__ as shader_template_location
+from heart.peripheral.core.input import (GamepadAxis, GamepadButton,
+                                         GamepadSnapshot, KeyboardSnapshot)
 from heart.peripheral.core.manager import PeripheralManager
 from heart.renderers import StatefulBaseRenderer
 from heart.runtime.display_context import DisplayContext

--- a/src/heart/renderers/three_fractal/renderer.py
+++ b/src/heart/renderers/three_fractal/renderer.py
@@ -10,8 +10,8 @@ from manyfold import StreamNode, shutdown
 from manyfold.graph import SubscriptionLike
 from OpenGL.error import GLError
 from OpenGL.GL import (GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT, GL_MODELVIEW,
-                       GL_NEAREST, GL_PROJECTION, GL_QUADS, GL_RENDERER, GL_RGBA,
-                       GL_SHADING_LANGUAGE_VERSION, GL_TEXTURE_2D,
+                       GL_NEAREST, GL_PROJECTION, GL_QUADS, GL_RENDERER,
+                       GL_RGBA, GL_SHADING_LANGUAGE_VERSION, GL_TEXTURE_2D,
                        GL_TEXTURE_MAG_FILTER, GL_TEXTURE_MIN_FILTER,
                        GL_UNSIGNED_BYTE, GL_VENDOR, GL_VERSION, glBegin,
                        glBindTexture, glClear, glDeleteTextures, glDisable,
@@ -24,8 +24,10 @@ from pygame.math import lerp
 from heart import DeviceDisplayMode
 from heart.device import Cube, Orientation, Rectangle
 from heart.device.local import LocalScreen
-from heart.display.shaders.fullscreen import FullscreenShaderRuntime, UniformValue
-from heart.display.shaders.shader_templates.three_fractal import __file__ as shader_template_location
+from heart.display.shaders.fullscreen import (FullscreenShaderRuntime,
+                                              UniformValue)
+from heart.display.shaders.shader_templates.three_fractal import \
+    __file__ as shader_template_location
 from heart.peripheral.core.input import (GamepadAxis, GamepadButton,
                                          GamepadSnapshot, KeyboardSnapshot)
 from heart.peripheral.core.manager import PeripheralManager

--- a/src/heart/renderers/vibe/state.py
+++ b/src/heart/renderers/vibe/state.py
@@ -4,8 +4,8 @@ from pathlib import Path
 from heart.renderers import StatefulBaseRenderer
 from heart.renderers.spritesheet import (BoundingBox, FrameDescription, Size,
                                          SpritesheetLoop)
-from heart.renderers.vibe.overmono_runner import OvermonoRunner
 from heart.renderers.vibe.oppi_renderer import OppiRenderer
+from heart.renderers.vibe.overmono_runner import OvermonoRunner
 
 SUNSLEEPER2_SHEET_PATH = Path("vibe") / "sunsleeper_64x64_spritesheet.png"
 TREE_SHEET_PATH = Path("vibe") / "tree_384x384_spritesheet.png"

--- a/tests/renderers/test_palette_tunnel_renderer.py
+++ b/tests/renderers/test_palette_tunnel_renderer.py
@@ -9,14 +9,10 @@ import pygame
 
 from heart import DeviceDisplayMode
 from heart.device import Cube
-from heart.peripheral.core.input import (
-    GamepadAxis,
-    GamepadDpadValue,
-    GamepadSnapshot,
-    KeyboardSnapshot,
-)
-from heart.renderers.palette_tunnel.renderer import PaletteTunnelScene
-from heart.renderers.palette_tunnel.renderer import MOUSE_SCALE
+from heart.peripheral.core.input import (GamepadAxis, GamepadDpadValue,
+                                         GamepadSnapshot, KeyboardSnapshot)
+from heart.renderers.palette_tunnel.renderer import (MOUSE_SCALE,
+                                                     PaletteTunnelScene)
 
 
 class _Subscription:


### PR DESCRIPTION
## Summary
- Restore the Mandelbrot snapshot-based gamepad Y-axis sign to match the existing stream-based control contract.
- Include formatter output required by the repository commit hook.

## Root Cause
The snapshot migration read `LEFT_Y` directly into `move_y`, while the prior stick-value path inverted the left-stick Y axis. That caused gamepad-up movement to emit `0.75` instead of the expected `1.25` in CI.

## Validation
- `PATH="$HOME/.local/bin:$PATH" make test` -> `522 passed, 2 skipped`