### PR TITLE
Add signer-backed ManyFold node mesh

### DIFF
--- a/docs/manyfold_node_runtime.md
+++ b/docs/manyfold_node_runtime.md
@@ -1,0 +1,141 @@
+# ManyFold node runtime
+
+Heart owns one `ManyfoldNodeRuntime` per process. The runtime container starts it
+before peripheral detection, the game loop calls its bounded `poll()`, and
+shutdown closes it before the process exits.
+
+The integration uses only public APIs from ManyFold main commit
+`726f64d72b36d8bd134bda63e29ebd80472736b6`. Canonical
+`manyfold.cluster.NodeRuntime` owns signer acquisition, discovery,
+mutually-authenticated bootstrap links, membership, SWIM, reconnect, and
+shutdown. Heart composes the public `TransportMesh` beside it because PubSub
+mesh construction is deliberately outside `NodeRuntime`. There are no
+compatibility aliases, runtime version checks, Heart transports, or Heart
+keepalives.
+
+## Trust and liveness
+
+A discovery result is an address candidate only. It does not enter membership
+until the canonical bootstrap link authenticates a short-lived process
+credential issued by the local `MachineSignerService`. The certificate is
+rooted in cluster enrollment and binds:
+
+```text
+manyfold://identity/<cluster_id>/<node_id>
+```
+
+SWIM owns probing, suspicion, death, leave dissemination, and incarnation
+changes. `ManyfoldNodeRuntime.poll()` only coalesces low-rate sensor state,
+drains at most 64 queued mesh publications, and reads immutable snapshots.
+Discovery, loss detection, and reconnect remain on upstream workers instead of
+blocking the game loop.
+
+## Distribution policy
+
+`HEART_TOPIC_POLICIES` is the authoritative policy.
+`topic_policy_manifest()` exposes the same policy as JSON.
+
+| Named topic | Delivery | Durable | Raft |
+| --- | --- | --- | --- |
+| `heart.node.status` | Mesh best-effort | No | No |
+| `heart.input.navigation` | Mesh best-effort | No | No |
+| `heart.sensor.external.state` | Mesh coalesced at 10 Hz | No | No |
+| `heart.frame_tick` | Local | No | No |
+| `heart.rendered_frame` | Local | No | No |
+| `heart.microphone.level` | Local | No | No |
+| `heart.input` | Local debug tap | No | No |
+
+Heart subscribes the mesh to exactly the first three topics. Navigation and
+sensor envelopes carry a globally unique event ID. The origin ignores its mesh
+echo, each process retains a bounded 4,096-ID duplicate window, and remote
+events retain their ID when republished locally. This prevents one physical
+navigation action from being applied twice when multiple peers observe it or a
+mesh contains cycles.
+
+Sensor updates are last-value coalesced. Frames, frame ticks, microphone-rate
+samples, and debug taps never enter mesh, durable delivery, or Raft.
+
+## Configuration
+
+Set `HEART_MANYFOLD_CONFIG` to a strict JSON file. Leaving it unset disables
+distributed operation without starting workers. The machine signer must
+already be running and the node must already be enrolled.
+
+Bootstrap TCP and SWIM UDP share the numeric `listen_port`. The PubSub mesh
+listener uses a separate port.
+
+```json
+{
+  "cluster_id": "heart",
+  "node_id": "totem1",
+  "instance_id": "totem1-boot-20260725",
+  "incarnation": 12,
+  "listen_host": "0.0.0.0",
+  "listen_port": 7443,
+  "signer_socket": "/run/manyfold/signer.sock",
+  "connector_server_hostname": "totem2.local",
+  "swim_key_hex": "<64 hexadecimal characters>",
+  "peers": [
+    {
+      "node_id": "totem2",
+      "bootstrap_host": "totem2.local",
+      "bootstrap_port": 7443,
+      "mesh_host": "totem2.local",
+      "mesh_port": 7444,
+      "swim_key_hex": "<totem2's 64 hexadecimal characters>",
+      "mesh_role": "connect"
+    }
+  ]
+}
+```
+
+The listener side uses `mesh_role: "listen"` and adds
+`mesh_listen_host`/`mesh_listen_port` to the peer entry. A process restart must
+use a fresh `instance_id` and a higher incarnation. Signer state and SWIM keys
+are deployment secrets and must not be committed.
+
+## Real-process qualification
+
+PR 945 is the prerequisite Heart migration. The dependency is pinned to the
+canonical ManyFold commit, so the qualification needs no `PYTHONPATH` override:
+
+```sh
+HEART_MANYFOLD_TEST_ARTIFACT=/tmp/heart-manyfold-mesh.json \
+uv run pytest -n 0 \
+tests/runtime/test_manyfold_node_mesh.py::test_real_process_mesh_story -q
+```
+
+The test runs two spawned Heart processes plus two real machine signer services
+over TCP, UDP, and Unix sockets. In one continuous story it proves:
+
+1. An offline discovered address remains unauthenticated and outside membership.
+1. Enrollment-backed mutual TLS authenticates the peer, SWIM admits it, and
+   three PubSub interests converge.
+1. One navigation event and one accelerometer update reach each process once.
+1. Killing a peer causes SWIM death and reconnect status while foreground poll
+   CPU remains below 50 ms.
+1. Restarting with a new instance and incarnation restores bootstrap, SWIM,
+   mesh, subscriptions, navigation, and sensor delivery.
+1. Duplicate counts remain bounded and both surviving processes shut down with
+   no ManyFold worker threads.
+
+The command writes `/tmp/heart-manyfold-mesh.json`. Machine assertions include
+exactly-once navigation/sensor counts, all story booleans, the exact upstream
+commit, and:
+
+```json
+{
+  "durable_delivery_topics": [],
+  "raft_topics": [],
+  "local_only_topics": [
+    "heart.frame_tick",
+    "heart.rendered_frame",
+    "heart.microphone.level",
+    "heart.input"
+  ]
+}
+```
+
+Those fields are the consumer gate proving hot paths do not enter durable
+delivery or Raft. `max_poll_seconds_during_story` is per-thread CPU time, so
+parallel CI scheduling cannot be mistaken for inline discovery or SWIM work.

--- a/src/heart/peripheral/core/input/external_sensors.py
+++ b/src/heart/peripheral/core/input/external_sensors.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from threading import Lock
-from typing import Any
+from typing import Any, cast
 
 from manyfold import Graph, Subscribable
+from manyfold.architecture import (PubSub, PubSubCallbackSubscription,
+                                   PubSubTopic)
 
 from heart.peripheral.core.input.debug import InputDebugStage, InputDebugTap
 from heart.peripheral.core.streams import GraphRouteStream, runtime_route
@@ -13,6 +15,8 @@ from heart.peripheral.sensor import Acceleration
 ACCELEROMETER_PATHS = frozenset({"x", "y", "z"})
 EXTERNAL_SENSOR_STREAM_NAME = "beats.sensor.control"
 EXTERNAL_SENSOR_SOURCE = "beats.sensor"
