### PR TITLE
Add env launcher for Beats phone controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Key `totem run` flags:
 
 - `--configuration <name>` selects modules from `heart.programs.configurations`.
 - `--add-low-power-mode/--no-add-low-power-mode` toggles the standby mode that keeps LEDs dim when no scenes are active.
-- `totem run --with-beats --configuration <name>` launches the streamed totem runtime and a LAN-visible Beats web UI together, wiring `FORWARD_TO_BEATS_APP=1`, `BEATS_WEBSOCKET_BIND_HOST=0.0.0.0`, and a Vite dev server on `http://localhost:5173`.
+- `totem run --with-beats --configuration <name>` launches the totem runtime, a Beats control websocket for phone text/image/navigation commands, and a LAN-visible Beats web UI together, wiring `BEATS_WEBSOCKET_ENABLED=1`, `BEATS_WEBSOCKET_BIND_HOST=0.0.0.0`, and a Vite dev server on `http://localhost:5173`.
+- `BEATS_WEB_ENABLED=1 totem run --configuration <name>` enables the same Beats web UI and phone-control websocket from an environment file or shell without setting `FORWARD_TO_BEATS_APP`.
 - `totem run --with-beats --remote-runtime --beats-runtime-host totem.local` launches only the browser-served Beats UI and points it at an existing runtime websocket on the Pi.
 
 ## Architecture Summary

--- a/src/heart/cli/commands/run.py
+++ b/src/heart/cli/commands/run.py
@@ -15,6 +15,7 @@ from heart.cli.commands.run_options import (DEFAULT_ADD_LOW_POWER_MODE,
                                             DEFAULT_INSTALL_BEATS_DEPS,
                                             DEFAULT_LOCAL_BEATS_RUNTIME,
                                             DEFAULT_WITH_BEATS,
+                                            beats_web_enabled,
                                             resolve_configuration_name)
 from heart.programs.registry import ConfigurationRegistry
 from heart.runtime.game_loop import GameLoop
@@ -98,7 +99,7 @@ def run_command(
 ) -> None:
     resolved_configuration = resolve_configuration_name(configuration)
 
