### PR TITLE
Add cube pong and controller pairing to lib 2026

### DIFF
--- a/src/heart/programs/configurations/controller_pairing.py
+++ b/src/heart/programs/configurations/controller_pairing.py
@@ -1,0 +1,8 @@
+from heart.renderers.controller_pairing import ControllerPairingRenderer
+from heart.runtime.game_loop import GameLoop
+
+
+def configure(loop: GameLoop) -> None:
+    controller_pairing_mode = loop.add_mode("pair bt")
+    controller_pairing_mode.add_renderer(ControllerPairingRenderer())
+    loop.components.game_modes.state.in_select_mode = False

--- a/src/heart/programs/configurations/cube_pong.py
+++ b/src/heart/programs/configurations/cube_pong.py
@@ -1,0 +1,6 @@
+from heart.renderers.cube_pong import add_cube_pong_mode
+from heart.runtime.game_loop import GameLoop
+
+
+def configure(loop: GameLoop) -> None:
+    add_cube_pong_mode(loop)

--- a/src/heart/programs/configurations/lib_2026.py
+++ b/src/heart/programs/configurations/lib_2026.py
@@ -7,6 +7,8 @@ from heart.navigation import MultiScene
 from heart.peripheral.providers.randomness import RandomnessProvider
 from heart.renderers.audio_storm import AudioStormScene
 from heart.renderers.bouncing_ball import BouncingBallRenderer
+from heart.renderers.controller_pairing import ControllerPairingRenderer
+from heart.renderers.cube_pong import add_cube_pong_mode
 from heart.renderers.hilbert_curve import HilbertScene
 from heart.renderers.image import RenderImage
 from heart.renderers.kirby import KirbyScene
@@ -87,6 +89,11 @@ def friend_beacon_text(text: str) -> TextRendering:
 
 def configure(loop: GameLoop) -> None:
     randomness = RandomnessProvider()
+    controller_pairing_mode = loop.add_mode("pair bt")
+    controller_pairing_mode.add_renderer(ControllerPairingRenderer())
+
+    add_cube_pong_mode(loop)
+
     kirby_mode = loop.add_mode(KirbyScene.title_scene())
     kirby_mode.add_renderer(KirbyScene)
 

--- a/src/heart/renderers/controller_pairing/__init__.py
+++ b/src/heart/renderers/controller_pairing/__init__.py
@@ -1,0 +1,1 @@
+from .renderer import ControllerPairingRenderer as ControllerPairingRenderer

