### PR TITLE
Move Bluetooth pairing before sleep mode

### DIFF
--- a/src/heart/programs/configurations/lib_2026.py
+++ b/src/heart/programs/configurations/lib_2026.py
@@ -91,8 +91,6 @@ def friend_beacon_text(text: str) -> TextRendering:
 
 def configure(loop: GameLoop) -> None:
     randomness = RandomnessProvider()
-    controller_pairing_mode = loop.add_mode("pair bt")
-    controller_pairing_mode.add_renderer(ControllerPairingRenderer())
 
     add_cube_pong_mode(loop)
 
@@ -289,3 +287,6 @@ def configure(loop: GameLoop) -> None:
             randomness=randomness,
         )
     )
+
+    controller_pairing_mode = loop.add_mode("pair bt")
+    controller_pairing_mode.add_renderer(ControllerPairingRenderer())

--- a/tests/programs/test_lib_2026_configuration.py
+++ b/tests/programs/test_lib_2026_configuration.py
@@ -2,6 +2,7 @@
 
 from heart.display.color import Color
 from heart.programs.configurations.lib_2026 import configure
+from heart.renderers.controller_pairing import ControllerPairingRenderer
 from heart.renderers.mandelbrot.scene import MandelbrotMode
 from heart.renderers.mandelbulb import MandelbulbScene
 from heart.renderers.text import TextRendering
@@ -67,3 +68,19 @@ def test_mandelbulb_mode_follows_mandelbrot(loop) -> None:
     )
     assert isinstance(mandelbulb_entry.title_renderer, TextRendering)
     assert mandelbulb_entry.title_renderer._provider._text == ("mandel\nbulb",)
+
+
+def test_pair_bluetooth_mode_precedes_sleep(loop) -> None:
+    configure(loop)
+    loop.add_sleep_mode()
+
+    entries = loop.components.game_modes.state.entries
+    pair_entry = entries[-2]
+    sleep_entry = entries[-1]
+
+    assert any(
+        isinstance(renderer, ControllerPairingRenderer)
+        for renderer in pair_entry.renderer.renderers
+    )
+    assert isinstance(sleep_entry.title_renderer.renderers[-1], TextRendering)
+    assert sleep_entry.title_renderer.renderers[-1]._provider._text == ("sleep",)


### PR DESCRIPTION
## Summary
- move the 2026 library pair bt mode to the end of the configuration so it appears immediately before the CLI-appended sleep mode
- add a regression test that appends sleep and verifies the previous mode uses ControllerPairingRenderer

## Tests
- uv run pytest tests/programs/test_lib_2026_configuration.py -q
- uv run ruff check src/heart/programs/configurations/lib_2026.py tests/programs/test_lib_2026_configuration.py