-    if with_beats or with_beats_web:
+    if with_beats or with_beats_web or beats_web_enabled():
         run_beats.run_beats_web_command(
             configuration=resolved_configuration,
             add_low_power_mode=add_low_power_mode,

--- a/src/heart/cli/commands/run_beats.py
+++ b/src/heart/cli/commands/run_beats.py
@@ -12,6 +12,7 @@ from typing import Annotated
 import typer
 
 from heart.cli.commands.run_options import (DEFAULT_ADD_LOW_POWER_MODE,
+                                            BEATS_WEB_ENABLED_ENV_VAR,
                                             DEFAULT_BEATS_RUNTIME_HOST,
                                             DEFAULT_BEATS_RUNTIME_PORT,
                                             DEFAULT_BEATS_WEB_HOST,
@@ -28,6 +29,7 @@ logger = get_logger(__name__)
 
 DEFAULT_BEATS_WEB_START_SCRIPT = "web"
 FORWARD_TO_BEATS_ENV_VAR = "FORWARD_TO_BEATS_APP"
+BEATS_WEBSOCKET_ENABLED_ENV_VAR = "BEATS_WEBSOCKET_ENABLED"
 BEATS_WEBSOCKET_HOST_ENV_VAR = "VITE_BEATS_WEBSOCKET_HOST"
 BEATS_WEBSOCKET_PORT_ENV_VAR = "VITE_BEATS_WEBSOCKET_PORT"
 BEATS_WEBSOCKET_URL_ENV_VAR = "VITE_BEATS_WEBSOCKET_URL"
@@ -240,7 +242,7 @@ def build_totem_run_command(
     configuration: str,
     add_low_power_mode: bool,
 ) -> list[str]:
-    """Build the runtime command that forwards frames into Beats."""
+    """Build the runtime command that serves the Beats control websocket."""
 
     command = ["uv", "run", "totem", "run", "--configuration", configuration]
     if not add_low_power_mode:
@@ -270,10 +272,11 @@ def build_runtime_env(
     websocket_bind_host: str | None = None,
     websocket_port: int | None = None,
 ) -> dict[str, str]:
-    """Prepare runtime environment variables for Beats forwarding."""
+    """Prepare runtime environment variables for Beats phone controls."""
 
     runtime_env = dict(base_env)
-    runtime_env[FORWARD_TO_BEATS_ENV_VAR] = "1"
+    runtime_env.pop(BEATS_WEB_ENABLED_ENV_VAR, None)
+    runtime_env[BEATS_WEBSOCKET_ENABLED_ENV_VAR] = "1"
     if websocket_bind_host is not None:
         runtime_env[WEBSOCKET_BIND_HOST_ENV_VAR] = websocket_bind_host
     if websocket_port is not None:

--- a/src/heart/cli/commands/run_options.py
+++ b/src/heart/cli/commands/run_options.py
@@ -1,12 +1,14 @@
 import os
 from pathlib import Path
 
+from heart.utilities.env.parsing import _env_flag
 from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
 
 DEFAULT_CONFIGURATION = "lib_2025"
 CONFIGURATION_OVERRIDE_ENV_VAR = "HEART_RUN_CONFIGURATION"
+BEATS_WEB_ENABLED_ENV_VAR = "BEATS_WEB_ENABLED"
 DEFAULT_ADD_LOW_POWER_MODE = True
 DEFAULT_WITH_BEATS = False
 DEFAULT_INSTALL_BEATS_DEPS = True
@@ -31,3 +33,9 @@ def resolve_configuration_name(configuration: str) -> str:
             override,
         )
     return override
+
+
+def beats_web_enabled() -> bool:
+    """Return True when the combined Beats web launcher is enabled by env."""
+
+    return _env_flag(BEATS_WEB_ENABLED_ENV_VAR, default=False)

--- a/src/heart/runtime/peripheral_runtime.py
+++ b/src/heart/runtime/peripheral_runtime.py
@@ -61,7 +61,11 @@ class PeripheralRuntime:
         self._peripheral_manager.start()
 
     def configure_streaming(self, websocket: Any | None = None) -> None:
-        if websocket is None and not Configuration.forward_to_beats_app():
+        if (
+            websocket is None
+            and not Configuration.forward_to_beats_app()
+            and not Configuration.beats_websocket_enabled()
+        ):
             logger.debug("Beats streaming disabled; skipping websocket startup")
             return
 

--- a/src/heart/utilities/env/system.py
+++ b/src/heart/utilities/env/system.py
@@ -58,6 +58,10 @@ class SystemConfiguration:
         return _env_flag("FORWARD_TO_BEATS_APP", default=False)
 
     @classmethod
+    def beats_websocket_enabled(cls) -> bool:
+        return _env_flag("BEATS_WEBSOCKET_ENABLED", default=False)
+
+    @classmethod
     def stream_beats_input_debug(cls) -> bool:
         return _env_flag("BEATS_STREAM_INPUT_DEBUG", default=False)
 

--- a/tests/cli/test_run_beats.py
+++ b/tests/cli/test_run_beats.py
@@ -12,14 +12,17 @@ from typer.testing import CliRunner
 from heart import loop
 from heart.cli.commands import run as run_module
 from heart.cli.commands.run_beats import (BEATS_WEBSOCKET_HOST_ENV_VAR,
+                                          BEATS_WEBSOCKET_ENABLED_ENV_VAR,
                                           BEATS_WEBSOCKET_PORT_ENV_VAR,
                                           BEATS_WEBSOCKET_URL_ENV_VAR,
                                           FORWARD_TO_BEATS_ENV_VAR,
+                                          build_runtime_env,
                                           build_beats_web_env,
                                           build_totem_run_command,
                                           ensure_beats_dependencies,
                                           resolve_beats_workspace)
-from heart.cli.commands.run_options import CONFIGURATION_OVERRIDE_ENV_VAR
+from heart.cli.commands.run_options import (BEATS_WEB_ENABLED_ENV_VAR,
+                                            CONFIGURATION_OVERRIDE_ENV_VAR)
 
 runner = CliRunner()
 
@@ -68,10 +71,21 @@ class TestRunBeatsCommandBuilders:
             "/tmp/heart/experimental/beats"
         )
 
-    def test_runtime_env_flag_name_remains_stable(self) -> None:
-        """Verify the runtime forwarding env var stays stable so the combined launcher continues selecting the streamed device path."""
+    def test_runtime_env_enables_control_websocket_without_frame_forwarding(
+        self,
+    ) -> None:
+        """Verify the combined launcher starts the control websocket without replacing the physical display device."""
 
         assert FORWARD_TO_BEATS_ENV_VAR == "FORWARD_TO_BEATS_APP"
+        env = build_runtime_env(
+            {"PATH": "/bin", BEATS_WEB_ENABLED_ENV_VAR: "1"},
+            websocket_bind_host="0.0.0.0",
+        )
+
+        assert env[BEATS_WEBSOCKET_ENABLED_ENV_VAR] == "1"
+        assert FORWARD_TO_BEATS_ENV_VAR not in env
+        assert BEATS_WEB_ENABLED_ENV_VAR not in env
+        assert env["BEATS_WEBSOCKET_BIND_HOST"] == "0.0.0.0"
 
 
 class TestEnsureBeatsDependencies:
