### PR TITLE
Add Tetris mirrored modes and gravity ramp

### DIFF
--- a/src/heart/programs/configurations/lib_2026.py
+++ b/src/heart/programs/configurations/lib_2026.py
@@ -6,9 +6,10 @@ from heart.display.color import Color
 from heart.navigation import MultiScene
 from heart.peripheral.providers.randomness import RandomnessProvider
 from heart.renderers.audio_storm import AudioStormScene
-from heart.renderers.bouncing_ball import (BouncingBallRenderer,
-                                           BouncingBallStateProvider)
-from heart.renderers.controller_pairing import ControllerPairingRenderer
+from heart.renderers.bouncing_ball import (
+    BouncingBallRenderer,
+    BouncingBallStateProvider,
+)
 from heart.renderers.cube_pong import add_cube_pong_mode
 from heart.renderers.hilbert_curve import HilbertScene
 from heart.renderers.image import RenderImage
@@ -91,8 +92,6 @@ def friend_beacon_text(text: str) -> TextRendering:
 
 def configure(loop: GameLoop) -> None:
     randomness = RandomnessProvider()
-    controller_pairing_mode = loop.add_mode("pair bt")
-    controller_pairing_mode.add_renderer(ControllerPairingRenderer())
 
     add_cube_pong_mode(loop)
 

--- a/src/heart/renderers/tetris/renderer.py
+++ b/src/heart/renderers/tetris/renderer.py
@@ -46,6 +46,7 @@ BOARD_BACKGROUND_COLOR = pygame.Color(0, 0, 0)
 BOARD_BORDER_COLOR = pygame.Color(40, 255, 226)
 BOARD_BORDER_SHADOW_COLOR = pygame.Color(0, 78, 148)
 GHOST_PIECE_COLOR = pygame.Color(96, 108, 132)
+MODE_LABEL_COLOR = pygame.Color(255, 255, 255)
 GARBAGE_WARNING_COLOR = pygame.Color(255, 70, 80)
 GAME_OVER_COLOR = pygame.Color(255, 35, 60)
 WIN_OVERLAY_COLOR = pygame.Color(255, 228, 68)
@@ -71,13 +72,15 @@ RNG_NAMESPACE = "tetris"
 PIXEL_FONT_PATH = "Grand9K Pixel.ttf"
 PREVIEW_CELL_SIZE_PX = 2
 NEXT_PREVIEW_COUNT = 6
-SOLO_PLAYER_COUNT = 2
+DUAL_SYNCED_PLAYER_COUNT = 2
+SOLO_MIRRORED_PLAYER_COUNT = 1
 logger = get_logger(__name__)
 
 
 class TetrisPlayMode(StrEnum):
     FOUR_PLAYER = "four_player"
-    SOLO_SYNCED = "solo_synced"
+    DUAL_SYNCED = "dual_synced"
+    SOLO_MIRRORED = "solo_mirrored"
 
 
 class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
@@ -145,6 +148,7 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
             render_target,
             window.device.individual_display_size(),
             orientation.layout.columns,
+            orientation.layout.rows,
         )
         if render_target is not window.screen:
             pygame.transform.scale(
@@ -185,8 +189,10 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
         )
 
     def _player_count_for_mode(self) -> int:
-        if self._play_mode is TetrisPlayMode.SOLO_SYNCED:
-            return SOLO_PLAYER_COUNT
+        if self._play_mode is TetrisPlayMode.DUAL_SYNCED:
+            return DUAL_SYNCED_PLAYER_COUNT
+        if self._play_mode is TetrisPlayMode.SOLO_MIRRORED:
+            return SOLO_MIRRORED_PLAYER_COUNT
         return PLAYER_COUNT
 
     def _controls_by_player(
@@ -194,7 +200,7 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
         snapshots: list[DirectGamepadSnapshot],
         elapsed_ms: float,
     ) -> list[TetrisControls]:
-        if self._play_mode is TetrisPlayMode.SOLO_SYNCED:
+        if self._uses_synchronized_controls():
             controls = self._controls_for_snapshots(
                 self._synchronized_input_memory,
                 snapshots,
@@ -219,6 +225,12 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
             controls_by_player.append(controls)
         return controls_by_player
 
+    def _uses_synchronized_controls(self) -> bool:
+        return self._play_mode in {
+            TetrisPlayMode.DUAL_SYNCED,
+            TetrisPlayMode.SOLO_MIRRORED,
+        }
+
     def _consume_mode_switch_chord(
         self,
         snapshots: list[DirectGamepadSnapshot],
@@ -233,11 +245,9 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
         return should_switch
 
     def _switch_play_mode(self) -> None:
-        self._play_mode = (
-            TetrisPlayMode.SOLO_SYNCED
-            if self._play_mode is TetrisPlayMode.FOUR_PLAYER
-            else TetrisPlayMode.FOUR_PLAYER
-        )
+        play_modes = tuple(TetrisPlayMode)
+        next_index = (play_modes.index(self._play_mode) + 1) % len(play_modes)
+        self._play_mode = play_modes[next_index]
         self._reset_current_game()
 
     def _reset_current_game(self) -> None:
@@ -407,12 +417,18 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
         screen: pygame.Surface,
         panel_size: tuple[int, int],
         panel_columns: int,
+        panel_rows: int,
     ) -> None:
         panel_width, panel_height = panel_size
         columns = max(1, panel_columns)
-        for player_index, player in enumerate(self.state.players):
-            col = player_index % columns
-            row = player_index // columns
+        rows = max(1, panel_rows)
+        for panel_index in range(columns * rows):
+            player_index = self._player_index_for_panel(panel_index, columns * rows)
+            if player_index >= len(self.state.players):
+                continue
+            player = self.state.players[player_index]
+            col = panel_index % columns
+            row = panel_index // columns
             panel = pygame.Rect(
                 col * panel_width,
                 row * panel_height,
@@ -425,6 +441,15 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
                 player,
                 player_index,
             )
+
+    def _player_index_for_panel(self, panel_index: int, panel_count: int) -> int:
+        if self._play_mode is TetrisPlayMode.SOLO_MIRRORED:
+            return 0
+        if self._play_mode is TetrisPlayMode.DUAL_SYNCED:
+            if panel_count >= DUAL_SYNCED_PLAYER_COUNT * 2:
+                return min(panel_index // 2, DUAL_SYNCED_PLAYER_COUNT - 1)
+            return panel_index % DUAL_SYNCED_PLAYER_COUNT
+        return panel_index
 
     def _render_player_panel(
         self,
@@ -499,6 +524,25 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
             self._render_game_over(screen, board_rect)
         if self.state.match_finished:
             self._render_match_result(screen, panel, board_rect, player_index)
+        self._render_mode_label(screen, panel)
+
+    def _render_mode_label(self, screen: pygame.Surface, panel: pygame.Rect) -> None:
+        label = self._mode_label()
+        label_surface = self._font(7).render(label, False, MODE_LABEL_COLOR)
+        screen.blit(
+            label_surface,
+            (
+                panel.left + 2,
+                panel.bottom - label_surface.get_height() - 1,
+            ),
+        )
+
+    def _mode_label(self) -> str:
+        if self._play_mode is TetrisPlayMode.FOUR_PLAYER:
+            return "F"
+        if self._play_mode is TetrisPlayMode.DUAL_SYNCED:
+            return "D"
+        return "S"
 
     def _draw_hud_frame(
         self,

--- a/src/heart/renderers/tetris/renderer.py
+++ b/src/heart/renderers/tetris/renderer.py
@@ -34,6 +34,7 @@ from .state import (
     TetrisPieceKind,
     TetrisPlayerState,
     advance_player,
+    collides,
     queue_garbage_for_opponents,
     update_match_end_state,
 )
@@ -44,6 +45,7 @@ HUD_PANEL_COLOR = pygame.Color(0, 3, 7)
 BOARD_BACKGROUND_COLOR = pygame.Color(0, 0, 0)
 BOARD_BORDER_COLOR = pygame.Color(40, 255, 226)
 BOARD_BORDER_SHADOW_COLOR = pygame.Color(0, 78, 148)
+GHOST_PIECE_COLOR = pygame.Color(96, 108, 132)
 GARBAGE_WARNING_COLOR = pygame.Color(255, 70, 80)
 GAME_OVER_COLOR = pygame.Color(255, 35, 60)
 WIN_OVERLAY_COLOR = pygame.Color(255, 228, 68)
@@ -472,6 +474,7 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
         board_inner = board_rect.inflate(-2, -2)
         pygame.draw.rect(screen, BOARD_BACKGROUND_COLOR, board_inner)
         self._render_board(screen, board_left, board_top, player, cell_size)
+        self._render_ghost_piece(screen, board_left, board_top, player, cell_size)
         self._render_active_piece(screen, board_left, board_top, player, cell_size)
         self._render_hold_panel(
             screen,
@@ -527,6 +530,30 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
                 if color is not None:
                     rect = self._cell_rect(board_left, board_top, x, y, cell_size)
                     self._draw_block(screen, rect, TETRIS_PALETTE[color])
+
+    def _render_ghost_piece(
+        self,
+        screen: pygame.Surface,
+        board_left: int,
+        board_top: int,
+        player: TetrisPlayerState,
+        cell_size: int,
+    ) -> None:
+        ghost = self._landing_piece(player)
+        if ghost is None or ghost == player.active:
+            return
+        for x, y in ghost.cells():
+            if y >= 0:
+                rect = self._cell_rect(board_left, board_top, x, y, cell_size)
+                pygame.draw.rect(screen, GHOST_PIECE_COLOR, rect, 1)
+
+    def _landing_piece(self, player: TetrisPlayerState) -> TetrisPiece | None:
+        if player.active is None or player.game_over:
+            return None
+        ghost = player.active
+        while not collides(player.board, ghost.moved(0, 1)):
+            ghost = ghost.moved(0, 1)
+        return ghost
 
     def _render_active_piece(
         self,

--- a/src/heart/renderers/tetris/renderer.py
+++ b/src/heart/renderers/tetris/renderer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import random
 import time
 from dataclasses import replace
+from enum import StrEnum
 
 import pygame
 
@@ -17,13 +18,25 @@ from heart.runtime.display_context import DisplayContext
 from heart.utilities.logging import get_logger
 
 from .direct_gamepad import DirectGamepadSnapshot, DirectTetrisGamepads
-from .state import (BOARD_HEIGHT, BOARD_WIDTH, CELL_SIZE_PX,
-                    MOVE_REPEAT_DELAY_MS, MOVE_REPEAT_INTERVAL_MS,
-                    PIECE_ROTATIONS, TetrisColor, TetrisControls,
-                    TetrisGameState, TetrisInputMemory, TetrisPiece,
-                    TetrisPieceKind, TetrisPlayerState, advance_player,
-                    queue_garbage_for_opponents, restart_match,
-                    update_match_end_state)
+from .state import (
+    BOARD_HEIGHT,
+    BOARD_WIDTH,
+    CELL_SIZE_PX,
+    MOVE_REPEAT_DELAY_MS,
+    MOVE_REPEAT_INTERVAL_MS,
+    PIECE_ROTATIONS,
+    PLAYER_COUNT,
+    TetrisColor,
+    TetrisControls,
+    TetrisGameState,
+    TetrisInputMemory,
+    TetrisPiece,
+    TetrisPieceKind,
+    TetrisPlayerState,
+    advance_player,
+    queue_garbage_for_opponents,
+    update_match_end_state,
+)
 
 BACKGROUND_COLOR = pygame.Color(0, 8, 20)
 PANEL_BACKGROUND_COLOR = pygame.Color(0, 18, 40)
@@ -56,7 +69,13 @@ RNG_NAMESPACE = "tetris"
 PIXEL_FONT_PATH = "Grand9K Pixel.ttf"
 PREVIEW_CELL_SIZE_PX = 2
 NEXT_PREVIEW_COUNT = 6
+SOLO_PLAYER_COUNT = 2
 logger = get_logger(__name__)
+
+
+class TetrisPlayMode(StrEnum):
+    FOUR_PLAYER = "four_player"
+    SOLO_SYNCED = "solo_synced"
 
 
 class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
@@ -73,6 +92,9 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
         self._last_logged_controls_by_player: dict[int, tuple[object, ...]] = {}
         self._gamepads = DirectTetrisGamepads()
         self._native_surface: pygame.Surface | None = None
+        self._play_mode = TetrisPlayMode.FOUR_PLAYER
+        self._mode_switch_chord_held = False
+        self._synchronized_input_memory = TetrisInputMemory()
 
     def _create_initial_state(
         self,
@@ -81,7 +103,7 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
         orientation: Orientation,
     ) -> TetrisGameState:
         del window, peripheral_manager, orientation
-        return TetrisGameState.create(self._rng)
+        return self._create_game_state()
 
     def real_process(
         self,
@@ -91,26 +113,24 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
         if window.screen is None:
             raise RuntimeError("TetrisRenderer requires an initialized display surface")
         elapsed_ms = self._elapsed_ms(window)
-        self._gamepads.refresh(player_count=len(self.state.players))
-        controls_by_player: list[TetrisControls] = []
-        for player_index, player in enumerate(self.state.players):
-            snapshot = self._snapshot_for_player(player_index)
-            controls = self._controls_for_snapshot(
-                player.input_memory,
-                snapshot,
-                elapsed_ms,
-            )
-            self._log_renderer_command(player_index, snapshot, controls)
-            controls_by_player.append(controls)
+        self._gamepads.refresh(player_count=PLAYER_COUNT)
+        snapshots = [self._latest_snapshot(slot) for slot in range(PLAYER_COUNT)]
+        if self._consume_mode_switch_chord(snapshots):
+            self._switch_play_mode()
+            controls_by_player = [TetrisControls() for _player in self.state.players]
+        else:
+            controls_by_player = self._controls_by_player(snapshots, elapsed_ms)
         if self.state.match_finished:
             if any(controls.restart for controls in controls_by_player):
-                restart_match(self.state, self._rng)
+                self._reset_current_game()
         else:
             for player_index, player in enumerate(self.state.players):
                 controls = replace(controls_by_player[player_index], restart=False)
                 cleared = advance_player(player, controls, elapsed_ms, self._rng)
-                queue_garbage_for_opponents(self.state, player_index, cleared)
-            update_match_end_state(self.state)
+                if self._play_mode is TetrisPlayMode.FOUR_PLAYER:
+                    queue_garbage_for_opponents(self.state, player_index, cleared)
+            if self._play_mode is TetrisPlayMode.FOUR_PLAYER:
+                update_match_end_state(self.state)
 
         render_target = self._native_render_target(window)
         render_target.fill((0, 0, 0, 0))
@@ -125,7 +145,9 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
             orientation.layout.columns,
         )
         if render_target is not window.screen:
-            pygame.transform.scale(render_target, window.screen.get_size(), window.screen)
+            pygame.transform.scale(
+                render_target, window.screen.get_size(), window.screen
+            )
 
     def _native_render_target(self, window: DisplayContext) -> pygame.Surface:
         if window.screen is None:
@@ -133,7 +155,10 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
         native_size = window.device.full_display_size()
         if window.screen.get_size() == native_size:
             return window.screen
-        if self._native_surface is None or self._native_surface.get_size() != native_size:
+        if (
+            self._native_surface is None
+            or self._native_surface.get_size() != native_size
+        ):
             self._native_surface = pygame.Surface(native_size, pygame.SRCALPHA)
         return self._native_surface
 
@@ -151,6 +176,73 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
     def _latest_snapshot(self, player_index: int) -> DirectGamepadSnapshot:
         return self._gamepads.snapshot_for_slot(player_index)
 
+    def _create_game_state(self) -> TetrisGameState:
+        return TetrisGameState.create(
+            self._rng,
+            player_count=self._player_count_for_mode(),
+        )
+
+    def _player_count_for_mode(self) -> int:
+        if self._play_mode is TetrisPlayMode.SOLO_SYNCED:
+            return SOLO_PLAYER_COUNT
+        return PLAYER_COUNT
+
+    def _controls_by_player(
+        self,
+        snapshots: list[DirectGamepadSnapshot],
+        elapsed_ms: float,
+    ) -> list[TetrisControls]:
+        if self._play_mode is TetrisPlayMode.SOLO_SYNCED:
+            controls = self._controls_for_snapshots(
+                self._synchronized_input_memory,
+                snapshots,
+                elapsed_ms,
+            )
+            self._log_renderer_command(
+                0,
+                self._command_source_snapshot(snapshots),
+                controls,
+            )
+            return [controls for _player in self.state.players]
+
+        controls_by_player: list[TetrisControls] = []
+        for player_index, player in enumerate(self.state.players):
+            snapshot = snapshots[player_index]
+            controls = self._controls_for_snapshot(
+                player.input_memory,
+                snapshot,
+                elapsed_ms,
+            )
+            self._log_renderer_command(player_index, snapshot, controls)
+            controls_by_player.append(controls)
+        return controls_by_player
+
+    def _consume_mode_switch_chord(
+        self,
+        snapshots: list[DirectGamepadSnapshot],
+    ) -> bool:
+        chord_held = any(
+            snapshot.button_held(GamepadButton.PLUS)
+            and snapshot.button_held(GamepadButton.MINUS)
+            for snapshot in snapshots
+        )
+        should_switch = chord_held and not self._mode_switch_chord_held
+        self._mode_switch_chord_held = chord_held
+        return should_switch
+
+    def _switch_play_mode(self) -> None:
+        self._play_mode = (
+            TetrisPlayMode.SOLO_SYNCED
+            if self._play_mode is TetrisPlayMode.FOUR_PLAYER
+            else TetrisPlayMode.FOUR_PLAYER
+        )
+        self._reset_current_game()
+
+    def _reset_current_game(self) -> None:
+        self.set_state(self._create_game_state())
+        self._synchronized_input_memory = TetrisInputMemory()
+        self._last_logged_controls_by_player.clear()
+
     def _internal_process(
         self,
         window: DisplayContext,
@@ -166,19 +258,28 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
         snapshot: DirectGamepadSnapshot,
         elapsed_ms: float,
     ) -> TetrisControls:
-        move_direction = self._move_direction(snapshot)
+        return self._controls_for_snapshots(memory, [snapshot], elapsed_ms)
+
+    def _controls_for_snapshots(
+        self,
+        memory: TetrisInputMemory,
+        snapshots: list[DirectGamepadSnapshot],
+        elapsed_ms: float,
+    ) -> TetrisControls:
+        move_direction = self._move_direction_for_snapshots(snapshots)
         move_x = self._repeat_move(memory, move_direction, elapsed_ms)
-        dpad_up = snapshot.dpad.y > 0 and memory.previous_dpad_y <= 0
-        memory.previous_dpad_y = snapshot.dpad.y
+        dpad_y = self._dpad_y(snapshots)
+        dpad_up = dpad_y > 0 and memory.previous_dpad_y <= 0
+        memory.previous_dpad_y = dpad_y
         # NORTH is reserved for the global navigation alternate-activate exit.
         return TetrisControls(
             move_x=move_x,
-            soft_drop=self._soft_drop(snapshot),
-            hard_drop=snapshot.button_tapped(GamepadButton.SOUTH),
-            rotate_cw=snapshot.button_tapped(GamepadButton.EAST),
+            soft_drop=dpad_y < 0,
+            hard_drop=self._button_tapped(snapshots, GamepadButton.SOUTH),
+            rotate_cw=self._button_tapped(snapshots, GamepadButton.EAST),
             rotate_ccw=False,
             hold=dpad_up,
-            restart=snapshot.button_tapped(GamepadButton.MINUS),
+            restart=self._button_tapped(snapshots, GamepadButton.MINUS),
         )
 
     def _log_renderer_command(
@@ -230,9 +331,41 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
         )
 
     def _move_direction(self, snapshot: DirectGamepadSnapshot) -> int:
-        if snapshot.dpad.x != 0:
-            return 1 if snapshot.dpad.x > 0 else -1
+        return self._move_direction_for_snapshots([snapshot])
+
+    def _move_direction_for_snapshots(
+        self,
+        snapshots: list[DirectGamepadSnapshot],
+    ) -> int:
+        for snapshot in snapshots:
+            if snapshot.dpad.x != 0:
+                return 1 if snapshot.dpad.x > 0 else -1
         return 0
+
+    def _dpad_y(self, snapshots: list[DirectGamepadSnapshot]) -> int:
+        for snapshot in snapshots:
+            if snapshot.dpad.y != 0:
+                return 1 if snapshot.dpad.y > 0 else -1
+        return 0
+
+    def _button_tapped(
+        self,
+        snapshots: list[DirectGamepadSnapshot],
+        button: GamepadButton,
+    ) -> bool:
+        return any(snapshot.button_tapped(button) for snapshot in snapshots)
+
+    def _command_source_snapshot(
+        self,
+        snapshots: list[DirectGamepadSnapshot],
+    ) -> DirectGamepadSnapshot:
+        for snapshot in snapshots:
+            if snapshot.dpad.x != 0 or snapshot.dpad.y != 0 or snapshot.tapped_buttons:
+                return snapshot
+        for snapshot in snapshots:
+            if snapshot.connected:
+                return snapshot
+        return snapshots[0]
 
     def _soft_drop(self, snapshot: DirectGamepadSnapshot) -> bool:
         return snapshot.dpad.y < 0
@@ -307,11 +440,7 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
         board_total_width = board_width_px + 2
         board_total_height = board_height_px + 2
         board_left = panel.left + ((panel.width - board_total_width) // 2) + 1
-        board_top = (
-            panel.top
-            + max(1, (panel.height - board_total_height) // 2)
-            + 1
-        )
+        board_top = panel.top + max(1, (panel.height - board_total_height) // 2) + 1
         board_rect = pygame.Rect(
             board_left - 1,
             board_top - 1,
@@ -593,9 +722,7 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
             reset_surface = restart_font.render("RESTART", False, pygame.Color("white"))
             surfaces = (label_surface, press_surface, reset_surface)
             gaps = (2, 0)
-            total_height = (
-                sum(surface.get_height() for surface in surfaces) + sum(gaps)
-            )
+            total_height = sum(surface.get_height() for surface in surfaces) + sum(gaps)
             widest = max(surface.get_width() for surface in surfaces)
             if total_height <= bounds.height and widest <= bounds.width:
                 return surfaces, gaps
@@ -609,7 +736,9 @@ class TetrisRenderer(StatefulBaseRenderer[TetrisGameState]):
                     False,
                     RESTART_BUTTON_COLOR,
                 ),
-                self._font(restart_size).render("RESTART", False, pygame.Color("white")),
+                self._font(restart_size).render(
+                    "RESTART", False, pygame.Color("white")
+                ),
             ),
             (1, 0),
         )

--- a/src/heart/renderers/tetris/state.py
+++ b/src/heart/renderers/tetris/state.py
@@ -11,8 +11,12 @@ BOARD_HEIGHT = 20
 CELL_SIZE_PX = 3
 PLAYER_COUNT = 4
 QUEUE_PREVIEW_LENGTH = 6
-FALL_INTERVAL_MS = 700
+LINES_PER_LEVEL = 10
+MAX_GRAVITY_LEVEL = 15
+FALL_INTERVAL_MS = 1000.0
 SOFT_DROP_INTERVAL_MS = 120
+SOFT_DROP_GRAVITY_MULTIPLIER = 20
+SOFT_DROP_MIN_INTERVAL_MS = 16.0
 LOCK_DELAY_MS = 450
 MOVE_REPEAT_DELAY_MS = 80
 MOVE_REPEAT_INTERVAL_MS = 35
@@ -184,7 +188,9 @@ class TetrisGameState:
     winner_index: int | None = None
 
     @classmethod
-    def create(cls, rng: random.Random, player_count: int = PLAYER_COUNT) -> "TetrisGameState":
+    def create(
+        cls, rng: random.Random, player_count: int = PLAYER_COUNT
+    ) -> "TetrisGameState":
         return cls(players=[TetrisPlayerState.create(rng) for _ in range(player_count)])
 
 
@@ -306,6 +312,26 @@ def clear_lines(player: TetrisPlayerState) -> int:
     return cleared
 
 
+def player_level(player: TetrisPlayerState) -> int:
+    return (player.lines_cleared // LINES_PER_LEVEL) + 1
+
+
+def guideline_fall_interval_ms(level: int) -> float:
+    gravity_level = max(1, min(level, MAX_GRAVITY_LEVEL))
+    seconds_per_row = (0.8 - ((gravity_level - 1) * 0.007)) ** (gravity_level - 1)
+    return seconds_per_row * FALL_INTERVAL_MS
+
+
+def soft_drop_interval_ms(level: int) -> float:
+    return min(
+        SOFT_DROP_INTERVAL_MS,
+        max(
+            SOFT_DROP_MIN_INTERVAL_MS,
+            guideline_fall_interval_ms(level) / SOFT_DROP_GRAVITY_MULTIPLIER,
+        ),
+    )
+
+
 def apply_garbage(
     player: TetrisPlayerState,
     line_count: int,
@@ -315,10 +341,7 @@ def apply_garbage(
         hole = rng.randrange(BOARD_WIDTH)
         player.board.pop(0)
         player.board.append(
-            [
-                None if x == hole else TetrisColor.GARBAGE
-                for x in range(BOARD_WIDTH)
-            ]
+            [None if x == hole else TetrisColor.GARBAGE for x in range(BOARD_WIDTH)]
         )
     if player.active is not None and collides(player.board, player.active):
         while player.active is not None and collides(player.board, player.active):
@@ -402,23 +425,25 @@ def advance_player(
     if controls.hard_drop:
         return hard_drop(player, rng)
 
+    level = player_level(player)
     if controls.soft_drop:
+        soft_drop_interval = soft_drop_interval_ms(level)
         player.fall_elapsed_ms = 0.0
         player.input_memory.soft_drop_elapsed_ms += elapsed_ms
-        if player.input_memory.soft_drop_elapsed_ms < SOFT_DROP_INTERVAL_MS:
+        if player.input_memory.soft_drop_elapsed_ms < soft_drop_interval:
             return 0
         player.input_memory.soft_drop_elapsed_ms = 0.0
         if try_move(player, 0, 1):
             player.score += 1
             player.lock_elapsed_ms = 0.0
             return 0
-        player.lock_elapsed_ms += SOFT_DROP_INTERVAL_MS
+        player.lock_elapsed_ms += soft_drop_interval
         if player.lock_elapsed_ms >= LOCK_DELAY_MS:
             return lock_piece(player, rng)
         return 0
 
     player.input_memory.soft_drop_elapsed_ms = 0.0
-    fall_interval = FALL_INTERVAL_MS
+    fall_interval = guideline_fall_interval_ms(level)
     player.fall_elapsed_ms += elapsed_ms
     cleared = 0
     while player.fall_elapsed_ms >= fall_interval and not player.game_over:

--- a/tests/programs/test_lib_2026_configuration.py
+++ b/tests/programs/test_lib_2026_configuration.py
@@ -20,6 +20,18 @@ def test_centered_titles_use_kirby_color(loop) -> None:
     assert fractal_entry.title_renderer._provider._color == Color.kirby()
 
 
+def test_pair_bluetooth_mode_is_not_registered(loop) -> None:
+    configure(loop)
+
+    title_texts = {
+        entry.title_renderer._provider._text
+        for entry in loop.components.game_modes.state.entries
+        if isinstance(entry.title_renderer, TextRendering)
+    }
+
+    assert ("pair bt",) not in title_texts
+
+
 def test_vibe_title_uses_centered_kirby_title(loop) -> None:
     configure(loop)
 
@@ -57,7 +69,10 @@ def test_mandelbulb_mode_follows_mandelbrot(loop) -> None:
     mandelbrot_index = next(
         index
         for index, entry in enumerate(entries)
-        if any(isinstance(renderer, MandelbrotMode) for renderer in entry.renderer.renderers)
+        if any(
+            isinstance(renderer, MandelbrotMode)
+            for renderer in entry.renderer.renderers
+        )
     )
     mandelbulb_entry = entries[mandelbrot_index + 1]
 

--- a/tests/renderers/test_tetris_renderer.py
+++ b/tests/renderers/test_tetris_renderer.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import random
+
+import pygame
+
+from heart.device import Device, Rectangle
+from heart.peripheral.core.input import GamepadButton, GamepadDpadValue
+from heart.renderers.tetris.direct_gamepad import DirectGamepadSnapshot
+from heart.renderers.tetris.renderer import (
+    BOARD_BORDER_COLOR,
+    TetrisPlayMode,
+    TetrisRenderer,
+)
+from heart.renderers.tetris.state import (
+    BOARD_WIDTH,
+    TetrisControls,
+    TetrisGameState,
+    TetrisInputMemory,
+    TetrisPiece,
+    TetrisPieceKind,
+    advance_player,
+    queue_garbage_for_opponents,
+)
+from heart.runtime.display_context import DisplayContext
+
+
+class TestTetrisRules:
+    def test_line_clear_queues_garbage_for_all_live_opponents(self) -> None:
+        rng = random.Random(1)
+        state = TetrisGameState.create(rng)
+        player = state.players[0]
+        player.board[-1] = [
+            player.active.color if player.active else None
+        ] * BOARD_WIDTH
+        for x in range(4):
+            player.board[-1][x] = None
+        player.active = TetrisPiece(TetrisPieceKind.I_PIECE, rotation=0, x=0, y=18)
+
+        cleared = advance_player(
+            player,
+            TetrisControls(hard_drop=True),
+            elapsed_ms=16,
+            rng=rng,
+        )
+        queue_garbage_for_opponents(state, sender_index=0, line_count=cleared)
+
+        assert cleared == 1
+        assert [opponent.pending_garbage for opponent in state.players[1:]] == [
+            1,
+            1,
+            1,
+        ]
+
+
+class TestTetrisRenderer:
+    def test_plus_minus_chord_switches_mode_once_until_released(self) -> None:
+        renderer = TetrisRenderer(rng=random.Random(1))
+        chord = [
+            DirectGamepadSnapshot(
+                connected=True,
+                identifier="test",
+                buttons={GamepadButton.PLUS: True, GamepadButton.MINUS: True},
+                slot=0,
+            )
+        ]
+        released = [DirectGamepadSnapshot(connected=True, identifier="test", slot=0)]
+
+        assert renderer._consume_mode_switch_chord(chord) is True
+        assert renderer._consume_mode_switch_chord(chord) is False
+        assert renderer._consume_mode_switch_chord(released) is False
+        assert renderer._consume_mode_switch_chord(chord) is True
+
+    def test_switch_play_mode_resets_to_two_synced_boards(self) -> None:
+        renderer = TetrisRenderer(rng=random.Random(1))
+        renderer.set_state(TetrisGameState.create(random.Random(2)))
+        renderer.state.players[0].score = 900
+
+        renderer._switch_play_mode()
+
+        assert renderer._play_mode is TetrisPlayMode.SOLO_SYNCED
+        assert len(renderer.state.players) == 2
+        assert all(player.score == 0 for player in renderer.state.players)
+        assert renderer.state.players[0].active is not None
+        assert renderer.state.players[1].active is not None
+        assert (
+            renderer.state.players[0].active.kind
+            != renderer.state.players[1].active.kind
+        )
+
+    def test_solo_mode_applies_any_controller_to_both_boards(self) -> None:
+        renderer = TetrisRenderer(rng=random.Random(1))
+        renderer._play_mode = TetrisPlayMode.SOLO_SYNCED
+        renderer.set_state(TetrisGameState.create(random.Random(1), player_count=2))
+        snapshots = [
+            DirectGamepadSnapshot(connected=False, identifier=None, slot=0),
+            DirectGamepadSnapshot(connected=False, identifier=None, slot=1),
+            DirectGamepadSnapshot(connected=False, identifier=None, slot=2),
+            DirectGamepadSnapshot(
+                connected=True,
+                identifier="test",
+                tapped_buttons=frozenset({GamepadButton.EAST}),
+                dpad=GamepadDpadValue(x=-1),
+                slot=3,
+            ),
+        ]
+
+        controls = renderer._controls_by_player(snapshots, elapsed_ms=16)
+
+        assert controls == [
+            TetrisControls(move_x=-1, rotate_cw=True),
+            TetrisControls(move_x=-1, rotate_cw=True),
+        ]
+
+    def test_north_button_is_reserved_for_navigation_exit(self) -> None:
+        renderer = TetrisRenderer(rng=random.Random(1))
+        controls = renderer._controls_for_snapshot(
+            TetrisInputMemory(),
+            DirectGamepadSnapshot(
+                connected=True,
+                identifier="test",
+                tapped_buttons=frozenset({GamepadButton.NORTH}),
+            ),
+            elapsed_ms=16,
+        )
+
+        assert controls == TetrisControls()
+
+    def test_solo_mode_draws_two_screen_panels(self, device: Device) -> None:
+        device.orientation = Rectangle.with_layout(columns=2, rows=1)
+        window = DisplayContext(
+            device=device,
+            screen=pygame.Surface(device.full_display_size()),
+            clock=pygame.time.Clock(),
+        )
+        renderer = TetrisRenderer(rng=random.Random(1))
+        renderer._play_mode = TetrisPlayMode.SOLO_SYNCED
+        renderer.set_state(TetrisGameState.create(random.Random(1), player_count=2))
+        renderer.initialized = True
+
+        renderer.real_process(window, device.orientation)
+
+        assert window.screen.get_at((16, 2))[:3] == BOARD_BORDER_COLOR[:3]
+        assert window.screen.get_at((80, 2))[:3] == BOARD_BORDER_COLOR[:3]

--- a/tests/renderers/test_tetris_renderer.py
+++ b/tests/renderers/test_tetris_renderer.py
@@ -9,6 +9,7 @@ from heart.peripheral.core.input import GamepadButton, GamepadDpadValue
 from heart.renderers.tetris.direct_gamepad import DirectGamepadSnapshot
 from heart.renderers.tetris.renderer import (
     BOARD_BORDER_COLOR,
+    GHOST_PIECE_COLOR,
     TetrisPlayMode,
     TetrisRenderer,
 )
@@ -125,6 +126,25 @@ class TestTetrisRenderer:
         )
 
         assert controls == TetrisControls()
+
+    def test_landing_piece_projects_to_bottom(self) -> None:
+        renderer = TetrisRenderer(rng=random.Random(1))
+        player = TetrisGameState.create(random.Random(1), player_count=1).players[0]
+        player.active = TetrisPiece(TetrisPieceKind.I_PIECE, rotation=0, x=0, y=0)
+
+        ghost = renderer._landing_piece(player)
+
+        assert ghost == TetrisPiece(TetrisPieceKind.I_PIECE, rotation=0, x=0, y=18)
+
+    def test_render_ghost_piece_draws_bottom_shade(self) -> None:
+        renderer = TetrisRenderer(rng=random.Random(1))
+        player = TetrisGameState.create(random.Random(1), player_count=1).players[0]
+        player.active = TetrisPiece(TetrisPieceKind.I_PIECE, rotation=0, x=0, y=0)
+        surface = pygame.Surface((64, 64))
+
+        renderer._render_ghost_piece(surface, 0, 0, player, 3)
+
+        assert surface.get_at((0, 57))[:3] == GHOST_PIECE_COLOR[:3]
 
     def test_solo_mode_draws_two_screen_panels(self, device: Device) -> None:
         device.orientation = Rectangle.with_layout(columns=2, rows=1)

--- a/tests/renderers/test_tetris_renderer.py
+++ b/tests/renderers/test_tetris_renderer.py
@@ -10,6 +10,7 @@ from heart.renderers.tetris.direct_gamepad import DirectGamepadSnapshot
 from heart.renderers.tetris.renderer import (
     BOARD_BORDER_COLOR,
     GHOST_PIECE_COLOR,
+    MODE_LABEL_COLOR,
     TetrisPlayMode,
     TetrisRenderer,
 )
@@ -21,6 +22,8 @@ from heart.renderers.tetris.state import (
     TetrisPiece,
     TetrisPieceKind,
     advance_player,
+    guideline_fall_interval_ms,
+    player_level,
     queue_garbage_for_opponents,
 )
 from heart.runtime.display_context import DisplayContext
@@ -53,6 +56,42 @@ class TestTetrisRules:
             1,
         ]
 
+    def test_gravity_speeds_up_after_lines_are_cleared(self) -> None:
+        rng = random.Random(1)
+        player = TetrisGameState.create(rng, player_count=1).players[0]
+        player.active = TetrisPiece(TetrisPieceKind.I_PIECE, rotation=0, x=0, y=0)
+
+        advance_player(player, TetrisControls(), elapsed_ms=900, rng=rng)
+
+        assert player.active == TetrisPiece(
+            TetrisPieceKind.I_PIECE,
+            rotation=0,
+            x=0,
+            y=0,
+        )
+
+        player.lines_cleared = 10
+        player.fall_elapsed_ms = 0
+        advance_player(player, TetrisControls(), elapsed_ms=900, rng=rng)
+
+        assert player.active == TetrisPiece(
+            TetrisPieceKind.I_PIECE,
+            rotation=0,
+            x=0,
+            y=1,
+        )
+
+    def test_guideline_fall_interval_uses_line_clear_levels(self) -> None:
+        player = TetrisGameState.create(random.Random(1), player_count=1).players[0]
+
+        assert player_level(player) == 1
+        assert guideline_fall_interval_ms(player_level(player)) == 1000
+
+        player.lines_cleared = 10
+
+        assert player_level(player) == 2
+        assert guideline_fall_interval_ms(player_level(player)) < 800
+
 
 class TestTetrisRenderer:
     def test_plus_minus_chord_switches_mode_once_until_released(self) -> None:
@@ -72,14 +111,14 @@ class TestTetrisRenderer:
         assert renderer._consume_mode_switch_chord(released) is False
         assert renderer._consume_mode_switch_chord(chord) is True
 
-    def test_switch_play_mode_resets_to_two_synced_boards(self) -> None:
+    def test_switch_play_mode_cycles_and_resets_boards(self) -> None:
         renderer = TetrisRenderer(rng=random.Random(1))
         renderer.set_state(TetrisGameState.create(random.Random(2)))
         renderer.state.players[0].score = 900
 
         renderer._switch_play_mode()
 
-        assert renderer._play_mode is TetrisPlayMode.SOLO_SYNCED
+        assert renderer._play_mode is TetrisPlayMode.DUAL_SYNCED
         assert len(renderer.state.players) == 2
         assert all(player.score == 0 for player in renderer.state.players)
         assert renderer.state.players[0].active is not None
@@ -89,9 +128,19 @@ class TestTetrisRenderer:
             != renderer.state.players[1].active.kind
         )
 
-    def test_solo_mode_applies_any_controller_to_both_boards(self) -> None:
+        renderer._switch_play_mode()
+
+        assert renderer._play_mode is TetrisPlayMode.SOLO_MIRRORED
+        assert len(renderer.state.players) == 1
+
+        renderer._switch_play_mode()
+
+        assert renderer._play_mode is TetrisPlayMode.FOUR_PLAYER
+        assert len(renderer.state.players) == 4
+
+    def test_dual_mode_applies_any_controller_to_both_boards(self) -> None:
         renderer = TetrisRenderer(rng=random.Random(1))
-        renderer._play_mode = TetrisPlayMode.SOLO_SYNCED
+        renderer._play_mode = TetrisPlayMode.DUAL_SYNCED
         renderer.set_state(TetrisGameState.create(random.Random(1), player_count=2))
         snapshots = [
             DirectGamepadSnapshot(connected=False, identifier=None, slot=0),
@@ -112,6 +161,73 @@ class TestTetrisRenderer:
             TetrisControls(move_x=-1, rotate_cw=True),
             TetrisControls(move_x=-1, rotate_cw=True),
         ]
+
+    def test_single_mode_applies_any_controller_to_one_board(self) -> None:
+        renderer = TetrisRenderer(rng=random.Random(1))
+        renderer._play_mode = TetrisPlayMode.SOLO_MIRRORED
+        renderer.set_state(TetrisGameState.create(random.Random(1), player_count=1))
+        snapshots = [
+            DirectGamepadSnapshot(connected=False, identifier=None, slot=0),
+            DirectGamepadSnapshot(connected=False, identifier=None, slot=1),
+            DirectGamepadSnapshot(
+                connected=True,
+                identifier="test",
+                tapped_buttons=frozenset({GamepadButton.EAST}),
+                dpad=GamepadDpadValue(x=1),
+                slot=2,
+            ),
+            DirectGamepadSnapshot(connected=False, identifier=None, slot=3),
+        ]
+
+        controls = renderer._controls_by_player(snapshots, elapsed_ms=16)
+
+        assert controls == [TetrisControls(move_x=1, rotate_cw=True)]
+
+    def test_mode_panel_mapping_mirrors_dual_and_single_modes(self) -> None:
+        renderer = TetrisRenderer(rng=random.Random(1))
+
+        assert [renderer._player_index_for_panel(index, 4) for index in range(4)] == [
+            0,
+            1,
+            2,
+            3,
+        ]
+
+        renderer._play_mode = TetrisPlayMode.DUAL_SYNCED
+
+        assert [renderer._player_index_for_panel(index, 4) for index in range(4)] == [
+            0,
+            0,
+            1,
+            1,
+        ]
+
+        renderer._play_mode = TetrisPlayMode.SOLO_MIRRORED
+
+        assert [renderer._player_index_for_panel(index, 4) for index in range(4)] == [
+            0,
+            0,
+            0,
+            0,
+        ]
+
+    def test_modes_have_distinct_bottom_left_labels(self) -> None:
+        renderer = TetrisRenderer(rng=random.Random(1))
+
+        labels = []
+        for mode in TetrisPlayMode:
+            renderer._play_mode = mode
+            labels.append(renderer._mode_label())
+            surface = pygame.Surface((64, 64))
+
+            renderer._render_mode_label(surface, pygame.Rect(0, 0, 64, 64))
+
+            label_pixels = [
+                surface.get_at((x, y))[:3] for x in range(16) for y in range(52, 64)
+            ]
+            assert MODE_LABEL_COLOR[:3] in label_pixels
+
+        assert labels == ["F", "D", "S"]
 
     def test_north_button_is_reserved_for_navigation_exit(self) -> None:
         renderer = TetrisRenderer(rng=random.Random(1))
@@ -146,15 +262,15 @@ class TestTetrisRenderer:
 
         assert surface.get_at((0, 57))[:3] == GHOST_PIECE_COLOR[:3]
 
-    def test_solo_mode_draws_two_screen_panels(self, device: Device) -> None:
-        device.orientation = Rectangle.with_layout(columns=2, rows=1)
+    def test_dual_mode_draws_two_mirrored_pairs(self, device: Device) -> None:
+        device.orientation = Rectangle.with_layout(columns=4, rows=1)
         window = DisplayContext(
             device=device,
             screen=pygame.Surface(device.full_display_size()),
             clock=pygame.time.Clock(),
         )
         renderer = TetrisRenderer(rng=random.Random(1))
-        renderer._play_mode = TetrisPlayMode.SOLO_SYNCED
+        renderer._play_mode = TetrisPlayMode.DUAL_SYNCED
         renderer.set_state(TetrisGameState.create(random.Random(1), player_count=2))
         renderer.initialized = True
 
@@ -162,3 +278,27 @@ class TestTetrisRenderer:
 
         assert window.screen.get_at((16, 2))[:3] == BOARD_BORDER_COLOR[:3]
         assert window.screen.get_at((80, 2))[:3] == BOARD_BORDER_COLOR[:3]
+        assert window.screen.get_at((144, 2))[:3] == BOARD_BORDER_COLOR[:3]
+        assert window.screen.get_at((208, 2))[:3] == BOARD_BORDER_COLOR[:3]
+
+    def test_single_mode_draws_one_board_on_four_screens(
+        self,
+        device: Device,
+    ) -> None:
+        device.orientation = Rectangle.with_layout(columns=4, rows=1)
+        window = DisplayContext(
+            device=device,
+            screen=pygame.Surface(device.full_display_size()),
+            clock=pygame.time.Clock(),
+        )
+        renderer = TetrisRenderer(rng=random.Random(1))
+        renderer._play_mode = TetrisPlayMode.SOLO_MIRRORED
+        renderer.set_state(TetrisGameState.create(random.Random(1), player_count=1))
+        renderer.initialized = True
+
+        renderer.real_process(window, device.orientation)
+
+        assert window.screen.get_at((16, 2))[:3] == BOARD_BORDER_COLOR[:3]
+        assert window.screen.get_at((80, 2))[:3] == BOARD_BORDER_COLOR[:3]
+        assert window.screen.get_at((144, 2))[:3] == BOARD_BORDER_COLOR[:3]
+        assert window.screen.get_at((208, 2))[:3] == BOARD_BORDER_COLOR[:3]


### PR DESCRIPTION
## Summary
- Add internal Tetris mode cycling on plus+minus: F = four-player, D = two synced games mirrored as screen pairs, S = one game mirrored on all four screens.
- Add a ghost-piece landing shade and line-clear-based gravity ramp using the Tetris Worlds / Guideline-style curve.
- Remove the Bluetooth pairing mode from lib_2026 while leaving the standalone controller_pairing configuration available.

## Tests
- uv run pytest tests/renderers/test_tetris_renderer.py
- uv run pytest tests/renderers/test_tetris_renderer.py tests/runtime/test_game_loop.py tests/navigation/test_game_modes.py
- uv run pytest tests/programs/test_lib_2026_configuration.py tests/programs/test_bouncing_ball_configuration.py
- uv run ruff check src/heart/renderers/tetris/renderer.py src/heart/renderers/tetris/state.py tests/renderers/test_tetris_renderer.py
- uv run ruff format --check src/heart/renderers/tetris/renderer.py src/heart/renderers/tetris/state.py tests/renderers/test_tetris_renderer.py
- uv run ruff check src/heart/programs/configurations/lib_2026.py tests/programs/test_lib_2026_configuration.py
- uv run ruff format --check src/heart/programs/configurations/lib_2026.py tests/programs/test_lib_2026_configuration.py

## Manual
- Started local Tetris with `uv run totem run --configuration tetris --no-add-low-power-mode`.