--- a/src/heart/renderers/controller_pairing/renderer.py
+++ b/src/heart/renderers/controller_pairing/renderer.py
@@ -1,0 +1,553 @@
+from __future__ import annotations
+
+import re
+import subprocess
+import threading
+from dataclasses import replace
+from subprocess import TimeoutExpired
+from typing import Iterable
+
+import pygame
+
+from heart import DeviceDisplayMode
+from heart.device import Orientation
+from heart.peripheral.core.manager import PeripheralManager
+from heart.renderers import StatefulBaseRenderer
+from heart.renderers.controller_pairing.state import (
+    ControllerPairingDeviceState, ControllerPairingState,
+    ControllerPairingTarget)
+from heart.runtime.display_context import DisplayContext
+from heart.utilities.logging import get_logger
+
+logger = get_logger(__name__)
+
+DEFAULT_CONTROLLER_TARGETS = (
+    ControllerPairingTarget("1", "E4:17:D8:43:5C:48", "teal"),
+    ControllerPairingTarget("2", "E4:17:D8:58:22:8A", "teal"),
+    ControllerPairingTarget("3", "E4:17:D8:E9:76:C8", "pink"),
+    ControllerPairingTarget("4", "E4:17:D8:91:15:35", "pink"),
+)
+DEFAULT_SCAN_SECONDS = 10.0
+DEFAULT_CYCLE_DELAY_SECONDS = 2.0
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 20.0
+INFO_LINE_PATTERN = re.compile(r"^\s*(?P<key>[A-Za-z]+):\s*(?P<value>.*)$")
+SCAN_DEVICE_PATTERN = re.compile(
+    r"(?:Device\s+)(?P<address>[0-9A-F:]{17})(?:\s+(?P<name>.*))?",
+    re.IGNORECASE,
+)
+BACKGROUND_COLOR = (3, 5, 10)
+TEXT_COLOR = (230, 235, 240)
+PANEL_TEXT_COLOR = (255, 255, 255)
+PANEL_MUTED_TEXT_COLOR = (20, 25, 32)
+MUTED_COLOR = (120, 130, 145)
+SCANNING_COLOR = (80, 180, 255)
+PAIRED_COLOR = (255, 202, 88)
+CONNECTED_COLOR = (95, 230, 150)
+ERROR_COLOR = (255, 92, 92)
+CONTROLLER_COLOR_SWATCHES = {
+    "pink": (255, 105, 180),
+    "teal": (0, 210, 190),
+}
+CONTROLLER_PANEL_COLORS = {
+    "pink": (170, 34, 106),
+    "teal": (0, 126, 118),
+}
+FONT_SIZE_PX = 14
+SMALL_FONT_SIZE_PX = 12
+PANEL_NUMBER_FONT_SIZE_PX = 36
+PANEL_STATUS_FONT_SIZE_PX = 14
+
+
+class BluetoothctlControllerPairer:
+    def __init__(
+        self,
+        targets: Iterable[ControllerPairingTarget] = DEFAULT_CONTROLLER_TARGETS,
+        *,
+        scan_seconds: float = DEFAULT_SCAN_SECONDS,
+        cycle_delay_seconds: float = DEFAULT_CYCLE_DELAY_SECONDS,
+        command_timeout_seconds: float = DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    ) -> None:
+        devices = tuple(
+            ControllerPairingDeviceState(target=target) for target in targets
+        )
+        self._state = ControllerPairingState(devices=devices)
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._scan_seconds = scan_seconds
+        self._cycle_delay_seconds = cycle_delay_seconds
+        self._command_timeout_seconds = command_timeout_seconds
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="heart-controller-pairing",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1.0)
+            self._thread = None
+        self._update_state(scanning=False, last_message="stopped")
+
+    def snapshot(self) -> ControllerPairingState:
+        with self._lock:
+            return self._state
+
+    def _run(self) -> None:
+        try:
+            self._setup_adapter()
+            self._refresh_known_devices()
+            while not self._stop_event.is_set():
+                self._refresh_known_devices()
+                self._scan_once()
+                self._pair_known_devices()
+                if self._stop_event.wait(self._cycle_delay_seconds):
+                    break
+        except Exception:
+            logger.exception("Controller pairing worker failed")
+            self._update_state(scanning=False, last_message="worker failed")
+
+    def _setup_adapter(self) -> None:
+        self._update_state(last_message="preparing bluetooth")
+        self._bluetoothctl("power", "on", timeout_seconds=5.0)
+        self._bluetoothctl("pairable", "on", timeout_seconds=5.0)
+        self._bluetoothctl("agent", "NoInputNoOutput", timeout_seconds=5.0)
+        self._bluetoothctl("default-agent", timeout_seconds=5.0)
+
+    def _scan_once(self) -> None:
+        self._update_state(scanning=True, last_message="scanning")
+        result = self._bluetoothctl(
+            "scan",
+            "on",
+            timeout_seconds=self._scan_seconds + 2.0,
+            bluetoothctl_timeout_seconds=self._scan_seconds,
+        )
+        self._bluetoothctl("scan", "off", timeout_seconds=5.0)
+        discovered = self._parse_scan_output(result.output)
+        for address, name in discovered.items():
+            self._update_device(
+                address,
+                seen=True,
+                name=name,
+                last_action="seen",
+                error=None,
+            )
+        self._update_state(
+            scanning=False,
+            cycle=self.snapshot().cycle + 1,
+            last_message=f"scan found {len(discovered)} known",
+        )
+
+    def _pair_known_devices(self) -> None:
+        for device in self.snapshot().devices:
+            if self._stop_event.is_set():
+                return
+            self._refresh_info(device)
+            current = self._device_state(device.target.address)
+            if current is None:
+                continue
+            if not current.seen and not current.paired:
+                continue
+            if not current.paired:
+                self._pair_device(current.target.address)
+                self._refresh_info(current)
+                current = self._device_state(current.target.address)
+                if current is None or not current.paired:
+                    continue
+            if not current.trusted:
+                self._trust_device(current.target.address)
+                self._refresh_info(current)
+                current = self._device_state(current.target.address)
+                if current is None:
+                    continue
+            if not current.connected:
+                self._connect_device(current.target.address)
+                self._refresh_info(current)
+
+    def _refresh_known_devices(self) -> None:
+        for device in self.snapshot().devices:
+            if self._stop_event.is_set():
+                return
+            self._refresh_info(device)
+
+    def _pair_device(self, address: str) -> None:
+        self._update_device(address, pairing=True, last_action="pairing", error=None)
+        result = self._bluetoothctl(
+            "pair",
+            address,
+            agent=True,
+            timeout_seconds=self._command_timeout_seconds + 2.0,
+            bluetoothctl_timeout_seconds=self._command_timeout_seconds,
+        )
+        self._update_device(
+            address,
+            pairing=False,
+            last_action="paired" if result.returncode == 0 else "pair failed",
+            error=None if result.returncode == 0 else _last_output_line(result.output),
+        )
+
+    def _trust_device(self, address: str) -> None:
+        result = self._bluetoothctl("trust", address)
+        self._update_device(
+            address,
+            last_action="trusted" if result.returncode == 0 else "trust failed",
+            error=None if result.returncode == 0 else _last_output_line(result.output),
+        )
+
+    def _connect_device(self, address: str) -> None:
+        result = self._bluetoothctl(
+            "connect",
+            address,
+            timeout_seconds=self._command_timeout_seconds + 2.0,
+            bluetoothctl_timeout_seconds=self._command_timeout_seconds,
+        )
+        self._update_device(
+            address,
+            last_action="connected" if result.returncode == 0 else "connect failed",
+            error=None if result.returncode == 0 else _last_output_line(result.output),
+        )
+
+    def _refresh_info(self, device: ControllerPairingDeviceState) -> None:
+        result = self._bluetoothctl("info", device.target.address, timeout_seconds=5.0)
+        info = self._parse_info_output(result.output)
+        if not info and "not available" in result.output:
+            return
+        self._update_device(device.target.address, **info)
+
+    def _bluetoothctl(
+        self,
+        *args: str,
+        agent: bool = False,
+        timeout_seconds: float | None = None,
+        bluetoothctl_timeout_seconds: float | None = None,
+    ) -> "BluetoothctlResult":
+        command = ["bluetoothctl"]
+        if agent:
+            command.extend(["--agent", "NoInputNoOutput"])
+        if bluetoothctl_timeout_seconds is not None:
+            command.extend(["--timeout", str(int(bluetoothctl_timeout_seconds))])
+        command.extend(args)
+        timeout = timeout_seconds or self._command_timeout_seconds
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except FileNotFoundError:
+            return BluetoothctlResult(
+                command=tuple(command),
+                returncode=127,
+                output="bluetoothctl not found",
+            )
+        except TimeoutExpired as exc:
+            output = "\n".join(
+                part
+                for part in (
+                    _decode_timeout_output(exc.stdout),
+                    _decode_timeout_output(exc.stderr),
+                    "bluetoothctl timed out",
+                )
+                if part
+            )
+            return BluetoothctlResult(
+                command=tuple(command),
+                returncode=124,
+                output=output,
+            )
+        output = "\n".join(
+            part for part in (result.stdout, result.stderr) if part
+        ).strip()
+        return BluetoothctlResult(
+            command=tuple(command),
+            returncode=result.returncode,
+            output=output,
+        )
+
+    def _parse_scan_output(self, output: str) -> dict[str, str | None]:
+        targets = {device.target.address.upper() for device in self.snapshot().devices}
+        discovered: dict[str, str | None] = {}
+        for line in output.splitlines():
+            match = SCAN_DEVICE_PATTERN.search(line)
+            if match is None:
+                continue
+            address = match.group("address").upper()
+            if address not in targets:
+                continue
+            name = match.group("name")
+            if name is not None:
+                name = name.strip() or None
+            discovered[address] = name
+        return discovered
+
+    def _parse_info_output(self, output: str) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for line in output.splitlines():
+            match = INFO_LINE_PATTERN.match(line)
+            if match is None:
+                continue
+            key = match.group("key")
+            value = match.group("value").strip()
+            if key == "Name":
+                result["name"] = value
+            elif key == "Paired":
+                result["paired"] = value.lower() == "yes"
+            elif key == "Trusted":
+                result["trusted"] = value.lower() == "yes"
+            elif key == "Connected":
+                result["connected"] = value.lower() == "yes"
+        if result:
+            result["error"] = None
+        return result
+
+    def _device_state(self, address: str) -> ControllerPairingDeviceState | None:
+        normalized = address.upper()
+        for device in self.snapshot().devices:
+            if device.target.address.upper() == normalized:
+                return device
+        return None
+
+    def _update_state(self, **changes: object) -> None:
+        with self._lock:
+            self._state = replace(self._state, **changes)
+
+    def _update_device(self, address: str, **changes: object) -> None:
+        normalized = address.upper()
+        with self._lock:
+            devices = tuple(
+                replace(device, **changes)
+                if device.target.address.upper() == normalized
+                else device
+                for device in self._state.devices
+            )
+            self._state = replace(self._state, devices=devices)
+
+
+class BluetoothctlResult:
+    def __init__(
+        self,
+        *,
+        command: tuple[str, ...],
+        returncode: int,
+        output: str,
+    ) -> None:
+        self.command = command
+        self.returncode = returncode
+        self.output = output
+
+
+class ControllerPairingRenderer(StatefulBaseRenderer[ControllerPairingState]):
+    def __init__(
+        self,
+        targets: Iterable[ControllerPairingTarget] = DEFAULT_CONTROLLER_TARGETS,
+    ) -> None:
+        self._targets = tuple(targets)
+        self._pairer: BluetoothctlControllerPairer | None = None
+        self._font: pygame.font.Font | None = None
+        self._small_font: pygame.font.Font | None = None
+        self._panel_number_font: pygame.font.Font | None = None
+        self._panel_status_font: pygame.font.Font | None = None
+        super().__init__()
+        self.device_display_mode = DeviceDisplayMode.FULL
+
+    def _create_initial_state(
+        self,
+        window: DisplayContext,
+        peripheral_manager: PeripheralManager,
+        orientation: Orientation,
+    ) -> ControllerPairingState:
+        return ControllerPairingState(
+            devices=tuple(
+                ControllerPairingDeviceState(target=target)
+                for target in self._targets
+            )
+        )
+
+    def real_process(
+        self,
+        window: DisplayContext,
+        orientation: Orientation,
+    ) -> None:
+        screen = window.screen
+        if screen is None:
+            return
+        self._ensure_pairer_started()
+        pairer = self._pairer
+        if pairer is not None:
+            self.set_state(pairer.snapshot())
+
+        if not pygame.font.get_init():
+            pygame.font.init()
+        if self._font is None:
+            self._font = pygame.font.Font(None, FONT_SIZE_PX)
+        if self._small_font is None:
+            self._small_font = pygame.font.Font(None, SMALL_FONT_SIZE_PX)
+        if self._panel_number_font is None:
+            self._panel_number_font = pygame.font.Font(
+                None,
+                PANEL_NUMBER_FONT_SIZE_PX,
+            )
+        if self._panel_status_font is None:
+            self._panel_status_font = pygame.font.Font(
+                None,
+                PANEL_STATUS_FONT_SIZE_PX,
+            )
+
+        screen.fill(BACKGROUND_COLOR)
+        self._draw_device_panels(screen)
+
+    def reset(self) -> None:
+        if self._pairer is not None:
+            self._pairer.stop()
+            self._pairer = None
+        super().reset()
+
+    def _ensure_pairer_started(self) -> None:
+        if self._pairer is None:
+            logger.info("Starting controller pairing renderer worker")
+            self._pairer = BluetoothctlControllerPairer(self._targets)
+            self._pairer.start()
+
+    def _draw_header(self, screen: pygame.Surface) -> None:
+        if self._font is None:
+            return
+        paired_count = sum(1 for device in self.state.devices if device.paired)
+        connected_count = sum(1 for device in self.state.devices if device.connected)
+        scan_label = "scan" if self.state.scanning else "idle"
+        label = (
+            f"BT PAIR {paired_count}/{len(self.state.devices)} "
+            f"paired {connected_count} con {scan_label}"
+        )
+        surface = self._font.render(label, True, TEXT_COLOR)
+        screen.blit(surface, (4, 1))
+
+    def _draw_device_panels(self, screen: pygame.Surface) -> None:
+        if self._panel_number_font is None or self._panel_status_font is None:
+            return
+        devices = self.state.devices
+        if not devices:
+            return
+        panel_width = max(1, screen.get_width() // len(devices))
+        panel_height = screen.get_height()
+        for index, device in enumerate(devices):
+            x = index * panel_width
+            width = (
+                screen.get_width() - x
+                if index == len(devices) - 1
+                else panel_width
+            )
+            rect = pygame.Rect(x, 0, width, panel_height)
+            base_color = CONTROLLER_PANEL_COLORS.get(
+                device.target.color,
+                BACKGROUND_COLOR,
+            )
+            pygame.draw.rect(screen, base_color, rect)
+
+            self._draw_centered_text(
+                screen,
+                self._panel_number_font,
+                device.target.label,
+                pygame.Rect(x, 4, width, 30),
+                PANEL_TEXT_COLOR,
+            )
+            self._draw_centered_text(
+                screen,
+                self._panel_status_font,
+                device.target.color.upper(),
+                pygame.Rect(x, 35, width, 13),
+                PANEL_TEXT_COLOR,
+            )
+            self._draw_centered_text(
+                screen,
+                self._panel_status_font,
+                _status_label(device).upper(),
+                pygame.Rect(x, 49, width, 12),
+                PANEL_TEXT_COLOR,
+            )
+        if screen.get_flags() & pygame.SRCALPHA:
+            screen.fill((255, 255, 255, 255), special_flags=pygame.BLEND_RGBA_MULT)
+
+    def _draw_centered_text(
+        self,
+        screen: pygame.Surface,
+        font: pygame.font.Font,
+        text: str,
+        rect: pygame.Rect,
+        color: tuple[int, int, int],
+    ) -> None:
+        surface = font.render(text, True, color)
+        text_rect = surface.get_rect(center=rect.center)
+        screen.blit(surface, text_rect)
+
+    def _draw_centered_text(
+        self,
+        screen: pygame.Surface,
+        font: pygame.font.Font,
+        text: str,
+        rect: pygame.Rect,
+        color: tuple[int, int, int],
+    ) -> None:
+        surface = font.render(text, True, color)
+        text_rect = surface.get_rect(center=rect.center)
+        screen.blit(surface, text_rect)
+
+
+def _status_label(device: ControllerPairingDeviceState) -> str:
+    if device.connected:
+        return "connected"
+    if device.pairing:
+        return "pairing"
+    if device.paired:
+        return "paired"
+    if device.seen:
+        return "seen"
+    if device.error:
+        return "error"
+    return "waiting"
+
+
+def _status_color(device: ControllerPairingDeviceState) -> tuple[int, int, int]:
+    if device.connected:
+        return CONNECTED_COLOR
+    if device.pairing or device.seen:
+        return SCANNING_COLOR
+    if device.paired:
+        return PAIRED_COLOR
+    if device.error:
+        return ERROR_COLOR
+    return MUTED_COLOR
+
+
+def _short_address(address: str) -> str:
+    return address[-8:]
+
+
+def _compact_error(error: str) -> str:
+    cleaned = " ".join(error.split())
+    if len(cleaned) <= 18:
+        return cleaned
+    return f"{cleaned[:17]}..."
+
+
+def _last_output_line(output: str) -> str | None:
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
+    if not lines:
+        return None
+    return lines[-1]
+
+
+def _decode_timeout_output(output: str | bytes | None) -> str:
+    if output is None:
+        return ""
+    if isinstance(output, bytes):
+        return output.decode("utf-8", errors="replace")
+    return output

--- a/src/heart/renderers/controller_pairing/state.py
+++ b/src/heart/renderers/controller_pairing/state.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ControllerPairingTarget:
+    label: str
+    address: str
+    color: str
+
+
+@dataclass(frozen=True)
+class ControllerPairingDeviceState:
+    target: ControllerPairingTarget
+    name: str | None = None
+    seen: bool = False
+    paired: bool = False
+    trusted: bool = False
+    connected: bool = False
+    pairing: bool = False
+    last_action: str = "waiting"
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class ControllerPairingState:
+    devices: tuple[ControllerPairingDeviceState, ...] = field(default_factory=tuple)
+    scanning: bool = False
+    cycle: int = 0
+    last_message: str = "idle"

--- a/src/heart/renderers/cube_pong/__init__.py
+++ b/src/heart/renderers/cube_pong/__init__.py
@@ -1,0 +1,7 @@
+from heart.renderers.cube_pong.renderer import CubePongRenderer
+from heart.runtime.game_loop import GameLoop
+
+
+def add_cube_pong_mode(loop: GameLoop) -> None:
+    mode = loop.add_mode("cube\npong")
+    mode.add_renderer(CubePongRenderer())

--- a/src/heart/renderers/cube_pong/renderer.py
+++ b/src/heart/renderers/cube_pong/renderer.py
@@ -1,0 +1,413 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pygame
+
+from heart import DeviceDisplayMode
+from heart.device import Orientation
+from heart.peripheral.core.input import GamepadAxis, GamepadSnapshot
+from heart.peripheral.core.manager import PeripheralManager
+from heart.peripheral.gamepad import Gamepad
+from heart.renderers import StatefulBaseRenderer
+from heart.renderers.cube_pong.state import (
+    PLAYER_ONE, PLAYER_TWO, CubePongControls, CubePongState,
+    advance_cube_pong_state, ball_radius, face_position_for_ball,
+    new_cube_pong_round, paddle_path_x, paddle_size)
+from heart.runtime.display_context import DisplayContext
+from heart.utilities.logging import get_logger
+
+BACKGROUND_COLOR = (4, 5, 8)
+SEAM_COLOR = (32, 38, 48)
+CENTER_MARK_COLOR = (24, 31, 39)
+PINK_CONTROLLER_COLOR = (255, 105, 160)
+TEAL_CONTROLLER_COLOR = (69, 214, 255)
+PADDLE_ONE_COLOR = PINK_CONTROLLER_COLOR
+PADDLE_TWO_COLOR = TEAL_CONTROLLER_COLOR
+BALL_COLORS = ((250, 245, 128), (139, 255, 180))
+LOSS_FLASH_COLOR = (105, 10, 24)
+KEYBOARD_CONTROL_STEP = 1.0
+GAMEPAD_DEAD_ZONE = 0.15
+LINUX_JOYSTICK_SYSFS = Path("/sys/class/input")
+SCORE_FONT_SCALE = 0.38
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class PongControllerBinding:
+    player: int
+    mac_address: str
+    color_name: str
+
+
+PONG_CONTROLLER_BINDINGS: tuple[PongControllerBinding, ...] = (
+    PongControllerBinding(
+        player=PLAYER_ONE,
+        mac_address="E4:17:D8:E9:76:C8",  # Pink 8BitDo Lite 2 controller.
+        color_name="pink",
+    ),
+    PongControllerBinding(
+        player=PLAYER_ONE,
+        mac_address="E4:17:D8:91:15:35",  # Pink 8BitDo Lite 2 controller.
+        color_name="pink",
+    ),
+    PongControllerBinding(
+        player=PLAYER_TWO,
+        mac_address="E4:17:D8:43:5C:48",  # Teal 8BitDo Lite 2 controller.
+        color_name="teal",
+    ),
+    PongControllerBinding(
+        player=PLAYER_TWO,
+        mac_address="E4:17:D8:58:22:8A",  # Teal 8BitDo Lite 2 controller.
+        color_name="teal",
+    ),
+)
+
+
+class CubePongRenderer(StatefulBaseRenderer[CubePongState]):
+    def __init__(self) -> None:
+        super().__init__()
+        self.device_display_mode = DeviceDisplayMode.FULL
+        self._peripheral_manager: PeripheralManager | None = None
+        self._fonts: dict[int, pygame.font.Font] = {}
+        self._last_logged_controller_signature: dict[int, tuple[object, ...]] = {}
+
+    def _create_initial_state(
+        self,
+        window: DisplayContext,
+        peripheral_manager: PeripheralManager,
+        orientation: Orientation,
+    ) -> CubePongState:
+        self._peripheral_manager = peripheral_manager
+        screen_width, screen_height = self._individual_screen_size(window, orientation)
+        return new_cube_pong_round(screen_width, screen_height)
+
+    def real_process(
+        self,
+        window: DisplayContext,
+        orientation: Orientation,
+    ) -> None:
+        del orientation
+        if window.screen is None:
+            raise RuntimeError("CubePongRenderer requires an initialized display")
+        controls = self._read_controls()
+        state = advance_cube_pong_state(self.state, controls, self._delta_s(window))
+        self.set_state(state)
+        self._draw(window, state)
+
+    def _draw(self, window: DisplayContext, state: CubePongState) -> None:
+        window.fill(BACKGROUND_COLOR)
+        self._draw_face_guides(window, state)
+        if state.losing_player is not None:
+            self._draw_loss_flash(window, state)
+        self._draw_scores(window, state)
+        self._draw_paddles(window, state)
+        self._draw_balls(window, state)
+
+    def _draw_face_guides(self, window: DisplayContext, state: CubePongState) -> None:
+        if window.screen is None:
+            raise RuntimeError("CubePongRenderer requires an initialized display")
+        screen = window.screen
+        for face_index in range(1, 4):
+            x = face_index * state.screen_width
+            pygame.draw.line(
+                screen,
+                SEAM_COLOR,
+                (x, 0),
+                (x, state.screen_height),
+                width=1,
+            )
+        for face_index in (1, 3):
+            left = face_index * state.screen_width
+            pygame.draw.line(
+                screen,
+                CENTER_MARK_COLOR,
+                (left, state.screen_height // 2),
+                (left + state.screen_width, state.screen_height // 2),
+                width=1,
+            )
+
+    def _draw_loss_flash(self, window: DisplayContext, state: CubePongState) -> None:
+        if window.screen is None:
+            raise RuntimeError("CubePongRenderer requires an initialized display")
+        screen = window.screen
+        face_index = 0 if state.losing_player == PLAYER_ONE else 2
+        rect = pygame.Rect(
+            face_index * state.screen_width,
+            0,
+            state.screen_width,
+            state.screen_height,
+        )
+        pygame.draw.rect(screen, LOSS_FLASH_COLOR, rect)
+
+    def _draw_paddles(self, window: DisplayContext, state: CubePongState) -> None:
+        paddle_width, paddle_height = paddle_size(
+            state.screen_width, state.screen_height
+        )
+        paddle_one_path_x, paddle_two_path_x = paddle_path_x(state.screen_width)
+        paddle_one_x = paddle_one_path_x - (paddle_width / 2)
+        paddle_two_x = paddle_two_path_x - (paddle_width / 2)
+        self._draw_paddle(
+            window,
+            x=round(paddle_one_x),
+            y=round(state.paddle_one_y - paddle_height / 2),
+            width=paddle_width,
+            height=paddle_height,
+            color=PADDLE_ONE_COLOR,
+        )
+        self._draw_paddle(
+            window,
+            x=round(paddle_two_x),
+            y=round(state.paddle_two_y - paddle_height / 2),
+            width=paddle_width,
+            height=paddle_height,
+            color=PADDLE_TWO_COLOR,
+        )
+
+    def _draw_scores(self, window: DisplayContext, state: CubePongState) -> None:
+        if window.screen is None:
+            raise RuntimeError("CubePongRenderer requires an initialized display")
+        self._draw_score(
+            window.screen,
+            score=state.player_one_score,
+            color=PADDLE_ONE_COLOR,
+            center_x=state.screen_width // 2,
+            top=2,
+        )
+        self._draw_score(
+            window.screen,
+            score=state.player_two_score,
+            color=PADDLE_TWO_COLOR,
+            center_x=round(state.screen_width * 2.5),
+            top=2,
+        )
+
+    def _draw_score(
+        self,
+        screen: pygame.Surface,
+        *,
+        score: int,
+        color: tuple[int, int, int],
+        center_x: int,
+        top: int,
+    ) -> None:
+        font_size = max(18, round(screen.get_height() * SCORE_FONT_SCALE))
+        surface = self._font(font_size).render(str(score), False, color)
+        rect = surface.get_rect()
+        rect.midtop = (center_x, top)
+        screen.blit(surface, rect)
+
+    def _font(self, size: int) -> pygame.font.Font:
+        if not pygame.font.get_init():
+            pygame.font.init()
+        font = self._fonts.get(size)
+        if font is None:
+            font = pygame.font.Font(None, size)
+            self._fonts[size] = font
+        return font
+
+    def _draw_paddle(
+        self,
+        window: DisplayContext,
+        *,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        color: tuple[int, int, int],
+    ) -> None:
+        if window.screen is None:
+            raise RuntimeError("CubePongRenderer requires an initialized display")
+        screen = window.screen
+        rect = pygame.Rect(x, y, width, height)
+        pygame.draw.rect(screen, color, rect)
+
+    def _draw_balls(self, window: DisplayContext, state: CubePongState) -> None:
+        if window.screen is None:
+            raise RuntimeError("CubePongRenderer requires an initialized display")
+        screen = window.screen
+        radius = ball_radius(state.screen_width)
+        for index, ball in enumerate(state.balls):
+            position = face_position_for_ball(ball, state.screen_width)
+            if position is None:
+                continue
+            center = (
+                round(position.face_index * state.screen_width + position.x),
+                round(position.y),
+            )
+            pygame.draw.circle(screen, BALL_COLORS[index], center, radius)
+
+    def _read_controls(self) -> CubePongControls:
+        pad_one = 0.0
+        pad_two = 0.0
+        if self._peripheral_manager is not None:
+            assigned, connected = self._assigned_controller_snapshots()
+            if assigned:
+                if PLAYER_ONE in assigned:
+                    pad_one = self._combined_left_control(assigned[PLAYER_ONE])
+                if PLAYER_TWO in assigned:
+                    pad_two = self._combined_left_control(assigned[PLAYER_TWO])
+            elif len(connected) >= 2:
+                pad_one = self._left_control(connected[0])
+                pad_two = self._left_control(connected[1])
+            elif len(connected) == 1:
+                pad_one = self._left_control(connected[0])
+                pad_two = self._right_control(connected[0])
+
+        keyboard_one, keyboard_two = self._keyboard_controls()
+        return CubePongControls(
+            player_one=keyboard_one if keyboard_one != 0 else pad_one,
+            player_two=keyboard_two if keyboard_two != 0 else pad_two,
+        )
+
+    def _assigned_controller_snapshots(
+        self,
+    ) -> tuple[dict[int, tuple[GamepadSnapshot, ...]], tuple[GamepadSnapshot, ...]]:
+        if self._peripheral_manager is None:
+            return {}, ()
+        controller = self._peripheral_manager.input_io.gamepad
+        bindings_by_mac = {
+            _normalize_bluetooth_mac(binding.mac_address): binding
+            for binding in PONG_CONTROLLER_BINDINGS
+        }
+        assigned: dict[int, list[GamepadSnapshot]] = {}
+        connected: list[GamepadSnapshot] = []
+        unassigned: list[GamepadSnapshot] = []
+        for gamepad in sorted(
+            self._gamepads(),
+            key=lambda candidate: candidate.joystick_id,
+        ):
+            snapshot = controller.snapshot_for_gamepad(gamepad, consume_taps=False)
+            if not snapshot.connected:
+                continue
+            connected.append(snapshot)
+            mac_address = _bluetooth_mac_for_gamepad(gamepad)
+            binding = bindings_by_mac.get(_normalize_bluetooth_mac(mac_address or ""))
+            if binding is None:
+                unassigned.append(snapshot)
+                continue
+            assigned.setdefault(binding.player, []).append(snapshot)
+            self._log_controller_input(binding, mac_address, gamepad, snapshot)
+
+        for player in (PLAYER_ONE, PLAYER_TWO):
+            if player not in assigned and unassigned:
+                assigned[player] = [unassigned.pop(0)]
+        return {
+            player: tuple(snapshots) for player, snapshots in assigned.items()
+        }, tuple(connected)
+
+    def _gamepads(self) -> tuple[Gamepad, ...]:
+        if self._peripheral_manager is None:
+            return ()
+        return tuple(
+            peripheral
+            for peripheral in self._peripheral_manager.peripherals
+            if isinstance(peripheral, Gamepad)
+        )
+
+    def _log_controller_input(
+        self,
+        binding: PongControllerBinding,
+        mac_address: str | None,
+        gamepad: Gamepad,
+        snapshot: GamepadSnapshot,
+    ) -> None:
+        left_y = round(snapshot.axes.get(GamepadAxis.LEFT_Y, 0.0), 2)
+        signature = (
+            binding.color_name,
+            mac_address,
+            snapshot.dpad.y,
+            left_y if abs(left_y) >= GAMEPAD_DEAD_ZONE else 0.0,
+        )
+        if signature == self._last_logged_controller_signature.get(binding.player):
+            return
+        self._last_logged_controller_signature[binding.player] = signature
+        if snapshot.dpad.y == 0 and abs(left_y) < GAMEPAD_DEAD_ZONE:
+            return
+        logger.info(
+            "cube_pong.controller player=%s color=%s mac=%s joystick_id=%s dpad_y=%s left_y=%.2f",
+            binding.player,
+            binding.color_name,
+            mac_address,
+            gamepad.joystick_id,
+            snapshot.dpad.y,
+            left_y,
+        )
+
+    def _left_control(self, snapshot: GamepadSnapshot) -> float:
+        axis = snapshot.axis_value(GamepadAxis.LEFT_Y, dead_zone=GAMEPAD_DEAD_ZONE)
+        if axis != 0:
+            return axis
+        return -float(snapshot.dpad.y)
+
+    def _combined_left_control(self, snapshots: tuple[GamepadSnapshot, ...]) -> float:
+        for snapshot in snapshots:
+            control = self._left_control(snapshot)
+            if control != 0:
+                return control
+        return 0.0
+
+    def _right_control(self, snapshot: GamepadSnapshot) -> float:
+        return snapshot.axis_value(GamepadAxis.RIGHT_Y, dead_zone=GAMEPAD_DEAD_ZONE)
+
+    def _keyboard_controls(self) -> tuple[float, float]:
+        try:
+            pygame.event.pump()
+            keys = pygame.key.get_pressed()
+        except pygame.error:
+            return 0.0, 0.0
+
+        player_one = 0.0
+        player_two = 0.0
+        if keys[pygame.K_w]:
+            player_one -= KEYBOARD_CONTROL_STEP
+        if keys[pygame.K_s]:
+            player_one += KEYBOARD_CONTROL_STEP
+        if keys[pygame.K_UP]:
+            player_two -= KEYBOARD_CONTROL_STEP
+        if keys[pygame.K_DOWN]:
+            player_two += KEYBOARD_CONTROL_STEP
+        return player_one, player_two
+
+    def _delta_s(self, window: DisplayContext) -> float:
+        if window.clock is None:
+            return 1 / 60
+        elapsed_ms = window.clock.get_time()
+        if elapsed_ms <= 0:
+            return 1 / 60
+        return elapsed_ms / 1000
+
+    def _individual_screen_size(
+        self,
+        window: DisplayContext,
+        orientation: Orientation,
+    ) -> tuple[int, int]:
+        width, height = window.get_size()
+        columns = max(1, orientation.layout.columns)
+        rows = max(1, orientation.layout.rows)
+        return max(1, width // columns), max(1, height // rows)
+
+
+def _bluetooth_mac_for_gamepad(gamepad: Gamepad) -> str | None:
+    joystick_paths = _joystick_paths()
+    if gamepad.joystick_id >= len(joystick_paths):
+        return None
+    joystick_path = joystick_paths[gamepad.joystick_id]
+    try:
+        return (joystick_path / "device" / "uniq").read_text().strip()
+    except OSError:
+        return None
+
+
+def _joystick_paths() -> tuple[Path, ...]:
+    return tuple(
+        sorted(
+            LINUX_JOYSTICK_SYSFS.glob("js*"),
+            key=lambda path: int(path.name.removeprefix("js")),
+        )
+    )
+
+
+def _normalize_bluetooth_mac(mac_address: str) -> str:
+    return mac_address.replace(":", "").lower()

--- a/src/heart/renderers/cube_pong/state.py
+++ b/src/heart/renderers/cube_pong/state.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+PLAYER_ONE = 1
+PLAYER_TWO = 2
+ROUTE_ACROSS_SCREEN_TWO = "screens_1_2_3"
+ROUTE_ACROSS_SCREEN_FOUR = "screens_1_4_3"
+ROUND_RESET_HOLD_S = 1.0
+
+
+@dataclass(frozen=True, slots=True)
+class CubePongRoute:
+    name: str
+    faces: tuple[int, int, int]
+    start_player: int
+    end_player: int
+
+
+@dataclass(frozen=True, slots=True)
+class CubePongBall:
+    route_name: str
+    x: float
+    y: float
+    vx: float
+    vy: float
+
+
+@dataclass(frozen=True, slots=True)
+class CubePongControls:
+    player_one: float = 0.0
+    player_two: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class CubePongState:
+    screen_width: int
+    screen_height: int
+    paddle_one_y: float
+    paddle_two_y: float
+    balls: tuple[CubePongBall, CubePongBall]
+    player_one_score: int = 0
+    player_two_score: int = 0
+    losing_player: int | None = None
+    reset_remaining_s: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class FacePosition:
+    face_index: int
+    x: float
+    y: float
+
+
+ROUTES = {
+    ROUTE_ACROSS_SCREEN_TWO: CubePongRoute(
+        name=ROUTE_ACROSS_SCREEN_TWO,
+        faces=(0, 1, 2),
+        start_player=PLAYER_ONE,
+        end_player=PLAYER_TWO,
+    ),
+    ROUTE_ACROSS_SCREEN_FOUR: CubePongRoute(
+        name=ROUTE_ACROSS_SCREEN_FOUR,
+        faces=(2, 3, 0),
+        start_player=PLAYER_TWO,
+        end_player=PLAYER_ONE,
+    ),
+}
+
+
+def new_cube_pong_round(screen_width: int, screen_height: int) -> CubePongState:
+    return _new_cube_pong_round(
+        screen_width,
+        screen_height,
+        player_one_score=0,
+        player_two_score=0,
+    )
+
+
+def _new_cube_pong_round(
+    screen_width: int,
+    screen_height: int,
+    *,
+    player_one_score: int,
+    player_two_score: int,
+) -> CubePongState:
+    paddle_one_x, paddle_two_x = paddle_path_x(screen_width)
+    radius = ball_radius(screen_width)
+    paddle_width, _ = paddle_size(screen_width, screen_height)
+    ball_speed = base_ball_speed(screen_width)
+    vertical_speed = max(screen_height * 0.24, 10.0)
+    start_offset = radius + (paddle_width / 2) + 1
+
+    return CubePongState(
+        screen_width=screen_width,
+        screen_height=screen_height,
+        paddle_one_y=screen_height / 2,
+        paddle_two_y=screen_height / 2,
+        balls=(
+            CubePongBall(
+                route_name=ROUTE_ACROSS_SCREEN_TWO,
+                x=paddle_one_x + start_offset,
+                y=screen_height * 0.35,
+                vx=ball_speed,
+                vy=vertical_speed,
+            ),
+            CubePongBall(
+                route_name=ROUTE_ACROSS_SCREEN_FOUR,
+                x=paddle_one_x + start_offset,
+                y=screen_height * 0.65,
+                vx=ball_speed,
+                vy=-vertical_speed,
+            ),
+        ),
+        player_one_score=player_one_score,
+        player_two_score=player_two_score,
+    )
+
+
+def advance_cube_pong_state(
+    state: CubePongState,
+    controls: CubePongControls,
+    delta_s: float,
+) -> CubePongState:
+    delta_s = max(0.0, min(delta_s, 0.05))
+    if state.losing_player is not None:
+        remaining = state.reset_remaining_s - delta_s
+        if remaining <= 0:
+            return _new_cube_pong_round(
+                state.screen_width,
+                state.screen_height,
+                player_one_score=state.player_one_score,
+                player_two_score=state.player_two_score,
+            )
+        return CubePongState(
+            screen_width=state.screen_width,
+            screen_height=state.screen_height,
+            paddle_one_y=state.paddle_one_y,
+            paddle_two_y=state.paddle_two_y,
+            balls=state.balls,
+            player_one_score=state.player_one_score,
+            player_two_score=state.player_two_score,
+            losing_player=state.losing_player,
+            reset_remaining_s=remaining,
+        )
+
+    paddle_speed = max(state.screen_height * 1.9, 80.0)
+    paddle_one_y = _move_paddle(
+        state.paddle_one_y,
+        controls.player_one,
+        paddle_speed,
+        delta_s,
+        state.screen_width,
+        state.screen_height,
+    )
+    paddle_two_y = _move_paddle(
+        state.paddle_two_y,
+        controls.player_two,
+        paddle_speed,
+        delta_s,
+        state.screen_width,
+        state.screen_height,
+    )
+
+    balls: list[CubePongBall] = []
+    for ball in state.balls:
+        next_ball, losing_player = _advance_ball(
+            ball,
+            state.screen_width,
+            state.screen_height,
+            paddle_one_y,
+            paddle_two_y,
+            delta_s,
+        )
+        balls.append(next_ball)
+        if losing_player is not None:
+            player_one_score = state.player_one_score
+            player_two_score = state.player_two_score
+            if losing_player == PLAYER_ONE:
+                player_two_score += 1
+            else:
+                player_one_score += 1
+            updated_balls = [state.balls[0], state.balls[1]]
+            for index, updated_ball in enumerate(balls):
+                updated_balls[index] = updated_ball
+            return CubePongState(
+                screen_width=state.screen_width,
+                screen_height=state.screen_height,
+                paddle_one_y=paddle_one_y,
+                paddle_two_y=paddle_two_y,
+                balls=(updated_balls[0], updated_balls[1]),
+                player_one_score=player_one_score,
+                player_two_score=player_two_score,
+                losing_player=losing_player,
+                reset_remaining_s=ROUND_RESET_HOLD_S,
+            )
+
+    return CubePongState(
+        screen_width=state.screen_width,
+        screen_height=state.screen_height,
+        paddle_one_y=paddle_one_y,
+        paddle_two_y=paddle_two_y,
+        balls=(balls[0], balls[1]),
+        player_one_score=state.player_one_score,
+        player_two_score=state.player_two_score,
+    )
+
+
+def face_position_for_ball(
+    ball: CubePongBall, screen_width: int
+) -> FacePosition | None:
+    route = ROUTES[ball.route_name]
+    court_width = screen_width * len(route.faces)
+    if ball.x < 0 or ball.x > court_width:
+        return None
+    segment = min(int(ball.x // screen_width), len(route.faces) - 1)
+    local_x = ball.x - segment * screen_width
+    return FacePosition(face_index=route.faces[segment], x=local_x, y=ball.y)
+
+
+def paddle_size(screen_width: int, screen_height: int) -> tuple[int, int]:
+    width = max(3, round(screen_width * 0.06))
+    height = max(14, round(screen_height * 0.34))
+    return width, min(height, screen_height)
+
+
+def ball_radius(screen_width: int) -> int:
+    return max(3, round(screen_width * 0.045))
+
+
+def paddle_path_x(screen_width: int) -> tuple[float, float]:
+    return screen_width * 0.5, screen_width * 2.5
+
+
+def base_ball_speed(screen_width: int) -> float:
+    return max(screen_width * 0.95, 42.0)
+
+
+def _advance_ball(
+    ball: CubePongBall,
+    screen_width: int,
+    screen_height: int,
+    paddle_one_y: float,
+    paddle_two_y: float,
+    delta_s: float,
+) -> tuple[CubePongBall, int | None]:
+    radius = ball_radius(screen_width)
+    next_x = ball.x + ball.vx * delta_s
+    next_y = ball.y + ball.vy * delta_s
+    next_vx = ball.vx
+    next_vy = ball.vy
+
+    if next_y <= radius:
+        next_y = radius
+        next_vy = abs(next_vy)
+    elif next_y >= screen_height - radius:
+        next_y = screen_height - radius
+        next_vy = -abs(next_vy)
+
+    paddle_one_x, paddle_two_x = paddle_path_x(screen_width)
+    paddle_width, paddle_height = paddle_size(screen_width, screen_height)
+    half_width = paddle_width / 2
+    max_speed = base_ball_speed(screen_width) * 1.45
+    route = ROUTES[ball.route_name]
+
+    if next_vx > 0:
+        defending_player = route.end_player
+        defending_paddle_y = _paddle_y_for_player(
+            defending_player,
+            paddle_one_y,
+            paddle_two_y,
+        )
+        contact_x = paddle_two_x - half_width - radius
+        missed_x = paddle_two_x + half_width + radius
+        if ball.x <= contact_x <= next_x:
+            hit_offset = _hit_offset(
+                next_y,
+                defending_paddle_y,
+                paddle_height,
+                radius,
+            )
+            if hit_offset is None:
+                return (
+                    CubePongBall(ball.route_name, next_x, next_y, next_vx, next_vy),
+                    defending_player,
+                )
+            next_x = contact_x
+            next_vx = -min(abs(next_vx) * 1.02, max_speed)
+            next_vy = _spin_velocity(next_vy, hit_offset, screen_height)
+        elif next_x > missed_x:
+            return (
+                CubePongBall(ball.route_name, next_x, next_y, next_vx, next_vy),
+                defending_player,
+            )
+    else:
+        defending_player = route.start_player
+        defending_paddle_y = _paddle_y_for_player(
+            defending_player,
+            paddle_one_y,
+            paddle_two_y,
+        )
+        contact_x = paddle_one_x + half_width + radius
+        missed_x = paddle_one_x - half_width - radius
+        if ball.x >= contact_x >= next_x:
+            hit_offset = _hit_offset(
+                next_y,
+                defending_paddle_y,
+                paddle_height,
+                radius,
+            )
+            if hit_offset is None:
+                return (
+                    CubePongBall(ball.route_name, next_x, next_y, next_vx, next_vy),
+                    defending_player,
+                )
+            next_x = contact_x
+            next_vx = min(abs(next_vx) * 1.02, max_speed)
+            next_vy = _spin_velocity(next_vy, hit_offset, screen_height)
+        elif next_x < missed_x:
+            return (
+                CubePongBall(ball.route_name, next_x, next_y, next_vx, next_vy),
+                defending_player,
+            )
+
+    return CubePongBall(ball.route_name, next_x, next_y, next_vx, next_vy), None
+
+
+def _move_paddle(
+    current_y: float,
+    control: float,
+    paddle_speed: float,
+    delta_s: float,
+    screen_width: int,
+    screen_height: int,
+) -> float:
+    _, paddle_height = paddle_size(screen_width, screen_height)
+    half_height = paddle_height / 2
+    next_y = current_y + _clamp(control, -1.0, 1.0) * paddle_speed * delta_s
+    return _clamp(next_y, half_height, screen_height - half_height)
+
+
+def _paddle_y_for_player(
+    player: int,
+    paddle_one_y: float,
+    paddle_two_y: float,
+) -> float:
+    return paddle_one_y if player == PLAYER_ONE else paddle_two_y
+
+
+def _hit_offset(
+    ball_y: float,
+    paddle_y: float,
+    paddle_height: int,
+    radius: int,
+) -> float | None:
+    half_height = paddle_height / 2
+    if abs(ball_y - paddle_y) > half_height + radius:
+        return None
+    return _clamp((ball_y - paddle_y) / max(half_height, 1), -1.0, 1.0)
+
+
+def _spin_velocity(current_vy: float, hit_offset: float, screen_height: int) -> float:
+    spin = hit_offset * max(screen_height * 0.48, 16.0)
+    return _clamp(current_vy + spin, -screen_height * 1.1, screen_height * 1.1)
+
+
+def _clamp(value: float, minimum: float, maximum: float) -> float:
+    return max(minimum, min(maximum, value))

--- a/src/heart/renderers/tetris/renderer.py
+++ b/src/heart/renderers/tetris/renderer.py
@@ -159,6 +159,7 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
         move_x = self._repeat_move(memory, move_direction, elapsed_ms)
         dpad_up = snapshot.dpad.y > 0 and memory.previous_dpad_y <= 0
         memory.previous_dpad_y = snapshot.dpad.y
+        # NORTH is reserved for the global navigation alternate-activate exit.
         return TetrisControls(
             move_x=move_x,
             soft_drop=self._soft_drop(snapshot),


### PR DESCRIPTION
## Summary
- rebase cube-pong/Tetris controller work onto latest main
- add a lib_2026 controller pairing mode backed by bluetoothctl
- reconnect known 8BitDo controllers from the gamepad peripheral

## Verification
- PYENV_VERSION=system PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile src/heart/programs/configurations/lib_2026.py src/heart/programs/configurations/controller_pairing.py src/heart/renderers/controller_pairing/renderer.py src/heart/renderers/controller_pairing/state.py src/heart/peripheral/gamepad/gamepad.py src/heart/runtime/game_loop/__init__.py
- Deployed rebased src/heart to totem3.local
- Restarted heart-xvfb, heart-rp1-scanner, and heart-app with RUN_CONFIGURATION=lib_2026