### PR TITLE
Add phone floating emoji overlay

### DIFF
--- a/experimental/beats/src/actions/ws/websocket.tsx
+++ b/experimental/beats/src/actions/ws/websocket.tsx
@@ -22,6 +22,22 @@ type WSContextValue = {
   sendSensorControl: (sensorKey: string, sensorValue: number | null) => boolean;
   sendTextControl: (text: string | null) => boolean;
   sendImageControl: (imageBase64: string, imageMimeType: string) => boolean;
+  sendEmojiControl: (
+    emoji:
+      | "poop"
+      | "skull"
+      | "heart"
+      | "star"
+      | "rainbow"
+      | "seb"
+      | "faye"
+      | "will"
+      | "clem"
+      | "cal"
+      | "sri"
+      | "lampe"
+      | "ditto",
+  ) => boolean;
 };
 
 const WSContext = createContext<WSContextValue>({
@@ -31,6 +47,7 @@ const WSContext = createContext<WSContextValue>({
   sendSensorControl: () => false,
   sendTextControl: () => false,
   sendImageControl: () => false,
+  sendEmojiControl: () => false,
 });
 
 interface WSProviderProps {
@@ -246,6 +263,25 @@ export function WSProvider({
     [],
   );
 
+  const sendEmojiControl = useCallback<WSContextValue["sendEmojiControl"]>(
+    (emoji) => {
+      const ws = socketRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        return false;
+      }
+
+      ws.send(
+        JSON.stringify({
+          kind: "control",
+          command: "emoji_update",
+          emoji,
+        }),
+      );
+      return true;
+    },
+    [],
+  );
+
   return (
     <WSContext.Provider
       value={{
@@ -255,6 +291,7 @@ export function WSProvider({
         sendSensorControl,
         sendTextControl,
         sendImageControl,
+        sendEmojiControl,
       }}
     >
       {children}

--- a/experimental/beats/src/components/phone-control-panel.tsx
+++ b/experimental/beats/src/components/phone-control-panel.tsx
@@ -23,6 +23,20 @@ const PHOTO_CROP_BOX_SIZE_PERCENT = 76;
 const PHOTO_CROP_BOX_INSET_PERCENT = (100 - PHOTO_CROP_BOX_SIZE_PERCENT) / 2;
 
 type PhoneControlCommand = "browse" | "activate" | "alternate_activate";
+type FloatingEmojiKey =
+  | "poop"
+  | "skull"
+  | "heart"
+  | "star"
+  | "rainbow"
+  | "seb"
+  | "faye"
+  | "will"
+  | "clem"
+  | "cal"
+  | "sri"
+  | "lampe"
+  | "ditto";
 type PhotoDraft = {
   cropOffsetXPercent: number;
   cropOffsetYPercent: number;
@@ -40,6 +54,12 @@ type PhoneControlAction = {
   label: string;
   browseStep?: number;
   tone: "primary" | "secondary";
+};
+
+type FloatingEmojiAction = {
+  emoji: FloatingEmojiKey;
+  glyph: string;
+  label: string;
 };
 
 const PHONE_CONTROL_ACTIONS: PhoneControlAction[] = [
@@ -79,9 +99,29 @@ const PHONE_CONTROL_ACTIONS: PhoneControlAction[] = [
   },
 ];
 
+const FLOATING_EMOJI_ACTIONS: FloatingEmojiAction[] = [
+  { emoji: "poop", glyph: "💩", label: "Poop" },
+  { emoji: "skull", glyph: "💀", label: "Skull" },
+  { emoji: "heart", glyph: "❤️", label: "Heart" },
+  { emoji: "star", glyph: "⭐", label: "Star" },
+  { emoji: "rainbow", glyph: "🌈", label: "Rainbow" },
+];
+
+const FLOATING_FACE_ACTIONS: FloatingEmojiAction[] = [
+  { emoji: "seb", glyph: "SE", label: "Seb" },
+  { emoji: "faye", glyph: "FA", label: "Faye" },
+  { emoji: "will", glyph: "WI", label: "Will" },
+  { emoji: "clem", glyph: "CL", label: "Clem" },
+  { emoji: "cal", glyph: "CA", label: "Cal" },
+  { emoji: "sri", glyph: "SR", label: "Sri" },
+  { emoji: "lampe", glyph: "LA", label: "Lampe" },
+  { emoji: "ditto", glyph: "DI", label: "Ditto" },
+];
+
 export function PhoneControlPanel() {
   const {
     readyState,
+    sendEmojiControl,
     sendImageControl,
     sendNavigationControl,
     sendTextControl,
@@ -174,6 +214,19 @@ export function PhoneControlPanel() {
 
     setTextDraft("");
     setLastActionLabel("Text cleared");
+  };
+
+  const handleEmojiSend = (action: FloatingEmojiAction) => {
+    if (controlsLocked) {
+      return;
+    }
+
+    const sent = sendEmojiControl(action.emoji);
+    if (!sent) {
+      return;
+    }
+
+    setLastActionLabel(`${action.label} emoji`);
   };
 
   const handleStartPhotoCapture = () => {
@@ -439,6 +492,44 @@ export function PhoneControlPanel() {
         </div>
 
         <div className="mt-4 grid gap-3 sm:mt-5">
+          <div className="beats-console-card rounded-2xl px-4 py-4">
+            <div className="beats-console-kicker font-tomorrow text-[10px] tracking-[0.2em] uppercase">
+              Floating Emoji
+            </div>
+            <div className="mt-3 grid grid-cols-5 gap-2">
+              {FLOATING_EMOJI_ACTIONS.map((action) => (
+                <button
+                  key={action.emoji}
+                  type="button"
+                  disabled={controlsLocked}
+                  onClick={() => handleEmojiSend(action)}
+                  className="flex aspect-square min-h-16 items-center justify-center rounded-[1.1rem] border border-fuchsia-300/25 bg-fuchsia-400/10 text-3xl transition hover:bg-fuchsia-400/16 active:translate-y-[1px] disabled:cursor-not-allowed disabled:opacity-45"
+                  aria-label={`Send ${action.label} emoji`}
+                >
+                  <span aria-hidden="true">{action.glyph}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="beats-console-card rounded-2xl px-4 py-4">
+            <div className="beats-console-kicker font-tomorrow text-[10px] tracking-[0.2em] uppercase">
+              Floating Faces
+            </div>
+            <div className="mt-3 grid grid-cols-4 gap-2">
+              {FLOATING_FACE_ACTIONS.map((action) => (
+                <button
+                  key={action.emoji}
+                  type="button"
+                  disabled={controlsLocked}
+                  onClick={() => handleEmojiSend(action)}
+                  className="font-tomorrow flex aspect-square min-h-14 items-center justify-center rounded-[1.1rem] border border-amber-300/25 bg-amber-400/10 text-sm tracking-[0.1em] text-amber-50 transition hover:bg-amber-400/16 active:translate-y-[1px] disabled:cursor-not-allowed disabled:opacity-45"
+                  aria-label={`Send ${action.label} face`}
+                >
+                  <span aria-hidden="true">{action.glyph}</span>
+                </button>
+              ))}
+            </div>
+          </div>
           <div className="beats-console-card rounded-2xl px-4 py-4">
             <div className="beats-console-kicker font-tomorrow text-[10px] tracking-[0.2em] uppercase">
               Display Text

--- a/experimental/beats/src/tests/unit/actions/ws/websocket.test.tsx
+++ b/experimental/beats/src/tests/unit/actions/ws/websocket.test.tsx
@@ -61,6 +61,16 @@ function SensorControlProbe() {
   );
 }
 
+function EmojiControlProbe() {
+  const { sendEmojiControl } = useWS();
+
+  return (
+    <button type="button" onClick={() => sendEmojiControl("rainbow")}>
+      Send Emoji Control
+    </button>
+  );
+}
+
 describe("WSProvider", () => {
   beforeEach(() => {
     FakeWebSocket.instances = [];
@@ -146,6 +156,34 @@ describe("WSProvider", () => {
         sensor_key: "accelerometer:debug:z",
         sensor_value: 12.5,
         clear: false,
+      }),
+    ]);
+  });
+
+  test("sends emoji control envelopes over the websocket", () => {
+    render(
+      <WSProvider
+        url="ws://localhost:8765"
+        retryDelay={100}
+        maxRetryDelay={200}
+      >
+        <EmojiControlProbe />
+      </WSProvider>,
+    );
+
+    act(() => {
+      FakeWebSocket.instances[0].triggerOpen();
+    });
+
+    act(() => {
+      screen.getByRole("button", { name: "Send Emoji Control" }).click();
+    });
+
+    expect(FakeWebSocket.instances[0].sent).toEqual([
+      JSON.stringify({
+        kind: "control",
+        command: "emoji_update",
+        emoji: "rainbow",
       }),
     ]);
   });

--- a/src/heart/device/beats/websocket.py
+++ b/src/heart/device/beats/websocket.py
@@ -44,6 +44,32 @@ CONTROL_COMMAND_ALTERNATE = "alternate_activate"
 CONTROL_COMMAND_SENSOR_UPDATE = "sensor_update"
 CONTROL_COMMAND_TEXT_UPDATE = "text_update"
 CONTROL_COMMAND_IMAGE_UPDATE = "image_update"
+CONTROL_COMMAND_EMOJI_UPDATE = "emoji_update"
+CONTROL_EMOJI_POOP = "poop"
+CONTROL_EMOJI_SKULL = "skull"
+CONTROL_EMOJI_HEART = "heart"
+CONTROL_EMOJI_STAR = "star"
+CONTROL_EMOJI_RAINBOW = "rainbow"
+CONTROL_FACE_NAMES = (
+    "seb",
+    "faye",
+    "will",
+    "clem",
+    "cal",
+    "sri",
+    "lampe",
+    "ditto",
+)
+SUPPORTED_CONTROL_EMOJIS = frozenset(
+    {
+        CONTROL_EMOJI_POOP,
+        CONTROL_EMOJI_SKULL,
+        CONTROL_EMOJI_HEART,
+        CONTROL_EMOJI_STAR,
+        CONTROL_EMOJI_RAINBOW,
+        *CONTROL_FACE_NAMES,
+    }
+)
 MAX_CONTROL_IMAGE_BASE64_LENGTH = 2_000_000
 BEATS_WEBSOCKET_OWNER = OwnerName("heart.beats.websocket")
 BEATS_WEBSOCKET_FAMILY = StreamFamily("beats")
@@ -58,6 +84,7 @@ class ControlMessage:
     text: str | None = None
     image_base64: str | None = None
     image_mime_type: str | None = None
+    emoji: str | None = None
     clear: bool = False
 
 
@@ -218,6 +245,7 @@ def decode_control_message(message: str | bytes) -> ControlMessage | None:
         CONTROL_COMMAND_SENSOR_UPDATE,
         CONTROL_COMMAND_TEXT_UPDATE,
         CONTROL_COMMAND_IMAGE_UPDATE,
+        CONTROL_COMMAND_EMOJI_UPDATE,
     }:
         logger.warning("Unknown websocket control command: %s.", command)
         return None
@@ -282,6 +310,17 @@ def decode_control_message(message: str | bytes) -> ControlMessage | None:
             image_base64=image_base64 if isinstance(image_base64, str) else None,
             image_mime_type=image_mime_type if isinstance(image_mime_type, str) else None,
             clear=clear,
+        )
+
+    if command == CONTROL_COMMAND_EMOJI_UPDATE:
+        emoji = parsed.get("emoji")
+        if not isinstance(emoji, str) or emoji not in SUPPORTED_CONTROL_EMOJIS:
+            logger.warning("Invalid websocket emoji payload: %r.", emoji)
+            return None
+        return ControlMessage(
+            command=command,
+            browse_step=browse_step,
+            emoji=emoji,
         )
 
     return ControlMessage(command=command, browse_step=browse_step)

--- a/src/heart/programs/configurations/lib_2026.py
+++ b/src/heart/programs/configurations/lib_2026.py
@@ -10,6 +10,7 @@ from heart.renderers.bouncing_ball import (
     BouncingBallRenderer,
     BouncingBallStateProvider,
 )
+from heart.renderers.controller_pairing import ControllerPairingRenderer
 from heart.renderers.cube_pong import add_cube_pong_mode
 from heart.renderers.hilbert_curve import HilbertScene
 from heart.renderers.image import RenderImage
@@ -288,3 +289,6 @@ def configure(loop: GameLoop) -> None:
             randomness=randomness,
         )
     )
+
+    controller_pairing_mode = loop.add_mode("pair bt")
+    controller_pairing_mode.add_renderer(ControllerPairingRenderer())

--- a/src/heart/renderers/cube_pong/renderer.py
+++ b/src/heart/renderers/cube_pong/renderer.py
@@ -118,6 +118,8 @@ class CubePongRenderer(StatefulBaseRenderer[CubePongState]):
         self._draw_scores(window, state)
         self._draw_paddles(window, state)
         self._draw_balls(window, state)
+        if state.winning_player is not None:
+            self._draw_winner_callout(window, state)
 
     def _draw_face_guides(self, window: DisplayContext, state: CubePongState) -> None:
         if window.screen is None:
@@ -223,6 +225,29 @@ class CubePongRenderer(StatefulBaseRenderer[CubePongState]):
         screen.blit(surfaces[1], (x, top))
         x += surfaces[1].get_width() + separator_gap
         screen.blit(surfaces[2], (x, top))
+
+    def _draw_winner_callout(
+        self,
+        window: DisplayContext,
+        state: CubePongState,
+    ) -> None:
+        if window.screen is None:
+            raise RuntimeError("CubePongRenderer requires an initialized display")
+        screen = window.screen
+        color = (
+            PADDLE_ONE_COLOR
+            if state.winning_player == PLAYER_ONE
+            else PADDLE_TWO_COLOR
+        )
+        label = "P1 WINS" if state.winning_player == PLAYER_ONE else "P2 WINS"
+        font_size = max(18, round(state.screen_height * WINNER_FONT_SCALE))
+        surface = self._font(font_size).render(label, False, color)
+        rect = surface.get_rect()
+        rect.center = (
+            screen.get_width() // 2,
+            screen.get_height() // 2,
+        )
+        screen.blit(surface, rect)
 
     def _font(self, size: int) -> pygame.font.Font:
         if not pygame.font.get_init():

--- a/src/heart/renderers/cube_pong/state.py
+++ b/src/heart/renderers/cube_pong/state.py
@@ -8,6 +8,9 @@ ROUTE_ACROSS_SCREEN_TWO = "screens_1_2_3"
 ROUTE_ACROSS_SCREEN_FOUR = "screens_1_4_3"
 ROUND_RESET_HOLD_S = 1.0
 SECOND_BALL_START_DELAY_S = 0.45
+SCORE_TO_WIN = 10
+RALLY_SPEEDUP_BOUNCES = 3
+RALLY_SPEEDUP_MULTIPLIER = 1.15
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,6 +29,7 @@ class CubePongBall:
     vx: float
     vy: float
     launch_delay_s: float = 0.0
+    rally_bounces: int = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,6 +49,7 @@ class CubePongState:
     player_two_score: int = 0
     losing_player: int | None = None
     reset_remaining_s: float = 0.0
+    winning_player: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -126,6 +131,9 @@ def advance_cube_pong_state(
     delta_s: float,
 ) -> CubePongState:
     delta_s = max(0.0, min(delta_s, 0.05))
+    if state.winning_player is not None:
+        return state
+
     if state.losing_player is not None:
         remaining = state.reset_remaining_s - delta_s
         if remaining <= 0:
@@ -145,6 +153,7 @@ def advance_cube_pong_state(
             player_two_score=state.player_two_score,
             losing_player=state.losing_player,
             reset_remaining_s=remaining,
+            winning_player=state.winning_player,
         )
 
     paddle_speed = max(state.screen_height * 1.9, 80.0)
@@ -183,6 +192,7 @@ def advance_cube_pong_state(
                 player_two_score += 1
             else:
                 player_one_score += 1
+            winning_player = _winning_player(player_one_score, player_two_score)
             updated_balls = [state.balls[0], state.balls[1]]
             for index, updated_ball in enumerate(balls):
                 updated_balls[index] = updated_ball
@@ -195,7 +205,10 @@ def advance_cube_pong_state(
                 player_one_score=player_one_score,
                 player_two_score=player_two_score,
                 losing_player=losing_player,
-                reset_remaining_s=ROUND_RESET_HOLD_S,
+                reset_remaining_s=0.0
+                if winning_player is not None
+                else ROUND_RESET_HOLD_S,
+                winning_player=winning_player,
             )
 
     return CubePongState(
@@ -265,6 +278,7 @@ def _advance_ball(
     next_y = ball.y + ball.vy * delta_s
     next_vx = ball.vx
     next_vy = ball.vy
+    rally_bounces = ball.rally_bounces
 
     if next_y <= radius:
         next_y = radius
@@ -276,7 +290,6 @@ def _advance_ball(
     paddle_one_x, paddle_two_x = paddle_path_x(screen_width)
     paddle_width, paddle_height = paddle_size(screen_width, screen_height)
     half_width = paddle_width / 2
-    max_speed = base_ball_speed(screen_width) * 1.45
     route = ROUTES[ball.route_name]
 
     if next_vx > 0:
@@ -297,15 +310,18 @@ def _advance_ball(
             )
             if hit_offset is None:
                 return (
-                    CubePongBall(ball.route_name, next_x, next_y, next_vx, next_vy),
+                    _moved_ball(ball, next_x, next_y, next_vx, next_vy),
                     defending_player,
                 )
             next_x = contact_x
-            next_vx = -min(abs(next_vx) * 1.02, max_speed)
-            next_vy = _spin_velocity(next_vy, hit_offset, screen_height)
+            next_vx, next_vy, rally_bounces = _paddle_bounce_velocity(
+                ball,
+                next_vx=-abs(next_vx),
+                next_vy=_spin_velocity(next_vy, hit_offset, screen_height),
+            )
         elif next_x > missed_x:
             return (
-                CubePongBall(ball.route_name, next_x, next_y, next_vx, next_vy),
+                _moved_ball(ball, next_x, next_y, next_vx, next_vy),
                 defending_player,
             )
     else:
@@ -326,19 +342,73 @@ def _advance_ball(
             )
             if hit_offset is None:
                 return (
-                    CubePongBall(ball.route_name, next_x, next_y, next_vx, next_vy),
+                    _moved_ball(ball, next_x, next_y, next_vx, next_vy),
                     defending_player,
                 )
             next_x = contact_x
-            next_vx = min(abs(next_vx) * 1.02, max_speed)
-            next_vy = _spin_velocity(next_vy, hit_offset, screen_height)
+            next_vx, next_vy, rally_bounces = _paddle_bounce_velocity(
+                ball,
+                next_vx=abs(next_vx),
+                next_vy=_spin_velocity(next_vy, hit_offset, screen_height),
+            )
         elif next_x < missed_x:
             return (
-                CubePongBall(ball.route_name, next_x, next_y, next_vx, next_vy),
+                _moved_ball(ball, next_x, next_y, next_vx, next_vy),
                 defending_player,
             )
 
-    return CubePongBall(ball.route_name, next_x, next_y, next_vx, next_vy), None
+    return (
+        CubePongBall(
+            route_name=ball.route_name,
+            x=next_x,
+            y=next_y,
+            vx=next_vx,
+            vy=next_vy,
+            rally_bounces=rally_bounces,
+        ),
+        None,
+    )
+
+
+def _moved_ball(
+    ball: CubePongBall,
+    x: float,
+    y: float,
+    vx: float,
+    vy: float,
+) -> CubePongBall:
+    return CubePongBall(
+        route_name=ball.route_name,
+        x=x,
+        y=y,
+        vx=vx,
+        vy=vy,
+        rally_bounces=ball.rally_bounces,
+    )
+
+
+def _paddle_bounce_velocity(
+    ball: CubePongBall,
+    *,
+    next_vx: float,
+    next_vy: float,
+) -> tuple[float, float, int]:
+    rally_bounces = ball.rally_bounces + 1
+    if rally_bounces % RALLY_SPEEDUP_BOUNCES != 0:
+        return next_vx, next_vy, rally_bounces
+    return (
+        next_vx * RALLY_SPEEDUP_MULTIPLIER,
+        next_vy * RALLY_SPEEDUP_MULTIPLIER,
+        rally_bounces,
+    )
+
+
+def _winning_player(player_one_score: int, player_two_score: int) -> int | None:
+    if player_one_score >= SCORE_TO_WIN:
+        return PLAYER_ONE
+    if player_two_score >= SCORE_TO_WIN:
+        return PLAYER_TWO
+    return None
 
 
 def _move_paddle(

--- a/src/heart/renderers/emoji_overlay.py
+++ b/src/heart/renderers/emoji_overlay.py
@@ -1,0 +1,467 @@
+from __future__ import annotations
+
+import math
+import random
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import pygame
+
+from heart import DeviceDisplayMode
+from heart.assets.loader import Loader
+from heart.device import Orientation
+from heart.peripheral.core.manager import PeripheralManager
+from heart.renderers import StatefulBaseRenderer
+from heart.runtime.display_context import DisplayContext
+
+FLOATING_EMOJI_POOP = "poop"
+FLOATING_EMOJI_SKULL = "skull"
+FLOATING_EMOJI_HEART = "heart"
+FLOATING_EMOJI_STAR = "star"
+FLOATING_EMOJI_RAINBOW = "rainbow"
+FLOATING_FACE_NAMES = (
+    "seb",
+    "faye",
+    "will",
+    "clem",
+    "cal",
+    "sri",
+    "lampe",
+    "ditto",
+)
+SUPPORTED_FLOATING_EMOJIS = frozenset(
+    {
+        FLOATING_EMOJI_POOP,
+        FLOATING_EMOJI_SKULL,
+        FLOATING_EMOJI_HEART,
+        FLOATING_EMOJI_STAR,
+        FLOATING_EMOJI_RAINBOW,
+        *FLOATING_FACE_NAMES,
+    }
+)
+FLOATING_EMOJI_DURATION_SECONDS = 3.2
+FLOATING_EMOJI_MAX_PARTICLES_PER_SCREEN = 5
+
+
+@dataclass(frozen=True)
+class FloatingEmojiOverlayState:
+    width: int
+    height: int
+    columns: int
+    rows: int
+
+
+@dataclass(frozen=True)
+class FloatingEmojiParticle:
+    emoji: str
+    born_at: float
+    x: float
+    size: int
+    drift_pixels: float
+    duration_seconds: float = FLOATING_EMOJI_DURATION_SECONDS
+
+
+class FloatingEmojiOverlayRenderer(StatefulBaseRenderer[FloatingEmojiOverlayState]):
+    def __init__(
+        self,
+        *,
+        now: Callable[[], float] | None = None,
+        rng: random.Random | None = None,
+    ) -> None:
+        super().__init__()
+        self.device_display_mode = DeviceDisplayMode.FULL
+        self._now = now or time.monotonic
+        self._rng = rng or random.Random()
+        self._particles: list[FloatingEmojiParticle] = []
+        self._avatar_images: dict[str, pygame.Surface | None] = {}
+
+    def _create_initial_state(
+        self,
+        window: DisplayContext,
+        peripheral_manager: PeripheralManager,
+        orientation: Orientation,
+    ) -> FloatingEmojiOverlayState:
+        width, height = window.get_size()
+        return FloatingEmojiOverlayState(
+            width=width,
+            height=height,
+            columns=max(1, orientation.layout.columns),
+            rows=max(1, orientation.layout.rows),
+        )
+
+    def spawn(self, emoji: str) -> None:
+        if emoji not in SUPPORTED_FLOATING_EMOJIS:
+            raise ValueError(f"Unsupported floating emoji: {emoji}")
+
+        now = self._now()
+        width = self.state.width if self.initialized else 256
+        height = self.state.height if self.initialized else 64
+        size = max(14, min(42, int(height * 0.54)))
+        margin = size * 0.65
+        x = self._rng.uniform(margin, max(margin, width - margin))
+        particle = FloatingEmojiParticle(
+            emoji=emoji,
+            born_at=now,
+            x=x,
+            size=size,
+            drift_pixels=self._rng.uniform(-size * 0.65, size * 0.65),
+        )
+        self._particles.append(particle)
+        self._enforce_screen_particle_limit(particle.x)
+
+    def has_active_emojis(self) -> bool:
+        self._drop_expired_particles(self._now())
+        return bool(self._particles)
+
+    def real_process(
+        self,
+        window: DisplayContext,
+        orientation: Orientation,
+    ) -> None:
+        if window.screen is None:
+            return
+
+        width, height = window.get_size()
+        columns = max(1, orientation.layout.columns)
+        rows = max(1, orientation.layout.rows)
+        if (width, height, columns, rows) != (
+            self.state.width,
+            self.state.height,
+            self.state.columns,
+            self.state.rows,
+        ):
+            self.set_state(
+                FloatingEmojiOverlayState(
+                    width=width,
+                    height=height,
+                    columns=columns,
+                    rows=rows,
+                )
+            )
+
+        window.screen.fill((0, 0, 0, 0))
+        now = self._now()
+        self._drop_expired_particles(now)
+        for particle in self._particles:
+            self._draw_particle(window.screen, particle, now)
+
+    def _drop_expired_particles(self, now: float) -> None:
+        self._particles = [
+            particle
+            for particle in self._particles
+            if now - particle.born_at < particle.duration_seconds
+        ]
+
+    def _enforce_screen_particle_limit(self, x: float) -> None:
+        screen_index = self._screen_index_for_x(x)
+        particles_on_screen = [
+            particle
+            for particle in self._particles
+            if self._screen_index_for_x(particle.x) == screen_index
+        ]
+        overflow = len(particles_on_screen) - FLOATING_EMOJI_MAX_PARTICLES_PER_SCREEN
+        if overflow <= 0:
+            return
+
+        ids_to_drop = {
+            id(particle)
+            for particle in sorted(
+                particles_on_screen,
+                key=lambda particle: particle.born_at,
+            )[:overflow]
+        }
+        self._particles = [
+            particle for particle in self._particles if id(particle) not in ids_to_drop
+        ]
+
+    def _screen_index_for_x(self, x: float) -> int:
+        column_width = max(1.0, self.state.width / self.state.columns)
+        column = int(max(0, min(self.state.columns - 1, x // column_width)))
+        return column
+
+    def _draw_particle(
+        self,
+        screen: pygame.Surface,
+        particle: FloatingEmojiParticle,
+        now: float,
+    ) -> None:
+        progress = max(
+            0.0,
+            min(1.0, (now - particle.born_at) / particle.duration_seconds),
+        )
+        _, height = screen.get_size()
+        wobble = math.sin(progress * math.tau * 1.7) * particle.size * 0.12
+        x = particle.x + particle.drift_pixels * progress + wobble
+        y = (height - particle.size * 0.52) - progress * (height + particle.size * 0.9)
+        alpha = 255 if progress < 0.78 else int(255 * (1.0 - progress) / 0.22)
+        icon = pygame.Surface((particle.size, particle.size), pygame.SRCALPHA)
+        self._draw_icon(icon, particle.emoji)
+        icon.set_alpha(max(0, min(255, alpha)))
+        screen.blit(icon, (round(x - particle.size / 2), round(y - particle.size / 2)))
+
+    def _draw_icon(self, surface: pygame.Surface, emoji: str) -> None:
+        if emoji in FLOATING_FACE_NAMES:
+            self._draw_avatar_icon(surface, emoji)
+            return
+        _draw_emoji_icon(surface, emoji)
+
+    def _draw_avatar_icon(self, surface: pygame.Surface, name: str) -> None:
+        avatar = self._load_avatar(name)
+        if avatar is None:
+            _draw_face_placeholder(surface, name)
+            return
+
+        size = surface.get_width()
+        image_size = max(1, round(size * 0.88))
+        scaled = pygame.transform.scale(avatar, (image_size, image_size))
+        rect = scaled.get_rect(center=(size // 2, size // 2))
+        pygame.draw.circle(
+            surface,
+            (255, 255, 255, 230),
+            (size // 2, size // 2),
+            round(size * 0.48),
+        )
+        pygame.draw.circle(
+            surface,
+            (20, 25, 30, 230),
+            (size // 2, size // 2),
+            round(size * 0.43),
+        )
+        surface.blit(scaled, rect)
+
+    def _load_avatar(self, name: str) -> pygame.Surface | None:
+        if name in self._avatar_images:
+            return self._avatar_images[name]
+        try:
+            avatar = Loader.load(f"avatars/{name}_32.png")
+        except Exception:
+            avatar = None
+        self._avatar_images[name] = avatar
+        return avatar
+
+
+def _draw_emoji_icon(surface: pygame.Surface, emoji: str) -> None:
+    if emoji == FLOATING_EMOJI_HEART:
+        _draw_heart(surface)
+    elif emoji == FLOATING_EMOJI_STAR:
+        _draw_star(surface)
+    elif emoji == FLOATING_EMOJI_RAINBOW:
+        _draw_rainbow(surface)
+    elif emoji == FLOATING_EMOJI_SKULL:
+        _draw_skull(surface)
+    elif emoji == FLOATING_EMOJI_POOP:
+        _draw_poop(surface)
+
+
+def _draw_heart(surface: pygame.Surface) -> None:
+    size = surface.get_width()
+    points = [
+        (size * 0.50, size * 0.86),
+        (size * 0.16, size * 0.54),
+        (size * 0.10, size * 0.30),
+        (size * 0.26, size * 0.14),
+        (size * 0.43, size * 0.22),
+        (size * 0.50, size * 0.34),
+        (size * 0.57, size * 0.22),
+        (size * 0.74, size * 0.14),
+        (size * 0.90, size * 0.30),
+        (size * 0.84, size * 0.54),
+    ]
+    pygame.draw.polygon(surface, (80, 0, 20, 220), points)
+    pygame.draw.polygon(surface, (255, 45, 92, 255), points)
+    pygame.draw.circle(
+        surface,
+        (255, 94, 132, 255),
+        (round(size * 0.32), round(size * 0.34)),
+        round(size * 0.19),
+    )
+    pygame.draw.circle(
+        surface,
+        (255, 94, 132, 255),
+        (round(size * 0.68), round(size * 0.34)),
+        round(size * 0.19),
+    )
+
+
+def _draw_star(surface: pygame.Surface) -> None:
+    size = surface.get_width()
+    center = size / 2
+    outer = size * 0.43
+    inner = size * 0.19
+    points: list[tuple[float, float]] = []
+    for index in range(10):
+        radius = outer if index % 2 == 0 else inner
+        angle = -math.pi / 2 + index * math.pi / 5
+        points.append(
+            (center + math.cos(angle) * radius, center + math.sin(angle) * radius)
+        )
+    pygame.draw.polygon(surface, (90, 58, 0, 230), points)
+    pygame.draw.polygon(surface, (255, 211, 58, 255), points)
+    pygame.draw.circle(
+        surface,
+        (255, 246, 145, 255),
+        (round(size * 0.38), round(size * 0.34)),
+        max(1, round(size * 0.06)),
+    )
+
+
+def _draw_rainbow(surface: pygame.Surface) -> None:
+    size = surface.get_width()
+    rect_base = size * 0.08
+    colors = [
+        (255, 56, 66, 255),
+        (255, 140, 36, 255),
+        (255, 226, 61, 255),
+        (58, 216, 96, 255),
+        (53, 171, 255, 255),
+        (147, 95, 255, 255),
+    ]
+    band_width = max(2, round(size * 0.08))
+    for index, color in enumerate(colors):
+        inset = rect_base + index * band_width
+        pygame.draw.arc(
+            surface,
+            color,
+            (inset, inset, size - inset * 2, size - inset * 2),
+            0,
+            math.pi,
+            band_width,
+        )
+    cloud_color = (244, 247, 255, 255)
+    for cx, cy, radius in (
+        (0.22, 0.73, 0.13),
+        (0.34, 0.70, 0.16),
+        (0.76, 0.73, 0.13),
+        (0.64, 0.70, 0.16),
+    ):
+        pygame.draw.circle(
+            surface,
+            cloud_color,
+            (round(size * cx), round(size * cy)),
+            round(size * radius),
+        )
+
+
+def _draw_skull(surface: pygame.Surface) -> None:
+    size = surface.get_width()
+    ivory = (236, 238, 226, 255)
+    shade = (188, 195, 188, 255)
+    dark = (26, 25, 28, 255)
+    pygame.draw.ellipse(
+        surface, (0, 0, 0, 190), (size * 0.14, size * 0.11, size * 0.72, size * 0.66)
+    )
+    pygame.draw.ellipse(
+        surface, ivory, (size * 0.12, size * 0.08, size * 0.76, size * 0.68)
+    )
+    pygame.draw.rect(
+        surface,
+        ivory,
+        (size * 0.29, size * 0.56, size * 0.42, size * 0.27),
+        border_radius=max(1, round(size * 0.08)),
+    )
+    pygame.draw.rect(
+        surface, shade, (size * 0.32, size * 0.73, size * 0.36, size * 0.08)
+    )
+    pygame.draw.circle(
+        surface, dark, (round(size * 0.35), round(size * 0.41)), round(size * 0.11)
+    )
+    pygame.draw.circle(
+        surface, dark, (round(size * 0.65), round(size * 0.41)), round(size * 0.11)
+    )
+    pygame.draw.polygon(
+        surface,
+        dark,
+        [
+            (size * 0.50, size * 0.49),
+            (size * 0.42, size * 0.62),
+            (size * 0.58, size * 0.62),
+        ],
+    )
+    for x in (0.39, 0.50, 0.61):
+        pygame.draw.line(
+            surface,
+            dark,
+            (size * x, size * 0.68),
+            (size * x, size * 0.79),
+            max(1, round(size * 0.04)),
+        )
+
+
+def _draw_poop(surface: pygame.Surface) -> None:
+    size = surface.get_width()
+    brown = (124, 69, 34, 255)
+    light = (181, 104, 52, 255)
+    dark = (54, 31, 22, 255)
+    pygame.draw.ellipse(
+        surface, (0, 0, 0, 170), (size * 0.13, size * 0.66, size * 0.74, size * 0.22)
+    )
+    pygame.draw.ellipse(
+        surface, brown, (size * 0.13, size * 0.58, size * 0.74, size * 0.29)
+    )
+    pygame.draw.ellipse(
+        surface, light, (size * 0.22, size * 0.39, size * 0.56, size * 0.31)
+    )
+    pygame.draw.ellipse(
+        surface, brown, (size * 0.33, size * 0.23, size * 0.38, size * 0.29)
+    )
+    pygame.draw.polygon(
+        surface,
+        light,
+        [
+            (size * 0.50, size * 0.08),
+            (size * 0.36, size * 0.31),
+            (size * 0.63, size * 0.29),
+        ],
+    )
+    pygame.draw.circle(
+        surface,
+        (255, 255, 255, 255),
+        (round(size * 0.39), round(size * 0.57)),
+        round(size * 0.07),
+    )
+    pygame.draw.circle(
+        surface,
+        (255, 255, 255, 255),
+        (round(size * 0.61), round(size * 0.57)),
+        round(size * 0.07),
+    )
+    pygame.draw.circle(
+        surface,
+        dark,
+        (round(size * 0.40), round(size * 0.58)),
+        max(1, round(size * 0.035)),
+    )
+    pygame.draw.circle(
+        surface,
+        dark,
+        (round(size * 0.60), round(size * 0.58)),
+        max(1, round(size * 0.035)),
+    )
+    pygame.draw.arc(
+        surface,
+        dark,
+        (size * 0.39, size * 0.59, size * 0.22, size * 0.14),
+        0.15,
+        math.pi - 0.15,
+        max(1, round(size * 0.035)),
+    )
+
+
+def _draw_face_placeholder(surface: pygame.Surface, name: str) -> None:
+    size = surface.get_width()
+    pygame.draw.circle(
+        surface,
+        (255, 255, 255, 230),
+        (size // 2, size // 2),
+        round(size * 0.48),
+    )
+    pygame.draw.circle(
+        surface,
+        (255, 105, 180, 255),
+        (size // 2, size // 2),
+        round(size * 0.42),
+    )
+    font = pygame.font.Font(None, max(12, round(size * 0.42)))
+    label = font.render(name[:1].upper(), True, (16, 16, 22))
+    surface.blit(label, label.get_rect(center=(size // 2, size // 2)))

--- a/src/heart/renderers/text/renderer.py
+++ b/src/heart/renderers/text/renderer.py
@@ -11,6 +11,7 @@ from heart.runtime.display_context import DisplayContext
 
 PIXEL_FONT_PATH = "Grand9K Pixel.ttf"
 PIXEL_FONT_ANTIALIAS = False
+MIN_PREVIEW_SCALE = 2
 
 
 class TextRendering(StatefulBaseRenderer[TextRenderingState]):
@@ -83,7 +84,15 @@ class TextRendering(StatefulBaseRenderer[TextRenderingState]):
         if font is None:
             return
 
-        window_width, window_height = window.get_size()
+        if window.screen is None:
+            return
+
+        output_surface = window.screen
+        native_size = self._native_text_surface_size(window)
+        if native_size is not None:
+            output_surface = pygame.Surface(native_size, pygame.SRCALPHA)
+
+        window_width, window_height = output_surface.get_size()
         if self.state.y_location is not None:
             y_offset = int(self.state.y_location * window_height)
         else:
@@ -105,5 +114,30 @@ class TextRendering(StatefulBaseRenderer[TextRenderingState]):
                 x_offset = (window_width - text_width) // 2
             else:
                 x_offset = int(self.state.x_location * window_width)
-            window.screen.blit(text_surface, (x_offset, y_offset))
+            output_surface.blit(text_surface, (x_offset, y_offset))
             y_offset += line_height
+
+        if output_surface is not window.screen:
+            scaled = pygame.transform.scale(output_surface, window.screen.get_size())
+            window.screen.blit(scaled, (0, 0))
+
+    def _native_text_surface_size(
+        self,
+        window: DisplayContext,
+    ) -> tuple[int, int] | None:
+        scale_factor = window.device.scale_factor
+        if scale_factor < MIN_PREVIEW_SCALE:
+            return None
+
+        window_width, window_height = window.get_size()
+        if window_width % scale_factor != 0 or window_height % scale_factor != 0:
+            return None
+
+        native_size = (window_width // scale_factor, window_height // scale_factor)
+        valid_native_sizes = {
+            window.device.individual_display_size(),
+            window.device.full_display_size(),
+        }
+        if native_size not in valid_native_sizes:
+            return None
+        return native_size

--- a/src/heart/renderers/title_screen.py
+++ b/src/heart/renderers/title_screen.py
@@ -14,6 +14,8 @@ from heart.peripheral.core.manager import PeripheralManager
 from heart.renderers import StatefulBaseRenderer
 from heart.runtime.display_context import DisplayContext
 
+MIN_PREVIEW_SCALE = 2
+
 
 @dataclass(frozen=True)
 class TextBlock:
@@ -86,19 +88,28 @@ class TitleScreen(StatefulBaseRenderer[TitleScreenState]):
         if window.screen is None:
             return
 
-        window.fill(self.background._as_tuple())
+        output_window = self._native_title_window(window)
+        output_window.fill(self.background._as_tuple())
         text_block = self._render_text_block()
-        text_x = (window.get_width() - text_block.width) // 2
-        text_y = window.get_height() - text_block.height - self.text_bottom_margin_px
+        text_x = (output_window.get_width() - text_block.width) // 2
+        text_y = (
+            output_window.get_height() - text_block.height - self.text_bottom_margin_px
+        )
         image_bottom = max(0, text_y - self.image_text_gap_px)
 
-        image_surface = self._render_image(window, orientation)
+        image_surface = self._render_image(output_window, orientation)
         self._blit_image_centered_in_region(
-            window=window,
+            window=output_window,
             image_surface=image_surface,
             image_bottom=image_bottom,
         )
-        self._blit_text_block(window, text_block, x=text_x, y=text_y)
+        self._blit_text_block(output_window, text_block, x=text_x, y=text_y)
+        if output_window is not window:
+            assert output_window.screen is not None
+            scaled = pygame.transform.scale(
+                output_window.screen, window.screen.get_size()
+            )
+            window.screen.blit(scaled, (0, 0))
 
     def _render_text_block(self) -> TextBlock:
         font = self._load_font()
@@ -123,6 +134,39 @@ class TitleScreen(StatefulBaseRenderer[TitleScreenState]):
                 self._font = pygame.ftfont.SysFont(self.font, self.font_size)
             self._font_key = font_key
         return self._font
+
+    def _native_title_window(self, window: DisplayContext) -> DisplayContext:
+        native_size = self._native_title_surface_size(window)
+        if native_size is None:
+            return window
+        return DisplayContext(
+            device=window.device,
+            screen=pygame.Surface(native_size, pygame.SRCALPHA),
+            clock=window.clock,
+            last_render_mode=window.last_render_mode,
+            can_configure_display=False,
+        )
+
+    def _native_title_surface_size(
+        self,
+        window: DisplayContext,
+    ) -> tuple[int, int] | None:
+        scale_factor = window.device.scale_factor
+        if scale_factor < MIN_PREVIEW_SCALE:
+            return None
+
+        window_width, window_height = window.get_size()
+        if window_width % scale_factor != 0 or window_height % scale_factor != 0:
+            return None
+
+        native_size = (window_width // scale_factor, window_height // scale_factor)
+        valid_native_sizes = {
+            window.device.individual_display_size(),
+            window.device.full_display_size(),
+        }
+        if native_size not in valid_native_sizes:
+            return None
+        return native_size
 
     def _render_image(
         self,

--- a/src/heart/runtime/game_loop/__init__.py
+++ b/src/heart/runtime/game_loop/__init__.py
@@ -13,6 +13,7 @@ from manyfold import shutdown
 from heart import DeviceDisplayMode
 from heart.device import Device
 from heart.navigation import ComposedRenderer, MultiScene
+from heart.renderers.emoji_overlay import FloatingEmojiOverlayRenderer
 from heart.runtime.active_game_loop import set_active_game_loop
 from heart.runtime.container import (build_runtime_container,
                                      configure_runtime_container)
@@ -117,6 +118,7 @@ class GameLoop:
         self.edge_thresh = EDGE_THRESHOLD
         self._temporary_renderer: "StatefulBaseRenderer[Any]" | None = None
         self._temporary_renderer_deadline_monotonic: float | None = None
+        self._emoji_overlay_renderer: FloatingEmojiOverlayRenderer | None = None
         self._frame_index = 0
         self._last_perf_log_monotonic = 0.0
 
@@ -277,9 +279,13 @@ class GameLoop:
     def _select_renderers(self) -> list["StatefulBaseRenderer[Any]"]:
         temporary_renderer = self._active_temporary_renderer()
         if temporary_renderer is not None:
-            return [temporary_renderer]
-        base_renderers = self.components.game_modes.get_renderers()
-        renderers = list(base_renderers) if base_renderers else []
+            renderers = [temporary_renderer]
+        else:
+            base_renderers = self.components.game_modes.get_renderers()
+            renderers = list(base_renderers) if base_renderers else []
+        emoji_overlay = self._active_emoji_overlay_renderer()
+        if emoji_overlay is not None:
+            renderers.append(emoji_overlay)
         return renderers
 
     def present_temporary_renderer(
@@ -296,6 +302,18 @@ class GameLoop:
 
     def clear_temporary_renderer(self) -> None:
         self._clear_temporary_renderer()
+
+    def present_floating_emoji(self, emoji: str) -> None:
+        if self._emoji_overlay_renderer is None:
+            self._emoji_overlay_renderer = FloatingEmojiOverlayRenderer()
+        if not self._emoji_overlay_renderer.initialized:
+            self._ensure_display_initialized()
+            self._emoji_overlay_renderer.initialize(
+                window=self.components.display,
+                peripheral_manager=self.components.peripheral_manager,
+                orientation=self.device.orientation,
+            )
+        self._emoji_overlay_renderer.spawn(emoji)
 
     @property
     def peripheral_manager(self):
@@ -364,6 +382,8 @@ class GameLoop:
 
         if self._temporary_renderer is not None:
             visit(self._temporary_renderer)
+        if self._emoji_overlay_renderer is not None:
+            visit(self._emoji_overlay_renderer)
 
         game_modes = self.components.game_modes
         if game_modes._state is not None:
@@ -481,6 +501,16 @@ class GameLoop:
         self._temporary_renderer_deadline_monotonic = None
         if renderer is not None:
             renderer.reset()
+
+    def _active_emoji_overlay_renderer(self) -> FloatingEmojiOverlayRenderer | None:
+        renderer = self._emoji_overlay_renderer
+        if renderer is None:
+            return None
+        if not renderer.has_active_emojis():
+            self._emoji_overlay_renderer = None
+            renderer.reset()
+            return None
+        return renderer
 
     def _maybe_log_perf_frame(
         self,

--- a/src/heart/runtime/peripheral_runtime.py
+++ b/src/heart/runtime/peripheral_runtime.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import base64
 import io
+import os
+from datetime import datetime, timezone
+from pathlib import Path
 from queue import Empty, SimpleQueue
 from typing import Any
 
@@ -31,8 +34,12 @@ CONTROL_COMMAND_ALTERNATE = "alternate_activate"
 CONTROL_COMMAND_SENSOR_UPDATE = "sensor_update"
 CONTROL_COMMAND_TEXT_UPDATE = "text_update"
 CONTROL_COMMAND_IMAGE_UPDATE = "image_update"
+CONTROL_COMMAND_EMOJI_UPDATE = "emoji_update"
 PHONE_TEXT_DISPLAY_DURATION_SECONDS = 5.0
 PHONE_IMAGE_DISPLAY_DURATION_SECONDS = 5.0
+PHONE_PHOTO_DIRECTORY_ENV_VAR = "HEART_PHONE_PHOTO_DIR"
+DEFAULT_PHONE_PHOTO_DIRECTORY = Path("~/heart-phone-photos")
+GAMEPAD_NAVIGATION_STICK_THRESHOLD = 0.6
 
 
 class PeripheralRuntime:
@@ -130,6 +137,9 @@ class PeripheralRuntime:
                 image_base64=control_message.image_base64,
             )
             return
+        if control_message.command == CONTROL_COMMAND_EMOJI_UPDATE:
+            self._present_phone_emoji(control_message.emoji)
+            return
 
     def _streaming_envelope(
         self, envelope: InputDebugEnvelope
@@ -185,6 +195,8 @@ class PeripheralRuntime:
             image_bytes = base64.b64decode(image_base64, validate=True)
             with Image.open(io.BytesIO(image_bytes)) as uploaded_image:
                 normalized = ImageOps.exif_transpose(uploaded_image).convert("RGBA")
+                saved_path = save_phone_photo(normalized)
+                logger.info("Saved phone photo to %s", saved_path)
                 surface = pygame.image.fromstring(
                     normalized.tobytes(),
                     normalized.size,
@@ -202,6 +214,18 @@ class PeripheralRuntime:
             renderer,
             duration_seconds=PHONE_IMAGE_DISPLAY_DURATION_SECONDS,
         )
+
+    def _present_phone_emoji(self, emoji: str | None) -> None:
+        if emoji is None:
+            return
+        loop = get_active_game_loop()
+        if loop is None:
+            logger.debug("No active GameLoop available for phone emoji display.")
+            return
+        try:
+            loop.present_floating_emoji(emoji)
+        except ValueError:
+            logger.warning("Ignoring unsupported phone emoji: %s", emoji)
 
     def poll(self) -> None:
         drain_frame_thread_queue()
@@ -226,3 +250,19 @@ def _build_websocket() -> Any:
     """Construct the Beats websocket only when streaming is enabled."""
 
     return WebSocket()
+
+
+def phone_photo_directory() -> Path:
+    configured = os.environ.get(PHONE_PHOTO_DIRECTORY_ENV_VAR)
+    if configured:
+        return Path(configured).expanduser()
+    return DEFAULT_PHONE_PHOTO_DIRECTORY.expanduser()
+
+
+def save_phone_photo(image: Image.Image) -> Path:
+    output_dir = phone_photo_directory()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    output_path = output_dir / f"phone-photo-{timestamp}.png"
+    image.save(output_path, format="PNG")
+    return output_path

--- a/tests/device/test_beats_websocket.py
+++ b/tests/device/test_beats_websocket.py
@@ -312,6 +312,52 @@ class TestControlMessageDecoding:
         assert decoded.image_base64 is None
         assert decoded.clear is True
 
+    def test_decodes_emoji_update_control_messages(self) -> None:
+        """Verify phone emoji controls decode into a validated overlay trigger."""
+        decoded = decode_control_message(
+            json.dumps(
+                {
+                    "kind": "control",
+                    "command": "emoji_update",
+                    "emoji": "rainbow",
+                }
+            )
+        )
+
+        assert decoded is not None
+        assert decoded.command == "emoji_update"
+        assert decoded.emoji == "rainbow"
+
+    def test_decodes_face_update_control_messages(self) -> None:
+        """Verify phone face controls reuse the validated floating overlay trigger."""
+        decoded = decode_control_message(
+            json.dumps(
+                {
+                    "kind": "control",
+                    "command": "emoji_update",
+                    "emoji": "seb",
+                }
+            )
+        )
+
+        assert decoded is not None
+        assert decoded.command == "emoji_update"
+        assert decoded.emoji == "seb"
+
+    def test_rejects_unknown_emoji_update_control_messages(self) -> None:
+        """Reject unsupported emoji names so the runtime only handles known overlay art."""
+        decoded = decode_control_message(
+            json.dumps(
+                {
+                    "kind": "control",
+                    "command": "emoji_update",
+                    "emoji": "fire",
+                }
+            )
+        )
+
+        assert decoded is None
+
 
 class TestWebSocketReplayCache:
     """Verify replay caching so reconnecting Beats clients immediately recover current stream state."""

--- a/tests/renderers/test_emoji_overlay_renderer.py
+++ b/tests/renderers/test_emoji_overlay_renderer.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import random
+
+import pygame
+import pytest
+
+from heart.device import Rectangle
+from heart.peripheral.core.manager import PeripheralManager
+from heart.renderers.emoji_overlay import FloatingEmojiOverlayRenderer
+from heart.runtime.display_context import DisplayContext
+
+
+class TestFloatingEmojiOverlayRenderer:
+    """Validate the phone-triggered emoji overlay animation."""
+
+    def test_spawned_emoji_starts_at_bottom_and_floats_up(self, device) -> None:
+        now = 10.0
+
+        def _now() -> float:
+            return now
+
+        screen = pygame.Surface((256, 64), pygame.SRCALPHA)
+        window = DisplayContext(device=device, screen=screen, clock=pygame.time.Clock())
+        renderer = FloatingEmojiOverlayRenderer(now=_now, rng=random.Random(1))
+        renderer.initialize(window, PeripheralManager(), Rectangle.with_layout(4, 1))
+
+        renderer.spawn("heart")
+        renderer.real_process(window, device.orientation)
+        initial_bounds = _alpha_bounds(screen)
+
+        assert initial_bounds is not None
+        assert initial_bounds.bottom >= 54
+
+        now += 1.6
+        renderer.real_process(window, device.orientation)
+        midpoint_bounds = _alpha_bounds(screen)
+
+        assert midpoint_bounds is not None
+        assert midpoint_bounds.bottom < initial_bounds.bottom
+        assert renderer.has_active_emojis()
+
+        now += 2.0
+        renderer.real_process(window, device.orientation)
+
+        assert _alpha_bounds(screen) is None
+        assert not renderer.has_active_emojis()
+
+    def test_rejects_unsupported_emoji(self, device) -> None:
+        screen = pygame.Surface((256, 64), pygame.SRCALPHA)
+        window = DisplayContext(device=device, screen=screen, clock=pygame.time.Clock())
+        renderer = FloatingEmojiOverlayRenderer()
+        renderer.initialize(window, PeripheralManager(), Rectangle.with_layout(4, 1))
+
+        with pytest.raises(ValueError, match="Unsupported floating emoji"):
+            renderer.spawn("bogus")
+
+    def test_draws_rainbow_and_face_reactions(self, device) -> None:
+        now = 10.0
+
+        def _now() -> float:
+            return now
+
+        screen = pygame.Surface((256, 64), pygame.SRCALPHA)
+        window = DisplayContext(device=device, screen=screen, clock=pygame.time.Clock())
+        renderer = FloatingEmojiOverlayRenderer(now=_now, rng=random.Random(2))
+        renderer.initialize(window, PeripheralManager(), Rectangle.with_layout(4, 1))
+
+        renderer.spawn("rainbow")
+        renderer.spawn("seb")
+        renderer.real_process(window, device.orientation)
+
+        bounds = _alpha_bounds(screen)
+        assert bounds is not None
+        assert bounds.width > 20
+
+    def test_caps_active_reactions_per_screen(self, device) -> None:
+        now = 10.0
+
+        def _now() -> float:
+            return now
+
+        screen = pygame.Surface((256, 64), pygame.SRCALPHA)
+        window = DisplayContext(device=device, screen=screen, clock=pygame.time.Clock())
+        renderer = FloatingEmojiOverlayRenderer(now=_now, rng=_CenteredRandom())
+        renderer.initialize(window, PeripheralManager(), Rectangle.with_layout(4, 1))
+
+        for _ in range(6):
+            renderer.spawn("star")
+            now += 0.01
+
+        assert len(renderer._particles) == 5
+
+
+def _alpha_bounds(surface: pygame.Surface) -> pygame.Rect | None:
+    rects = pygame.mask.from_surface(surface, 1).get_bounding_rects()
+    if not rects:
+        return None
+    bounds = rects[0].copy()
+    for rect in rects[1:]:
+        bounds.union_ip(rect)
+    return bounds
+
+
+class _CenteredRandom:
+    def uniform(self, start: float, end: float) -> float:
+        return (start + end) / 2

--- a/tests/runtime/test_game_loop.py
+++ b/tests/runtime/test_game_loop.py
@@ -148,3 +148,25 @@ class TestGameLoop:
         loop.render_frame([renderer])
 
         assert renderer.reset_calls == 0
+
+    def test_select_renderers_appends_floating_emoji_overlay(
+        self,
+        device,
+        resolver,
+    ) -> None:
+        """Keep phone emoji bursts layered above the active renderer instead of replacing it."""
+        loop = GameLoop(device=device, resolver=resolver)
+        loop.ensure_screen_initialized()
+        renderer = _Renderer(display_mode=DeviceDisplayMode.MIRRORED)
+        loop.components.game_modes.set_state(
+            GameModeState(
+                entries=[ModeEntry(title_renderer=renderer, renderer=renderer)]
+            )
+        )
+
+        loop.present_floating_emoji("star")
+
+        selected = loop._select_renderers()
+
+        assert selected[0] is renderer
+        assert selected[-1] is loop._emoji_overlay_renderer

--- a/tests/runtime/test_peripheral_runtime.py
+++ b/tests/runtime/test_peripheral_runtime.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+from PIL import Image
+
 from heart.device.beats.websocket import ControlMessage
 from heart.peripheral.core.input import InputDebugStage, InputDebugTap
 from heart.runtime.peripheral_runtime import (INPUT_DEBUG_STAGE_TAG,
                                               INPUT_DEBUG_STREAM_TAG,
-                                              PeripheralRuntime)
+                                              PeripheralRuntime,
+                                              save_phone_photo)
 
 
 class _PeripheralManagerStub:
@@ -61,9 +64,13 @@ class _WebSocketStub:
 class _TemporaryRendererLoop:
     def __init__(self) -> None:
         self.clear_count = 0
+        self.floating_emojis: list[str] = []
 
     def clear_temporary_renderer(self) -> None:
         self.clear_count += 1
+
+    def present_floating_emoji(self, emoji: str) -> None:
+        self.floating_emojis.append(emoji)
 
 
 class TestPeripheralRuntimeStreaming:
@@ -250,3 +257,40 @@ class TestPeripheralRuntimeStreaming:
         runtime._drain_control_messages()
 
         assert loop.clear_count == 1
+
+    def test_emoji_control_presents_floating_overlay(self, monkeypatch) -> None:
+        """Verify emoji controls are layered through the active loop instead of replacing the current renderer."""
+        manager = _PeripheralManagerStub()
+        runtime = PeripheralRuntime(manager)  # type: ignore[arg-type]
+        websocket = _WebSocketStub()
+        loop = _TemporaryRendererLoop()
+        monkeypatch.setattr(
+            "heart.runtime.peripheral_runtime.get_active_game_loop",
+            lambda: loop,
+        )
+
+        runtime.configure_streaming(websocket=websocket)  # type: ignore[arg-type]
+        assert websocket.control_handler is not None
+
+        websocket.control_handler(ControlMessage(command="emoji_update", emoji="heart"))
+        runtime._drain_control_messages()
+
+        assert loop.floating_emojis == ["heart"]
+        assert loop.clear_count == 0
+
+    def test_save_phone_photo_writes_png_to_configured_directory(
+        self,
+        monkeypatch,
+        tmp_path,
+    ) -> None:
+        """Verify phone photos persist on the runtime host so Pi sessions keep captured images."""
+        monkeypatch.setenv("HEART_PHONE_PHOTO_DIR", str(tmp_path))
+        image = Image.new("RGBA", (2, 2), (255, 0, 0, 255))
+
+        saved_path = save_phone_photo(image)
+
+        assert saved_path.parent == tmp_path
+        assert saved_path.name.startswith("phone-photo-")
+        assert saved_path.suffix == ".png"
+        with Image.open(saved_path) as saved_image:
+            assert saved_image.size == (2, 2)


### PR DESCRIPTION
## Summary
- add phone UI controls for floating emoji and face reactions
- layer floating reactions above the active renderer with a five-per-screen cap
- persist uploaded phone photos on the runtime host

## Tests
- uv run ruff check src/heart/renderers/emoji_overlay.py src/heart/device/beats/websocket.py src/heart/runtime/game_loop/__init__.py src/heart/runtime/peripheral_runtime.py tests/renderers/test_emoji_overlay_renderer.py tests/device/test_beats_websocket.py tests/runtime/test_game_loop.py tests/runtime/test_peripheral_runtime.py
- uv run pytest tests/renderers/test_emoji_overlay_renderer.py tests/device/test_beats_websocket.py::TestControlMessageDecoding tests/runtime/test_game_loop.py::TestGameLoop::test_select_renderers_appends_floating_emoji_overlay tests/runtime/test_peripheral_runtime.py::TestPeripheralRuntimeStreaming::test_emoji_control_presents_floating_overlay tests/runtime/test_peripheral_runtime.py::TestPeripheralRuntimeStreaming::test_save_phone_photo_writes_png_to_configured_directory -q
- npm test -- --run src/tests/unit/actions/ws/websocket.test.tsx