+EXTERNAL_SENSOR_STATE_TOPIC = "heart.sensor.external.state"
+HEART_SENSOR_PUBSUB = "heart"
 EXTERNAL_ACCELEROMETER_ROUTE = runtime_route(
     "external_sensor.accelerometer",
     "HeartExternalSensorAcceleration",
@@ -27,6 +31,24 @@ class ExternalSensorUpdate:
     value: float | None
 
 
+@dataclass(frozen=True, slots=True)
+class ExternalSensorStateEvent:
+    """Low-rate external sensor state eligible for best-effort node sharing."""
+
+    sensor_key: str
+    value: float | None
+    event_id: str = ""
+    origin_node_id: str = ""
+
+
+def external_sensor_state_topic() -> PubSub:
+    return PubSubTopic(
+        EXTERNAL_SENSOR_STATE_TOPIC,
+        schema=ExternalSensorStateEvent,
+        pubsub=HEART_SENSOR_PUBSUB,
+    )
+
+
 class ExternalSensorHub:
     def __init__(self, debug_tap: InputDebugTap, *, graph: Graph | None = None) -> None:
         self._debug_tap = debug_tap
@@ -37,33 +59,45 @@ class ExternalSensorHub:
         self._accelerometer_stream: GraphRouteStream[Acceleration | None] = (
             GraphRouteStream(self._graph, EXTERNAL_ACCELEROMETER_ROUTE)
         )
+        self._state_topic = external_sensor_state_topic()
+        self._state_subscription: PubSubCallbackSubscription = (
+            self._state_topic.subscribe(self._apply_state)
+        )
         self._accelerometer_stream.emit(None)
 
     def set_value(self, sensor_key: str, value: float) -> None:
-        peripheral_id, path = _split_sensor_key(sensor_key)
-        with self._lock:
-            self._values[sensor_key] = value
-            snapshot = self._peripheral_snapshots.setdefault(peripheral_id, {})
-            _set_snapshot_value(snapshot, path, value)
-            acceleration = self._resolve_acceleration_locked()
-            published_snapshot = dict(snapshot)
-        self._accelerometer_stream.emit(acceleration)
-        self._debug_tap.publish(
-            stage=InputDebugStage.LOGICAL,
-            stream_name=EXTERNAL_SENSOR_STREAM_NAME,
-            source_id=peripheral_id,
-            payload=published_snapshot,
-            upstream_ids=(EXTERNAL_SENSOR_SOURCE,),
+        _split_sensor_key(sensor_key)
+        self._state_topic.publish(
+            ExternalSensorStateEvent(sensor_key=sensor_key, value=value)
         )
 
     def clear_value(self, sensor_key: str) -> None:
-        peripheral_id, path = _split_sensor_key(sensor_key)
+        _split_sensor_key(sensor_key)
+        self._state_topic.publish(
+            ExternalSensorStateEvent(sensor_key=sensor_key, value=None)
+        )
+
+    def observable_acceleration(self) -> Subscribable[Acceleration | None]:
+        return cast(
+            Subscribable[Acceleration | None],
+            self._accelerometer_stream.start_with(self._accelerometer_stream.value),
+        )
+
+    def close(self) -> None:
+        self._state_subscription.dispose()
+
+    def _apply_state(self, event: ExternalSensorStateEvent) -> None:
+        peripheral_id, path = _split_sensor_key(event.sensor_key)
         with self._lock:
-            self._values.pop(sensor_key, None)
             snapshot = self._peripheral_snapshots.setdefault(peripheral_id, {})
-            _delete_snapshot_value(snapshot, path)
-            if not snapshot:
-                self._peripheral_snapshots.pop(peripheral_id, None)
+            if event.value is None:
+                self._values.pop(event.sensor_key, None)
+                _delete_snapshot_value(snapshot, path)
+                if not snapshot:
+                    self._peripheral_snapshots.pop(peripheral_id, None)
+            else:
+                self._values[event.sensor_key] = event.value
+                _set_snapshot_value(snapshot, path, event.value)
             acceleration = self._resolve_acceleration_locked()
             published_snapshot = dict(snapshot)
         self._accelerometer_stream.emit(acceleration)
@@ -74,9 +108,6 @@ class ExternalSensorHub:
             payload=published_snapshot,
             upstream_ids=(EXTERNAL_SENSOR_SOURCE,),
         )
-
-    def observable_acceleration(self) -> Subscribable[Acceleration | None]:
-        return self._accelerometer_stream.start_with(self._accelerometer_stream.value)
 
     def _resolve_acceleration_locked(self) -> Acceleration | None:
         matching = {

--- a/src/heart/peripheral/core/input/io.py
+++ b/src/heart/peripheral/core/input/io.py
@@ -202,6 +202,8 @@ class InputIO:
     def close(self) -> None:
         if "navigation" in self.__dict__:
             self.navigation.close()
+        if "external_sensors" in self.__dict__:
+            self.external_sensors.close()
         if "keyboard" in self.__dict__:
             self.keyboard.close()
         for subscription in reversed(self._subscriptions):

--- a/src/heart/peripheral/core/input/profiles/navigation.py
+++ b/src/heart/peripheral/core/input/profiles/navigation.py
@@ -42,6 +42,8 @@ class NavigationEvent:
     kind: str
     source: str
     step: int
+    event_id: str = ""
+    origin_node_id: str = ""
 
 
 class NavigationProfile:
@@ -121,9 +123,7 @@ class NavigationProfile:
 
     def _publish(self, intent: NavigationIntent) -> None:
         if isinstance(intent, BrowseIntent):
-            event = NavigationEvent(
-                kind="browse", source=intent.source, step=intent.step
-            )
+            event = NavigationEvent(kind="browse", source=intent.source, step=intent.step)
         elif isinstance(intent, ActivateIntent):
             event = NavigationEvent(kind="activate", source=intent.source, step=0)
         else:

--- a/src/heart/runtime/container/initialize.py
+++ b/src/heart/runtime/container/initialize.py
@@ -13,6 +13,7 @@ from heart.peripheral.core.providers import apply_provider_registrations
 from heart.peripheral.registry import PeripheralConfigurationRegistry
 from heart.programs.registry import ConfigurationRegistry
 from heart.runtime.display_context import DisplayContext
+from heart.runtime.manyfold_node import ManyfoldNodeRuntime
 from heart.runtime.peripheral_runtime import PeripheralRuntime
 
 OverrideMap = Mapping[type[Any], Any]
@@ -72,7 +73,16 @@ def configure_runtime_container(
     )
     _define_default(container, DisplayContext, Singleton(DisplayContext), override_keys)
     _define_default(
-        container, PeripheralRuntime, Singleton(PeripheralRuntime), override_keys
+        container,
+        ManyfoldNodeRuntime,
+        Singleton(ManyfoldNodeRuntime),
+        override_keys,
+    )
+    _define_default(
+        container,
+        PeripheralRuntime,
+        Singleton(_build_peripheral_runtime),
+        override_keys,
     )
     _define_default(
         container,
@@ -132,6 +142,15 @@ def _build_peripheral_manager(
 ) -> PeripheralManager:
     return PeripheralManager(
         configuration_loader=container.resolve(PeripheralConfigurationLoader)
+    )
+
+
+def _build_peripheral_runtime(
+    container: RuntimeContainer,
+) -> PeripheralRuntime:
+    return PeripheralRuntime(
+        peripheral_manager=container.resolve(PeripheralManager),
+        manyfold_node=container.resolve(ManyfoldNodeRuntime),
     )
 
 

--- a/src/heart/runtime/manyfold_node.py
+++ b/src/heart/runtime/manyfold_node.py
@@ -1,0 +1,1092 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections import deque
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from enum import Enum
+from pathlib import Path
+from threading import Lock
+from typing import final
+from uuid import uuid4
+
+from manyfold.architecture import (CompositeDiscovery, LinkState,
+                                   MachineSignerClient, MembershipConfig,
+                                   MeshConfig, MeshHealth, MeshPeerHealth,
+                                   MeshPublication, MeshSubscription,
+                                   NodeIdentity, PeerEndpoint, PubSub,
+                                   PubSubCallbackSubscription, PubSubTopic,
+                                   ReconnectPolicy, StaticSeedDiscovery,
+                                   TcpAddress, TransportConfig, TransportMesh,
+                                   TransportSecurity)
+from manyfold.architecture.swim import (HmacDatagramTransport,
+                                        HmacPeerCredentials,
+                                        HmacTransportConfig, SwimConfig,
+                                        SwimMessageTransport,
+                                        UdpDatagramSocket)
+from manyfold.architecture.transport_mesh import (MeshBackpressureError,
+                                                  MeshClosed, MeshRouteError)
+from manyfold.architecture.transport_mesh import \
+    PeerDiscovery as MeshPeerDiscovery
+from manyfold.cluster import (NodeConfig, NodeRuntime, NodeSnapshot,
+                              ProcessTransportSecurity)
+
+from heart.peripheral.core.input.events import (FRAME_TICK_TOPIC,
+                                                INPUT_EVENT_TOPIC)
+from heart.peripheral.core.input.external_sensors import (
+    EXTERNAL_SENSOR_STATE_TOPIC, ExternalSensorStateEvent,
+    external_sensor_state_topic)
+from heart.peripheral.core.input.profiles.navigation import (
+    HEART_INPUT_PUBSUB, NAVIGATION_TOPIC, NavigationEvent)
+from heart.utilities.logging import get_logger
+
+DEFAULT_MAX_PUBLICATIONS_PER_POLL = 64
+DEFAULT_SENSOR_MESH_INTERVAL_SECONDS = 0.1
+DEFAULT_SEEN_EVENT_LIMIT = 4096
+HEART_MANYFOLD_CONFIG = "HEART_MANYFOLD_CONFIG"
+HEART_MANYFOLD_PUBSUB = "heart"
+HEART_MANYFOLD_STATUS_TOPIC = "heart.node.status"
+MICROPHONE_SAMPLE_STREAM = "heart.microphone.level"
+RENDERED_FRAME_STREAM = "heart.rendered_frame"
+
+logger = get_logger(__name__)
+
+
+def topic_policy_manifest() -> tuple[dict[str, object], ...]:
+    """Return the authoritative machine-readable Heart distribution policy."""
+    return tuple(asdict(policy) for policy in HEART_TOPIC_POLICIES)
+
+
+@final
+class TopicDelivery(str, Enum):
+    """How one named Heart stream may leave its process."""
+
+    LOCAL = "local"
+    MESH_BEST_EFFORT = "mesh_best_effort"
+    MESH_COALESCED = "mesh_coalesced"
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class TopicPolicy:
+    """Explicit transport and persistence decision for one Heart stream."""
+
+    topic: str
+    delivery: TopicDelivery
+    purpose: str
+    durable: bool = False
+    raft: bool = False
+
+
+HEART_TOPIC_POLICIES = (
+    TopicPolicy(
+        HEART_MANYFOLD_STATUS_TOPIC,
+        TopicDelivery.MESH_BEST_EFFORT,
+        "node lifecycle and peer health",
+    ),
+    TopicPolicy(
+        NAVIGATION_TOPIC,
+        TopicDelivery.MESH_BEST_EFFORT,
+        "deduplicated user navigation intent",
+    ),
+    TopicPolicy(
+        EXTERNAL_SENSOR_STATE_TOPIC,
+        TopicDelivery.MESH_COALESCED,
+        "selected low-rate external sensor state",
+    ),
+    TopicPolicy(
+        FRAME_TICK_TOPIC,
+        TopicDelivery.LOCAL,
+        "frame-clock scheduling",
+    ),
+    TopicPolicy(
+        RENDERED_FRAME_STREAM,
+        TopicDelivery.LOCAL,
+        "rendered frame buffers",
+    ),
+    TopicPolicy(
+        MICROPHONE_SAMPLE_STREAM,
+        TopicDelivery.LOCAL,
+        "microphone-rate samples",
+    ),
+    TopicPolicy(
+        INPUT_EVENT_TOPIC,
+        TopicDelivery.LOCAL,
+        "input debug taps",
+    ),
+)
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class ManyfoldNodeConfig:
+    """Optional canonical ManyFold node and mesh configuration."""
+
+    bootstrap: _HeartNodeBootstrap | None
+
+    @property
+    def is_enabled(self) -> bool:
+        return self.bootstrap is not None
+
+    @classmethod
+    def from_environment(cls) -> "ManyfoldNodeConfig":
+        """Load an optional signer-enrolled node from ``HEART_MANYFOLD_CONFIG``."""
+        value = os.environ.get(HEART_MANYFOLD_CONFIG, "").strip()
+        if not value:
+            return cls(bootstrap=None)
+        return cls.from_file(Path(value).expanduser())
+
+    @classmethod
+    def from_file(cls, path: Path) -> "ManyfoldNodeConfig":
+        """Load one strict JSON bootstrap file."""
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except OSError as error:
+            raise ValueError(
+                f"Failed to read ManyFold node config {path}: {error}"
+            ) from error
+        except json.JSONDecodeError as error:
+            raise ValueError(
+                f"ManyFold node config {path} must contain valid JSON: {error}"
+            ) from error
+        return cls(bootstrap=_bootstrap_from_json(_require_mapping(raw, "config")))
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class ManyfoldNodeStatus:
+    """Heart-facing canonical node and mesh lifecycle snapshot."""
+
+    is_enabled: bool
+    is_started: bool
+    node: NodeSnapshot | None
+    mesh: MeshHealth | None
+    mesh_peers: tuple[MeshPeerHealth, ...]
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class ManyfoldNodeEvent:
+    """Compact distributed status row for operations and SQL inspection."""
+
+    event_type: str
+    event_id: str
+    origin_node_id: str
+    authenticated_peers_json: str
+    members_json: str
+    candidate_count: int
+    discovery_failure_count: int
+    last_error: str
+    timestamp_monotonic: float
+
+
+@final
+class ManyfoldNodeRuntime:
+    """Apply Heart topic policy beside ManyFold's canonical node bootstrap."""
+
+    def __init__(self, config: ManyfoldNodeConfig | None = None) -> None:
+        self.config = config or ManyfoldNodeConfig.from_environment()
+        self.status_topic = PubSubTopic(
+            HEART_MANYFOLD_STATUS_TOPIC,
+            schema=ManyfoldNodeEvent,
+            pubsub=HEART_MANYFOLD_PUBSUB,
+        )
+        self._node: NodeRuntime | None = None
+        self._mesh: TransportMesh | None = None
+        self._signer_client: MachineSignerClient | None = None
+        self._mesh_subscriptions: list[MeshSubscription] = []
+        self._local_subscriptions: list[PubSubCallbackSubscription] = []
+        self._topics: dict[str, PubSub] = {}
+        self._pending_sensor: ExternalSensorStateEvent | None = None
+        self._pending_sensor_lock = Lock()
+        self._next_sensor_publish_at = 0.0
+        self._seen = _SeenEventIds(DEFAULT_SEEN_EVENT_LIMIT)
+        self._last_status_key: tuple[object, ...] | None = None
+
+    @property
+    def is_started(self) -> bool:
+        return self._node is not None
+
+    def start(self) -> ManyfoldNodeStatus:
+        """Start signer-backed bootstrap and the public best-effort mesh once."""
+        if self._node is not None:
+            return self.status()
+        bootstrap = self.config.bootstrap
+        if bootstrap is None:
+            return self.status()
+        signer_client = MachineSignerClient(
+            bootstrap.signer_socket,
+            bootstrap.identity,
+        )
+        security_provider = _MachineSignerSecurityProvider(
+            signer_client,
+            bootstrap.connector_server_hostname,
+            bootstrap.transport,
+        )
+        node = NodeRuntime(bootstrap.node_config(security_provider))
+        self._signer_client = signer_client
+        self._node = node
+        try:
+            node.start()
+            process_security = security_provider.process_security
+            mesh = TransportMesh(
+                bootstrap.identity,
+                connector_config=process_security.connector_transport,
+                listener_config=process_security.listener_transport,
+                config=bootstrap.mesh,
+            )
+            self._mesh = mesh
+            bootstrap.configure_mesh(mesh, process_security)
+            self._install_bridges()
+            self._publish_status("started")
+        except Exception:
+            self.close()
+            raise
+        return self.status()
+
+    def status(self) -> ManyfoldNodeStatus:
+        node = self._node
+        mesh = self._mesh
+        return ManyfoldNodeStatus(
+            is_enabled=self.config.is_enabled,
+            is_started=node is not None,
+            node=None if node is None else node.snapshot(),
+            mesh=None if mesh is None else mesh.health(),
+            mesh_peers=() if mesh is None else mesh.peer_health(),
+        )
+
+    def poll(self) -> None:
+        """Drain bounded mesh work without running discovery or SWIM inline."""
+        node = self._node
+        mesh = self._mesh
+        if node is None or mesh is None:
+            return
+        self._flush_sensor()
+        for _index in range(DEFAULT_MAX_PUBLICATIONS_PER_POLL):
+            try:
+                publication = mesh.receive(timeout=0.0)
+            except TimeoutError:
+                break
+            except MeshClosed:
+                return
+            self._accept_publication(publication)
+        snapshot = node.snapshot()
+        peer_health = mesh.peer_health()
+        status_key = _status_key(snapshot, peer_health)
+        if status_key != self._last_status_key:
+            self._publish_status(
+                "changed",
+                snapshot=snapshot,
+                peer_health=peer_health,
+            )
+
+    def close(self) -> None:
+        """Release bridges, mesh, canonical bootstrap, and signer client."""
+        node = self._node
+        mesh = self._mesh
+        signer_client = self._signer_client
+        if node is None and mesh is None and signer_client is None:
+            return
+        if node is not None and mesh is not None:
+            self._publish_status("stopping")
+        for local_subscription in reversed(self._local_subscriptions):
+            local_subscription.dispose()
+        self._local_subscriptions.clear()
+        for mesh_subscription in reversed(self._mesh_subscriptions):
+            try:
+                mesh_subscription.dispose()
+            except (MeshBackpressureError, MeshClosed) as error:
+                logger.warning("ManyFold topic withdrawal failed: %s", error)
+        self._mesh_subscriptions.clear()
+        self._topics.clear()
+        with self._pending_sensor_lock:
+            self._pending_sensor = None
+        self._mesh = None
+        self._node = None
+        self._signer_client = None
+        try:
+            if mesh is not None:
+                mesh.close()
+        finally:
+            try:
+                if node is not None:
+                    node.stop()
+            finally:
+                if signer_client is not None:
+                    signer_client.close()
+        self._last_status_key = None
+
+    def _install_bridges(self) -> None:
+        mesh = self._require_mesh()
+        navigation_topic = PubSubTopic(
+            NAVIGATION_TOPIC,
+            schema=NavigationEvent,
+            pubsub=HEART_INPUT_PUBSUB,
+        )
+        sensor_topic = external_sensor_state_topic()
+        self._topics = {
+            HEART_MANYFOLD_STATUS_TOPIC: self.status_topic,
+            NAVIGATION_TOPIC: navigation_topic,
+            EXTERNAL_SENSOR_STATE_TOPIC: sensor_topic,
+        }
+        self._mesh_subscriptions = [mesh.subscribe(topic) for topic in self._topics]
+        self._local_subscriptions = [
+            self.status_topic.subscribe(self._publish_local_status),
+            navigation_topic.subscribe(self._publish_local_navigation),
+            sensor_topic.subscribe(self._queue_local_sensor),
+        ]
+
+    def _publish_local_status(self, event: ManyfoldNodeEvent) -> None:
+        if event.event_id:
+            return
+        self._publish_mesh(
+            HEART_MANYFOLD_STATUS_TOPIC,
+            {
+                "event_type": event.event_type,
+                "origin_node_id": event.origin_node_id,
+                "authenticated_peers_json": event.authenticated_peers_json,
+                "members_json": event.members_json,
+                "candidate_count": event.candidate_count,
+                "discovery_failure_count": event.discovery_failure_count,
+                "last_error": event.last_error,
+                "timestamp_monotonic": event.timestamp_monotonic,
+            },
+        )
+
+    def _publish_local_navigation(self, event: NavigationEvent) -> None:
+        if event.event_id:
+            return
+        self._publish_mesh(
+            NAVIGATION_TOPIC,
+            {
+                "kind": event.kind,
+                "source": event.source,
+                "step": event.step,
+            },
+        )
+
+    def _queue_local_sensor(self, event: ExternalSensorStateEvent) -> None:
+        if event.event_id:
+            return
+        with self._pending_sensor_lock:
+            self._pending_sensor = event
+
+    def _flush_sensor(self) -> None:
+        now = time.monotonic()
+        if now < self._next_sensor_publish_at:
+            return
+        with self._pending_sensor_lock:
+            event = self._pending_sensor
+            self._pending_sensor = None
+        if event is None:
+            return
+        self._next_sensor_publish_at = now + DEFAULT_SENSOR_MESH_INTERVAL_SECONDS
+        self._publish_mesh(
+            EXTERNAL_SENSOR_STATE_TOPIC,
+            {
+                "sensor_key": event.sensor_key,
+                "value": event.value,
+            },
+        )
+
+    def _publish_mesh(self, topic: str, payload: Mapping[str, object]) -> None:
+        node = self._require_node()
+        mesh = self._require_mesh()
+        event_id = f"{node.config.identity.node_id}:{uuid4().hex}"
+        encoded = json.dumps(
+            {"event_id": event_id, "payload": payload},
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        try:
+            mesh.publish(topic, encoded, message_id=event_id)
+        except (MeshBackpressureError, MeshClosed, MeshRouteError) as error:
+            logger.warning("ManyFold best-effort topic %s dropped: %s", topic, error)
+            return
+        self._seen.add(event_id)
+
+    def _accept_publication(self, publication: MeshPublication) -> None:
+        node = self._require_node()
+        if publication.source_node_id == node.config.identity.node_id:
+            return
+        try:
+            event_id, payload = _decode_mesh_payload(publication.payload)
+            if event_id != publication.message_id:
+                raise ValueError("event_id does not match mesh message_id")
+        except ValueError as error:
+            logger.warning(
+                "Ignoring malformed ManyFold topic %s from %s: %s",
+                publication.topic,
+                publication.source_node_id,
+                error,
+            )
+            return
+        if self._seen.contains(event_id):
+            return
+        self._seen.add(event_id)
+        topic = self._topics.get(publication.topic)
+        if topic is None:
+            return
+        if publication.topic == NAVIGATION_TOPIC:
+            topic.publish(
+                NavigationEvent(
+                    kind=_require_text(payload.get("kind"), "navigation kind"),
+                    source=_require_text(payload.get("source"), "navigation source"),
+                    step=_require_integer(payload.get("step"), "navigation step"),
+                    event_id=event_id,
+                    origin_node_id=publication.source_node_id,
+                )
+            )
+        elif publication.topic == EXTERNAL_SENSOR_STATE_TOPIC:
+            topic.publish(
+                ExternalSensorStateEvent(
+                    sensor_key=_require_text(payload.get("sensor_key"), "sensor key"),
+                    value=_optional_number(payload.get("value"), "sensor value"),
+                    event_id=event_id,
+                    origin_node_id=publication.source_node_id,
+                )
+            )
+        else:
+            topic.publish(
+                ManyfoldNodeEvent(
+                    event_type=_require_text(payload.get("event_type"), "event type"),
+                    event_id=event_id,
+                    origin_node_id=publication.source_node_id,
+                    authenticated_peers_json=_require_text(
+                        payload.get("authenticated_peers_json"),
+                        "authenticated peers",
+                    ),
+                    members_json=_require_text(payload.get("members_json"), "members"),
+                    candidate_count=_require_integer(
+                        payload.get("candidate_count"),
+                        "candidate count",
+                    ),
+                    discovery_failure_count=_require_integer(
+                        payload.get("discovery_failure_count"),
+                        "discovery failure count",
+                    ),
+                    last_error=_require_string(payload.get("last_error"), "last error"),
+                    timestamp_monotonic=_require_number(
+                        payload.get("timestamp_monotonic"),
+                        "status timestamp",
+                    ),
+                )
+            )
+
+    def _publish_status(
+        self,
+        event_type: str,
+        *,
+        snapshot: NodeSnapshot | None = None,
+        peer_health: tuple[MeshPeerHealth, ...] | None = None,
+    ) -> None:
+        node = self._require_node()
+        mesh = self._require_mesh()
+        resolved_snapshot = snapshot or node.snapshot()
+        resolved_peer_health = peer_health or mesh.peer_health()
+        self._last_status_key = _status_key(
+            resolved_snapshot,
+            resolved_peer_health,
+        )
+        authenticated_peers = sorted(
+            {
+                peer.health.remote_identity.node_id
+                for peer in resolved_snapshot.peers
+                if peer.health.state is LinkState.CONNECTED
+                and peer.health.remote_identity is not None
+            }
+        )
+        self.status_topic.publish(
+            ManyfoldNodeEvent(
+                event_type=event_type,
+                event_id="",
+                origin_node_id=resolved_snapshot.identity.node_id,
+                authenticated_peers_json=json.dumps(authenticated_peers),
+                members_json=json.dumps(
+                    [
+                        {
+                            "node_id": member.identity.node_id,
+                            "instance_id": member.identity.instance_id,
+                            "incarnation": member.incarnation,
+                            "state": member.state.value,
+                        }
+                        for member in resolved_snapshot.members
+                    ],
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ),
+                candidate_count=len(resolved_snapshot.peers),
+                discovery_failure_count=sum(
+                    diagnostic.code.startswith("discovery-")
+                    and diagnostic.severity.value != "info"
+                    for diagnostic in resolved_snapshot.diagnostics
+                ),
+                last_error=_last_node_error(resolved_snapshot),
+                timestamp_monotonic=time.monotonic(),
+            )
+        )
+
+    def _require_node(self) -> NodeRuntime:
+        if self._node is None:
+            raise RuntimeError("Heart ManyFold node is not started")
+        return self._node
+
+    def _require_mesh(self) -> TransportMesh:
+        if self._mesh is None:
+            raise RuntimeError("Heart ManyFold mesh is not started")
+        return self._mesh
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class _TransportLimits:
+    outbound_queue_limit: int
+    inbound_queue_limit: int
+    max_payload_bytes: int
+    connect_timeout: float
+    handshake_timeout: float
+    heartbeat_interval: float
+    peer_timeout: float
+    reconnect: ReconnectPolicy
+
+    def config(self, security: TransportSecurity) -> TransportConfig:
+        return TransportConfig(
+            security=security,
+            outbound_queue_limit=self.outbound_queue_limit,
+            inbound_queue_limit=self.inbound_queue_limit,
+            max_payload_bytes=self.max_payload_bytes,
+            connect_timeout=self.connect_timeout,
+            handshake_timeout=self.handshake_timeout,
+            heartbeat_interval=self.heartbeat_interval,
+            peer_timeout=self.peer_timeout,
+            reconnect=self.reconnect,
+        )
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class _MeshPeer:
+    node_id: str
+    bootstrap_endpoint: PeerEndpoint
+    mesh_address: TcpAddress
+    swim_key: bytes
+    mesh_role: str
+    mesh_listen_address: TcpAddress | None
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class _HeartNodeBootstrap:
+    identity: NodeIdentity
+    listen_address: TcpAddress
+    signer_socket: Path
+    connector_server_hostname: str
+    local_swim_key: bytes
+    peers: tuple[_MeshPeer, ...]
+    local_incarnation: int
+    transport: _TransportLimits
+    membership: MembershipConfig
+    swim: SwimConfig
+    swim_transport: HmacTransportConfig
+    mesh: MeshConfig
+    reconcile_interval_seconds: float
+    startup_peer_timeout_seconds: float
+    peer_absence_seconds: float
+    signer_timeout_seconds: float
+    minimum_credential_lifetime_seconds: float
+    shutdown_timeout_seconds: float
+
+    def node_config(
+        self,
+        security_provider: _MachineSignerSecurityProvider,
+    ) -> NodeConfig:
+        endpoints = tuple(peer.bootstrap_endpoint for peer in self.peers)
+        max_peers = max(1, len(self.peers))
+        return NodeConfig(
+            identity=self.identity,
+            listen_address=self.listen_address,
+            discovery=CompositeDiscovery(
+                (
+                    StaticSeedDiscovery(
+                        endpoints,
+                        max_candidates=max_peers,
+                    ),
+                ),
+                max_candidates=max_peers,
+            ),
+            transport_security_provider=security_provider,
+            membership=self.membership,
+            swim=self.swim,
+            swim_transport_factory=self._swim_transport,
+            local_incarnation=self.local_incarnation,
+            max_peers=max_peers,
+            reconcile_interval_seconds=self.reconcile_interval_seconds,
+            startup_peer_timeout_seconds=self.startup_peer_timeout_seconds,
+            peer_absence_seconds=self.peer_absence_seconds,
+            signer_timeout_seconds=self.signer_timeout_seconds,
+            minimum_credential_lifetime_seconds=(
+                self.minimum_credential_lifetime_seconds
+            ),
+            shutdown_timeout_seconds=self.shutdown_timeout_seconds,
+        )
+
+    def configure_mesh(
+        self,
+        mesh: TransportMesh,
+        security: ProcessTransportSecurity,
+    ) -> None:
+        for peer in self.peers:
+            if peer.mesh_role == "listen":
+                mesh.listen(
+                    peer.node_id,
+                    peer.mesh_listen_address,
+                    transport_config=security.listener_transport,
+                )
+        mesh.apply_discovery(
+            tuple(
+                MeshPeerDiscovery(
+                    peer.node_id,
+                    peer.mesh_address,
+                    transport_config=security.connector_transport,
+                )
+                for peer in self.peers
+                if peer.mesh_role == "connect"
+            )
+        )
+
+    def _swim_transport(
+        self,
+        identity: NodeIdentity,
+        endpoint: PeerEndpoint,
+    ) -> SwimMessageTransport:
+        return HmacDatagramTransport(
+            UdpDatagramSocket(endpoint),
+            HmacPeerCredentials(
+                local_identity=identity,
+                advertised_endpoint=endpoint,
+                local_key=self.local_swim_key,
+                peer_keys={peer.node_id: peer.swim_key for peer in self.peers},
+                max_peers=max(1, len(self.peers)),
+            ),
+            config=self.swim_transport,
+        )
+
+
+@final
+class _MachineSignerSecurityProvider:
+    def __init__(
+        self,
+        client: MachineSignerClient,
+        server_hostname: str,
+        limits: _TransportLimits,
+    ) -> None:
+        self._client = client
+        self._server_hostname = server_hostname
+        self._limits = limits
+        self._process_security: ProcessTransportSecurity | None = None
+
+    @property
+    def process_security(self) -> ProcessTransportSecurity:
+        if self._process_security is None:
+            raise RuntimeError(
+                "canonical node bootstrap did not acquire signer security"
+            )
+        return self._process_security
+
+    def acquire(
+        self,
+        identity: NodeIdentity,
+        *,
+        timeout_seconds: float,
+        minimum_lifetime_seconds: float,
+    ) -> ProcessTransportSecurity:
+        if identity != self._client.identity:
+            raise ValueError("signer client identity does not match node identity")
+        status = self._client.ensure_process_credentials(
+            max_attempts=3,
+            retry_delay_seconds=min(0.05, timeout_seconds / 3),
+        )
+        if not status.is_usable or status.expires_at is None:
+            raise RuntimeError("machine signer returned no usable process credential")
+        remaining_seconds = status.expires_at.timestamp() - time.time()
+        if remaining_seconds < minimum_lifetime_seconds:
+            raise RuntimeError(
+                "machine signer credential lifetime is insufficient: "
+                f"remaining={max(0.0, remaining_seconds):.3f}s "
+                f"required={minimum_lifetime_seconds:.3f}s"
+            )
+        process_security = ProcessTransportSecurity(
+            listener_transport=self._limits.config(
+                self._client.transport_security(server_side=True)
+            ),
+            connector_transport=self._limits.config(
+                self._client.transport_security(
+                    server_side=False,
+                    server_hostname=self._server_hostname,
+                )
+            ),
+            expires_at_epoch_seconds=status.expires_at.timestamp(),
+        )
+        self._process_security = process_security
+        return process_security
+
+
+def _bootstrap_from_json(raw: Mapping[str, object]) -> _HeartNodeBootstrap:
+    identity = NodeIdentity(
+        _mapping_text(raw, "cluster_id"),
+        _mapping_text(raw, "node_id"),
+        _mapping_text(raw, "instance_id"),
+    )
+    peers = tuple(
+        _mesh_peer_from_json(_require_mapping(peer, "peer"))
+        for peer in _require_list(raw.get("peers"), "peers")
+    )
+    max_peers = max(1, len(peers))
+    return _HeartNodeBootstrap(
+        identity=identity,
+        listen_address=TcpAddress(
+            _mapping_text(raw, "listen_host"),
+            _mapping_integer(raw, "listen_port"),
+        ),
+        signer_socket=Path(_mapping_text(raw, "signer_socket")).expanduser(),
+        connector_server_hostname=_mapping_text(
+            raw,
+            "connector_server_hostname",
+        ),
+        local_swim_key=_mapping_hex_bytes(raw, "swim_key_hex"),
+        peers=peers,
+        local_incarnation=_mapping_integer(raw, "incarnation", default=0),
+        transport=_transport_limits_from_json(raw),
+        membership=MembershipConfig(
+            lease_seconds=_mapping_number(raw, "lease_seconds", default=15.0),
+            suspect_seconds=_mapping_number(raw, "suspect_seconds", default=5.0),
+            dead_retention_seconds=_mapping_number(
+                raw,
+                "dead_retention_seconds",
+                default=300.0,
+            ),
+            max_members=_mapping_integer(
+                raw,
+                "max_members",
+                default=max_peers + 1,
+            ),
+            max_changes=_mapping_integer(raw, "max_membership_changes", default=256),
+        ),
+        swim=SwimConfig(
+            probe_interval_seconds=_mapping_number(
+                raw,
+                "swim_probe_interval_seconds",
+                default=1.0,
+            ),
+            ping_timeout_seconds=_mapping_number(
+                raw,
+                "swim_ping_timeout_seconds",
+                default=0.2,
+            ),
+            indirect_timeout_seconds=_mapping_number(
+                raw,
+                "swim_indirect_timeout_seconds",
+                default=0.3,
+            ),
+            helper_count=_mapping_integer(raw, "swim_helper_count", default=3),
+        ),
+        swim_transport=HmacTransportConfig(),
+        mesh=MeshConfig(
+            max_peers=_mapping_integer(raw, "max_mesh_peers", default=32),
+            max_subscriptions=_mapping_integer(
+                raw,
+                "max_mesh_subscriptions",
+                default=4096,
+            ),
+            duplicate_window=_mapping_integer(
+                raw,
+                "mesh_duplicate_window",
+                default=8192,
+            ),
+            publication_queue_limit=_mapping_integer(
+                raw,
+                "mesh_publication_queue_limit",
+                default=1024,
+            ),
+        ),
+        reconcile_interval_seconds=_mapping_number(
+            raw,
+            "reconcile_interval_seconds",
+            default=0.1,
+        ),
+        startup_peer_timeout_seconds=_mapping_number(
+            raw,
+            "startup_peer_timeout_seconds",
+            default=0.1,
+        ),
+        peer_absence_seconds=_mapping_number(
+            raw,
+            "peer_absence_seconds",
+            default=15.0,
+        ),
+        signer_timeout_seconds=_mapping_number(
+            raw,
+            "signer_timeout_seconds",
+            default=2.0,
+        ),
+        minimum_credential_lifetime_seconds=_mapping_number(
+            raw,
+            "minimum_credential_lifetime_seconds",
+            default=30.0,
+        ),
+        shutdown_timeout_seconds=_mapping_number(
+            raw,
+            "shutdown_timeout_seconds",
+            default=5.0,
+        ),
+    )
+
+
+def _mesh_peer_from_json(raw: Mapping[str, object]) -> _MeshPeer:
+    mesh_role = _mapping_text(raw, "mesh_role")
+    if mesh_role not in {"connect", "listen"}:
+        raise ValueError("mesh_role must be 'connect' or 'listen'")
+    listen_address = None
+    if mesh_role == "listen":
+        listen_address = TcpAddress(
+            _mapping_text(raw, "mesh_listen_host"),
+            _mapping_integer(raw, "mesh_listen_port"),
+        )
+    return _MeshPeer(
+        node_id=_mapping_text(raw, "node_id"),
+        bootstrap_endpoint=PeerEndpoint(
+            _mapping_text(raw, "bootstrap_host"),
+            _mapping_integer(raw, "bootstrap_port"),
+        ),
+        mesh_address=TcpAddress(
+            _mapping_text(raw, "mesh_host"),
+            _mapping_integer(raw, "mesh_port"),
+        ),
+        swim_key=_mapping_hex_bytes(raw, "swim_key_hex"),
+        mesh_role=mesh_role,
+        mesh_listen_address=listen_address,
+    )
+
+
+def _transport_limits_from_json(raw: Mapping[str, object]) -> _TransportLimits:
+    return _TransportLimits(
+        outbound_queue_limit=_mapping_integer(
+            raw,
+            "transport_outbound_queue_limit",
+            default=1024,
+        ),
+        inbound_queue_limit=_mapping_integer(
+            raw,
+            "transport_inbound_queue_limit",
+            default=1024,
+        ),
+        max_payload_bytes=_mapping_integer(
+            raw,
+            "transport_max_payload_bytes",
+            default=16 * 1024 * 1024,
+        ),
+        connect_timeout=_mapping_number(
+            raw,
+            "transport_connect_timeout_seconds",
+            default=2.0,
+        ),
+        handshake_timeout=_mapping_number(
+            raw,
+            "transport_handshake_timeout_seconds",
+            default=2.0,
+        ),
+        heartbeat_interval=_mapping_number(
+            raw,
+            "transport_heartbeat_interval_seconds",
+            default=1.0,
+        ),
+        peer_timeout=_mapping_number(
+            raw,
+            "transport_peer_timeout_seconds",
+            default=5.0,
+        ),
+        reconnect=ReconnectPolicy(
+            initial_delay=_mapping_number(
+                raw,
+                "transport_reconnect_initial_seconds",
+                default=0.05,
+            ),
+            multiplier=_mapping_number(
+                raw,
+                "transport_reconnect_multiplier",
+                default=2.0,
+            ),
+            max_delay=_mapping_number(
+                raw,
+                "transport_reconnect_max_seconds",
+                default=1.0,
+            ),
+        ),
+    )
+
+
+def _decode_mesh_payload(payload: bytes) -> tuple[str, Mapping[str, object]]:
+    try:
+        raw = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"payload must be UTF-8 JSON: {error}") from error
+    envelope = _require_mapping(raw, "mesh envelope")
+    event_id = _mapping_text(envelope, "event_id")
+    return event_id, _require_mapping(envelope.get("payload"), "mesh payload")
+
+
+def _status_key(
+    snapshot: NodeSnapshot,
+    mesh_peers: tuple[MeshPeerHealth, ...],
+) -> tuple[object, ...]:
+    return (
+        snapshot.phase.value,
+        tuple(
+            (
+                member.identity.node_id,
+                member.identity.instance_id,
+                member.incarnation,
+                member.state.value,
+            )
+            for member in snapshot.members
+        ),
+        tuple(
+            (
+                peer.endpoint.host,
+                peer.endpoint.port,
+                peer.health.state.value,
+                (
+                    ""
+                    if peer.health.remote_identity is None
+                    else peer.health.remote_identity.instance_id
+                ),
+            )
+            for peer in snapshot.peers
+        ),
+        tuple(
+            (
+                peer.node_id,
+                peer.link.state.value,
+                tuple(peer.interested_topics),
+            )
+            for peer in mesh_peers
+        ),
+        tuple(
+            (diagnostic.sequence, diagnostic.code)
+            for diagnostic in snapshot.diagnostics
+        ),
+    )
+
+
+def _last_node_error(snapshot: NodeSnapshot) -> str:
+    for diagnostic in reversed(snapshot.diagnostics):
+        if diagnostic.severity.value == "error":
+            return diagnostic.message
+    return ""
+
+
+def _mapping_hex_bytes(raw: Mapping[str, object], name: str) -> bytes:
+    value = _mapping_text(raw, name)
+    try:
+        return bytes.fromhex(value)
+    except ValueError as error:
+        raise ValueError(f"{name} must be hexadecimal bytes") from error
+
+
+def _mapping_integer(
+    raw: Mapping[str, object],
+    name: str,
+    *,
+    default: int | None = None,
+) -> int:
+    if name not in raw:
+        if default is None:
+            raise ValueError(f"{name} is required")
+        return default
+    return _require_integer(raw[name], name)
+
+
+def _mapping_number(
+    raw: Mapping[str, object],
+    name: str,
+    *,
+    default: float,
+) -> float:
+    if name not in raw:
+        return default
+    return _require_number(raw[name], name)
+
+
+def _mapping_text(raw: Mapping[str, object], name: str) -> str:
+    if name not in raw:
+        raise ValueError(f"{name} is required")
+    return _require_text(raw[name], name)
+
+
+def _optional_number(value: object, name: str) -> float | None:
+    if value is None:
+        return None
+    return _require_number(value, name)
+
+
+def _require_integer(value: object, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{name} must be an integer")
+    return value
+
+
+def _require_list(value: object, name: str) -> list[object]:
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be a list")
+    return value
+
+
+def _require_mapping(value: object, name: str) -> Mapping[str, object]:
+    if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
+        raise ValueError(f"{name} must be an object with string keys")
+    return value
+
+
+def _require_number(value: object, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"{name} must be a number")
+    return float(value)
+
+
+def _require_string(value: object, name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be text")
+    return value
+
+
+def _require_text(value: object, name: str) -> str:
+    result = _require_string(value, name).strip()
+    if not result:
+        raise ValueError(f"{name} must not be empty")
+    return result
+
+
+@final
+class _SeenEventIds:
+    def __init__(self, limit: int) -> None:
+        self._limit = limit
+        self._order: deque[str] = deque()
+        self._ids: set[str] = set()
+        self._lock = Lock()
+
+    def add(self, event_id: str) -> None:
+        with self._lock:
+            if event_id in self._ids:
+                return
+            while len(self._order) >= self._limit:
+                expired = self._order.popleft()
+                self._ids.remove(expired)
+            self._order.append(event_id)
+            self._ids.add(event_id)
+
+    def contains(self, event_id: str) -> bool:
+        with self._lock:
+            return event_id in self._ids

--- a/src/heart/runtime/peripheral_runtime.py
+++ b/src/heart/runtime/peripheral_runtime.py
@@ -24,6 +24,7 @@ from heart.renderers.free_text import FreeTextRenderer
 from heart.renderers.image import (ContainRenderImage,
                                    SurfaceRenderImageStateProvider)
 from heart.runtime.active_game_loop import get_active_game_loop
+from heart.runtime.manyfold_node import ManyfoldNodeRuntime
 from heart.utilities.env import Configuration
 from heart.utilities.logging import get_logger
 
@@ -52,8 +53,10 @@ class PeripheralRuntime:
     def __init__(
         self,
         peripheral_manager: PeripheralManager,
+        manyfold_node: ManyfoldNodeRuntime | None = None,
     ) -> None:
         self._peripheral_manager = peripheral_manager
+        self._manyfold_node = manyfold_node or ManyfoldNodeRuntime()
         self._control_messages: SimpleQueue[Any] = SimpleQueue()
         self._frame_clock: pygame.time.Clock | None = None
         self._navigation_dpad_armed = True
@@ -71,16 +74,21 @@ class PeripheralRuntime:
         self._subscriptions: list[Any] = []
 
     def detect_and_start(self) -> None:
-        logger.info("Attempting to detect attached peripherals")
-        self._peripheral_manager.detect()
-        peripherals = self._peripheral_manager.peripherals
-        logger.info(
-            "Detected attached peripherals - found %d. peripherals=%s",
-            len(peripherals),
-            peripherals,
-        )
-        logger.info("Starting all peripherals")
-        self._peripheral_manager.start()
+        self._manyfold_node.start()
+        try:
+            logger.info("Attempting to detect attached peripherals")
+            self._peripheral_manager.detect()
+            peripherals = self._peripheral_manager.peripherals
+            logger.info(
+                "Detected attached peripherals - found %d. peripherals=%s",
+                len(peripherals),
+                peripherals,
+            )
+            logger.info("Starting all peripherals")
+            self._peripheral_manager.start()
+        except Exception:
+            self._manyfold_node.close()
+            raise
 
     def configure_streaming(self, websocket: Any | None = None) -> None:
         if (
@@ -107,9 +115,12 @@ class PeripheralRuntime:
         )
 
     def close(self) -> None:
-        for subscription in reversed(self._subscriptions):
-            subscription.dispose()
-        self._subscriptions.clear()
+        try:
+            for subscription in reversed(self._subscriptions):
+                subscription.dispose()
+        finally:
+            self._subscriptions.clear()
+            self._manyfold_node.close()
 
     def _handle_control_message(self, control_message: Any) -> None:
         self._control_messages.put(control_message)
@@ -255,6 +266,7 @@ class PeripheralRuntime:
             logger.warning("Ignoring unsupported phone emoji: %s", emoji)
 
     def poll(self) -> None:
+        self._manyfold_node.poll()
         keyboard, gamepads = self._peripheral_manager.input_io.poll()
         self._poll_navigation(keyboard, gamepads)
         self._drain_control_messages()

--- a/tests/runtime/test_container.py
+++ b/tests/runtime/test_container.py
@@ -6,6 +6,7 @@ from heart.peripheral.registry import PeripheralConfigurationRegistry
 from heart.runtime.container import build_runtime_container
 from heart.runtime.display_context import DisplayContext
 from heart.runtime.game_loop import GameLoop
+from heart.runtime.manyfold_node import ManyfoldNodeRuntime
 
 
 class TestRuntimeContainer:
@@ -26,6 +27,7 @@ class TestRuntimeContainer:
             DisplayContext,
             GameModes,
             RandomnessProvider,
+            ManyfoldNodeRuntime,
         ):
             assert container.resolve(service) is container.resolve(service)
 

--- a/tests/runtime/test_manyfold_node.py
+++ b/tests/runtime/test_manyfold_node.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+
+from heart.runtime.manyfold_node import (EXTERNAL_SENSOR_STATE_TOPIC,
+                                         FRAME_TICK_TOPIC,
+                                         HEART_MANYFOLD_STATUS_TOPIC,
+                                         HEART_TOPIC_POLICIES,
+                                         INPUT_EVENT_TOPIC,
+                                         MICROPHONE_SAMPLE_STREAM,
+                                         NAVIGATION_TOPIC,
+                                         RENDERED_FRAME_STREAM,
+                                         ManyfoldNodeConfig,
+                                         ManyfoldNodeRuntime, TopicDelivery,
+                                         topic_policy_manifest)
+
+
+class TestManyfoldNodeRuntime:
+    def test_unconfigured_runtime_is_an_idempotent_disabled_boundary(self) -> None:
+        runtime = ManyfoldNodeRuntime(ManyfoldNodeConfig(bootstrap=None))
+
+        first = runtime.start()
+        second = runtime.start()
+        runtime.poll()
+        runtime.close()
+        runtime.close()
+
+        assert first == second
+        assert not first.is_enabled
+        assert not first.is_started
+        assert first.node is None
+
+    def test_topic_policy_keeps_hot_paths_local_and_all_topics_non_durable(
+        self,
+    ) -> None:
+        policy_by_topic = {policy.topic: policy for policy in HEART_TOPIC_POLICIES}
+
+        assert policy_by_topic[HEART_MANYFOLD_STATUS_TOPIC].delivery is (
+            TopicDelivery.MESH_BEST_EFFORT
+        )
+        assert policy_by_topic[NAVIGATION_TOPIC].delivery is (
+            TopicDelivery.MESH_BEST_EFFORT
+        )
+        assert policy_by_topic[EXTERNAL_SENSOR_STATE_TOPIC].delivery is (
+            TopicDelivery.MESH_COALESCED
+        )
+        for topic in (
+            FRAME_TICK_TOPIC,
+            RENDERED_FRAME_STREAM,
+            MICROPHONE_SAMPLE_STREAM,
+            INPUT_EVENT_TOPIC,
+        ):
+            assert policy_by_topic[topic].delivery is TopicDelivery.LOCAL
+        assert all(not policy.durable for policy in HEART_TOPIC_POLICIES)
+        assert all(not policy.raft for policy in HEART_TOPIC_POLICIES)
+
+    def test_topic_policy_manifest_is_stable_machine_readable_json(self) -> None:
+        manifest = topic_policy_manifest()
+
+        encoded = json.dumps(manifest, sort_keys=True)
+
+        assert '"delivery": "local"' in encoded
+        assert '"delivery": "mesh_best_effort"' in encoded
+        assert '"delivery": "mesh_coalesced"' in encoded

--- a/tests/runtime/test_manyfold_node_mesh.py
+++ b/tests/runtime/test_manyfold_node_mesh.py
@@ -1,0 +1,880 @@
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+import queue
+import socket
+import tempfile
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from manyfold.architecture import (MachineSignerService, NodeIdentityStore,
+                                   PubSubTopic)
+
+from heart.peripheral.core.input.debug import InputDebugTap
+from heart.peripheral.core.input.external_sensors import (
+    ExternalSensorHub, external_sensor_state_topic)
+from heart.peripheral.core.input.profiles.navigation import (
+    HEART_INPUT_PUBSUB, NAVIGATION_TOPIC, NavigationEvent)
+from heart.runtime.manyfold_node import (EXTERNAL_SENSOR_STATE_TOPIC,
+                                         FRAME_TICK_TOPIC,
+                                         HEART_MANYFOLD_STATUS_TOPIC,
+                                         HEART_TOPIC_POLICIES,
+                                         INPUT_EVENT_TOPIC,
+                                         MICROPHONE_SAMPLE_STREAM,
+                                         RENDERED_FRAME_STREAM,
+                                         ManyfoldNodeConfig,
+                                         ManyfoldNodeRuntime, TopicDelivery,
+                                         topic_policy_manifest)
+
+MANYFOLD_MESH_BASE_COMMIT = "726f64d72b36d8bd134bda63e29ebd80472736b6"
+CLUSTER_ID = "heart-mesh-test"
+LOCAL_HOST = "127.0.0.1"
+SWIM_KEY_A = "a1" * 32
+SWIM_KEY_B = "b2" * 32
+PROCESS_TIMEOUT_SECONDS = 15.0
+CONVERGENCE_TIMEOUT_SECONDS = 10.0
+POLL_LATENCY_LIMIT_SECONDS = 0.05
+
+
+@dataclass
+class _NodeProcess:
+    node_id: str
+    process: multiprocessing.Process
+    commands: Any
+    reports: Any
+
+
+@pytest.mark.skipif(
+    bool(os.environ.get("PYTEST_XDIST_WORKER")),
+    reason="real socket loss/restart qualification runs serially with -n 0",
+)
+def test_real_process_mesh_story(tmp_path: Path) -> None:
+    """Exercise one signed discovery, SWIM, mesh, loss, and reconnect story."""
+    (
+        signer_a,
+        signer_b,
+        signer_socket_a,
+        signer_socket_b,
+        signer_directory,
+    ) = _start_signers(tmp_path)
+    bootstrap_port_a = _unused_port()
+    bootstrap_port_b = _unused_port()
+    mesh_port_b = _unused_port()
+    config_a = tmp_path / "node-a.json"
+    config_b = tmp_path / "node-b.json"
+    _write_node_config(
+        config_a,
+        node_id="node-a",
+        instance_id="instance-a-1",
+        incarnation=0,
+        bootstrap_port=bootstrap_port_a,
+        signer_socket=signer_socket_a,
+        swim_key_hex=SWIM_KEY_A,
+        peer_node_id="node-b",
+        peer_bootstrap_port=bootstrap_port_b,
+        peer_mesh_port=mesh_port_b,
+        peer_swim_key_hex=SWIM_KEY_B,
+        mesh_role="connect",
+    )
+    _write_node_config(
+        config_b,
+        node_id="node-b",
+        instance_id="instance-b-1",
+        incarnation=0,
+        bootstrap_port=bootstrap_port_b,
+        signer_socket=signer_socket_b,
+        swim_key_hex=SWIM_KEY_B,
+        peer_node_id="node-a",
+        peer_bootstrap_port=bootstrap_port_a,
+        peer_mesh_port=mesh_port_b,
+        peer_swim_key_hex=SWIM_KEY_A,
+        mesh_role="listen",
+        mesh_listen_port=mesh_port_b,
+    )
+
+    node_a: _NodeProcess | None = None
+    node_b: _NodeProcess | None = None
+    restarted_b: _NodeProcess | None = None
+    try:
+        node_a = _start_node("node-a", config_a)
+    except BaseException:
+        signer_b.stop()
+        signer_a.stop()
+        signer_directory.cleanup()
+        raise
+    assert node_a is not None
+    try:
+        discovered = _wait_snapshot(
+            node_a,
+            lambda snapshot: (
+                snapshot["candidate_count"] == 1
+                and snapshot["authenticated_peers"] == []
+                and "node-b" not in snapshot["members"]
+            ),
+        )
+        assert discovered["candidate_count"] == 1
+        assert discovered["authenticated_peers"] == []
+        assert "node-b" not in discovered["members"]
+
+        node_b = _start_node("node-b", config_b)
+        connected_a = _wait_snapshot(node_a, _connected_to("node-b"))
+        connected_b = _wait_snapshot(node_b, _connected_to("node-a"))
+        assert connected_a["members"]["node-b"]["state"] == "alive"
+        assert connected_b["members"]["node-a"]["state"] == "alive"
+        assert connected_a["remote_subscriptions"] == 3
+        assert connected_b["remote_subscriptions"] == 3
+
+        _command(node_a, "navigation", source="mesh-test.first", step=1)
+        _wait_snapshot(
+            node_b,
+            lambda snapshot: (
+                _event_count(
+                    snapshot["navigation_events"],
+                    source="mesh-test.first",
+                )
+                == 1
+            ),
+        )
+        _command(
+            node_a,
+            "sensor",
+            sensor_key="mesh-accelerometer:x",
+            value=0.25,
+        )
+        _wait_snapshot(
+            node_b,
+            lambda snapshot: (
+                _sensor_count(
+                    snapshot["sensor_events"],
+                    sensor_key="mesh-accelerometer:x",
+                    value=0.25,
+                )
+                == 1
+            ),
+        )
+        first_a = _wait_snapshot(node_a, lambda _snapshot: True)
+        first_b = _wait_snapshot(node_b, lambda _snapshot: True)
+        assert (
+            _event_count(
+                first_a["navigation_events"],
+                source="mesh-test.first",
+            )
+            == 1
+        )
+        assert (
+            _event_count(
+                first_b["navigation_events"],
+                source="mesh-test.first",
+            )
+            == 1
+        )
+        assert (
+            _sensor_count(
+                first_a["sensor_events"],
+                sensor_key="mesh-accelerometer:x",
+                value=0.25,
+            )
+            == 1
+        )
+        assert (
+            _sensor_count(
+                first_b["sensor_events"],
+                sensor_key="mesh-accelerometer:x",
+                value=0.25,
+            )
+            == 1
+        )
+
+        node_b.process.terminate()
+        node_b.process.join(PROCESS_TIMEOUT_SECONDS)
+        assert not node_b.process.is_alive()
+        loss = _wait_snapshot(
+            node_a,
+            lambda snapshot: (
+                snapshot["members"].get("node-b", {}).get("state") == "dead"
+                and snapshot["mesh_peer_links"].get("node-b") == "reconnecting"
+            ),
+        )
+        loss = _wait_snapshot(
+            node_a,
+            lambda snapshot: any(
+                event["event_type"] == "changed"
+                and '"node_id":"node-b"' in event["members_json"]
+                and '"state":"dead"' in event["members_json"]
+                for event in snapshot["status_events"]
+            ),
+        )
+        assert loss["max_poll_seconds"] < POLL_LATENCY_LIMIT_SECONDS
+        assert any(
+            event["event_type"] == "changed"
+            and '"node_id":"node-b"' in event["members_json"]
+            and '"state":"dead"' in event["members_json"]
+            for event in loss["status_events"]
+        )
+
+        _write_node_config(
+            config_b,
+            node_id="node-b",
+            instance_id="instance-b-2",
+            incarnation=1,
+            bootstrap_port=bootstrap_port_b,
+            signer_socket=signer_socket_b,
+            swim_key_hex=SWIM_KEY_B,
+            peer_node_id="node-a",
+            peer_bootstrap_port=bootstrap_port_a,
+            peer_mesh_port=mesh_port_b,
+            peer_swim_key_hex=SWIM_KEY_A,
+            mesh_role="listen",
+            mesh_listen_port=mesh_port_b,
+        )
+        restarted_b = _start_node("node-b", config_b)
+        reconnected_a = _wait_snapshot(
+            node_a,
+            lambda snapshot: (
+                _connected_to("node-b")(snapshot)
+                and snapshot["members"]["node-b"]["instance_id"] == "instance-b-2"
+                and snapshot["members"]["node-b"]["incarnation"] == 1
+            ),
+        )
+        reconnected_b = _wait_snapshot(restarted_b, _connected_to("node-a"))
+        assert reconnected_a["remote_subscriptions"] == 3
+        assert reconnected_b["remote_subscriptions"] == 3
+
+        _command(restarted_b, "navigation", source="mesh-test.reconnected", step=-1)
+        _wait_snapshot(
+            node_a,
+            lambda snapshot: (
+                _event_count(
+                    snapshot["navigation_events"],
+                    source="mesh-test.reconnected",
+                )
+                == 1
+            ),
+        )
+        _command(
+            restarted_b,
+            "sensor",
+            sensor_key="mesh-accelerometer:y",
+            value=-0.5,
+        )
+        final_a = _wait_snapshot(
+            node_a,
+            lambda snapshot: (
+                _sensor_count(
+                    snapshot["sensor_events"],
+                    sensor_key="mesh-accelerometer:y",
+                    value=-0.5,
+                )
+                == 1
+            ),
+        )
+        final_b = _wait_snapshot(restarted_b, lambda _snapshot: True)
+        time.sleep(0.25)
+        final_a = _wait_snapshot(node_a, lambda _snapshot: True)
+        final_b = _wait_snapshot(restarted_b, lambda _snapshot: True)
+
+        assert (
+            _event_count(
+                final_a["navigation_events"],
+                source="mesh-test.reconnected",
+            )
+            == 1
+        )
+        assert (
+            _event_count(
+                final_b["navigation_events"],
+                source="mesh-test.reconnected",
+            )
+            == 1
+        )
+        assert (
+            _sensor_count(
+                final_a["sensor_events"],
+                sensor_key="mesh-accelerometer:y",
+                value=-0.5,
+            )
+            == 1
+        )
+        assert (
+            _sensor_count(
+                final_b["sensor_events"],
+                sensor_key="mesh-accelerometer:y",
+                value=-0.5,
+            )
+            == 1
+        )
+        assert final_a["mesh_duplicate_publications"] <= 1
+        assert final_b["mesh_duplicate_publications"] <= 1
+        assert any(
+            '"instance_id":"instance-b-2"' in event["members_json"]
+            and '"state":"alive"' in event["members_json"]
+            for event in final_a["status_events"]
+        )
+
+        shutdown_b = _stop_node(restarted_b)
+        restarted_b = None
+        shutdown_a = _stop_node(node_a)
+        assert shutdown_a["manyfold_worker_threads"] == []
+        assert shutdown_b["manyfold_worker_threads"] == []
+
+        artifact = _mesh_artifact(
+            discovery_snapshot=discovered,
+            loss_snapshot=loss,
+            first_a=first_a,
+            first_b=first_b,
+            final_a=final_a,
+            final_b=final_b,
+            shutdown_a=shutdown_a,
+            shutdown_b=shutdown_b,
+        )
+        artifact_path = Path(
+            os.environ.get(
+                "HEART_MANYFOLD_TEST_ARTIFACT",
+                str(tmp_path / "heart-manyfold-mesh.json"),
+            )
+        )
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        artifact_path.write_text(
+            json.dumps(artifact, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        assert artifact["durable_delivery_topics"] == []
+        assert artifact["raft_topics"] == []
+        assert artifact["local_only_topics"] == [
+            FRAME_TICK_TOPIC,
+            RENDERED_FRAME_STREAM,
+            MICROPHONE_SAMPLE_STREAM,
+            INPUT_EVENT_TOPIC,
+        ]
+    finally:
+        for node in (restarted_b, node_b, node_a):
+            if node is not None and node.process.is_alive():
+                node.process.terminate()
+                node.process.join(PROCESS_TIMEOUT_SECONDS)
+        signer_b.stop()
+        signer_a.stop()
+        signer_directory.cleanup()
+
+
+def _node_worker(config_path: str, commands: Any, reports: Any) -> None:
+    runtime = ManyfoldNodeRuntime(ManyfoldNodeConfig.from_file(Path(config_path)))
+    navigation_topic = PubSubTopic(
+        NAVIGATION_TOPIC,
+        schema=NavigationEvent,
+        pubsub=HEART_INPUT_PUBSUB,
+    )
+    sensor_topic = external_sensor_state_topic()
+    sensor_hub = ExternalSensorHub(
+        InputDebugTap(history_size=0, latency_history_size=0)
+    )
+    navigation_events: list[dict[str, object]] = []
+    sensor_events: list[dict[str, object]] = []
+    status_events: list[dict[str, object]] = []
+    subscriptions = [
+        navigation_topic.subscribe(
+            lambda event: navigation_events.append(
+                {
+                    "kind": str(event.kind),
+                    "source": str(event.source),
+                    "step": int(event.step),
+                    "event_id": str(event.event_id),
+                    "origin_node_id": str(event.origin_node_id),
+                }
+            )
+        ),
+        sensor_topic.subscribe(
+            lambda event: sensor_events.append(
+                {
+                    "sensor_key": str(event.sensor_key),
+                    "value": event.value,
+                    "event_id": str(event.event_id),
+                    "origin_node_id": str(event.origin_node_id),
+                }
+            )
+        ),
+        runtime.status_topic.subscribe(
+            lambda event: status_events.append(
+                {
+                    "event_type": str(event.event_type),
+                    "event_id": str(event.event_id),
+                    "origin_node_id": str(event.origin_node_id),
+                    "members_json": str(event.members_json),
+                }
+            )
+        ),
+    ]
+    max_poll_seconds = 0.0
+    try:
+        runtime.start()
+        reports.put({"kind": "ready"})
+        should_run = True
+        while should_run:
+            try:
+                command = commands.get_nowait()
+            except queue.Empty:
+                command = None
+            if command is not None:
+                command_name = command["command"]
+                if command_name == "navigation":
+                    navigation_topic.publish(
+                        NavigationEvent(
+                            kind="browse",
+                            source=command["source"],
+                            step=command["step"],
+                        )
+                    )
+                elif command_name == "sensor":
+                    sensor_hub.set_value(command["sensor_key"], command["value"])
+                elif command_name == "snapshot":
+                    reports.put(
+                        _snapshot_report(
+                            runtime,
+                            request_id=command["request_id"],
+                            navigation_events=navigation_events,
+                            sensor_events=sensor_events,
+                            status_events=status_events,
+                            max_poll_seconds=max_poll_seconds,
+                        )
+                    )
+                elif command_name == "stop":
+                    should_run = False
+                else:
+                    raise ValueError(f"Unknown node command {command_name!r}")
+            started_at = time.thread_time()
+            runtime.poll()
+            max_poll_seconds = max(
+                max_poll_seconds,
+                time.thread_time() - started_at,
+            )
+            time.sleep(0.002)
+    except BaseException as error:
+        reports.put(
+            {
+                "kind": "error",
+                "error": f"{type(error).__name__}: {error}",
+            }
+        )
+        raise
+    finally:
+        for subscription in reversed(subscriptions):
+            subscription.dispose()
+        sensor_hub.close()
+        runtime.close()
+        deadline = time.monotonic() + 2.0
+        while _manyfold_worker_threads() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        reports.put(
+            {
+                "kind": "shutdown",
+                "manyfold_worker_threads": _manyfold_worker_threads(),
+            }
+        )
+
+
+def _snapshot_report(
+    runtime: ManyfoldNodeRuntime,
+    *,
+    request_id: str,
+    navigation_events: list[dict[str, object]],
+    sensor_events: list[dict[str, object]],
+    status_events: list[dict[str, object]],
+    max_poll_seconds: float,
+) -> dict[str, object]:
+    runtime_status = runtime.status()
+    status = runtime_status.node
+    mesh = runtime_status.mesh
+    if status is None or mesh is None:
+        raise RuntimeError("enabled node returned no upstream status")
+    return {
+        "kind": "snapshot",
+        "request_id": request_id,
+        "candidate_count": len(status.peers),
+        "authenticated_peers": sorted(
+            peer.health.remote_identity.node_id
+            for peer in status.peers
+            if peer.health.remote_identity is not None
+            and peer.health.state.value == "connected"
+        ),
+        "members": {
+            member.identity.node_id: {
+                "instance_id": member.identity.instance_id,
+                "incarnation": member.incarnation,
+                "state": member.state.value,
+            }
+            for member in status.members
+        },
+        "bootstrap_peer_links": {
+            peer.health.remote_identity.node_id: peer.health.state.value
+            for peer in status.peers
+            if peer.health.remote_identity is not None
+        },
+        "mesh_peer_links": {
+            peer.node_id: peer.link.state.value for peer in runtime_status.mesh_peers
+        },
+        "remote_subscriptions": mesh.remote_subscriptions,
+        "mesh_duplicate_publications": mesh.duplicate_publications,
+        "navigation_events": list(navigation_events),
+        "sensor_events": list(sensor_events),
+        "status_events": list(status_events),
+        "max_poll_seconds": max_poll_seconds,
+        "last_error": next(
+            (
+                diagnostic.message
+                for diagnostic in reversed(status.diagnostics)
+                if diagnostic.severity.value == "error"
+            ),
+            "",
+        ),
+    }
+
+
+def _manyfold_worker_threads() -> list[str]:
+    return sorted(
+        thread.name
+        for thread in threading.enumerate()
+        if thread is not threading.main_thread() and thread.name.startswith("manyfold")
+    )
+
+
+def _start_node(node_id: str, config_path: Path) -> _NodeProcess:
+    context = multiprocessing.get_context("spawn")
+    commands = context.Queue()
+    reports = context.Queue()
+    process = context.Process(
+        target=_node_worker,
+        args=(str(config_path), commands, reports),
+        name=f"heart-mesh-{node_id}",
+    )
+    process.start()
+    node = _NodeProcess(node_id, process, commands, reports)
+    report = _wait_report(node, lambda row: row["kind"] in ("ready", "error"))
+    if report["kind"] == "error":
+        process.join(PROCESS_TIMEOUT_SECONDS)
+        if process.is_alive():
+            process.terminate()
+            process.join(PROCESS_TIMEOUT_SECONDS)
+        raise AssertionError(f"{node_id} failed to start: {report['error']}")
+    return node
+
+
+def _stop_node(node: _NodeProcess) -> dict[str, object]:
+    _command(node, "stop")
+    report = _wait_report(node, lambda row: row["kind"] in ("shutdown", "error"))
+    node.process.join(PROCESS_TIMEOUT_SECONDS)
+    assert not node.process.is_alive()
+    assert node.process.exitcode == 0
+    if report["kind"] == "error":
+        raise AssertionError(
+            f"{node.node_id} failed during shutdown: {report['error']}"
+        )
+    return report
+
+
+def _wait_snapshot(
+    node: _NodeProcess,
+    predicate: Callable[[dict[str, Any]], bool],
+) -> dict[str, Any]:
+    deadline = time.monotonic() + CONVERGENCE_TIMEOUT_SECONDS
+    last_snapshot: dict[str, Any] | None = None
+    while time.monotonic() < deadline:
+        request_id = uuid4().hex
+        _command(node, "snapshot", request_id=request_id)
+        report = _wait_report(
+            node,
+            lambda row: (
+                row["kind"] == "error"
+                or (row["kind"] == "snapshot" and row.get("request_id") == request_id)
+            ),
+        )
+        if report["kind"] == "error":
+            raise AssertionError(f"{node.node_id} failed: {report['error']}")
+        last_snapshot = report
+        if predicate(report):
+            return report
+        time.sleep(0.025)
+    raise AssertionError(
+        f"{node.node_id} did not converge; last snapshot={last_snapshot!r}"
+    )
+
+
+def _wait_report(
+    node: _NodeProcess,
+    predicate: Callable[[dict[str, Any]], bool],
+) -> dict[str, Any]:
+    deadline = time.monotonic() + PROCESS_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        try:
+            report = node.reports.get(timeout=0.1)
+        except queue.Empty:
+            if not node.process.is_alive():
+                raise AssertionError(
+                    f"{node.node_id} exited early with {node.process.exitcode}"
+                )
+            continue
+        if predicate(report):
+            return report
+    raise AssertionError(f"Timed out waiting for {node.node_id} report")
+
+
+def _command(node: _NodeProcess, command: str, **fields: object) -> None:
+    node.commands.put({"command": command, **fields})
+
+
+def _connected_to(peer_node_id: str) -> Callable[[dict[str, Any]], bool]:
+    return lambda snapshot: (
+        peer_node_id in snapshot["authenticated_peers"]
+        and snapshot["members"].get(peer_node_id, {}).get("state") == "alive"
+        and snapshot["bootstrap_peer_links"].get(peer_node_id) == "connected"
+        and snapshot["mesh_peer_links"].get(peer_node_id) == "connected"
+        and snapshot["remote_subscriptions"] == 3
+    )
+
+
+def _event_count(events: list[dict[str, Any]], *, source: str) -> int:
+    return sum(event["source"] == source for event in events)
+
+
+def _sensor_count(
+    events: list[dict[str, Any]],
+    *,
+    sensor_key: str,
+    value: float,
+) -> int:
+    return sum(
+        event["sensor_key"] == sensor_key and event["value"] == value
+        for event in events
+    )
+
+
+def _mesh_artifact(
+    *,
+    discovery_snapshot: dict[str, Any],
+    loss_snapshot: dict[str, Any],
+    first_a: dict[str, Any],
+    first_b: dict[str, Any],
+    final_a: dict[str, Any],
+    final_b: dict[str, Any],
+    shutdown_a: dict[str, Any],
+    shutdown_b: dict[str, Any],
+) -> dict[str, object]:
+    manifest = topic_policy_manifest()
+    local_only_topics = [
+        policy.topic
+        for policy in HEART_TOPIC_POLICIES
+        if policy.delivery is TopicDelivery.LOCAL
+    ]
+    return {
+        "manyfold_mesh_base_commit": MANYFOLD_MESH_BASE_COMMIT,
+        "authentication": "machine_signer_enrollment_mutual_tls_identity_uri",
+        "process_count": 2,
+        "story": {
+            "discovery_candidate_untrusted_before_authentication": (
+                discovery_snapshot["candidate_count"] == 1
+                and not discovery_snapshot["authenticated_peers"]
+                and "node-b" not in discovery_snapshot["members"]
+            ),
+            "swim_loss_detected": (
+                loss_snapshot["members"]["node-b"]["state"] == "dead"
+            ),
+            "status_reported_loss_and_reconnect": (
+                any(
+                    '"state":"dead"' in event["members_json"]
+                    for event in loss_snapshot["status_events"]
+                )
+                and any(
+                    '"instance_id":"instance-b-2"' in event["members_json"]
+                    and '"state":"alive"' in event["members_json"]
+                    for event in final_a["status_events"]
+                )
+            ),
+            "transport_reconnected": (
+                final_a["bootstrap_peer_links"]["node-b"] == "connected"
+                and final_b["bootstrap_peer_links"]["node-a"] == "connected"
+                and final_a["mesh_peer_links"]["node-b"] == "connected"
+                and final_b["mesh_peer_links"]["node-a"] == "connected"
+            ),
+            "subscriptions_restored": (
+                final_a["remote_subscriptions"] == 3
+                and final_b["remote_subscriptions"] == 3
+            ),
+            "shutdown_clean": (
+                not shutdown_a["manyfold_worker_threads"]
+                and not shutdown_b["manyfold_worker_threads"]
+            ),
+        },
+        "navigation_counts": {
+            "node_a_first": _event_count(
+                first_a["navigation_events"],
+                source="mesh-test.first",
+            ),
+            "node_b_first": _event_count(
+                first_b["navigation_events"],
+                source="mesh-test.first",
+            ),
+            "node_a_reconnected": _event_count(
+                final_a["navigation_events"],
+                source="mesh-test.reconnected",
+            ),
+            "node_b_reconnected": _event_count(
+                final_b["navigation_events"],
+                source="mesh-test.reconnected",
+            ),
+        },
+        "sensor_counts": {
+            "node_a_first": _sensor_count(
+                first_a["sensor_events"],
+                sensor_key="mesh-accelerometer:x",
+                value=0.25,
+            ),
+            "node_b_first": _sensor_count(
+                first_b["sensor_events"],
+                sensor_key="mesh-accelerometer:x",
+                value=0.25,
+            ),
+            "node_a_reconnected": _sensor_count(
+                final_a["sensor_events"],
+                sensor_key="mesh-accelerometer:y",
+                value=-0.5,
+            ),
+            "node_b_reconnected": _sensor_count(
+                final_b["sensor_events"],
+                sensor_key="mesh-accelerometer:y",
+                value=-0.5,
+            ),
+        },
+        "topic_policy": manifest,
+        "mesh_topics": [
+            HEART_MANYFOLD_STATUS_TOPIC,
+            NAVIGATION_TOPIC,
+            EXTERNAL_SENSOR_STATE_TOPIC,
+        ],
+        "local_only_topics": local_only_topics,
+        "durable_delivery_topics": [
+            policy.topic for policy in HEART_TOPIC_POLICIES if policy.durable
+        ],
+        "raft_topics": [policy.topic for policy in HEART_TOPIC_POLICIES if policy.raft],
+        "max_poll_seconds_during_story": max(
+            final_a["max_poll_seconds"],
+            final_b["max_poll_seconds"],
+            loss_snapshot["max_poll_seconds"],
+        ),
+    }
+
+
+def _start_signers(
+    directory: Path,
+) -> tuple[
+    MachineSignerService,
+    MachineSignerService,
+    Path,
+    Path,
+    tempfile.TemporaryDirectory[str],
+]:
+    authority, token = NodeIdentityStore.initialize(
+        directory / "node-a-identity",
+        cluster_id=CLUSTER_ID,
+        node_id="node-a",
+        server_names=(LOCAL_HOST, "localhost"),
+    )
+    node_b = authority.enroll(
+        directory / "node-b-identity",
+        node_id="node-b",
+        token=token,
+        server_names=(LOCAL_HOST, "localhost"),
+    )
+    socket_directory = tempfile.TemporaryDirectory(prefix="heart-signers-")
+    socket_root = Path(socket_directory.name)
+    socket_a = socket_root / "a.sock"
+    socket_b = socket_root / "b.sock"
+    signer_a = MachineSignerService(
+        authority,
+        socket_a,
+        credential_ttl_seconds=120,
+    )
+    signer_b = MachineSignerService(
+        node_b,
+        socket_b,
+        credential_ttl_seconds=120,
+    )
+    signer_a.start()
+    try:
+        signer_b.start()
+    except BaseException:
+        signer_a.stop()
+        socket_directory.cleanup()
+        raise
+    return signer_a, signer_b, socket_a, socket_b, socket_directory
+
+
+def _write_node_config(
+    path: Path,
+    *,
+    node_id: str,
+    instance_id: str,
+    incarnation: int,
+    bootstrap_port: int,
+    signer_socket: Path,
+    swim_key_hex: str,
+    peer_node_id: str,
+    peer_bootstrap_port: int,
+    peer_mesh_port: int,
+    peer_swim_key_hex: str,
+    mesh_role: str,
+    mesh_listen_port: int | None = None,
+) -> None:
+    peer = {
+        "node_id": peer_node_id,
+        "bootstrap_host": LOCAL_HOST,
+        "bootstrap_port": peer_bootstrap_port,
+        "mesh_host": LOCAL_HOST,
+        "mesh_port": peer_mesh_port,
+        "swim_key_hex": peer_swim_key_hex,
+        "mesh_role": mesh_role,
+    }
+    if mesh_listen_port is not None:
+        peer["mesh_listen_host"] = LOCAL_HOST
+        peer["mesh_listen_port"] = mesh_listen_port
+    path.write_text(
+        json.dumps(
+            {
+                "cluster_id": CLUSTER_ID,
+                "node_id": node_id,
+                "instance_id": instance_id,
+                "incarnation": incarnation,
+                "listen_host": LOCAL_HOST,
+                "listen_port": bootstrap_port,
+                "signer_socket": str(signer_socket),
+                "connector_server_hostname": LOCAL_HOST,
+                "swim_key_hex": swim_key_hex,
+                "reconcile_interval_seconds": 0.05,
+                "startup_peer_timeout_seconds": 0.05,
+                "peer_absence_seconds": 0.1,
+                "minimum_credential_lifetime_seconds": 30.0,
+                "lease_seconds": 0.5,
+                "suspect_seconds": 0.25,
+                "dead_retention_seconds": 3.0,
+                "swim_probe_interval_seconds": 0.05,
+                "swim_ping_timeout_seconds": 0.025,
+                "swim_indirect_timeout_seconds": 0.025,
+                "peers": [peer],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _unused_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind((LOCAL_HOST, 0))
+        return int(probe.getsockname()[1])

--- a/tests/runtime/test_manyfold_signer.py
+++ b/tests/runtime/test_manyfold_signer.py
@@ -73,7 +73,7 @@ class TestManyfoldSignerConfig:
             ManyfoldSignerConfig(**arguments)
 
 
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(70)
 def test_real_multiprocess_signer_qualification(tmp_path: Path) -> None:
     signer_executable = Path(sys.executable).with_name("manyfold-machine-signer")
     enrollment_executable = Path(sys.executable).with_name("manyfold-enrollment")
@@ -95,7 +95,7 @@ def test_real_multiprocess_signer_qualification(tmp_path: Path) -> None:
         check=True,
         capture_output=True,
         text=True,
-        timeout=25,
+        timeout=60,
     )
 
     artifact = json.loads(artifact_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

Heart now joins signer-authenticated ManyFold nodes and shares only node status, navigation intents, and selected low-rate external sensor state over best-effort PubSub. Discovery candidates remain untrusted until canonical bootstrap authentication, SWIM owns loss detection, navigation events are bounded and deduplicated, and frame/render/microphone/debug hot paths stay local.

This draft is based on Heart main after [PR 948](https://github.com/Organization5762/heart/pull/948) merged its machine-local signer deployment and readiness at `09ef33b3386e37018cfdba3484ac1f428c8ad034`; [PR 945](https://github.com/Organization5762/heart/pull/945) previously merged the canonical ManyFold migration at `457111e613d35f90a3db331852c2122efa100b73`. ManyFold is pinned to exact merged main `726f64d72b36d8bd134bda63e29ebd80472736b6`.

## How it works

- `ManyfoldNodeRuntime` gives public `manyfold.cluster.NodeRuntime` the signer-backed transport provider, static discovery seeds, membership policy, and HMAC SWIM transport. Upstream owns discovery, authentication, membership, failure detection, reconnect, sockets, and workers.
- Heart composes public `TransportMesh` beside `NodeRuntime`, subscribes exactly three named topics, coalesces external sensor state to 10 Hz, and drains at most 64 queued publications per game-loop poll.
- Globally unique event IDs, source checks, the upstream mesh duplicate window, and a bounded 4,096-ID Heart window prevent mesh echoes and duplicate user actions.
- `HEART_TOPIC_POLICIES` is the authoritative machine-readable boundary. Frame ticks, rendered frames, microphone-rate samples, and debug taps are local and have `durable: false` and `raft: false`.
- Runtime container wiring starts the node before peripheral detection, polls it without running discovery or SWIM inline, and closes mesh, canonical node runtime, and signer client deterministically.

## How you can try this right now

Prerequisites: merged PR 948 signer deployment, an enrolled node, and the exact pinned ManyFold dependency.

Run the continuous real-process gate:

```sh
HEART_MANYFOLD_TEST_ARTIFACT=/tmp/heart-manyfold-mesh.json \
uv run pytest -n 0 \
tests/runtime/test_manyfold_node_mesh.py::test_real_process_mesh_story -q
```

Expected result: two spawned Heart processes use real TCP, UDP, and Unix signer sockets; the test observes untrusted offline discovery, enrollment-backed mutual TLS, SWIM admission, navigation and sensor delivery, SWIM death, reconnect with a fresh instance/incarnation, exactly three restored subscriptions, bounded duplicates, and clean shutdown.

The command writes `/tmp/heart-manyfold-mesh.json`. Expected machine assertions include:

```json
{
  "durable_delivery_topics": [],
  "raft_topics": [],
  "local_only_topics": [
    "heart.frame_tick",
    "heart.rendered_frame",
    "heart.microphone.level",
    "heart.input"
  ]
}
```

See `docs/manyfold_node_runtime.md` for deployment configuration and the complete artifact contract.

## Appendix

### Performance

Discovery, authentication, SWIM, and reconnect run on canonical ManyFold workers. The qualification observed maximum foreground Heart poll CPU of 2.111 ms against a 50 ms bound. Sensor publication is last-value coalesced at 10 Hz and each poll drains at most 64 mesh publications.

### Testing

- Real discovery-to-auth-to-SWIM-to-PubSub-to-loss/reconnect gate: passed three consecutive serial runs; final post-stack run passed.
- Combined PR 948 signer and mesh focused gate: 11 passed.
- Full Heart suite on the exact PR 948 stack: passed under 14-way xdist; the real socket qualification is intentionally skipped in xdist workers and run separately with `-n 0`.
- Full Ruff scan and repository format hook: passed.
- Focused mypy for node runtime and external sensor boundary: passed.
- Diff whitespace/error checks: passed.

### Security and reliability

A discovered address has no trusted node identity until the enrolled machine signer issues a short-lived process credential and mutual TLS authenticates the canonical bootstrap link. SWIM datagrams use per-node HMAC keys. Heart adds no keepalive. Best-effort publication drops on bounded backpressure with an operational warning instead of blocking or becoming durable.

### Change size

Non-test files: 1,337 additions, 40 deletions, net +1,297 lines. This includes the runtime configuration boundary and deployment/qualification documentation; generated files are excluded.

### Dependencies and rollout

Required base: merged PR 948 at `09ef33b3386e37018cfdba3484ac1f428c8ad034`; PR 945 previously merged at `457111e613d35f90a3db331852c2122efa100b73`. Do not enable mesh configuration until signer enrollment is ready. Leaving `HEART_MANYFOLD_CONFIG` unset keeps the node boundary disabled and starts no mesh workers.