### PR TITLE
[codex] Fix CircuitPython sensor bus firmware

### DIFF
--- a/drivers/sensor_bus/code.py
+++ b/drivers/sensor_bus/code.py
@@ -11,6 +11,7 @@ import json
 import time
 
 import board
+import busio
 from adafruit_lis2mdl import LIS2MDL
 from adafruit_lsm6ds import Rate
 from adafruit_lsm6ds.ism330dhcx import ISM330DHCX
@@ -23,6 +24,20 @@ DEFAULT_WAIT_BETWEEN_PAYLOADS_SECONDS: float = 0.1
 DEFAULT_MIN_CHANGE_THRESHOLD: float = 0.1
 DEBUG = False
 DEVICE_NAME = "sensor-bus"
+RUN_MODULE_NAMES = {"__main__", "code"}
+LSM303_ACCEL_ADDRESSES = (0x19,)
+LIS2MDL_ADDRESSES = (0x1E,)
+ISM330DHCX_ADDRESSES = (0x6A, 0x6B)
+
+
+def create_i2c_bus():
+    """Return the configured sensor I2C bus for STEMMA/Qwiic wiring."""
+    if hasattr(board, "STEMMA_I2C"):
+        try:
+            return board.STEMMA_I2C()
+        except Exception as exc:  # noqa: BLE001
+            _debug("Failed to initialize board.STEMMA_I2C(): %s" % exc)
+    return busio.I2C(board.RX, board.TX)
 
 
 def _debug(message: str) -> None:
@@ -115,18 +130,46 @@ def connect_to_sensors(i2c):
         ISM330DHCX: An instance of the ISM330DHCX sensor.
 
     """
+    scanned_addresses = _scan_i2c_addresses(i2c)
     sensor_factories = [
-        LSM303_Accel,
-        LIS2MDL,
-        ISM330DHCX,
+        (LSM303_Accel, LSM303_ACCEL_ADDRESSES),
+        (LIS2MDL, LIS2MDL_ADDRESSES),
+        (ISM330DHCX, ISM330DHCX_ADDRESSES),
     ]
     sensors = []
-    for sensor_factory in sensor_factories:
+    for sensor_factory, expected_addresses in sensor_factories:
+        if scanned_addresses is not None and not _has_any_address(
+            scanned_addresses, expected_addresses
+        ):
+            _debug(
+                "Skipping sensor %s; addresses %s not present"
+                % (sensor_factory.__name__, expected_addresses)
+            )
+            continue
         try:
             sensors.append(sensor_factory(i2c))
         except Exception as exc:  # noqa: BLE001
-            _debug(f"Failed to initialize sensor {sensor_factory.__name__}: {exc}")
+            _debug("Failed to initialize sensor %s: %s" % (sensor_factory.__name__, exc))
     return sensors
+
+
+def _scan_i2c_addresses(i2c):
+    if not hasattr(i2c, "try_lock") or not hasattr(i2c, "scan"):
+        return None
+    try:
+        while not i2c.try_lock():
+            time.sleep(0.01)
+        try:
+            return tuple(i2c.scan())
+        finally:
+            i2c.unlock()
+    except Exception as exc:  # noqa: BLE001
+        _debug("Failed to scan I2C bus: %s" % exc)
+        return None
+
+
+def _has_any_address(scanned_addresses, expected_addresses) -> bool:
+    return any(address in scanned_addresses for address in expected_addresses)
 
 
 class SensorReader:
@@ -180,7 +223,7 @@ def main() -> None:
         OSError: If an error occurs during sensor data reading or connection.
 
     """
-    i2c = board.STEMMA_I2C()
+    i2c = create_i2c_bus()
     sensors = connect_to_sensors(i2c=i2c)
 
     # This assumes two things:
@@ -210,5 +253,5 @@ def main() -> None:
             time.sleep(WAIT_BEFORE_TRYING_TO_CONNECT_TO_SENSOR_SECONDS)
 
 
-if __name__ == "__main__":
+if __name__ in RUN_MODULE_NAMES:
     main()

--- a/packages/heart-firmware-io/src/heart_firmware_io/device_id.py
+++ b/packages/heart-firmware-io/src/heart_firmware_io/device_id.py
@@ -2,33 +2,34 @@
 
 from __future__ import annotations
 
-import importlib
 import os
