### PR TITLE
Add reaction time game

### DIFF
--- a/src/heart/peripheral/gamepad/screen_mapping.py
+++ b/src/heart/peripheral/gamepad/screen_mapping.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+SCREEN_SLOT_BLUETOOTH_MACS: tuple[str | None, ...] = (
+    "E4:17:D8:E9:76:C8",  # Screen 1 / player 1
+    "E4:17:D8:43:5C:48",  # Screen 2 / player 2
+    "E4:17:D8:58:22:8A",  # Screen 3 / player 3
+    "E4:17:D8:91:15:35",  # Screen 4 / player 4
+)
+
+
+def bluetooth_mac_for_screen_slot(slot: int) -> str | None:
+    if slot >= len(SCREEN_SLOT_BLUETOOTH_MACS):
+        return None
+    return SCREEN_SLOT_BLUETOOTH_MACS[slot]
+
+
+def normalize_bluetooth_mac(mac_address: str) -> str:
+    return mac_address.replace(":", "").lower()

--- a/src/heart/programs/configurations/lib_2026.py
+++ b/src/heart/programs/configurations/lib_2026.py
@@ -21,6 +21,7 @@ from heart.renderers.mario.renderer import MarioRenderer
 from heart.renderers.multicolor import MulticolorRenderer
 from heart.renderers.palette_tunnel import PaletteTunnelScene
 from heart.renderers.pranay_sketch import PranaySketchRenderer
+from heart.renderers.reaction_time import ReactionTimeRenderer
 from heart.renderers.rock_paper_scissors import add_rock_paper_scissors_mode
 from heart.renderers.spritesheet import SpritesheetLoop
 from heart.renderers.spritesheet_random import SpritesheetLoopRandom
@@ -200,6 +201,9 @@ def configure(loop: GameLoop) -> None:
 
     tetris_mode = loop.add_mode("tetris")
     tetris_mode.add_renderer(TetrisRenderer)
+
+    reaction_mode = loop.add_mode(centered_text_title("reaction"))
+    reaction_mode.add_renderer(ReactionTimeRenderer(randomness=randomness))
 
     pranay_mode = loop.add_mode(friend_beacon_text(text=PRANAY_SKETCH_MODE_TITLE))
     pranay_mode.add_renderer(PranaySketchRenderer())

--- a/src/heart/programs/configurations/reaction_time.py
+++ b/src/heart/programs/configurations/reaction_time.py
@@ -1,0 +1,9 @@
+from heart.peripheral.providers.randomness import RandomnessProvider
+from heart.renderers.reaction_time import ReactionTimeRenderer
+from heart.runtime.game_loop import GameLoop
+
+
+def configure(loop: GameLoop) -> None:
+    mode = loop.add_mode("reaction")
+    mode.add_renderer(ReactionTimeRenderer(randomness=RandomnessProvider()))
+    loop.components.game_modes.state.in_select_mode = False

--- a/src/heart/renderers/cube_pong/renderer.py
+++ b/src/heart/renderers/cube_pong/renderer.py
@@ -10,6 +10,10 @@ from heart.device import Orientation
 from heart.peripheral.core.input import GamepadAxis, GamepadSnapshot
 from heart.peripheral.core.manager import PeripheralManager
 from heart.peripheral.gamepad import Gamepad
