### PR TITLE
Pace water simulation with frame ticks

### DIFF
--- a/src/heart/renderers/water_cube/provider.py
+++ b/src/heart/renderers/water_cube/provider.py
@@ -20,10 +20,17 @@ class WaterCubeStateProvider(ObservableProvider[WaterCubeState]):
         if peripheral_manager is None:
             msg = "WaterCubeStateProvider requires a PeripheralManager"
             raise ValueError(msg)
-        accel = peripheral_manager.input_io.active_acceleration()
-
         initial = WaterCubeState.initial_state(self.device)
-        return accel.scan(self._advance_state, seed=initial).start_with(initial)
+        acceleration = peripheral_manager.input_io.active_acceleration().start_with(None)
+        frame_ticks = peripheral_manager.input_io.frame_tick_stream()
+        return (
+            frame_ticks.with_latest_from(acceleration)
+            .scan(
+                lambda prev, latest: self._advance_state(prev, latest[1]),
+                seed=initial,
+            )
+            .start_with(initial)
+        )
 
     def _advance_state(
         self, prev: WaterCubeState, acceleration: Acceleration | None

--- a/tests/renderers/test_water_cube_provider.py
+++ b/tests/renderers/test_water_cube_provider.py
@@ -9,14 +9,26 @@ from heart.peripheral.sensor import Acceleration
 from heart.renderers.water_cube.provider import WaterCubeStateProvider
 
 
+class _Clock:
+    def __init__(self, delta_ms: float = 16.0, fps: float = 60.0) -> None:
+        self.delta_ms = delta_ms
+        self.fps = fps
+
+    def get_fps(self) -> float:
+        return self.fps
+
+    def get_time(self) -> float:
+        return self.delta_ms
+
+
 class TestWaterCubeStateProvider:
     """Ensure the default playlist's water renderer initializes from a valid state."""
 
-    def test_observable_emits_initial_state_before_accelerometer_updates(
+    def test_observable_steps_on_frame_tick_with_latest_accelerometer_update(
         self,
         monkeypatch,
     ) -> None:
-        """Verify startup emits a WaterCubeState instead of feeding the initial state through the reducer as acceleration."""
+        """Verify accelerometer input is sampled on frame ticks instead of advancing the simulation directly."""
         peripheral_manager = PeripheralManager()
         accelerometer_controller = peripheral_manager.input_io.accelerometer
         accelerometer_debug_profile = peripheral_manager.input_io.debug_accelerometer
@@ -32,7 +44,12 @@ class TestWaterCubeStateProvider:
 
         provider.observable(peripheral_manager).subscribe(observed_states.append)
         accelerometer_controller.node().on_next(Acceleration(x=1.0, y=2.0, z=3.0))
+        accelerometer_controller.node().on_next(Acceleration(x=4.0, y=5.0, z=6.0))
+
+        assert len(observed_states) == 1
+
+        peripheral_manager.input_io.frame_ticks.advance(_Clock())
 
         assert len(observed_states) == 2
         assert observed_states[0].gvec is None
-        assert observed_states[1].gvec == Acceleration(x=1.0, y=2.0, z=3.0)
+        assert observed_states[1].gvec == Acceleration(x=4.0, y=5.0, z=6.0)


### PR DESCRIPTION
## Summary
- advance the water cube simulation on frame ticks instead of raw accelerometer events
- sample only the latest accelerometer value per frame to avoid stale event backlog
- update the provider test to cover latest-only accelerometer sampling

## Validation
- `uv run pytest tests/renderers/test_water_cube_provider.py tests/peripheral/test_accelerometer.py tests/renderers/test_provider_signatures.py`
- commit hook: `make format`