### PR TITLE
[codex] Throttle water updates with averaged acceleration

### DIFF
--- a/src/heart/peripheral/core/input/streams.py
+++ b/src/heart/peripheral/core/input/streams.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TypeVar
 
 from manyfold import MergeNode, StreamNode
 
+from heart.peripheral.core.input.frame import FrameTick
+
 T = TypeVar("T")
 U = TypeVar("U")
+
+
+@dataclass(frozen=True)
+class _SampleAverage:
+    elapsed_ms: float = 0.0
+    total: float = 0.0
+    samples: int = 0
+    value: float | None = None
 
 
 def map_stream(source: StreamNode[T], mapper: Callable[[T], U]) -> StreamNode[U]:
@@ -15,6 +26,38 @@ def map_stream(source: StreamNode[T], mapper: Callable[[T], U]) -> StreamNode[U]
 
 def merge_streams(*streams: StreamNode[T]) -> StreamNode[T]:
     return MergeNode.merge(*streams)
+
+
+def average_by_frame_window(
+    source: StreamNode[T | None],
+    frame_ticks: StreamNode[FrameTick],
+    *,
+    interval_ms: float,
+    selector: Callable[[T], float],
+) -> StreamNode[float]:
+    def accumulate(previous: _SampleAverage, latest: tuple[FrameTick, T | None]):
+        frame_tick, value = latest
+        elapsed_ms = previous.elapsed_ms + max(float(frame_tick.delta_ms), 0.0)
+        total = previous.total
+        samples = previous.samples
+        if value is not None:
+            total += selector(value)
+            samples += 1
+        if elapsed_ms < interval_ms:
+            return _SampleAverage(
+                elapsed_ms=elapsed_ms,
+                total=total,
+                samples=samples,
+            )
+        average = None if samples == 0 else total / float(samples)
+        return _SampleAverage(value=average)
+
+    return (
+        frame_ticks.with_latest_from(source)
+        .scan(accumulate, seed=_SampleAverage())
+        .filter(lambda average: average.value is not None)
+        .map(lambda average: average.value)
+    )
 
 
 def threshold_direction(value: float, threshold: float) -> int:

--- a/src/heart/renderers/water_cube/provider.py
+++ b/src/heart/renderers/water_cube/provider.py
@@ -1,18 +1,24 @@
 from manyfold import StreamNode
 
 from heart.device import Device
+from heart.peripheral.core.input.frame import FrameTick
+from heart.peripheral.core.input.streams import average_by_frame_window
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.providers import ObservableProvider
 from heart.peripheral.sensor import Acceleration
 from heart.renderers.water_cube.state import WaterCubeState
+
+MIN_UPDATE_INTERVAL_MS = 100.0
 
 
 class WaterCubeStateProvider(ObservableProvider[WaterCubeState]):
     def __init__(
         self,
         device: Device,
+        min_update_interval_ms: float = MIN_UPDATE_INTERVAL_MS,
     ):
         self.device = device