-from pathlib import Path
-from types import ModuleType
-from typing import Callable, Mapping, TextIO
+
+try:
+    import microcontroller
+except ImportError:  # pragma: no cover - CPython fallback
+    microcontroller = None
 
 DEVICE_ID_ENV_VAR = "HEART_DEVICE_ID"
 DEVICE_ID_PATH_ENV_VAR = "HEART_DEVICE_ID_PATH"
 DEFAULT_DEVICE_ID_FILENAME = "device_id.txt"
-DEFAULT_DEVICE_ID_PATH = Path("/") / DEFAULT_DEVICE_ID_FILENAME
+DEFAULT_DEVICE_ID_PATH = "/" + DEFAULT_DEVICE_ID_FILENAME
 
 
-def default_device_id_path(env: Mapping[str, str] | None = None) -> Path:
+def default_device_id_path(env=None) -> str:
     """Return the filesystem path used to persist device identifiers."""
 
-    env_mapping = env or os.environ
+    env_mapping = env or getattr(os, "environ", {})
     configured = env_mapping.get(DEVICE_ID_PATH_ENV_VAR)
     if configured:
-        return Path(configured)
+        return configured
     return DEFAULT_DEVICE_ID_PATH
 
 
 def persistent_device_id(
     *,
-    storage_path: Path | str | None = None,
-    env: Mapping[str, str] | None = None,
-    opener: Callable[[str | Path, str], TextIO] | None = None,
+    storage_path=None,
+    env=None,
+    opener=None,
     microcontroller_module=None,
 ) -> str:
     """Return a device identifier that remains stable across boots.
@@ -45,8 +46,12 @@ def persistent_device_id(
     requiring the environment variable.
     """
 
-    env_mapping = env or os.environ
-    path = Path(storage_path) if storage_path else default_device_id_path(env_mapping)
+    env_mapping = env or getattr(os, "environ", {})
+    path = (
+        _pathlike_to_string(storage_path)
+        if storage_path
+        else default_device_id_path(env_mapping)
+    )
     opener_fn = opener or open
 
     existing = _read_device_id(path, opener_fn)
