### PR TITLE
Improve cube pong score display

### DIFF
--- a/src/heart/renderers/cube_pong/renderer.py
+++ b/src/heart/renderers/cube_pong/renderer.py
@@ -11,13 +11,18 @@ from heart.peripheral.core.input import GamepadAxis, GamepadSnapshot
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.gamepad import Gamepad
 from heart.renderers import StatefulBaseRenderer
-from heart.renderers.cube_pong.state import (PLAYER_ONE, PLAYER_TWO,
-                                             CubePongControls, CubePongState,
-                                             advance_cube_pong_state,
-                                             ball_radius,
-                                             face_position_for_ball,
-                                             new_cube_pong_round,
-                                             paddle_path_x, paddle_size)
+from heart.renderers.cube_pong.state import (
+    PLAYER_ONE,
+    PLAYER_TWO,
+    CubePongControls,
+    CubePongState,
+    advance_cube_pong_state,
+    ball_radius,
+    face_position_for_ball,
+    new_cube_pong_round,
+    paddle_path_x,
+    paddle_size,
+)
 from heart.runtime.display_context import DisplayContext
 from heart.utilities.logging import get_logger
 
@@ -33,7 +38,9 @@ LOSS_FLASH_COLOR = (105, 10, 24)
 KEYBOARD_CONTROL_STEP = 1.0
 GAMEPAD_DEAD_ZONE = 0.15
 LINUX_JOYSTICK_SYSFS = Path("/sys/class/input")
-SCORE_FONT_SCALE = 0.38
+SCORE_FONT_SCALE = 0.19
+SCORE_SEPARATOR_GAP_SCALE = 0.05
+SCORE_SEPARATOR_COLOR = (202, 211, 224)
 logger = get_logger(__name__)
 
 
@@ -171,35 +178,47 @@ class CubePongRenderer(StatefulBaseRenderer[CubePongState]):
     def _draw_scores(self, window: DisplayContext, state: CubePongState) -> None:
         if window.screen is None:
             raise RuntimeError("CubePongRenderer requires an initialized display")