+        self._min_update_interval_ms = min_update_interval_ms
 
     def observable(
         self, peripheral_manager: PeripheralManager | None = None
@@ -23,13 +29,41 @@ class WaterCubeStateProvider(ObservableProvider[WaterCubeState]):
         initial = WaterCubeState.initial_state(self.device)
         acceleration = peripheral_manager.input_io.active_acceleration().start_with(None)
         frame_ticks = peripheral_manager.input_io.frame_tick_stream()
+        average_acceleration = self._average_acceleration(acceleration, frame_ticks)
         return (
-            frame_ticks.with_latest_from(acceleration)
+            average_acceleration
             .scan(
-                lambda prev, latest: self._advance_state(prev, latest[1]),
+                lambda prev, latest: self._advance_state(prev, latest),
                 seed=initial,
             )
             .start_with(initial)
+        )
+
+    def _average_acceleration(
+        self,
+        acceleration: StreamNode[Acceleration | None],
+        frame_ticks: StreamNode[FrameTick],
+    ) -> StreamNode[Acceleration]:
+        average_x = average_by_frame_window(
+            acceleration,
+            frame_ticks,
+            interval_ms=self._min_update_interval_ms,
+            selector=lambda value: value.x,
+        )
+        average_y = average_by_frame_window(
+            acceleration,
+            frame_ticks,
+            interval_ms=self._min_update_interval_ms,
+            selector=lambda value: value.y,
+        )
+        average_z = average_by_frame_window(
+            acceleration,
+            frame_ticks,
+            interval_ms=self._min_update_interval_ms,
+            selector=lambda value: value.z,
+        )
+        return average_x.with_latest_from(average_y, average_z).map(
+            lambda latest: Acceleration(x=latest[0], y=latest[1], z=latest[2])
         )
 
     def _advance_state(

--- a/tests/peripheral/test_input_core.py
+++ b/tests/peripheral/test_input_core.py
@@ -27,6 +27,7 @@ from heart.peripheral.core.input.accelerometer import (
 from heart.peripheral.core.input.debug import InputDebugNode
 from heart.peripheral.core.input.peripheral_inputs import \
     PERIPHERAL_INPUT_DISPATCH_STREAM
+from heart.peripheral.core.input.streams import average_by_frame_window
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.core.streams import EventStream, runtime_route
 from heart.peripheral.gamepad import Gamepad
@@ -296,6 +297,46 @@ class TestFrameTickController:
         assert tap.snapshot()[-1].stage is InputDebugStage.FRAME
         assert tap.snapshot()[-1].stream_name == "frame.tick"
         assert tap.latency_snapshot()["frame.tick"].count == 1
+
+
+class TestInputStreamHelpers:
+    """Cover stream helpers shared across input-derived renderers."""
+
+    def test_average_by_frame_window_emits_once_per_elapsed_window(self) -> None:
+        """Verify frame-clocked stream averaging smooths samples without emitting intermediate values."""
+        source: EventStream[float | None] = EventStream()
+        frame_ticks: EventStream[FrameTick] = EventStream()
+        observed: list[float] = []
+
+        average_by_frame_window(
+            source.start_with(None),
+            frame_ticks,
+            interval_ms=100.0,
+            selector=lambda value: value,
+        ).subscribe(observed.append)
+
+        source.emit(2.0)
+        frame_ticks.emit(
+            FrameTick(
+                frame_index=0,
+                delta_ms=40.0,
+                delta_s=0.04,
+                monotonic_s=1.0,
+                fps=25.0,
+            )
+        )
+        source.emit(8.0)
+        frame_ticks.emit(
+            FrameTick(
+                frame_index=1,
+                delta_ms=60.0,
+                delta_s=0.06,
+                monotonic_s=1.06,
+                fps=25.0,
+            )
+        )
+
+        assert observed == [5.0]
 
 
 class TestKeyboardController:

--- a/tests/renderers/test_water_cube_provider.py
+++ b/tests/renderers/test_water_cube_provider.py
@@ -24,11 +24,11 @@ class _Clock:
 class TestWaterCubeStateProvider:
     """Ensure the default playlist's water renderer initializes from a valid state."""
 
-    def test_observable_steps_on_frame_tick_with_latest_accelerometer_update(
+    def test_observable_steps_at_most_once_per_100ms_with_averaged_acceleration(
         self,
         monkeypatch,
     ) -> None:
-        """Verify accelerometer input is sampled on frame ticks instead of advancing the simulation directly."""
+        """Verify accelerometer input is sampled on throttled frame ticks."""
         peripheral_manager = PeripheralManager()
         accelerometer_controller = peripheral_manager.input_io.accelerometer
         accelerometer_debug_profile = peripheral_manager.input_io.debug_accelerometer
@@ -48,8 +48,22 @@ class TestWaterCubeStateProvider:
 
         assert len(observed_states) == 1
 
-        peripheral_manager.input_io.frame_ticks.advance(_Clock())
+        peripheral_manager.input_io.frame_ticks.advance(_Clock(delta_ms=16.0))
+
+        assert len(observed_states) == 1
+
+        accelerometer_controller.node().on_next(Acceleration(x=10.0, y=20.0, z=30.0))
+        peripheral_manager.input_io.frame_ticks.advance(_Clock(delta_ms=83.0))
+
+        assert len(observed_states) == 1
+
+        accelerometer_controller.node().on_next(Acceleration(x=16.0, y=32.0, z=48.0))
+        peripheral_manager.input_io.frame_ticks.advance(_Clock(delta_ms=1.0))
 
         assert len(observed_states) == 2
         assert observed_states[0].gvec is None
-        assert observed_states[1].gvec == Acceleration(x=4.0, y=5.0, z=6.0)
+        assert observed_states[1].gvec == Acceleration(x=10.0, y=19.0, z=28.0)
+
+        peripheral_manager.input_io.frame_ticks.advance(_Clock(delta_ms=99.0))
+
+        assert len(observed_states) == 2


### PR DESCRIPTION
## Summary
- add a reusable frame-window average helper for input streams
- throttle WaterCube simulation updates to 100 ms windows
- average x/y/z acceleration over each window before advancing water state

## Validation
- `uv run pytest tests/renderers/test_water_cube_provider.py tests/peripheral/test_input_core.py::TestInputStreamHelpers`