@@ -67,12 +72,10 @@ def persistent_device_id(
     return candidate
 
 
-def _hardware_device_uid(microcontroller_module: ModuleType | None = None) -> str | None:
-    module = microcontroller_module
+def _hardware_device_uid(microcontroller_module=None) -> str | None:
+    module = microcontroller_module or microcontroller
     if module is None:
-        if importlib.util.find_spec("microcontroller") is None:  # pragma: no cover - hardware only
-            return None
-        module = importlib.import_module("microcontroller")
+        return None
 
     cpu = getattr(module, "cpu", None)
     uid = getattr(cpu, "uid", None) if cpu is not None else None
@@ -100,8 +103,8 @@ def _random_device_id() -> str:
 
 
 def _read_device_id(
-    path: Path | None,
-    opener: Callable[[str | Path, str], TextIO],
+    path: str | None,
+    opener,
 ) -> str | None:
     if not path:
         return None
@@ -115,8 +118,8 @@ def _read_device_id(
     return raw or None
 
 
-def _write_device_id(path: Path, value: str, opener: Callable[[str | Path, str], TextIO]) -> None:
-    _ensure_directory(path.parent)
+def _write_device_id(path: str, value: str, opener) -> None:
+    _ensure_directory(_parent_directory(path))
 
     try:
         with opener(path, "w") as handle:
@@ -125,11 +128,22 @@ def _write_device_id(path: Path, value: str, opener: Callable[[str | Path, str],
         return
 
 
-def _ensure_directory(path: Path) -> None:
-    if path in (Path("."), Path("/")):
+def _ensure_directory(path: str) -> None:
+    if path in ("", ".", "/"):
         return
 
     try:
-        path.mkdir(parents=True, exist_ok=True)
+        os.makedirs(path, exist_ok=True)
     except OSError:
         return
+
+
+def _pathlike_to_string(path) -> str:
+    try:
+        return os.fspath(path)
+    except AttributeError:
+        return str(path)
+
+
+def _parent_directory(path: str) -> str:
+    return path.rsplit("/", 1)[0] if "/" in path else ""

--- a/packages/heart-firmware-io/src/heart_firmware_io/identity.py
+++ b/packages/heart-firmware-io/src/heart_firmware_io/identity.py
@@ -2,18 +2,19 @@
 
 from __future__ import annotations
 
-import importlib
 import json
 import sys
-from types import ModuleType
-from typing import Callable, Iterable, Mapping, TextIO
 
 from heart_firmware_io import constants
 
-supervisor: ModuleType | None
-if importlib.util.find_spec("supervisor") is not None:  # pragma: no cover - exercised on hardware
-    supervisor = importlib.import_module("supervisor")
-else:  # pragma: no cover - supervisor is unavailable on CPython
+try:
+    import importlib
+except ImportError:  # pragma: no cover - CircuitPython fallback
+    importlib = None
+
+try:
+    import supervisor
+except ImportError:  # pragma: no cover - supervisor is unavailable on CPython
     supervisor = None
 
 
@@ -29,14 +30,14 @@ class Identity:
         firmware_commit: str,
         device_id: str,
         *,
-        metadata: Mapping[str, str] | None = None,
+        metadata=None,
     ) -> None:
         self.device_name = device_name
         self.firmware_commit = firmware_commit
         self.device_id = device_id
         self._metadata = dict(metadata or {})
 
-    def as_payload(self) -> Mapping[str, str]:
+    def as_payload(self):
         payload = {
             "device_name": self.device_name,
             "firmware_commit": self.firmware_commit,
@@ -66,8 +67,8 @@ def default_firmware_commit(default: str = DEFAULT_FIRMWARE_COMMIT) -> str:
 def poll_and_respond(
     identity: Identity,
     *,
-    stdin: TextIO | None = None,
-    print_fn: Callable[[str], None] = print,
+    stdin=None,
+    print_fn=print,
 ) -> bool:
     """Respond to any pending serial queries.
 
@@ -89,11 +90,23 @@ def _format_identity_payload(identity: Identity) -> str:
     return json.dumps({"event_type": constants.DEVICE_IDENTIFY, "data": identity.as_payload()})
 
 
-def _iter_serial_queries(*, stdin: TextIO | None) -> Iterable[str]:
+def _iter_serial_queries(*, stdin):
     provided_stream = stdin
     stream = stdin or sys.stdin
     if stream is None:
         return []
+
+    if provided_stream is None:
+        available = _serial_bytes_available_count()
+        if available <= 0:
+            return []
+        try:
+            raw = stream.read(available)
+        except OSError:
+            return []
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8", errors="ignore")
+        return [line.strip() for line in raw.splitlines() if line.strip()]
 
     queries = []
     while _serial_bytes_available(stdin_provided=provided_stream is not None):
@@ -110,6 +123,24 @@ def _iter_serial_queries(*, stdin: TextIO | None) -> Iterable[str]:
             queries.append(stripped)
 
     return queries
+
+
+def _serial_bytes_available_count() -> int:
+    if supervisor is None:
+        return 0
+
+    runtime = getattr(supervisor, "runtime", None)
+    if runtime is None:
+        return 0
+
+    available = getattr(runtime, "serial_bytes_available", None)
+    if available is None:
+        return 0
+
+    try:
+        return int(available)
+    except Exception:  # pragma: no cover - defensive fallback
+        return 0
 
 
 def _serial_bytes_available(*, stdin_provided: bool) -> bool:
@@ -142,7 +173,7 @@ def _extract_command(raw: str) -> str | None:
     except ValueError:
         return raw
 
-    if isinstance(parsed, Mapping):
+    if isinstance(parsed, dict):
         candidate = parsed.get("query") or parsed.get("command")
         if isinstance(candidate, str):
             return candidate
@@ -151,6 +182,8 @@ def _extract_command(raw: str) -> str | None:
 
 
 def _commit_from_generated_module() -> str | None:
+    if importlib is None:
+        return None
     if importlib.util.find_spec("heart_firmware_build") is None:
         return None
     module = importlib.import_module("heart_firmware_build")
@@ -162,6 +195,8 @@ def _commit_from_generated_module() -> str | None:
 
 
 def _commit_from_git(default: str) -> str | None:
+    if importlib is None:
+        return None
     if importlib.util.find_spec("subprocess") is None:  # pragma: no cover - hardware environments
         return None
     subprocess = importlib.import_module("subprocess")

--- a/tests/drivers/test_sensor_bus_driver.py
+++ b/tests/drivers/test_sensor_bus_driver.py
@@ -14,6 +14,7 @@ class FakeRate:
 
 STUBS = {
     "board": make_module("board"),
+    "busio": make_module("busio"),
     "adafruit_lis2mdl": make_module("adafruit_lis2mdl", LIS2MDL=object),
     "adafruit_lsm6ds": make_module("adafruit_lsm6ds", Rate=FakeRate),
     "adafruit_lsm6ds.ism330dhcx": make_module(
@@ -64,6 +65,22 @@ class StubGyroSensor:
         return self.current
 
 
+class StubI2CBus:
+    def __init__(self, addresses):
+        self.addresses = addresses
+        self.locked = False
+
+    def try_lock(self):
+        self.locked = True
+        return True
+
+    def scan(self):
+        return self.addresses
+
+    def unlock(self):
+        self.locked = False
+
+
 class TestDriversSensorBusDriver:
     """Group Drivers Sensor Bus Driver tests so drivers sensor bus driver behaviour stays reliable. This preserves confidence in drivers sensor bus driver for end-to-end scenarios."""
 
@@ -89,6 +106,18 @@ class TestDriversSensorBusDriver:
             == sensor_bus.Rate.string[sensor_bus.Rate.RATE_104_HZ]
         )
 
+    def test_create_i2c_bus_falls_back_to_kb2040_rx_tx(self, sensor_bus):
+        """Verify KB2040 boards without STEMMA_I2C use the documented RX/TX I2C pins."""
+        calls = []
+        sensor_bus.board.RX = "rx"
+        sensor_bus.board.TX = "tx"
+        sensor_bus.busio.I2C = lambda scl, sda: calls.append((scl, sda)) or "i2c"
+
+        i2c = sensor_bus.create_i2c_bus()
+
+        assert i2c == "i2c"
+        assert calls == [("rx", "tx")]
+
     def test_connect_to_sensors_skips_failures(self, monkeypatch, sensor_bus):
         """Verify that connect_to_sensors ignores constructors that fail and returns only the working sensors. This keeps initialization resilient so one bad component does not break the stack."""
         created = []
@@ -108,6 +137,30 @@ class TestDriversSensorBusDriver:
         sensors = sensor_bus.connect_to_sensors("i2c-bus")
         assert len(sensors) == 2
         assert created == [("GoodSensor", "i2c-bus"), ("GoodSensor", "i2c-bus")]
+
+    def test_connect_to_sensors_skips_missing_i2c_addresses(
+        self, monkeypatch, sensor_bus
+    ):
+        """Verify driver construction is gated by scan results so absent devices cannot block startup."""
+        created = []
+
+        class Sensor:
+            def __init__(self, i2c):
+                created.append((self.__class__.__name__, i2c))
+
+        class UnexpectedSensor:
+            def __init__(self, i2c):
+                raise AssertionError("unexpected constructor")
+
+        monkeypatch.setattr(sensor_bus, "LSM303_Accel", Sensor)
+        monkeypatch.setattr(sensor_bus, "LIS2MDL", Sensor)
+        monkeypatch.setattr(sensor_bus, "ISM330DHCX", UnexpectedSensor)
+
+        i2c = StubI2CBus([0x19, 0x1E])
+        sensors = sensor_bus.connect_to_sensors(i2c)
+
+        assert len(sensors) == 2
+        assert created == [("Sensor", i2c), ("Sensor", i2c)]
 
     def test_sensor_reader_emits_when_change_exceeds_threshold(self, sensor_bus):
         """Verify that SensorReader yields events only when the change exceeds the configured threshold. This filters out sensor noise so downstream analytics highlight meaningful movement."""


### PR DESCRIPTION
## Summary

Fix the CircuitPython sensor-bus firmware path used by the KB2040/LSM303AGR setup.

This PR makes the KB2040 firmware use the STEMMA I2C bus with an RX/TX fallback, runs when CircuitPython loads `code.py`, and gates sensor driver construction by the I2C addresses present on the bus. That keeps the LSM303AGR accel/mag pair from being blocked by an absent ISM330DHCX device.

It also removes CPython-only imports and environment assumptions from the firmware helper package so it can load on CircuitPython 9.x, and makes identity polling non-blocking on the USB console.

## Validation

- `uv run ruff check drivers/sensor_bus/code.py tests/drivers/test_sensor_bus_driver.py packages/heart-firmware-io/src/heart_firmware_io/device_id.py packages/heart-firmware-io/src/heart_firmware_io/identity.py`
- `uv run pytest tests/drivers/test_sensor_bus_driver.py tests/test_device_id.py`
- Deployed to `totem3` KB2040 and observed live `sensor.acceleration` and `sensor.magnetic` JSON from the LSM303AGR.