-        self._draw_score(
+        self._draw_full_score(
             window.screen,
-            score=state.player_one_score,
-            color=PADDLE_ONE_COLOR,
+            player_one_score=state.player_one_score,
+            player_two_score=state.player_two_score,
             center_x=state.screen_width // 2,
             top=2,
         )
-        self._draw_score(
+        self._draw_full_score(
             window.screen,
-            score=state.player_two_score,
-            color=PADDLE_TWO_COLOR,
+            player_one_score=state.player_one_score,
+            player_two_score=state.player_two_score,
             center_x=round(state.screen_width * 2.5),
             top=2,
         )
 
-    def _draw_score(
+    def _draw_full_score(
         self,
         screen: pygame.Surface,
         *,
-        score: int,
-        color: tuple[int, int, int],
+        player_one_score: int,
+        player_two_score: int,
         center_x: int,
         top: int,
     ) -> None:
-        font_size = max(18, round(screen.get_height() * SCORE_FONT_SCALE))
-        surface = self._font(font_size).render(str(score), False, color)
-        rect = surface.get_rect()
-        rect.midtop = (center_x, top)
-        screen.blit(surface, rect)
+        font_size = max(9, round(screen.get_height() * SCORE_FONT_SCALE))
+        font = self._font(font_size)
+        surfaces = (
+            font.render(str(player_one_score), False, PADDLE_ONE_COLOR),
+            font.render("-", False, SCORE_SEPARATOR_COLOR),
+            font.render(str(player_two_score), False, PADDLE_TWO_COLOR),
+        )
+        separator_gap = max(2, round(screen.get_height() * SCORE_SEPARATOR_GAP_SCALE))
+        total_width = sum(surface.get_width() for surface in surfaces) + (
+            separator_gap * 2
+        )
+        x = round(center_x - total_width / 2)
+        screen.blit(surfaces[0], (x, top))
+        x += surfaces[0].get_width() + separator_gap
+        screen.blit(surfaces[1], (x, top))
+        x += surfaces[1].get_width() + separator_gap
+        screen.blit(surfaces[2], (x, top))
 
     def _font(self, size: int) -> pygame.font.Font:
         if not pygame.font.get_init():
@@ -383,6 +402,13 @@ class CubePongRenderer(StatefulBaseRenderer[CubePongState]):
         if elapsed_ms <= 0:
             return 1 / 60
         return elapsed_ms / 1000
+
+    def reset(self) -> None:
+        super().reset()
+        self._peripheral_manager = None
+        self._last_logged_controller_signature.clear()
+        self._state = None
+        self.initialized = False
 
     def _individual_screen_size(
         self,

--- a/src/heart/renderers/cube_pong/state.py
+++ b/src/heart/renderers/cube_pong/state.py
@@ -7,6 +7,7 @@ PLAYER_TWO = 2
 ROUTE_ACROSS_SCREEN_TWO = "screens_1_2_3"
 ROUTE_ACROSS_SCREEN_FOUR = "screens_1_4_3"
 ROUND_RESET_HOLD_S = 1.0
+SECOND_BALL_START_DELAY_S = 0.45
 
 
 @dataclass(frozen=True, slots=True)
@@ -24,6 +25,7 @@ class CubePongBall:
     y: float
     vx: float
     vy: float
+    launch_delay_s: float = 0.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -110,6 +112,7 @@ def _new_cube_pong_round(
                 y=screen_height * 0.65,
                 vx=ball_speed,
                 vy=-vertical_speed,
+                launch_delay_s=SECOND_BALL_START_DELAY_S,
             ),
         ),
         player_one_score=player_one_score,
@@ -244,6 +247,19 @@ def _advance_ball(
     paddle_two_y: float,
     delta_s: float,
 ) -> tuple[CubePongBall, int | None]:
+    if ball.launch_delay_s > 0:
+        return (
+            CubePongBall(
+                route_name=ball.route_name,
+                x=ball.x,
+                y=ball.y,
+                vx=ball.vx,
+                vy=ball.vy,
+                launch_delay_s=max(0.0, ball.launch_delay_s - delta_s),
+            ),
+            None,
+        )
+
     radius = ball_radius(screen_width)
     next_x = ball.x + ball.vx * delta_s
     next_y = ball.y + ball.vy * delta_s

--- a/tests/renderers/test_cube_pong_renderer.py
+++ b/tests/renderers/test_cube_pong_renderer.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pygame
+
+from heart.device import Device
+from heart.peripheral.core.manager import PeripheralManager
+from heart.renderers.cube_pong.renderer import (
+    BALL_COLORS,
+    PADDLE_ONE_COLOR,
+    PADDLE_TWO_COLOR,
+    CubePongRenderer,
+)
+from heart.renderers.cube_pong.state import (
+    ROUTE_ACROSS_SCREEN_FOUR,
+    ROUTE_ACROSS_SCREEN_TWO,
+    CubePongBall,
+    CubePongControls,
+    CubePongState,
+    advance_cube_pong_state,
+    new_cube_pong_round,
+)
+from heart.runtime.display_context import DisplayContext
+
+
+def test_scores_show_both_player_colors_on_both_player_faces(device: Device) -> None:
+    screen_width = 64
+    window = _pong_window(device=device, screen_width=screen_width)
+    renderer = CubePongRenderer()
+    state = _pong_state(player_one_score=12, player_two_score=34)
+
+    renderer._draw_scores(window, state)
+
+    assert _color_count(window.screen, PADDLE_ONE_COLOR, pygame.Rect(0, 0, 64, 64)) > 0
+    assert _color_count(window.screen, PADDLE_TWO_COLOR, pygame.Rect(0, 0, 64, 64)) > 0
+    assert (
+        _color_count(
+            window.screen,
+            PADDLE_ONE_COLOR,
+            pygame.Rect(screen_width * 2, 0, 64, 64),
+        )
+        > 0
+    )
+    assert (
+        _color_count(
+            window.screen,
+            PADDLE_TWO_COLOR,
+            pygame.Rect(screen_width * 2, 0, 64, 64),
+        )
+        > 0
+    )
+
+
+def test_ball_draws_over_score_pixels(device: Device) -> None:
+    screen_width = 64
+    window = _pong_window(device=device, screen_width=screen_width)
+    renderer = CubePongRenderer()
+    state = _pong_state(player_one_score=8, player_two_score=8)
+
+    renderer._draw_scores(window, state)
+    score_pixel = _first_color_pixel(
+        window.screen,
+        (PADDLE_ONE_COLOR, PADDLE_TWO_COLOR),
+        pygame.Rect(0, 0, screen_width, 64),
+    )
+    assert score_pixel is not None
+
+    renderer._draw(
+        window,
+        replace(
+            state,
+            balls=(
+                CubePongBall(
+                    route_name=ROUTE_ACROSS_SCREEN_TWO,
+                    x=score_pixel[0],
+                    y=score_pixel[1],
+                    vx=0.0,
+                    vy=0.0,
+                ),
+                CubePongBall(
+                    route_name=ROUTE_ACROSS_SCREEN_FOUR,
+                    x=screen_width * 4,
+                    y=0.0,
+                    vx=0.0,
+                    vy=0.0,
+                ),
+            ),
+        ),
+    )
+
+    assert window.screen.get_at(score_pixel)[:3] == BALL_COLORS[0]
+
+
+def test_second_ball_start_is_staggered() -> None:
+    state = new_cube_pong_round(64, 64)
+
+    assert state.balls[0].launch_delay_s == 0
+    assert state.balls[1].launch_delay_s > 0
+
+    advanced = advance_cube_pong_state(state, CubePongControls(), 0.05)
+
+    assert advanced.balls[0].x > state.balls[0].x
+    assert advanced.balls[1].x == state.balls[1].x
+    assert advanced.balls[1].y == state.balls[1].y
+    assert advanced.balls[1].launch_delay_s < state.balls[1].launch_delay_s
+
+
+def test_reset_reinitializes_scores(
+    device: Device,
+    manager: PeripheralManager,
+) -> None:
+    renderer = CubePongRenderer()
+    window = DisplayContext(
+        device=device,
+        screen=pygame.Surface((256, 64), pygame.SRCALPHA),
+        clock=pygame.time.Clock(),
+    )
+    renderer.initialize(window, manager, device.orientation)
+    renderer.set_state(replace(renderer.state, player_one_score=7, player_two_score=9))
+
+    renderer.reset()
+
+    assert not renderer.initialized
+    renderer.initialize(window, manager, device.orientation)
+    assert renderer.state.player_one_score == 0
+    assert renderer.state.player_two_score == 0
+
+
+def _pong_state(
+    *,
+    player_one_score: int,
+    player_two_score: int,
+) -> CubePongState:
+    return CubePongState(
+        screen_width=64,
+        screen_height=64,
+        paddle_one_y=32,
+        paddle_two_y=32,
+        balls=(
+            CubePongBall(
+                route_name=ROUTE_ACROSS_SCREEN_TWO,
+                x=16,
+                y=16,
+                vx=0,
+                vy=0,
+            ),
+            CubePongBall(
+                route_name=ROUTE_ACROSS_SCREEN_FOUR,
+                x=16,
+                y=48,
+                vx=0,
+                vy=0,
+            ),
+        ),
+        player_one_score=player_one_score,
+        player_two_score=player_two_score,
+    )
+
+
+def _pong_window(*, device: Device, screen_width: int) -> DisplayContext:
+    return DisplayContext(
+        device=device,
+        screen=pygame.Surface((screen_width * 4, 64), pygame.SRCALPHA),
+        clock=pygame.time.Clock(),
+    )
+
+
+def _color_count(
+    screen: pygame.Surface | None,
+    color: tuple[int, int, int],
+    rect: pygame.Rect,
+) -> int:
+    assert screen is not None
+    return sum(
+        1
+        for y in range(rect.top, rect.bottom)
+        for x in range(rect.left, rect.right)
+        if screen.get_at((x, y))[:3] == color
+    )
+
+
+def _first_color_pixel(
+    screen: pygame.Surface | None,
+    colors: tuple[tuple[int, int, int], ...],
+    rect: pygame.Rect,
+) -> tuple[int, int] | None:
+    assert screen is not None
+    for y in range(rect.top, rect.bottom):
+        for x in range(rect.left, rect.right):
+            if screen.get_at((x, y))[:3] in colors:
+                return x, y
+    return None


### PR DESCRIPTION
## Summary
- show the full two-player score on both Pong player faces using each player color
- keep balls rendered over score text and stagger the second ball launch
- reset Pong state when leaving and re-entering the mode

## Tests
- uv run pytest tests/renderers/test_cube_pong_renderer.py -q
- uv run ruff check src/heart/renderers/cube_pong/state.py src/heart/renderers/cube_pong/renderer.py tests/renderers/test_cube_pong_renderer.py
- uv run ruff format --check src/heart/renderers/cube_pong/state.py src/heart/renderers/cube_pong/renderer.py tests/renderers/test_cube_pong_renderer.py