@@ -335,6 +349,28 @@ class TestRunCommandWithBeats:
         run_module.run_command(with_beats=True)
 
         assert recorded_call["configuration"] == "rubiks_connected_x_visualizer"
+
+    def test_run_command_env_enables_beats_web_launcher(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify service environments can launch Beats web without adding command-line flags."""
+
+        recorded_call: dict[str, object] = {}
+
+        def _fake_run_beats_web_command(**kwargs: object) -> None:
+            recorded_call.update(kwargs)
+
+        monkeypatch.setenv(BEATS_WEB_ENABLED_ENV_VAR, "1")
+        monkeypatch.setattr(
+            "heart.cli.commands.run_beats.run_beats_web_command",
+            _fake_run_beats_web_command,
+        )
+
+        run_module.run_command(configuration="lib_2026")
+
+        assert recorded_call["configuration"] == "lib_2026"
+        assert recorded_call["local_runtime"] is True
+        assert recorded_call["web_host"] == "0.0.0.0"
 
     def test_run_command_keeps_with_beats_web_as_alias(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/runtime/test_peripheral_runtime.py
+++ b/tests/runtime/test_peripheral_runtime.py
@@ -81,6 +81,10 @@ class TestPeripheralRuntimeStreaming:
             "heart.runtime.peripheral_runtime.Configuration.forward_to_beats_app",
             classmethod(lambda cls: False),
         )
+        monkeypatch.setattr(
+            "heart.runtime.peripheral_runtime.Configuration.beats_websocket_enabled",
+            classmethod(lambda cls: False),
+        )
 
         def _unexpected_websocket() -> object:
             raise AssertionError(
@@ -93,6 +97,32 @@ class TestPeripheralRuntimeStreaming:
         )
 
         runtime.configure_streaming()
+
+    def test_configure_streaming_starts_websocket_for_control_server(
+        self, monkeypatch
+    ) -> None:
+        """Verify phone controls can start the Beats websocket without switching the runtime to streamed display output."""
+
+        manager = _PeripheralManagerStub()
+        runtime = PeripheralRuntime(manager)  # type: ignore[arg-type]
+        websocket = _WebSocketStub()
+
+        monkeypatch.setattr(
+            "heart.runtime.peripheral_runtime.Configuration.forward_to_beats_app",
+            classmethod(lambda cls: False),
+        )
+        monkeypatch.setattr(
+            "heart.runtime.peripheral_runtime.Configuration.beats_websocket_enabled",
+            classmethod(lambda cls: True),
+        )
+        monkeypatch.setattr(
+            "heart.runtime.peripheral_runtime._build_websocket",
+            lambda: websocket,
+        )
+
+        runtime.configure_streaming()
+
+        assert websocket.control_handler is not None
 
     def test_configure_streaming_emits_peripheral_envelopes(self, monkeypatch) -> None:
         """Verify debug tap events are wrapped as peripheral payloads so the Beats websocket can replay and decode them after reconnects."""

--- a/tests/utilities/test_env.py
+++ b/tests/utilities/test_env.py
@@ -145,6 +145,17 @@ class TestUtilitiesEnv:
         monkeypatch.setenv("FORWARD_TO_BEATS_MAP", "true")
         assert Configuration.forward_to_beats_app() is False
 
+    def test_beats_websocket_enabled_reads_expected_env_flag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify the Beats websocket helper can enable phone controls without frame forwarding."""
+
+        _clear_env(monkeypatch, "BEATS_WEBSOCKET_ENABLED")
+        assert Configuration.beats_websocket_enabled() is False
+
+        monkeypatch.setenv("BEATS_WEBSOCKET_ENABLED", "true")
+        assert Configuration.beats_websocket_enabled() is True
+
     def test_asset_cache_strategy_defaults_all(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
- add BEATS_WEB_ENABLED=1 as an env-driven way to launch the Beats web UI from totem run
- split phone-control websocket enablement from FORWARD_TO_BEATS_APP so the physical display path is preserved
- prevent BEATS_WEB_ENABLED from leaking into the child runtime and recursively launching another webserver

## Tests
- uv run ruff check src/heart/cli/commands/run.py src/heart/cli/commands/run_beats.py src/heart/cli/commands/run_options.py src/heart/runtime/peripheral_runtime.py src/heart/utilities/env/system.py tests/cli/test_run_beats.py tests/runtime/test_peripheral_runtime.py tests/utilities/test_env.py
- uv run pytest tests/cli/test_run_beats.py tests/runtime/test_peripheral_runtime.py tests/utilities/test_env.py -q