### PR TITLE
Allow signer qualification scheduling headroom

### DIFF
--- a/tests/runtime/test_manyfold_signer.py
+++ b/tests/runtime/test_manyfold_signer.py
@@ -14,6 +14,10 @@ from heart.runtime.manyfold_signer import (DEFAULT_SIGNER_SOCKET,
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 QUALIFICATION_SCRIPT = PROJECT_ROOT / "scripts" / "qualify_manyfold_signer.py"
+# The real credential-window sleeps take about 13 seconds before CI scheduling
+# contention; these caps bound the harness without constraining signer policy.
+QUALIFICATION_SUBPROCESS_TIMEOUT_SECONDS = 45
+QUALIFICATION_TEST_TIMEOUT_SECONDS = 60
 
 
 class TestManyfoldSignerConfig:
@@ -73,7 +77,7 @@ class TestManyfoldSignerConfig:
             ManyfoldSignerConfig(**arguments)
 
 
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(QUALIFICATION_TEST_TIMEOUT_SECONDS)
 def test_real_multiprocess_signer_qualification(tmp_path: Path) -> None:
     signer_executable = Path(sys.executable).with_name("manyfold-machine-signer")
     enrollment_executable = Path(sys.executable).with_name("manyfold-enrollment")
@@ -95,7 +99,7 @@ def test_real_multiprocess_signer_qualification(tmp_path: Path) -> None:
         check=True,
         capture_output=True,
         text=True,
-        timeout=25,
+        timeout=QUALIFICATION_SUBPROCESS_TIMEOUT_SECONDS,
     )
 
     artifact = json.loads(artifact_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

The real multiprocess signer qualification could exceed its 25-second
subprocess timeout when scheduled alongside the full 14-worker Heart suite,
even though it was progressing normally and passed focused and hosted CI runs.

This follow-up gives the test harness scheduling headroom without changing
signer production behavior, credential policy, retries, IPC, or the
qualification script's bounded phase operations.

## How it works

- Increase the qualification subprocess wall-clock cap from 25 to 45 seconds.
- Increase the enclosing pytest timeout from 30 to 60 seconds so subprocess
  termination and fixture cleanup retain a separate bound.
- Name and document both test-only limits.

The focused test normally takes about 13 seconds. The 45-second subprocess cap
allows roughly three times that runtime under shared-runner contention while
remaining finite and below the enclosing 60-second test limit.

## How you can try this right now

```sh
.venv/bin/pytest \
  tests/runtime/test_manyfold_signer.py::test_real_multiprocess_signer_qualification \
  -q
.venv/bin/pytest -q
```

The focused qualification should pass in about 13 seconds. The full command
runs it with the repository's 14-worker configuration.

## Appendix

### Performance

Not applicable to production. This changes only test wall-clock allowances.

### Testing

- Full 14-worker Heart suite: 597 passed, 2 skipped in 44.65 seconds.
- Ruff check for the changed test: passed.
- Repository formatting and lock integrity: passed.

### Scope

Test-only change: 6 additions, 2 deletions. Non-test LOC is unchanged.