+from heart.peripheral.gamepad.screen_mapping import (
+    SCREEN_SLOT_BLUETOOTH_MACS,
+    normalize_bluetooth_mac,
+)
 from heart.renderers import StatefulBaseRenderer
 from heart.renderers.cube_pong.state import (PLAYER_ONE, PLAYER_TWO,
                                              CubePongControls, CubePongState,
@@ -47,22 +51,22 @@ class PongControllerBinding:
 PONG_CONTROLLER_BINDINGS: tuple[PongControllerBinding, ...] = (
     PongControllerBinding(
         player=PLAYER_ONE,
-        mac_address="E4:17:D8:E9:76:C8",  # Pink 8BitDo Lite 2 controller.
+        mac_address=SCREEN_SLOT_BLUETOOTH_MACS[0] or "",
         color_name="pink",
     ),
     PongControllerBinding(
         player=PLAYER_ONE,
-        mac_address="E4:17:D8:91:15:35",  # Pink 8BitDo Lite 2 controller.
+        mac_address=SCREEN_SLOT_BLUETOOTH_MACS[3] or "",
         color_name="pink",
     ),
     PongControllerBinding(
         player=PLAYER_TWO,
-        mac_address="E4:17:D8:43:5C:48",  # Teal 8BitDo Lite 2 controller.
+        mac_address=SCREEN_SLOT_BLUETOOTH_MACS[1] or "",
         color_name="teal",
     ),
     PongControllerBinding(
         player=PLAYER_TWO,
-        mac_address="E4:17:D8:58:22:8A",  # Teal 8BitDo Lite 2 controller.
+        mac_address=SCREEN_SLOT_BLUETOOTH_MACS[2] or "",
         color_name="teal",
     ),
 )
@@ -416,4 +420,4 @@ def _joystick_paths() -> tuple[Path, ...]:
 
 
 def _normalize_bluetooth_mac(mac_address: str) -> str:
-    return mac_address.replace(":", "").lower()
+    return normalize_bluetooth_mac(mac_address)

--- a/src/heart/renderers/reaction_time/__init__.py
+++ b/src/heart/renderers/reaction_time/__init__.py
@@ -1,0 +1,7 @@
+from heart.renderers.reaction_time.renderer import (
+    ReactionTimeRenderer as ReactionTimeRenderer,
+)
+from heart.renderers.reaction_time.state import ReactionPhase as ReactionPhase
+from heart.renderers.reaction_time.state import (
+    ReactionTimeState as ReactionTimeState,
+)

--- a/src/heart/renderers/reaction_time/renderer.py
+++ b/src/heart/renderers/reaction_time/renderer.py
@@ -1,0 +1,416 @@
+from __future__ import annotations
+
+import random
+import time
+from dataclasses import replace
+
+import pygame
+
+from heart import DeviceDisplayMode
+from heart.assets.loader import Loader
+from heart.device import Orientation
+from heart.peripheral.core.input import GamepadButton
+from heart.peripheral.core.manager import PeripheralManager
+from heart.peripheral.providers.randomness import RandomnessProvider
+from heart.renderers import StatefulBaseRenderer
+from heart.renderers.reaction_time.state import (
+    ReactionPhase,
+    ReactionPlayerState,
+    ReactionTimeState,
+    new_reaction_round,
+    reaction_winner,
+)
+from heart.renderers.tetris.direct_gamepad import (
+    DirectGamepadSnapshot,
+    DirectTetrisGamepads,
+)
+from heart.runtime.display_context import DisplayContext
+
+RNG_NAMESPACE = "reaction-time"
+PLAYER_COUNT = 4
+IDENTIFY_DURATION_S = 2.0
+COUNTDOWN_DURATION_S = 3.0
+MIN_GO_DELAY_S = 0.5
+MAX_GO_DELAY_S = 5.0
+MAX_REACTION_WINDOW_S = 3.0
+RESULTS_DURATION_S = 4.0
+PIXEL_FONT_PATH = "Grand9K Pixel.ttf"
+BACKGROUND_COLOR = pygame.Color(3, 5, 10)
+PANEL_COLORS = (
+    pygame.Color(10, 22, 34),
+    pygame.Color(28, 20, 6),
+    pygame.Color(22, 12, 32),
+    pygame.Color(7, 25, 15),
+)
+PLAYER_ACCENTS = (
+    pygame.Color(0, 220, 255),
+    pygame.Color(255, 211, 64),
+    pygame.Color(185, 112, 255),
+    pygame.Color(74, 222, 128),
+)
+TEXT_COLOR = pygame.Color(245, 250, 255)
+DIM_TEXT_COLOR = pygame.Color(104, 119, 138)
+FALSE_START_COLOR = pygame.Color(255, 55, 76)
+GO_COLOR = pygame.Color(80, 255, 138)
+REACTION_BUTTONS = (
+    GamepadButton.SOUTH,
+    GamepadButton.EAST,
+    GamepadButton.WEST,
+    GamepadButton.ZL,
+    GamepadButton.ZR,
+    GamepadButton.L3,
+    GamepadButton.R3,
+)
+KEYBOARD_KEYS_BY_PLAYER = (
+    (pygame.K_1, pygame.K_q, pygame.K_a),
+    (pygame.K_2, pygame.K_w, pygame.K_s),
+    (pygame.K_3, pygame.K_e, pygame.K_d),
+    (pygame.K_4, pygame.K_r, pygame.K_f),
+)
+
+
+class ReactionTimeRenderer(StatefulBaseRenderer[ReactionTimeState]):
+    def __init__(
+        self,
+        *,
+        randomness: RandomnessProvider | None = None,
+        rng: random.Random | None = None,
+    ) -> None:
+        self._rng = rng or (randomness or RandomnessProvider()).rng(RNG_NAMESPACE)
+        super().__init__()
+        self.device_display_mode = DeviceDisplayMode.FULL
+        self._gamepads = DirectTetrisGamepads()
+        self._fonts: dict[int, pygame.font.Font] = {}
+        self._native_surface: pygame.Surface | None = None
+
+    def _create_initial_state(
+        self,
+        window: DisplayContext,
+        peripheral_manager: PeripheralManager,
+        orientation: Orientation,
+    ) -> ReactionTimeState:
+        del window, peripheral_manager, orientation
+        return new_reaction_round(
+            now=time.monotonic(),
+            player_count=PLAYER_COUNT,
+            round_number=1,
+        )
+
+    def real_process(
+        self,
+        window: DisplayContext,
+        orientation: Orientation,
+    ) -> None:
+        if window.screen is None:
+            raise RuntimeError("ReactionTimeRenderer requires an initialized display")
+
+        now = time.monotonic()
+        self._gamepads.refresh(player_count=PLAYER_COUNT)
+        snapshots = tuple(
+            self._gamepads.snapshot_for_slot(player_index)
+            for player_index in range(PLAYER_COUNT)
+        )
+        keyboard_pressed = self._keyboard_pressed()
+        state = self._advance_phase_before_inputs(now)
+        state = self._apply_inputs(state, now, snapshots, keyboard_pressed)
+        state = self._advance_phase_after_inputs(state, now)
+        self.set_state(state)
+
+        render_target = self._native_render_target(window)
+        self._draw(
+            render_target,
+            window.device.individual_display_size(),
+            orientation.layout.columns,
+            snapshots,
+            keyboard_pressed,
+            now,
+        )
+        if render_target is not window.screen:
+            pygame.transform.scale(render_target, window.screen.get_size(), window.screen)
+
+    def reset(self) -> None:
+        self.set_state(
+            new_reaction_round(
+                now=time.monotonic(),
+                player_count=PLAYER_COUNT,
+                round_number=self.state.round_number + 1 if self._state else 1,
+            )
+        )
+
+    def _advance_phase_before_inputs(self, now: float) -> ReactionTimeState:
+        state = self.state
+        elapsed = now - state.phase_started_at
+        if state.phase is ReactionPhase.IDENTIFY and elapsed >= IDENTIFY_DURATION_S:
+            return replace(
+                state,
+                phase=ReactionPhase.COUNTDOWN,
+                phase_started_at=now,
+            )
+        if state.phase is ReactionPhase.COUNTDOWN and elapsed >= COUNTDOWN_DURATION_S:
+            return replace(
+                state,
+                phase=ReactionPhase.WAIT,
+                phase_started_at=now,
+                go_at=now + self._rng.uniform(MIN_GO_DELAY_S, MAX_GO_DELAY_S),
+            )
+        if state.phase is ReactionPhase.WAIT and now >= state.go_at:
+            return replace(
+                state,
+                phase=ReactionPhase.GO,
+                phase_started_at=state.go_at,
+            )
+        if state.phase is ReactionPhase.RESULTS and elapsed >= RESULTS_DURATION_S:
+            return new_reaction_round(
+                now=now,
+                player_count=PLAYER_COUNT,
+                round_number=state.round_number + 1,
+            )
+        return state
+
+    def _apply_inputs(
+        self,
+        state: ReactionTimeState,
+        now: float,
+        snapshots: tuple[DirectGamepadSnapshot, ...],
+        keyboard_pressed: tuple[bool, ...],
+    ) -> ReactionTimeState:
+        if state.phase is ReactionPhase.IDENTIFY:
+            return state
+        players = list(state.players)
+        for player_index, player in enumerate(players):
+            if player.false_start or player.reaction_time_s is not None:
+                continue
+            pressed = self._reaction_pressed(snapshots[player_index]) or keyboard_pressed[
+                player_index
+            ]
+            if not pressed:
+                continue
+            if state.phase in (ReactionPhase.COUNTDOWN, ReactionPhase.WAIT):
+                players[player_index] = replace(player, false_start=True)
+            elif state.phase is ReactionPhase.GO:
+                players[player_index] = replace(
+                    player,
+                    reaction_time_s=max(0.0, now - state.go_at),
+                )
+        return replace(state, players=tuple(players))
+
+    def _advance_phase_after_inputs(
+        self,
+        state: ReactionTimeState,
+        now: float,
+    ) -> ReactionTimeState:
+        if state.phase is not ReactionPhase.GO:
+            return state
+        elapsed = now - state.go_at
+        active_players = [
+            player for player in state.players if not player.false_start
+        ]
+        all_active_players_answered = active_players and all(
+            player.reaction_time_s is not None for player in active_players
+        )
+        if elapsed >= MAX_REACTION_WINDOW_S or all_active_players_answered:
+            return replace(
+                state,
+                phase=ReactionPhase.RESULTS,
+                phase_started_at=now,
+            )
+        return state
+
+    def _native_render_target(self, window: DisplayContext) -> pygame.Surface:
+        if window.screen is None:
+            raise RuntimeError("ReactionTimeRenderer requires an initialized display")
+        native_size = window.device.full_display_size()
+        if window.screen.get_size() == native_size:
+            return window.screen
+        if self._native_surface is None or self._native_surface.get_size() != native_size:
+            self._native_surface = pygame.Surface(native_size, pygame.SRCALPHA)
+        return self._native_surface
+
+    def _draw(
+        self,
+        screen: pygame.Surface,
+        panel_size: tuple[int, int],
+        panel_columns: int,
+        snapshots: tuple[DirectGamepadSnapshot, ...],
+        keyboard_pressed: tuple[bool, ...],
+        now: float,
+    ) -> None:
+        screen.fill(BACKGROUND_COLOR)
+        panel_width, panel_height = panel_size
+        columns = max(1, panel_columns)
+        winner = reaction_winner(self.state.players)
+        for player_index, player in enumerate(self.state.players):
+            col = player_index % columns
+            row = player_index // columns
+            panel = pygame.Rect(
+                col * panel_width,
+                row * panel_height,
+                panel_width,
+                panel_height,
+            )
+            active_input = self._reaction_pressed(
+                snapshots[player_index]
+            ) or keyboard_pressed[player_index]
+            self._draw_panel(
+                screen,
+                panel,
+                player_index,
+                player,
+                active_input,
+                winner,
+                now,
+            )
+
+    def _draw_panel(
+        self,
+        screen: pygame.Surface,
+        panel: pygame.Rect,
+        player_index: int,
+        player: ReactionPlayerState,
+        active_input: bool,
+        winner: int | None,
+        now: float,
+    ) -> None:
+        accent = PLAYER_ACCENTS[player_index % len(PLAYER_ACCENTS)]
+        panel_color = PANEL_COLORS[player_index % len(PANEL_COLORS)]
+        pygame.draw.rect(screen, panel_color, panel)
+        pygame.draw.rect(screen, accent, panel, width=1)
+        self._draw_player_label(screen, panel, player_index, accent)
+        self._draw_input_dot(screen, panel, active_input, accent)
+
+        if player.false_start:
+            self._draw_center_text(screen, panel, "Chill", FALSE_START_COLOR, 17)
+            self._draw_bottom_text(screen, panel, "bro", FALSE_START_COLOR, 12)
+            return
+
+        match self.state.phase:
+            case ReactionPhase.IDENTIFY:
+                self._draw_center_text(screen, panel, "press", TEXT_COLOR, 13)
+                self._draw_bottom_text(screen, panel, "match", DIM_TEXT_COLOR, 9)
+            case ReactionPhase.COUNTDOWN:
+                self._draw_center_text(
+                    screen,
+                    panel,
+                    self._countdown_label(now),
+                    TEXT_COLOR,
+                    28,
+                )
+                self._draw_bottom_text(screen, panel, "wait", DIM_TEXT_COLOR, 9)
+            case ReactionPhase.WAIT:
+                self._draw_center_text(screen, panel, "...", DIM_TEXT_COLOR, 24)
+                self._draw_bottom_text(screen, panel, "wait", DIM_TEXT_COLOR, 9)
+            case ReactionPhase.GO:
+                if player.reaction_time_s is None:
+                    self._draw_center_text(screen, panel, "GO!", GO_COLOR, 23)
+                else:
+                    self._draw_reaction_time(screen, panel, player.reaction_time_s)
+            case ReactionPhase.RESULTS:
+                if player.reaction_time_s is None:
+                    self._draw_center_text(screen, panel, "MISS", DIM_TEXT_COLOR, 17)
+                else:
+                    self._draw_reaction_time(screen, panel, player.reaction_time_s)
+                if winner == player_index:
+                    self._draw_bottom_text(screen, panel, "WIN", GO_COLOR, 12)
+
+    def _draw_player_label(
+        self,
+        screen: pygame.Surface,
+        panel: pygame.Rect,
+        player_index: int,
+        color: pygame.Color,
+    ) -> None:
+        surface = self._font(10).render(f"P{player_index + 1}", False, color)
+        screen.blit(surface, (panel.left + 3, panel.top + 3))
+
+    def _draw_input_dot(
+        self,
+        screen: pygame.Surface,
+        panel: pygame.Rect,
+        active_input: bool,
+        color: pygame.Color,
+    ) -> None:
+        dot_color = color if active_input else pygame.Color(35, 45, 56)
+        radius = 4 if active_input else 2
+        pygame.draw.circle(screen, dot_color, (panel.right - 8, panel.top + 8), radius)
+
+    def _draw_reaction_time(
+        self,
+        screen: pygame.Surface,
+        panel: pygame.Rect,
+        reaction_time_s: float,
+    ) -> None:
+        text = f"{reaction_time_s * 1000:.0f}"
+        self._draw_center_text(screen, panel, text, TEXT_COLOR, 20)
+        self._draw_bottom_text(screen, panel, "ms", DIM_TEXT_COLOR, 9)
+
+    def _draw_center_text(
+        self,
+        screen: pygame.Surface,
+        panel: pygame.Rect,
+        text: str,
+        color: pygame.Color,
+        font_size: int,
+    ) -> None:
+        surface = self._fit_text(text, color, font_size, max_width=panel.width - 4)
+        rect = surface.get_rect(center=panel.center)
+        screen.blit(surface, rect)
+
+    def _draw_bottom_text(
+        self,
+        screen: pygame.Surface,
+        panel: pygame.Rect,
+        text: str,
+        color: pygame.Color,
+        font_size: int,
+    ) -> None:
+        surface = self._fit_text(text, color, font_size, max_width=panel.width - 4)
+        rect = surface.get_rect(midbottom=(panel.centerx, panel.bottom - 4))
+        screen.blit(surface, rect)
+
+    def _fit_text(
+        self,
+        text: str,
+        color: pygame.Color,
+        font_size: int,
+        *,
+        max_width: int,
+    ) -> pygame.Surface:
+        size = font_size
+        while size > 6:
+            surface = self._font(size).render(text, False, color)
+            if surface.get_width() <= max_width:
+                return surface
+            size -= 1
+        return self._font(6).render(text, False, color)
+
+    def _countdown_label(self, now: float) -> str:
+        elapsed = max(0.0, now - self.state.phase_started_at)
+        return str(max(1, 3 - int(elapsed)))
+
+    def _reaction_pressed(self, snapshot: DirectGamepadSnapshot) -> bool:
+        if any(snapshot.button_held(button) for button in REACTION_BUTTONS):
+            return True
+        return snapshot.dpad.x != 0 or snapshot.dpad.y != 0
+
+    def _keyboard_pressed(self) -> tuple[bool, ...]:
+        try:
+            pygame.event.pump()
+            keys = pygame.key.get_pressed()
+        except pygame.error:
+            return tuple(False for _ in range(PLAYER_COUNT))
+        return tuple(
+            any(keys[key] for key in player_keys)
+            for player_keys in KEYBOARD_KEYS_BY_PLAYER
+        )
+
+    def _font(self, size: int) -> pygame.font.Font:
+        if not pygame.font.get_init():
+            pygame.font.init()
+        font = self._fonts.get(size)
+        if font is None:
+            try:
+                font = pygame.font.Font(Loader.resolve_path(PIXEL_FONT_PATH), size)
+            except (FileNotFoundError, pygame.error):
+                font = pygame.font.Font(None, size)
+            self._fonts[size] = font
+        return font

--- a/src/heart/renderers/reaction_time/state.py
+++ b/src/heart/renderers/reaction_time/state.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class ReactionPhase(StrEnum):
+    IDENTIFY = "identify"
+    COUNTDOWN = "countdown"
+    WAIT = "wait"
+    GO = "go"
+    RESULTS = "results"
+
+
+@dataclass(frozen=True, slots=True)
+class ReactionPlayerState:
+    reaction_time_s: float | None = None
+    false_start: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ReactionTimeState:
+    phase: ReactionPhase
+    phase_started_at: float
+    go_at: float
+    players: tuple[ReactionPlayerState, ...]
+    round_number: int = 1
+
+
+def new_reaction_round(
+    *,
+    now: float,
+    player_count: int,
+    round_number: int,
+) -> ReactionTimeState:
+    return ReactionTimeState(
+        phase=ReactionPhase.IDENTIFY,
+        phase_started_at=now,
+        go_at=0.0,
+        players=tuple(ReactionPlayerState() for _ in range(player_count)),
+        round_number=round_number,
+    )
+
+
+def reaction_winner(players: tuple[ReactionPlayerState, ...]) -> int | None:
+    best_index: int | None = None
+    best_time: float | None = None
+    for index, player in enumerate(players):
+        if player.false_start or player.reaction_time_s is None:
+            continue
+        if best_time is None or player.reaction_time_s < best_time:
+            best_time = player.reaction_time_s
+            best_index = index
+    return best_index

--- a/src/heart/renderers/tetris/direct_gamepad.py
+++ b/src/heart/renderers/tetris/direct_gamepad.py
@@ -15,18 +15,16 @@ from heart.peripheral.gamepad.peripheral_mappings import (BitDoLite2,
                                                           DpadType,
                                                           SwitchLikeMapping,
                                                           SwitchProMapping)
+from heart.peripheral.gamepad.screen_mapping import (
+    bluetooth_mac_for_screen_slot,
+    normalize_bluetooth_mac,
+)
 from heart.utilities.env import Configuration
 from heart.utilities.logging import get_logger
 
 logger = get_logger(__name__)
 LINUX_JOYSTICK_SYSFS = Path("/sys/class/input")
 STICK_LOG_THRESHOLD = 0.35
-TETRIS_SLOT_BLUETOOTH_MACS: tuple[str | None, ...] = (
-    "E4:17:D8:E9:76:C8",  # 8BitDo Lite 2
-    "E4:17:D8:43:5C:48",  # 8BitDo Lite 2
-    "E4:17:D8:58:22:8A",  # 8BitDo Lite 2
-    "E4:17:D8:91:15:35",  # 8BitDo Lite 2
-)
 
 
 @dataclass(frozen=True, slots=True)
@@ -218,13 +216,11 @@ def _mapped_joystick_index(slot: int) -> int | None:
 
 
 def _target_bluetooth_mac(slot: int) -> str | None:
-    if slot >= len(TETRIS_SLOT_BLUETOOTH_MACS):
-        return None
-    return TETRIS_SLOT_BLUETOOTH_MACS[slot]
+    return bluetooth_mac_for_screen_slot(slot)
 
 
 def _normalize_bluetooth_mac(mac_address: str) -> str:
-    return mac_address.replace(":", "").lower()
+    return normalize_bluetooth_mac(mac_address)
 
 
 def _mapping_for_joystick(joystick: pygame.joystick.JoystickType) -> SwitchLikeMapping:


### PR DESCRIPTION
## Summary
- add a four-player reaction time game with identify, countdown, randomized wait, GO, false-start, and results phases
- show live controller-to-screen feedback and reaction times per panel
- share the screen-slot controller MAC mapping across Tetris, Pong, and the reaction game
- add a standalone `reaction_time` configuration that starts directly in the game

## Verification
- `uv run ruff check src/heart/renderers/reaction_time/renderer.py`
- `uv run ruff check src/heart/programs/configurations/reaction_time.py src/heart/renderers/reaction_time`
- `uv run ruff check src/heart/programs/configurations/reaction_time.py src/heart/renderers/reaction_time src/heart/peripheral/gamepad/screen_mapping.py src/heart/renderers/tetris/direct_gamepad.py src/heart/renderers/cube_pong/renderer.py src/heart/programs/configurations/lib_2026.py`
- `uv run python -m compileall -q src/heart/renderers/reaction_time src/heart/peripheral/gamepad/screen_mapping.py`
- launched `uv run totem run --configuration reaction_time --no-add-low-power-mode` locally and verified it started

No tests added per request.