### PR TITLE
Add Raft-backed world coordination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,21 @@
 - Run expensive frame-tick-driven renderer state work through priority-aware background stream scheduling instead of inline on the main loop.
 
 ## Validation Log
+- 2026-07-25: Heart world coordination now projects only device records and
+  active mode/configuration ownership from ManyFold's persistent Raft log,
+  serves revisioned reads over typed coordinator RPC, and delivers committed
+  mode commands through restart-safe durable delivery keyed by the Raft
+  command ID. Added a machine-readable three-process proof that kills the
+  leader, verifies re-election and log recovery, retries a command without
+  duplicate application, restarts a delivery receiver before ACK, and confirms
+  navigation, sensors, microphone, frames, and debug data remain excluded.
+  Rebased onto mesh consumer PR949 at
+  `0926ac90923fb21e88ba63fbb74606c755c420b5`, based on the signer PR948 merge
+  `09ef33b3386e37018cfdba3484ac1f428c8ad034`, which pins ManyFold
+  `726f64d72b36d8bd134bda63e29ebd80472736b6`. Built and installed that exact
+  ManyFold wheel, ran the executable proof with wheel provenance in its
+  artifact, and ran full Ruff, focused Mypy, and the full Heart suite, which
+  passed 606 tests with 4 environment-dependent skips.
 - 2026-06-21: Heart-shaped Manyfold nowait publishing now covers
   process-local `Schema.any` routes. `GraphRouteStream.emit` still calls
   `publish_nowait`, and the focused test now patches `Graph.publish` to fail so

--- a/docs/world_coordination.md
+++ b/docs/world_coordination.md
@@ -1,0 +1,124 @@
+# World coordination
+
+Heart uses ManyFold's next coordinator contracts for a deliberately small
+control plane. Raft stores only durable, low-rate facts that must survive a
+device or leader restart:
+
+- device identity, physical position, dimensions, and capabilities;
+- the selected active mode, immutable configuration ID, and owning device.
+
+World reads use `RpcEndpoint` directly through the typed `WorldRpcClient` and
+`WorldRpcServer` domain codecs. Mode activation uses `DurableDelivery` after
+the corresponding Raft command commits. These transports use separate
+`TcpTransport` links because each ManyFold endpoint owns its receive stream.
+
+## Data boundary
+
+| Data | Path | Durable / Raft |
+| --- | --- | --- |
+| Device identity, position, dimensions, capabilities | Raft command and world RPC read | Yes |
+| Active mode, configuration ID, owner | Raft command; durable delivery to the owner | Yes |
+| Navigation events | Existing data plane | No |
+| Sensor and microphone samples | Existing data plane | No |
+| Frame ticks and rendered frames | Existing data plane | No |
+| Debug and tracing data | Existing observability paths | No |
+
+The code enforces this boundary with exactly two accepted command kinds:
+`heart.world.device.put` and `heart.world.mode.select`. The delivery consumer
+accepts only committed mode commands on `heart.world.mode.command`. It rejects
+other channels and command kinds without ACKing them.
+
+## Failure semantics
+
+- **Idempotency:** the caller supplies a stable Raft `command_id`. ManyFold
+  returns the original committed sequence for an identical retry and rejects
+  conflicting content. The same ID becomes the durable delivery `message_id`
+  and RPC correlation ID for the mode command.
+- **Exactly-once application:** `WorldState` records applied command IDs and
+  treats the state changes as idempotent assignments. A delivery is ACKed only
+  after projection. After restart, rebuild `WorldState` from the local Raft log
+  before resuming the durable inbox; a redelivery then produces no second
+  command transition and is ACKed.
+- **Deadlines:** every Heart RPC read requires an explicit positive deadline.
+  The ManyFold endpoint propagates the remaining deadline to the handler and
+  raises `RpcTimeout` locally when it expires. Raft write callers similarly
+  provide an operation timeout.
+- **Cancellation:** ManyFold sends typed cancellation on caller cancellation,
+  deadline expiry, disconnect, or endpoint disposal. Heart handlers check the
+  supplied `RpcCancellation` before and after reading the projection.
+- **Leader failure:** writes discover and retry the new Raft leader using the
+  same command ID. An unknown timeout outcome is therefore safe to retry.
+- **Reconnect:** RPC does not replay an ambiguous request across sessions; old
+  calls fail with `RpcDisconnected`, and callers issue a new request after the
+  endpoint handshake. Durable delivery does replay its journaled mode command
+  until an ACK arrives.
+- **Stale responses:** every world read includes the locally applied Raft
+  revision. `WorldRpcClient` remembers the highest observed revision and raises
+  `StaleWorldResponseError` instead of accepting an older follower response.
+
+Production links must use ManyFold mutual TLS. The proof uses the explicit
+loopback-only insecure development mode. Retention limits, message TTL, dedupe
+retention, queue sizes, and storage bounds are required `DeliveryConfig` and
+`TransportConfig` choices; size them from the longest supported device outage.
+
+## Reproducible proof
+
+Run the real three-process story and write a machine-readable artifact:
+
+```shell
+uv run python scripts/verify_manyfold_world_coordination.py \
+  --output .artifacts/heart-manyfold-coordination.json
+```
+
+The script:
+
+1. creates a configurable three-member ManyFold Raft cluster;
+1. commits and reads a Heart device record;
+1. kills the current leader and waits for a different leader;
+1. commits the active-mode command, retries its command ID, and verifies the
+   retry retains one sequence;
+1. restarts the failed member and verifies all three logs and Heart projections
+   converge;
+1. reads the recovered device projection over real ManyFold typed RPC;
+1. journals the committed mode command, restarts the receiver before ACK,
+   reconnects, applies it once, ACKs it, and verifies the sender outbox drains.
+
+The artifact contains process and leader identities, per-node command IDs and
+revisions, RPC read results, durable-delivery ACK/application counters, and the
+explicit hot-path exclusion list. It also records the installed ManyFold
+distribution version, installation kind, installation root, and PEP 610 direct
+URL metadata under `manyfold_installation`.
+
+To qualify an installed candidate wheel without letting `uv run` restore the
+Git-pinned dependency:
+
+```shell
+uv sync --locked
+uv pip install --python .venv/bin/python --reinstall \
+  /absolute/path/to/manyfold-0.1.42-cp310-abi3-platform.whl
+.venv/bin/python scripts/verify_manyfold_world_coordination.py \
+  --output .artifacts/heart-manyfold-wheel-coordination.json
+```
+
+The wheel artifact must report
+`manyfold_installation.install_kind == "wheel"` and the candidate version and
+wheel URL in `distribution_version` and `direct_url`. Its coordination fields
+must report `raft.node_count == 3`, `raft.leader_changed == true`,
+`raft.mode_sequence == raft.duplicate_mode_sequence == 2`, every
+`raft.node_revisions` value as `2`, `world_rpc.device_id == "totem3"`,
+`durable_delivery.receiver_restarted == true`,
+`durable_delivery.applied_count == 1`,
+`durable_delivery.receiver_acknowledgements == 1`, and
+`durable_delivery.sender_outbox_items == 0`.
+
+The CI entrypoint is:
+
+```shell
+uv run pytest tests/test_world.py tests/test_world_coordination.py -q
+```
+
+Mesh consumer PR949 (`0926ac90923fb21e88ba63fbb74606c755c420b5`) is based on
+the signer PR948 merge (`09ef33b3386e37018cfdba3484ac1f428c8ad034`) and pins
+public ManyFold commit `726f64d72b36d8bd134bda63e29ebd80472736b6`.
+Replace that Git pin with its qualified released version after the stack lands;
+do not add a Graph compatibility path.

