### PR TITLE
[codex] Use Kirby color for centered titles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,4 @@
 
 ## Validation Log
 - 2026-05-19: RP1 HUB75 runtime CIE1931 gamma mapping and totem brightness default update. Ran `cargo fmt && cargo test -q` from `rust/heart_rgb_matrix_driver` and `uv run pytest tests/test_rp1_hub75_regular_contract.py -q`.
+- 2026-05-19: 2026 library centered title color now uses the Kirby default. Ran `uv run pytest tests/programs/test_lib_2026_configuration.py -q`.

--- a/src/heart/programs/configurations/lib_2026.py
+++ b/src/heart/programs/configurations/lib_2026.py
@@ -22,13 +22,13 @@ from heart.renderers.pranay_sketch import PranaySketchRenderer
 from heart.renderers.rock_paper_scissors import add_rock_paper_scissors_mode
 from heart.renderers.spritesheet import SpritesheetLoop
 from heart.renderers.spritesheet_random import SpritesheetLoopRandom
+from heart.renderers.tetris import TetrisRenderer
 from heart.renderers.text import TextRendering
 from heart.renderers.three_fractal import FractalScene
 from heart.renderers.tixyland import Tixyland, TixylandFactory
 from heart.renderers.vibe import VibeScene
 from heart.renderers.water_cube.renderer import WaterCube
 from heart.renderers.water_title_screen import WaterTitleScreen
-from heart.renderers.tetris import TetrisRenderer
 from heart.runtime.game_loop import GameLoop
 
 TITLE_TILE_HEIGHT_PX = 64
@@ -48,7 +48,7 @@ def centered_text_title(text: str) -> TextRendering:
     return centered_text(
         text=text,
         font_size=TITLE_FONT_SIZE,
-        color=Color(255, 255, 255),
+        color=Color.kirby(),
         line_height_px=TITLE_LINE_HEIGHT_PX,
         line_spacing_px=TITLE_LINE_SPACING_PX,
     )

--- a/tests/programs/test_lib_2026_configuration.py
+++ b/tests/programs/test_lib_2026_configuration.py
@@ -1,7 +1,21 @@
 """Validate 2026 library configuration details."""
 
+from heart.display.color import Color
 from heart.programs.configurations.lib_2026 import configure
 from heart.renderers.text import TextRendering
+
+
+def test_centered_titles_use_kirby_color(loop) -> None:
+    configure(loop)
+
+    fractal_entry = next(
+        entry
+        for entry in loop.components.game_modes.state.entries
+        if isinstance(entry.title_renderer, TextRendering)
+        and entry.title_renderer._provider._text == ("3d\nfractal",)
+    )
+
+    assert fractal_entry.title_renderer._provider._color == Color.kirby()
 
 
 def test_spectrum_title_uses_smaller_pixel_font(loop) -> None:


### PR DESCRIPTION
## Summary
- Change the 2026 library centered title helper to use `Color.kirby()` instead of white.
- Add a regression test for the 3D fractal centered title color.
- Record the validation command in `AGENTS.md`.

## Validation
- `uv run pytest tests/programs/test_lib_2026_configuration.py -q`

Note: local commit/push hooks attempted to run broad `make format` and rewrote unrelated imports in two renderer files. Those unrelated edits were not included; the focused validation passed.