### PR TITLE
Fix gamepad menu navigation polling

### DIFF
--- a/src/heart/peripheral/core/input/gamepad.py
+++ b/src/heart/peripheral/core/input/gamepad.py
@@ -215,6 +215,9 @@ class GamepadController:
             upstream_ids=("gamepad.snapshot",),
         ).connect(stream)
 
+    def sample(self) -> GamepadSnapshot:
+        return self._sample()
+
     def _sample(self) -> GamepadSnapshot:
         gamepad = self._active_gamepad()
         if gamepad is None:

--- a/src/heart/runtime/peripheral_runtime.py
+++ b/src/heart/runtime/peripheral_runtime.py
@@ -13,7 +13,9 @@ from heart import DeviceDisplayMode
 from heart.device.beats.websocket import WebSocket
 from heart.peripheral.core import (PeripheralInfo, PeripheralMessageEnvelope,
                                    PeripheralTag)
-from heart.peripheral.core.input import InputDebugEnvelope
+from heart.peripheral.core.input import (GamepadAxis, GamepadButton,
+                                         InputDebugEnvelope)
+from heart.peripheral.core.input.streams import threshold_direction
 from heart.peripheral.core.manager import PeripheralManager
 from heart.renderers.free_text import FreeTextRenderer
 from heart.renderers.image import (ContainRenderImage,
@@ -33,6 +35,7 @@ CONTROL_COMMAND_TEXT_UPDATE = "text_update"
 CONTROL_COMMAND_IMAGE_UPDATE = "image_update"
 PHONE_TEXT_DISPLAY_DURATION_SECONDS = 5.0
 PHONE_IMAGE_DISPLAY_DURATION_SECONDS = 5.0
+GAMEPAD_NAVIGATION_STICK_THRESHOLD = 0.6
 
 
 class PeripheralRuntime:
@@ -42,6 +45,8 @@ class PeripheralRuntime:
         self._peripheral_manager = peripheral_manager
         self._control_messages: SimpleQueue[Any] = SimpleQueue()
         self._frame_clock: pygame.time.Clock | None = None
+        self._last_gamepad_dpad_x: int | None = None
+        self._last_gamepad_left_stick_direction: int | None = None
 
     def detect_and_start(self) -> None:
         logger.info("Attempting to detect attached peripherals")
@@ -202,9 +207,44 @@ class PeripheralRuntime:
     def poll(self) -> None:
         drain_frame_thread_queue()
         self._drain_control_messages()
+        self._poll_gamepad_navigation()
         gamepad = self._peripheral_manager.get_gamepad()
         if gamepad is not None:
             gamepad.update()
+
+    def _poll_gamepad_navigation(self) -> None:
+        snapshot = self._peripheral_manager.input_io.gamepad.sample()
+        if not snapshot.connected:
+            self._last_gamepad_dpad_x = None
+            self._last_gamepad_left_stick_direction = None
+            return
+
+        navigation = self._peripheral_manager.input_io.navigation
+        dpad_x = snapshot.dpad.x
+        if (
+            self._last_gamepad_dpad_x is not None
+            and self._last_gamepad_dpad_x != dpad_x
+            and dpad_x != 0
+        ):
+            navigation.inject_browse(dpad_x, source="gamepad.dpad")
+        self._last_gamepad_dpad_x = dpad_x
+
+        left_stick_direction = threshold_direction(
+            snapshot.axis_value(GamepadAxis.LEFT_X),
+            GAMEPAD_NAVIGATION_STICK_THRESHOLD,
+        )
+        if (
+            self._last_gamepad_left_stick_direction is not None
+            and self._last_gamepad_left_stick_direction != left_stick_direction
+            and left_stick_direction != 0
+        ):
+            navigation.inject_browse(left_stick_direction, source="gamepad.left_stick")
+        self._last_gamepad_left_stick_direction = left_stick_direction
+
+        if snapshot.button_tapped(GamepadButton.SOUTH):
+            navigation.inject_activate(source="gamepad.south")
+        if snapshot.button_tapped(GamepadButton.NORTH):
+            navigation.inject_alternate_activate(source="gamepad.north")
 
     def set_clock(self, clock: pygame.time.Clock | None) -> None:
         self._frame_clock = clock


### PR DESCRIPTION
## Summary
- sample gamepad state directly from the runtime poll loop
- inject menu navigation intents from dpad, left stick, and south/north button edges
- keep the existing stream APIs intact while bypassing the timer path that was not firing on the Pi

## Verification
- PYENV_VERSION=system PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile src/heart/runtime/peripheral_runtime.py src/heart/peripheral/core/input/gamepad.py
- synced to totem3.local and restarted heart-app; controller input moved the menu before logs were removed