### PR TITLE
Allow LAN hosts for Beats web

### DIFF
--- a/experimental/beats/vite.renderer.config.mts
+++ b/experimental/beats/vite.renderer.config.mts
@@ -8,6 +8,9 @@ import { defineConfig } from "vite";
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 export default defineConfig({
+  server: {
+    allowedHosts: true,
+  },
   plugins: [
     tanstackRouter({
       target: "react",


### PR DESCRIPTION
## Summary
- allow Vite to serve the Beats web UI for LAN hostnames such as totem3.local

## Validation
- verified http://totem3.local:5173/phone returns HTTP 200 on totem3.local after syncing this change
- npx vite --config vite.renderer.config.mts --host 127.0.0.1 --port 0 --help >/dev/null