### PR TITLE
Restore spectrum title font size

### DIFF
--- a/src/heart/programs/configurations/lib_2026.py
+++ b/src/heart/programs/configurations/lib_2026.py
@@ -114,7 +114,7 @@ def configure(loop: GameLoop) -> None:
     audio_storm_mode = loop.add_mode(
         centered_text(
             text="spectrum",
-            font_size=13,
+            font_size=12,
             color=Color(255, 255, 255),
             line_height_px=TITLE_LINE_HEIGHT_PX,
             line_spacing_px=TITLE_LINE_SPACING_PX,


### PR DESCRIPTION
## Summary
- restore the 2026 spectrum title font size to the existing test-backed value

## Validation
- `uv run pytest tests/programs/test_lib_2026_configuration.py tests/renderers/test_water_cube_provider.py tests/peripheral/test_accelerometer.py tests/renderers/test_provider_signatures.py`
- `make test`
- commit hook: `make format`