--- a/scripts/verify_manyfold_world_coordination.py
+++ b/scripts/verify_manyfold_world_coordination.py
@@ -1,0 +1,413 @@
+"""Prove Heart world coordination across Raft, RPC, and durable delivery."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from importlib.metadata import distribution
+from pathlib import Path
+from typing import final
+
+from manyfold.architecture.transport import (
+    NodeIdentity,
+    ReconnectPolicy,
+    TcpTransport,
+    TransportConfig,
+    TransportSecurity,
+)
+from manyfold.architecture.transport_delivery import (
+    DeliveryConfig,
+    DurableDelivery,
+)
+from manyfold.architecture.transport_rpc import RpcEndpoint
+from manyfold.cluster import CommittedCommand, ControlCommand, DevelopmentCluster
+
+from heart.world import (
+    COORDINATED_COMMAND_KINDS,
+    EXCLUDED_DURABLE_DATA_KINDS,
+    MODE_DELIVERY_CHANNEL,
+    ActiveMode,
+    WorldDevice,
+    WorldDeviceRead,
+    WorldDimensions,
+    WorldPosition,
+    WorldRpcClient,
+    WorldRpcServer,
+    WorldState,
+    apply_delivered_mode,
+    mode_delivery_message,
+    put_device_command,
+    select_mode_command,
+)
+
+_ARTIFACT_SCHEMA_VERSION = 1
+
+
+def run_proof(root: Path) -> dict[str, object]:
+    """Run the complete local fault story and return its JSON artifact."""
+    root.mkdir(parents=True, exist_ok=True)
+    cluster = DevelopmentCluster.create(root / "raft", node_count=3)
+    device = _device()
+    active_mode = _active_mode()
+    device_command = put_device_command("heart-device-totem3-v1", device)
+    mode_command = select_mode_command("heart-mode-mandelbulb-v1", active_mode)
+
+    with cluster:
+        node_ids = tuple(member.node_id for member in cluster.members)
+        initial_process_ids = {
+            node_id: cluster.process_id(node_id) for node_id in node_ids
+        }
+        initial_leader = cluster.wait_for_leader()
+        device_commit = _commit(cluster, device_command)
+        for node_id in node_ids:
+            cluster.wait_for_log_length(node_id, 1)
+
+        failed_process_id = cluster.process_id(initial_leader)
+        cluster.kill_node(initial_leader)
+        recovered_leader = cluster.wait_for_leader(
+            excluded_node_ids=frozenset({initial_leader})
+        )
+        mode_commit = _commit(cluster, mode_command)
+        duplicate_mode_commit = _commit(cluster, mode_command)
+
+        restarted_process_id = cluster.start_node(initial_leader)
+        node_logs = {
+            node_id: cluster.wait_for_log_length(node_id, 2) for node_id in node_ids
+        }
+
+        projections = {
+            node_id: _project(commands) for node_id, commands in node_logs.items()
+        }
+        rpc_device_read = _read_device_over_rpc(
+            projections[recovered_leader],
+            device.id,
+        )
+        durable_result = _prove_durable_mode_restart(
+            root / "delivery",
+            device_command,
+            mode_command,
+        )
+
+        return {
+            "schema_version": _ARTIFACT_SCHEMA_VERSION,
+            "manyfold_installation": _manyfold_installation(),
+            "raft": {
+                "node_count": len(node_ids),
+                "initial_process_ids": initial_process_ids,
+                "initial_leader": initial_leader,
+                "failed_process_id": failed_process_id,
+                "recovered_leader": recovered_leader,
+                "restarted_process_id": restarted_process_id,
+                "leader_changed": recovered_leader != initial_leader,
+                "restarted_process_changed": (
+                    restarted_process_id != failed_process_id
+                ),
+                "device_sequence": device_commit["sequence"],
+                "mode_sequence": mode_commit["sequence"],
+                "duplicate_mode_sequence": duplicate_mode_commit["sequence"],
+                "node_command_ids": {
+                    node_id: [command["command_id"] for command in commands]
+                    for node_id, commands in node_logs.items()
+                },
+                "node_revisions": {
+                    node_id: projection.revision
+                    for node_id, projection in projections.items()
+                },
+            },
+            "world_rpc": {
+                "revision": rpc_device_read.revision,
+                "device_id": rpc_device_read.device.id
+                if rpc_device_read.device is not None
+                else None,
+                "capabilities": list(rpc_device_read.device.capabilities)
+                if rpc_device_read.device is not None
+                else [],
+            },
+            "durable_delivery": durable_result,
+            "boundary": {
+                "raft_command_kinds": sorted(COORDINATED_COMMAND_KINDS),
+                "durable_channel": MODE_DELIVERY_CHANNEL,
+                "excluded_hot_path_data": sorted(EXCLUDED_DURABLE_DATA_KINDS),
+            },
+        }
+
+
+@final
+class _RpcProof:
+    def __init__(self, state: WorldState) -> None:
+        server_transport, client_transport = _transport_pair(
+            server_node_id="world-server",
+            client_node_id="world-client",
+        )
+        self._transports = (server_transport, client_transport)
+        self._server_endpoint = RpcEndpoint(server_transport)
+        self._client_endpoint = RpcEndpoint(client_transport)
+        if not self._server_endpoint.wait_until_ready(timeout=2.0):
+            raise TimeoutError("world RPC server handshake did not complete")
+        if not self._client_endpoint.wait_until_ready(timeout=2.0):
+            raise TimeoutError("world RPC client handshake did not complete")
+        self._server = WorldRpcServer(self._server_endpoint, state)
+        self.client = WorldRpcClient(self._client_endpoint)
+
+    def close(self) -> None:
+        self._server.dispose()
+        self._client_endpoint.close()
+        self._server_endpoint.close()
+        for transport in reversed(self._transports):
+            transport.close()
+
+
+def _commit(
+    cluster: DevelopmentCluster,
+    command: ControlCommand,
+) -> dict[str, object]:
+    return cluster.commit(
+        command.kind,
+        command.payload,
+        command_id=command.command_id,
+        timeout_seconds=10.0,
+    )
+
+
+def _project(commands: tuple[dict[str, object], ...]) -> WorldState:
+    state = WorldState()
+    state.apply_log(_committed(command) for command in commands)
+    return state
+
+
+def _committed(value: dict[str, object]) -> CommittedCommand:
+    sequence = value.get("sequence")
+    command_id = value.get("command_id")
+    kind = value.get("kind")
+    payload = value.get("payload")
+    if (
+        isinstance(sequence, bool)
+        or not isinstance(sequence, int)
+        or not isinstance(command_id, str)
+        or not isinstance(kind, str)
+        or not isinstance(payload, dict)
+    ):
+        raise ValueError(f"invalid ManyFold committed command {value!r}")
+    return CommittedCommand(sequence, command_id, kind, payload)
+
+
+def _read_device_over_rpc(
+    state: WorldState,
+    device_id: str,
+) -> WorldDeviceRead:
+    proof = _RpcProof(state)
+    try:
+        return proof.client.get_device(device_id, timeout_seconds=2.0)
+    finally:
+        proof.close()
+
+
+def _prove_durable_mode_restart(
+    root: Path,
+    device_command: ControlCommand,
+    mode_command: ControlCommand,
+) -> dict[str, object]:
+    root.mkdir(parents=True, exist_ok=True)
+    state = WorldState()
+    state.apply(_as_committed(1, device_command))
+    committed_mode = _as_committed(2, mode_command)
+    sender_transport, receiver_transport = _transport_pair()
+    sender = DurableDelivery(
+        sender_transport,
+        _delivery_config(root / "sender.sqlite3"),
+    )
+    receiver = DurableDelivery(
+        receiver_transport,
+        _delivery_config(root / "receiver.sqlite3"),
+    )
+    sender.send(
+        mode_delivery_message(committed_mode),
+        message_id=committed_mode.command_id,
+    )
+    received_before_restart = receiver.receive(timeout=2.0)
+    receiver.close()
+    receiver_transport.close()
+
+    restarted_transport = TcpTransport.listen(
+        NodeIdentity("heart", "receiver", "receiver-2"),
+        receiver_transport.address,
+        config=_transport_config(),
+        expected_peer_node_id="sender",
+    )
+    restarted = DurableDelivery(
+        restarted_transport,
+        _delivery_config(root / "receiver.sqlite3"),
+    )
+    try:
+        if not restarted_transport.wait_until_connected(timeout=2.0):
+            raise TimeoutError("durable receiver did not reconnect")
+        applied_count = int(
+            apply_delivered_mode(
+                state,
+                restarted,
+                timeout_seconds=2.0,
+            )
+        )
+        if not sender.flush(timeout=2.0):
+            raise TimeoutError("durable sender did not observe the mode ACK")
+        try:
+            restarted.receive(timeout=0.1)
+        except TimeoutError:
+            duplicate_exposed = False
+        else:
+            duplicate_exposed = True
+        return {
+            "message_id": committed_mode.command_id,
+            "received_before_restart": received_before_restart.message_id,
+            "receiver_restarted": True,
+            "applied_count": applied_count,
+            "duplicate_exposed_after_ack": duplicate_exposed,
+            "sender_outbox_items": sender.health().outbox_items,
+            "receiver_acknowledgements": (restarted.health().acknowledgements),
+            "revision": state.revision,
+        }
+    finally:
+        restarted.close()
+        restarted_transport.close()
+        sender.close()
+        sender_transport.close()
+
+
+def _transport_pair(
+    *,
+    server_node_id: str = "receiver",
+    client_node_id: str = "sender",
+) -> tuple[TcpTransport, TcpTransport]:
+    server = TcpTransport.listen(
+        NodeIdentity("heart", server_node_id, f"{server_node_id}-1"),
+        config=_transport_config(),
+        expected_peer_node_id=client_node_id,
+    )
+    client = TcpTransport.connect(
+        NodeIdentity("heart", client_node_id, f"{client_node_id}-1"),
+        server.address,
+        config=_transport_config(),
+        expected_peer_node_id=server_node_id,
+    )
+    if not server.wait_until_connected(timeout=2.0):
+        raise TimeoutError(f"{server_node_id} transport did not connect")
+    if not client.wait_until_connected(timeout=2.0):
+        raise TimeoutError(f"{client_node_id} transport did not connect")
+    return client, server
+
+
+def _transport_config() -> TransportConfig:
+    return TransportConfig(
+        security=TransportSecurity.insecure_local_development(),
+        outbound_queue_limit=16,
+        inbound_queue_limit=16,
+        max_payload_bytes=65536,
+        connect_timeout=0.1,
+        handshake_timeout=0.5,
+        heartbeat_interval=0.05,
+        peer_timeout=0.5,
+        reconnect=ReconnectPolicy(0.02, 1.5, 0.1),
+    )
+
+
+def _delivery_config(path: Path) -> DeliveryConfig:
+    return DeliveryConfig(
+        path,
+        max_outbox_items=16,
+        max_inbox_items=16,
+        max_storage_bytes=1024 * 1024,
+        receive_queue_limit=4,
+        max_message_bytes=4096,
+        message_ttl_seconds=5.0,
+        dedupe_retention_seconds=5.0,
+        retry_initial_seconds=0.05,
+        retry_multiplier=1.5,
+        retry_max_seconds=0.1,
+    )
+
+
+def _as_committed(
+    sequence: int,
+    command: ControlCommand,
+) -> CommittedCommand:
+    return CommittedCommand(
+        sequence=sequence,
+        command_id=command.command_id,
+        kind=command.kind,
+        payload=command.payload,
+    )
+
+
+def _device() -> WorldDevice:
+    return WorldDevice(
+        id="totem3",
+        position=WorldPosition(0.0, 0.0, 0.0),
+        dimensions=WorldDimensions(0.5, 2.0, 0.5),
+        capabilities=("hub75", "gamepad"),
+    )
+
+
+def _active_mode() -> ActiveMode:
+    return ActiveMode(
+        mode_id="mandelbulb",
+        configuration_id="lib-2026",
+        owner_device_id="totem3",
+    )
+
+
+def _manyfold_installation() -> dict[str, object]:
+    installed_distribution = distribution("manyfold")
+    direct_url_text = installed_distribution.read_text("direct_url.json")
+    direct_url_value = (
+        json.loads(direct_url_text) if direct_url_text is not None else None
+    )
+    if direct_url_value is not None and not isinstance(direct_url_value, dict):
+        raise ValueError("manyfold direct_url.json must contain a JSON object")
+    direct_url = direct_url_value or {}
+    url = direct_url.get("url")
+    if "vcs_info" in direct_url:
+        install_kind = "vcs"
+    elif isinstance(url, str) and url.endswith(".whl"):
+        install_kind = "wheel"
+    else:
+        install_kind = "index"
+    return {
+        "distribution_version": installed_distribution.version,
+        "install_kind": install_kind,
+        "installation_root": str(
+            Path(str(installed_distribution.locate_file(""))).resolve()
+        ),
+        "direct_url": direct_url_value,
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Path for the machine-readable JSON proof artifact.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    with tempfile.TemporaryDirectory(
+        prefix="heart-manyfold-coordination-"
+    ) as directory:
+        artifact = run_proof(Path(directory))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = args.output.with_name(f".{args.output.name}.tmp")
+    temporary.write_text(
+        f"{json.dumps(artifact, indent=2, sort_keys=True)}\n",
+        encoding="utf-8",
+    )
+    temporary.replace(args.output)
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/heart/world.py
+++ b/src/heart/world.py
@@ -1,0 +1,610 @@
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from threading import Lock
+from typing import cast, final
+
+from manyfold.architecture.transport import FrameKind, TransportMessage
+from manyfold.architecture.transport_delivery import (DurableDelivery,
+                                                      ReceivedDelivery)
+from manyfold.architecture.transport_rpc import (RpcCancellation, RpcEndpoint,
+                                                 RpcRequest)
+from manyfold.cluster import CommittedCommand, ControlCommand
+
+WORLD_RPC_SERVICE = "heart.world"
+GET_DEVICE_RPC_METHOD = "get_device"
+GET_ACTIVE_MODE_RPC_METHOD = "get_active_mode"
+PUT_DEVICE_COMMAND_KIND = "heart.world.device.put"
+SELECT_MODE_COMMAND_KIND = "heart.world.mode.select"
+MODE_DELIVERY_CHANNEL = "heart.world.mode.command"
+COORDINATED_COMMAND_KINDS = frozenset(
+    {
+        PUT_DEVICE_COMMAND_KIND,
+        SELECT_MODE_COMMAND_KIND,
+    }
+)
+EXCLUDED_DURABLE_DATA_KINDS = frozenset(
+    {
+        "debug",
+        "frame_tick",
+        "microphone_sample",
+        "navigation_event",
+        "rendered_frame",
+        "sensor_sample",
+    }
+)
+_WIRE_VERSION = 1
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class WorldPosition:
+    """A position in meters within the shared world coordinate system."""
+
+    x_m: float
+    y_m: float
+    z_m: float
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class WorldDimensions:
+    """The physical size of a device in meters."""
+
+    width_m: float
+    height_m: float
+    depth_m: float
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class WorldDevice:
+    """Durable, low-rate identity and placement for one Heart device."""
+
+    id: str
+    position: WorldPosition
+    dimensions: WorldDimensions
+    capabilities: tuple[str, ...] = ()
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class ActiveMode:
+    """The coordinated owner and immutable configuration selected for a mode."""
+
+    mode_id: str
+    configuration_id: str
+    owner_device_id: str
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class WorldDeviceRead:
+    """One RPC device read with the applied Raft sequence used to answer it."""
+
+    revision: int
+    device: WorldDevice | None
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class ActiveModeRead:
+    """One RPC mode read with the applied Raft sequence used to answer it."""
+
+    revision: int
+    active_mode: ActiveMode | None
+
+
+@final
+class StaleWorldResponseError(RuntimeError):
+    """Raised when a server answers from an older applied Raft revision."""
+
+
+def put_device_command(command_id: str, device: WorldDevice) -> ControlCommand:
+    """Build the sole Raft command that changes durable device state."""
+    _validate_device(device)
+    return ControlCommand(
+        command_id=command_id,
+        kind=PUT_DEVICE_COMMAND_KIND,
+        payload=_device_to_json(device),
+    )
+
+
+def select_mode_command(
+    command_id: str,
+    active_mode: ActiveMode,
+) -> ControlCommand:
+    """Build the sole Raft command that changes active mode ownership."""
+    _validate_active_mode(active_mode)
+    return ControlCommand(
+        command_id=command_id,
+        kind=SELECT_MODE_COMMAND_KIND,
+        payload=_active_mode_to_json(active_mode),
+    )
+
+
+def mode_delivery_message(command: CommittedCommand) -> TransportMessage:
+    """Encode one committed mode command for ManyFold durable delivery."""
+    if command.kind != SELECT_MODE_COMMAND_KIND:
+        raise ValueError(
+            f"durable mode delivery requires kind {SELECT_MODE_COMMAND_KIND!r}, "
+            f"observed {command.kind!r}"
+        )
+    return TransportMessage(
+        FrameKind.PUBSUB,
+        MODE_DELIVERY_CHANNEL,
+        _json_bytes(command.to_dict()),
+        correlation_id=command.command_id,
+    )
+
+
+def apply_delivered_mode(
+    state: WorldState,
+    delivery: DurableDelivery,
+    *,
+    timeout_seconds: float,
+) -> bool:
+    """Apply and ACK one delivered mode command, returning whether it was new."""
+    received = delivery.receive(timeout=timeout_seconds)
+    command = _mode_command_from_delivery(received)
+    was_applied = state.apply(command)
+    delivery.ack(received.message_id)
+    return was_applied
+
+
+@final
+class WorldState:
+    """Thread-safe projection of Heart's bounded Raft control log."""
+
+    def __init__(self) -> None:
+        self._devices: dict[str, WorldDevice] = {}
+        self._active_mode: ActiveMode | None = None
+        self._applied_commands: dict[str, tuple[str, bytes]] = {}
+        self._revision = 0
+        self._lock = Lock()
+
+    @property
+    def revision(self) -> int:
+        with self._lock:
+            return self._revision
+
+    def device(self, device_id: str) -> WorldDeviceRead:
+        _validate_id(device_id, "World device id")
+        with self._lock:
+            return WorldDeviceRead(
+                revision=self._revision,
+                device=self._devices.get(device_id),
+            )
+
+    def active_mode(self) -> ActiveModeRead:
+        with self._lock:
+            return ActiveModeRead(
+                revision=self._revision,
+                active_mode=self._active_mode,
+            )
+
+    def apply(self, command: CommittedCommand) -> bool:
+        """Apply one committed command exactly once by stable command ID."""
+        if not isinstance(command, CommittedCommand):
+            raise TypeError("command must be a ManyFold CommittedCommand")
+        if command.kind not in COORDINATED_COMMAND_KINDS:
+            raise ValueError(
+                f"command kind {command.kind!r} is outside Heart's durable "
+                f"coordination boundary"
+            )
+        fingerprint = (command.kind, _json_bytes(command.payload))
+        with self._lock:
+            existing = self._applied_commands.get(command.command_id)
+            if existing is not None:
+                if existing != fingerprint:
+                    raise ValueError(
+                        f"command_id {command.command_id!r} names conflicting "
+                        "Heart coordination content"
+                    )
+                return False
+            expected_sequence = self._revision + 1
+            if command.sequence != expected_sequence:
+                raise ValueError(
+                    f"Heart coordination sequence expected {expected_sequence}, "
+                    f"observed {command.sequence}"
+                )
+            if command.kind == PUT_DEVICE_COMMAND_KIND:
+                device = _device_from_json(command.payload)
+                self._devices[device.id] = device
+            else:
+                active_mode = _active_mode_from_json(command.payload)
+                if active_mode.owner_device_id not in self._devices:
+                    raise ValueError(
+                        f"Mode owner device {active_mode.owner_device_id!r} is "
+                        "not registered in world state"
+                    )
+                self._active_mode = active_mode
+            self._applied_commands[command.command_id] = fingerprint
+            self._revision = command.sequence
+            return True
+
+    def apply_log(self, commands: Iterable[CommittedCommand]) -> int:
+        """Apply a local ManyFold committed-log page in sequence order."""
+        applied = 0
+        for command in commands:
+            if self.apply(command):
+                applied += 1
+        return applied
+
+
+@final
+class WorldRpcServer:
+    """Typed, read-only world service on a ManyFold coordinator RPC endpoint."""
+
+    def __init__(self, endpoint: RpcEndpoint, state: WorldState) -> None:
+        if not isinstance(endpoint, RpcEndpoint):
+            raise TypeError("endpoint must be a ManyFold RpcEndpoint")
+        if not isinstance(state, WorldState):
+            raise TypeError("state must be a WorldState")
+        self._endpoint = endpoint
+        self._state = state
+        endpoint.register(
+            WORLD_RPC_SERVICE,
+            GET_DEVICE_RPC_METHOD,
+            self._get_device,
+        )
+        endpoint.register(
+            WORLD_RPC_SERVICE,
+            GET_ACTIVE_MODE_RPC_METHOD,
+            self._get_active_mode,
+        )
+
+    def dispose(self) -> None:
+        self._endpoint.unregister(WORLD_RPC_SERVICE, GET_DEVICE_RPC_METHOD)
+        self._endpoint.unregister(WORLD_RPC_SERVICE, GET_ACTIVE_MODE_RPC_METHOD)
+
+    def _get_device(
+        self,
+        request: RpcRequest,
+        cancellation: RpcCancellation,
+    ) -> bytes:
+        cancellation.raise_if_cancelled()
+        payload = _json_object(request.payload, "world device RPC request")
+        _require_wire_version(payload)
+        device_id = _json_string(payload, "device_id")
+        result = self._state.device(device_id)
+        cancellation.raise_if_cancelled()
+        return _json_bytes(
+            {
+                "version": _WIRE_VERSION,
+                "revision": result.revision,
+                "device": (
+                    _device_to_json(result.device)
+                    if result.device is not None
+                    else None
+                ),
+            }
+        )
+
+    def _get_active_mode(
+        self,
+        request: RpcRequest,
+        cancellation: RpcCancellation,
+    ) -> bytes:
+        cancellation.raise_if_cancelled()
+        payload = _json_object(request.payload, "active mode RPC request")
+        _require_wire_version(payload)
+        result = self._state.active_mode()
+        cancellation.raise_if_cancelled()
+        return _json_bytes(
+            {
+                "version": _WIRE_VERSION,
+                "revision": result.revision,
+                "active_mode": (
+                    _active_mode_to_json(result.active_mode)
+                    if result.active_mode is not None
+                    else None
+                ),
+            }
+        )
+
+
+@final
+class WorldRpcClient:
+    """Typed world read client with revision-based stale response rejection."""
+
+    def __init__(
+        self,
+        endpoint: RpcEndpoint,
+        *,
+        minimum_revision: int = 0,
+    ) -> None:
+        if not isinstance(endpoint, RpcEndpoint):
+            raise TypeError("endpoint must be a ManyFold RpcEndpoint")
+        _require_non_negative_int(minimum_revision, "minimum_revision")
+        self._endpoint = endpoint
+        self._observed_revision = minimum_revision
+        self._lock = Lock()
+
+    @property
+    def observed_revision(self) -> int:
+        with self._lock:
+            return self._observed_revision
+
+    def get_device(
+        self,
+        device_id: str,
+        *,
+        timeout_seconds: float,
+    ) -> WorldDeviceRead:
+        _validate_id(device_id, "World device id")
+        response = self._endpoint.call(
+            WORLD_RPC_SERVICE,
+            GET_DEVICE_RPC_METHOD,
+            _json_bytes(
+                {
+                    "version": _WIRE_VERSION,
+                    "device_id": device_id,
+                }
+            ),
+            timeout_seconds=timeout_seconds,
+        )
+        payload = _json_object(response, "world device RPC response")
+        _require_wire_version(payload)
+        revision = _json_non_negative_int(payload, "revision")
+        self._accept_revision(revision)
+        device_value = payload.get("device")
+        device = (
+            None
+            if device_value is None
+            else _device_from_json(
+                _json_mapping(device_value, "world device RPC device")
+            )
+        )
+        return WorldDeviceRead(revision=revision, device=device)
+
+    def get_active_mode(self, *, timeout_seconds: float) -> ActiveModeRead:
+        response = self._endpoint.call(
+            WORLD_RPC_SERVICE,
+            GET_ACTIVE_MODE_RPC_METHOD,
+            _json_bytes({"version": _WIRE_VERSION}),
+            timeout_seconds=timeout_seconds,
+        )
+        payload = _json_object(response, "active mode RPC response")
+        _require_wire_version(payload)
+        revision = _json_non_negative_int(payload, "revision")
+        self._accept_revision(revision)
+        active_mode_value = payload.get("active_mode")
+        active_mode = (
+            None
+            if active_mode_value is None
+            else _active_mode_from_json(
+                _json_mapping(active_mode_value, "active mode RPC value")
+            )
+        )
+        return ActiveModeRead(revision=revision, active_mode=active_mode)
+
+    def _accept_revision(self, revision: int) -> None:
+        with self._lock:
+            if revision < self._observed_revision:
+                raise StaleWorldResponseError(
+                    f"world RPC response revision {revision} is older than "
+                    f"observed revision {self._observed_revision}"
+                )
+            self._observed_revision = revision
+
+
+def _mode_command_from_delivery(received: ReceivedDelivery) -> CommittedCommand:
+    message = received.message
+    if message.kind is not FrameKind.PUBSUB:
+        raise ValueError("durable mode command must use a PubSub transport frame")
+    if message.channel != MODE_DELIVERY_CHANNEL:
+        raise ValueError(
+            f"durable mode command expected channel {MODE_DELIVERY_CHANNEL!r}, "
+            f"observed {message.channel!r}"
+        )
+    payload = _json_object(message.payload, "durable mode command")
+    command = _committed_command_from_json(payload)
+    if command.kind != SELECT_MODE_COMMAND_KIND:
+        raise ValueError(
+            f"durable mode command expected kind {SELECT_MODE_COMMAND_KIND!r}, "
+            f"observed {command.kind!r}"
+        )
+    if received.message_id != command.command_id:
+        raise ValueError(
+            f"delivery message_id {received.message_id!r} does not match "
+            f"command_id {command.command_id!r}"
+        )
+    if message.correlation_id != command.command_id:
+        raise ValueError(
+            f"delivery correlation_id {message.correlation_id!r} does not match "
+            f"command_id {command.command_id!r}"
+        )
+    return command
+
+
+def _committed_command_from_json(value: Mapping[str, object]) -> CommittedCommand:
+    return CommittedCommand(
+        sequence=_json_non_negative_int(value, "sequence"),
+        command_id=_json_string(value, "command_id"),
+        kind=_json_string(value, "kind"),
+        payload=_json_mapping(value.get("payload"), "command payload"),
+    )
+
+
+def _device_to_json(device: WorldDevice) -> dict[str, object]:
+    return {
+        "id": device.id,
+        "position": {
+            "x_m": device.position.x_m,
+            "y_m": device.position.y_m,
+            "z_m": device.position.z_m,
+        },
+        "dimensions": {
+            "width_m": device.dimensions.width_m,
+            "height_m": device.dimensions.height_m,
+            "depth_m": device.dimensions.depth_m,
+        },
+        "capabilities": list(device.capabilities),
+    }
+
+
+def _device_from_json(value: Mapping[str, object]) -> WorldDevice:
+    position = _json_mapping(value.get("position"), "device position")
+    dimensions = _json_mapping(value.get("dimensions"), "device dimensions")
+    capabilities_value = value.get("capabilities", [])
+    if not isinstance(capabilities_value, list) or not all(
+        isinstance(capability, str) for capability in capabilities_value
+    ):
+        raise ValueError("device capabilities must be a list of strings")
+    device = WorldDevice(
+        id=_json_string(value, "id"),
+        position=WorldPosition(
+            x_m=_json_number(position, "x_m"),
+            y_m=_json_number(position, "y_m"),
+            z_m=_json_number(position, "z_m"),
+        ),
+        dimensions=WorldDimensions(
+            width_m=_json_number(dimensions, "width_m"),
+            height_m=_json_number(dimensions, "height_m"),
+            depth_m=_json_number(dimensions, "depth_m"),
+        ),
+        capabilities=tuple(capabilities_value),
+    )
+    _validate_device(device)
+    return device
+
+
+def _active_mode_to_json(active_mode: ActiveMode) -> dict[str, object]:
+    return {
+        "mode_id": active_mode.mode_id,
+        "configuration_id": active_mode.configuration_id,
+        "owner_device_id": active_mode.owner_device_id,
+    }
+
+
+def _active_mode_from_json(value: Mapping[str, object]) -> ActiveMode:
+    active_mode = ActiveMode(
+        mode_id=_json_string(value, "mode_id"),
+        configuration_id=_json_string(value, "configuration_id"),
+        owner_device_id=_json_string(value, "owner_device_id"),
+    )
+    _validate_active_mode(active_mode)
+    return active_mode
+
+
+def _validate_device(device: WorldDevice) -> None:
+    if not isinstance(device, WorldDevice):
+        raise TypeError("device must be a WorldDevice")
+    _validate_id(device.id, "World device id")
+    _require_finite(
+        device.position.x_m,
+        device.position.y_m,
+        device.position.z_m,
+        device.dimensions.width_m,
+        device.dimensions.height_m,
+        device.dimensions.depth_m,
+    )
+    if (
+        min(
+            device.dimensions.width_m,
+            device.dimensions.height_m,
+            device.dimensions.depth_m,
+        )
+        <= 0
+    ):
+        raise ValueError("World dimensions must be greater than zero")
+    if any(
+        not isinstance(capability, str) or not capability.strip()
+        for capability in device.capabilities
+    ):
+        raise ValueError("World device capabilities must be non-empty strings")
+    if len(set(device.capabilities)) != len(device.capabilities):
+        raise ValueError("World device capabilities must be unique")
+
+
+def _validate_active_mode(active_mode: ActiveMode) -> None:
+    if not isinstance(active_mode, ActiveMode):
+        raise TypeError("active_mode must be an ActiveMode")
+    _validate_id(active_mode.mode_id, "Mode id")
+    _validate_id(active_mode.configuration_id, "Mode configuration id")
+    _validate_id(active_mode.owner_device_id, "Mode owner device id")
+
+
+def _validate_id(value: str, name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must not be empty")
+
+
+def _require_finite(*values: float) -> None:
+    if not all(
+        isinstance(value, (float, int))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+        for value in values
+    ):
+        raise ValueError("World coordinates and dimensions must be finite")
+
+
+def _json_bytes(value: object) -> bytes:
+    try:
+        return json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as error:
+        raise ValueError(
+            f"Heart coordination value must be finite JSON: {error}"
+        ) from error
+
+
+def _json_object(payload: bytes, name: str) -> Mapping[str, object]:
+    try:
+        value = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"{name} must be UTF-8 JSON: {error}") from error
+    return _json_mapping(value, name)
+
+
+def _json_mapping(value: object, name: str) -> dict[str, object]:
+    if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
+        raise ValueError(f"{name} must be a JSON object")
+    return value
+
+
+def _json_string(value: Mapping[str, object], field: str) -> str:
+    field_value = value.get(field)
+    if not isinstance(field_value, str) or not field_value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return field_value
+
+
+def _json_number(value: Mapping[str, object], field: str) -> float:
+    field_value = value.get(field)
+    if (
+        isinstance(field_value, bool)
+        or not isinstance(field_value, (int, float))
+        or not math.isfinite(field_value)
+    ):
+        raise ValueError(f"{field} must be a finite number")
+    return float(field_value)
+
+
+def _json_non_negative_int(value: Mapping[str, object], field: str) -> int:
+    field_value = value.get(field)
+    _require_non_negative_int(field_value, field)
+    return cast(int, field_value)
+
+
+def _require_non_negative_int(value: object, name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+
+
+def _require_wire_version(value: Mapping[str, object]) -> None:
+    version = value.get("version")
+    if version != _WIRE_VERSION:
+        raise ValueError(
+            f"Heart world RPC version must be {_WIRE_VERSION}, observed {version!r}"
+        )

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from manyfold.architecture.transport import (FrameKind, NodeIdentity,
+                                             ReconnectPolicy, TcpTransport,
+                                             TransportConfig, TransportMessage,
+                                             TransportSecurity)
+from manyfold.architecture.transport_delivery import (DeliveryConfig,
+                                                      DurableDelivery)
+from manyfold.architecture.transport_rpc import RpcEndpoint
+from manyfold.cluster import CommittedCommand, ControlCommand
+
+from heart.world import (COORDINATED_COMMAND_KINDS,
+                         EXCLUDED_DURABLE_DATA_KINDS, ActiveMode,
+                         StaleWorldResponseError, WorldDevice, WorldDimensions,
+                         WorldPosition, WorldRpcClient, WorldRpcServer,
+                         WorldState, apply_delivered_mode,
+                         mode_delivery_message, put_device_command,
+                         select_mode_command)
+
+
+class TestWorldState:
+    def test_applies_device_and_mode_commands_once(self) -> None:
+        state = WorldState()
+        device_command = _committed(1, put_device_command("device-1", _device()))
+        mode_command = _committed(
+            2,
+            select_mode_command("mode-1", _active_mode()),
+        )
+
+        assert state.apply(device_command)
+        assert state.apply(mode_command)
+        assert not state.apply(mode_command)
+        assert state.device("totem3").device == _device()
+        assert state.active_mode().active_mode == _active_mode()
+        assert state.revision == 2
+
+    def test_rejects_hot_path_data_and_sequence_gaps(self) -> None:
+        state = WorldState()
+        hot_path_command = CommittedCommand(
+            sequence=1,
+            command_id="frame-1",
+            kind="frame_tick",
+            payload={"frame": 7},
+        )
+
+        with pytest.raises(ValueError, match="outside Heart's durable"):
+            state.apply(hot_path_command)
+        with pytest.raises(ValueError, match="expected 1, observed 2"):
+            state.apply(
+                _committed(
+                    2,
+                    select_mode_command("mode-1", _active_mode()),
+                )
+            )
+
+        assert COORDINATED_COMMAND_KINDS.isdisjoint(EXCLUDED_DURABLE_DATA_KINDS)
+
+    def test_rejects_mode_ownership_by_an_unknown_device(self) -> None:
+        state = WorldState()
+
+        with pytest.raises(ValueError, match="not registered"):
+            state.apply(
+                _committed(
+                    1,
+                    select_mode_command("mode-1", _active_mode()),
+                )
+            )
+
+    def test_validates_device_dimensions_and_capabilities(self) -> None:
+        invalid_dimensions = WorldDevice(
+            id="totem3",
+            position=WorldPosition(0.0, 0.0, 0.0),
+            dimensions=WorldDimensions(0.0, 2.0, 0.5),
+        )
+        duplicate_capabilities = WorldDevice(
+            id="totem3",
+            position=WorldPosition(0.0, 0.0, 0.0),
+            dimensions=WorldDimensions(0.5, 2.0, 0.5),
+            capabilities=("matrix", "matrix"),
+        )
+
+        with pytest.raises(ValueError, match="greater than zero"):
+            put_device_command("invalid-dimensions", invalid_dimensions)
+        with pytest.raises(ValueError, match="must be unique"):
+            put_device_command("invalid-capabilities", duplicate_capabilities)
+
+
+class TestWorldRpc:
+    def test_reads_projected_state_over_typed_rpc(self) -> None:
+        state = WorldState()
+        state.apply(_committed(1, put_device_command("device-1", _device())))
+        state.apply(
+            _committed(
+                2,
+                select_mode_command("mode-1", _active_mode()),
+            )
+        )
+
+        with _rpc_pair(state) as client:
+            assert (
+                client.get_device(
+                    "totem3",
+                    timeout_seconds=1.0,
+                ).device
+                == _device()
+            )
+            assert (
+                client.get_active_mode(
+                    timeout_seconds=1.0,
+                ).active_mode
+                == _active_mode()
+            )
+            assert client.observed_revision == 2
+
+    def test_rejects_a_response_older_than_the_observed_revision(self) -> None:
+        with _rpc_pair(WorldState(), minimum_revision=4) as client:
+            with pytest.raises(StaleWorldResponseError, match="older than"):
+                client.get_active_mode(timeout_seconds=1.0)
+
+
+class TestWorldDurableDelivery:
+    def test_restart_before_ack_delivers_and_applies_mode_once(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            state = WorldState()
+            state.apply(_committed(1, put_device_command("device-1", _device())))
+            committed_mode = _committed(
+                2,
+                select_mode_command("mode-1", _active_mode()),
+            )
+            sender_transport, receiver_transport = _transport_pair()
+            sender = DurableDelivery(
+                sender_transport,
+                _delivery_config(root / "sender.sqlite3"),
+            )
+            receiver = DurableDelivery(
+                receiver_transport,
+                _delivery_config(root / "receiver.sqlite3"),
+            )
+            sender.send(
+                mode_delivery_message(committed_mode),
+                message_id=committed_mode.command_id,
+            )
+
+            first = receiver.receive(timeout=2.0)
+            assert first.message_id == "mode-1"
+            receiver.close()
+            receiver_transport.close()
+
+            restarted_transport = TcpTransport.listen(
+                NodeIdentity("heart", "receiver", "receiver-2"),
+                receiver_transport.address,
+                config=_transport_config(),
+                expected_peer_node_id="sender",
+            )
+            restarted = DurableDelivery(
+                restarted_transport,
+                _delivery_config(root / "receiver.sqlite3"),
+            )
+            try:
+                assert restarted_transport.wait_until_connected(timeout=2.0)
+                assert apply_delivered_mode(
+                    state,
+                    restarted,
+                    timeout_seconds=2.0,
+                )
+                assert sender.flush(timeout=2.0)
+                with pytest.raises(TimeoutError):
+                    restarted.receive(timeout=0.1)
+                assert state.active_mode().active_mode == _active_mode()
+                assert state.revision == 2
+            finally:
+                restarted.close()
+                restarted_transport.close()
+                sender.close()
+                sender_transport.close()
+
+    def test_rejects_non_mode_delivery_without_acknowledging_it(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            sender_transport, receiver_transport = _transport_pair()
+            sender = DurableDelivery(
+                sender_transport,
+                _delivery_config(root / "sender.sqlite3"),
+            )
+            receiver = DurableDelivery(
+                receiver_transport,
+                _delivery_config(root / "receiver.sqlite3"),
+            )
+            sender.send(
+                TransportMessage(FrameKind.PUBSUB, "frame_tick", b"{}"),
+                message_id="frame-1",
+            )
+            try:
+                with pytest.raises(ValueError, match="expected channel"):
+                    apply_delivered_mode(
+                        WorldState(),
+                        receiver,
+                        timeout_seconds=2.0,
+                    )
+                assert sender.health().outbox_items == 1
+            finally:
+                receiver.close()
+                sender.close()
+                receiver_transport.close()
+                sender_transport.close()
+
+
+class _RpcPair:
+    def __init__(self, state: WorldState, minimum_revision: int) -> None:
+        server_transport, client_transport = _transport_pair(
+            server_node_id="server",
+            client_node_id="client",
+        )
+        self._transports = (server_transport, client_transport)
+        self._server_endpoint = RpcEndpoint(server_transport)
+        self._client_endpoint = RpcEndpoint(client_transport)
+        assert self._server_endpoint.wait_until_ready(timeout=2.0)
+        assert self._client_endpoint.wait_until_ready(timeout=2.0)
+        self._server = WorldRpcServer(self._server_endpoint, state)
+        self.client = WorldRpcClient(
+            self._client_endpoint,
+            minimum_revision=minimum_revision,
+        )
+
+    def __enter__(self) -> WorldRpcClient:
+        return self.client
+
+    def __exit__(self, *error: object) -> None:
+        self._server.dispose()
+        self._client_endpoint.close()
+        self._server_endpoint.close()
+        for transport in reversed(self._transports):
+            transport.close()
+
+
+def _rpc_pair(
+    state: WorldState,
+    *,
+    minimum_revision: int = 0,
+) -> _RpcPair:
+    return _RpcPair(state, minimum_revision)
+
+
+def _transport_pair(
+    *,
+    server_node_id: str = "receiver",
+    client_node_id: str = "sender",
+) -> tuple[TcpTransport, TcpTransport]:
+    server = TcpTransport.listen(
+        NodeIdentity("heart", server_node_id, f"{server_node_id}-1"),
+        config=_transport_config(),
+        expected_peer_node_id=client_node_id,
+    )
+    client = TcpTransport.connect(
+        NodeIdentity("heart", client_node_id, f"{client_node_id}-1"),
+        server.address,
+        config=_transport_config(),
+        expected_peer_node_id=server_node_id,
+    )
+    assert server.wait_until_connected(timeout=2.0)
+    assert client.wait_until_connected(timeout=2.0)
+    return client, server
+
+
+def _transport_config() -> TransportConfig:
+    return TransportConfig(
+        security=TransportSecurity.insecure_local_development(),
+        outbound_queue_limit=16,
+        inbound_queue_limit=16,
+        max_payload_bytes=65536,
+        connect_timeout=0.1,
+        handshake_timeout=0.5,
+        heartbeat_interval=0.05,
+        peer_timeout=0.5,
+        reconnect=ReconnectPolicy(0.02, 1.5, 0.1),
+    )
+
+
+def _delivery_config(path: Path) -> DeliveryConfig:
+    return DeliveryConfig(
+        path,
+        max_outbox_items=16,
+        max_inbox_items=16,
+        max_storage_bytes=1024 * 1024,
+        receive_queue_limit=4,
+        max_message_bytes=4096,
+        message_ttl_seconds=5.0,
+        dedupe_retention_seconds=5.0,
+        retry_initial_seconds=0.05,
+        retry_multiplier=1.5,
+        retry_max_seconds=0.1,
+    )
+
+
+def _committed(sequence: int, command: ControlCommand) -> CommittedCommand:
+    return CommittedCommand(
+        sequence=sequence,
+        command_id=command.command_id,
+        kind=command.kind,
+        payload=command.payload,
+    )
+
+
+def _device() -> WorldDevice:
+    return WorldDevice(
+        id="totem3",
+        position=WorldPosition(0.0, 0.0, 0.0),
+        dimensions=WorldDimensions(0.5, 2.0, 0.5),
+        capabilities=("hub75", "gamepad"),
+    )
+
+
+def _active_mode() -> ActiveMode:
+    return ActiveMode(
+        mode_id="mandelbulb",
+        configuration_id="lib-2026",
+        owner_device_id="totem3",
+    )

--- a/tests/test_world_coordination.py
+++ b/tests/test_world_coordination.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_three_process_world_coordination_proof(tmp_path: Path) -> None:
+    artifact_path = tmp_path / "coordination.json"
+    subprocess.run(
+        (
+            sys.executable,
+            "scripts/verify_manyfold_world_coordination.py",
+            "--output",
+            str(artifact_path),
+        ),
+        check=True,
+        timeout=30,
+    )
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+
+    assert artifact["schema_version"] == 1
+    assert artifact["manyfold_installation"]["distribution_version"]
+    assert artifact["manyfold_installation"]["install_kind"] in {
+        "index",
+        "vcs",
+        "wheel",
+    }
+    assert artifact["manyfold_installation"]["installation_root"]
+    assert artifact["raft"]["node_count"] == 3
+    assert artifact["raft"]["leader_changed"]
+    assert artifact["raft"]["restarted_process_changed"]
+    assert artifact["raft"]["mode_sequence"] == 2
+    assert artifact["raft"]["duplicate_mode_sequence"] == 2
+    assert set(artifact["raft"]["node_revisions"].values()) == {2}
+    assert artifact["world_rpc"]["revision"] == 2
+    assert artifact["world_rpc"]["device_id"] == "totem3"
+    assert artifact["durable_delivery"]["receiver_restarted"]
+    assert artifact["durable_delivery"]["applied_count"] == 1
+    assert artifact["durable_delivery"]["receiver_acknowledgements"] == 1
+    assert not artifact["durable_delivery"]["duplicate_exposed_after_ack"]
+    assert artifact["durable_delivery"]["sender_outbox_items"] == 0
+    assert artifact["boundary"]["excluded_hot_path_data"] == [
+        "debug",
+        "frame_tick",
+        "microphone_sample",
+        "navigation_event",
+        "rendered_frame",
+        "sensor_sample",
+    ]


### PR DESCRIPTION
## Summary

Heart consumes ManyFold's public coordinator RPC, configurable three-member
Raft, and durable-delivery contracts for a deliberately narrow control plane.
Device identity/placement/capabilities and selected active
mode/configuration ownership survive leader and receiver restarts; world reads
remain ordinary typed RPC. Navigation, sensors, microphone samples, frame
ticks, rendered frames, and debug data remain outside Raft and durable
delivery.

This PR is stacked directly on mesh consumer PR949 head
`0926ac90923fb21e88ba63fbb74606c755c420b5`, which is based on the signer
PR948 merge `09ef33b3386e37018cfdba3484ac1f428c8ad034`. That consumer stack pins
exact ManyFold commit `726f64d72b36d8bd134bda63e29ebd80472736b6`.

## How it works

- `WorldState` projects exactly two Raft command kinds: device upsert and
  active-mode selection. Stable command IDs make retries idempotent,
  conflicting reuse is rejected, and projections require contiguous committed
  revisions.
- `WorldRpcClient` and `WorldRpcServer` compose `RpcEndpoint` directly. Calls
  require deadlines, handlers honor typed cancellation, reconnects create new
  calls, and revision tracking rejects stale follower responses.
- A committed mode command is journaled through `DurableDelivery` using its
  Raft command ID as message, correlation, and idempotency key. The receiver
  ACKs only after projection; restart-before-ACK redelivery applies once and
  drains the sender outbox.
- A real three-process proof starts a configurable Raft cluster, kills its
  leader, observes re-election, retries without duplicating the command,
  restarts the failed member, reads recovered state over RPC, and verifies
  durable reconnect/ACK behavior.
- The proof records installed ManyFold version and PEP 610 provenance so
  qualification can distinguish a candidate wheel from the Git-pinned
  development dependency.

## How you can try this right now

Git-pinned proof:

```shell
uv sync --locked
uv run python scripts/verify_manyfold_world_coordination.py \
  --output .artifacts/heart-manyfold-coordination.json
```

Installed-wheel qualification:

```shell
uv sync --locked
uv pip install --python .venv/bin/python --reinstall \
  /absolute/path/to/manyfold-0.1.42-cp310-abi3-platform.whl
.venv/bin/python scripts/verify_manyfold_world_coordination.py \
  --output .artifacts/heart-manyfold-wheel-coordination.json
```

The wheel artifact must report:

- `manyfold_installation.install_kind == "wheel"`
- candidate `distribution_version` and `.whl` `direct_url`
- `raft.node_count == 3` and `raft.leader_changed == true`
- `raft.mode_sequence == raft.duplicate_mode_sequence == 2`
- every `raft.node_revisions` value equals `2`
- `world_rpc.device_id == "totem3"` at revision `2`
- receiver restart, one application, one ACK, no post-ACK duplicate, and zero
  sender outbox items
- the explicit excluded hot-path data list

## Appendix

### Performance

No benchmark was added because the feature is limited to low-rate coordination
state. Transport queues, storage, payloads, retention, and retry timings are
bounded explicitly. Sensor, render, navigation, and debug hot paths do not
enter Raft or durable storage.

### Testing

- Exact `726f64d` ManyFold wheel built and installed on the PR949 stack:
  production proof and focused coordination suite passed with
  `install_kind == "wheel"` (9 tests).
- Full Heart suite against the locked PR949 stack: 606 passed, 4
  environment-dependent skips.
- Full Ruff passed.
- Focused Mypy passed for the world consumer and proof CLI.
- `uv lock --check` and formatting passed.

### Operational boundary

Raft accepts only `heart.world.device.put` and `heart.world.mode.select`.
Durable delivery accepts only `heart.world.mode.command`. The proof artifact
records that navigation events, sensor and microphone samples, frame ticks,
rendered frames, and debug data are excluded.

Production transport must use ManyFold mutual TLS. The proof intentionally
uses loopback-only insecure development transport.

### Compatibility

Replace the consumer stack's Git pin with the qualified ManyFold release
containing `726f64d72b36d8bd134bda63e29ebd80472736b6` after the stack lands. No
Graph compatibility path or Heart transport wrapper was added.

Non-test change: 1,162 additions, 0 deletions.
