### PR TITLE
Stabilize mesh replacement incarnation qualification

### DIFF
--- a/tests/runtime/test_manyfold_node_mesh.py
+++ b/tests/runtime/test_manyfold_node_mesh.py
@@ -220,11 +220,12 @@ def test_real_process_mesh_story(tmp_path: Path) -> None:
             for event in loss["status_events"]
         )
 
+        replacement_incarnation = 1
         _write_node_config(
             config_b,
             node_id="node-b",
             instance_id="instance-b-2",
-            incarnation=1,
+            incarnation=replacement_incarnation,
             bootstrap_port=bootstrap_port_b,
             signer_socket=signer_socket_b,
             swim_key_hex=SWIM_KEY_B,
@@ -238,13 +239,18 @@ def test_real_process_mesh_story(tmp_path: Path) -> None:
         restarted_b = _start_node("node-b", config_b)
         reconnected_a = _wait_snapshot(
             node_a,
-            lambda snapshot: (
-                _connected_to("node-b")(snapshot)
-                and snapshot["members"]["node-b"]["instance_id"] == "instance-b-2"
-                and snapshot["members"]["node-b"]["incarnation"] == 1
+            _connected_to_instance(
+                "node-b",
+                instance_id="instance-b-2",
+                minimum_incarnation=replacement_incarnation,
             ),
         )
         reconnected_b = _wait_snapshot(restarted_b, _connected_to("node-a"))
+        replacement_member = reconnected_a["members"]["node-b"]
+        assert replacement_member["instance_id"] == "instance-b-2"
+        assert replacement_member["state"] == "alive"
+        assert replacement_member["incarnation"] >= replacement_incarnation
+        assert "node-b" in reconnected_a["authenticated_peers"]
         assert reconnected_a["remote_subscriptions"] == 3
         assert reconnected_b["remote_subscriptions"] == 3
 
@@ -636,6 +642,27 @@ def _connected_to(peer_node_id: str) -> Callable[[dict[str, Any]], bool]:
         and snapshot["mesh_peer_links"].get(peer_node_id) == "connected"
         and snapshot["remote_subscriptions"] == 3
     )
+
+
+def _connected_to_instance(
+    peer_node_id: str,
+    *,
+    instance_id: str,
+    minimum_incarnation: int,
+) -> Callable[[dict[str, Any]], bool]:
+    connected = _connected_to(peer_node_id)
+
+    def predicate(snapshot: dict[str, Any]) -> bool:
+        member = snapshot["members"].get(peer_node_id, {})
+        incarnation = member.get("incarnation")
+        return (
+            connected(snapshot)
+            and member.get("instance_id") == instance_id
+            and isinstance(incarnation, int)
+            and incarnation >= minimum_incarnation
+        )
+
+    return predicate
 
 
 def _event_count(events: list[dict[str, Any]], *, source: str) -> int:


### PR DESCRIPTION
## Summary

The real ManyFold mesh qualification no longer requires a restarted peer's SWIM incarnation to remain exactly at its configured starting value. SWIM may legitimately advance that counter before Heart takes the reconnect snapshot, so the test now requires the replacement instance to retain an integer incarnation at or above its positive configured baseline.

This is test-only. Production behavior and the authentication, alive membership, link, restored-subscription, navigation, sensor-delivery, duplicate-bound, and clean-shutdown assertions are unchanged.

## How it works

The reconnect wait uses a focused `_connected_to_instance` predicate. It composes the existing authenticated/alive/bootstrap/mesh/subscription predicate with two replacement-identity invariants: the expected new `instance_id`, and an integer incarnation greater than or equal to the replacement's configured incarnation. Explicit post-convergence assertions repeat the replacement identity, alive state, non-regressing incarnation, authentication, and subscription expectations for clear failures.

## How you can try this right now

From the repository root, run the real two-process socket story serially:

```sh
HEART_MANYFOLD_TEST_ARTIFACT=/tmp/heart-manyfold-incarnation.json \
UV_NO_SYNC=1 .venv/bin/python -m pytest -n 0 \
tests/runtime/test_manyfold_node_mesh.py::test_real_process_mesh_story -q
```

Expected result: the test passes when the replacement node is authenticated and alive with `instance-b-2` and any incarnation at least `1`, then proves navigation and sensor delivery, bounded duplicates, and clean shutdown.

## Appendix

### Performance

Not applicable. This changes one qualification predicate and adds no production work.

### Testing

- Final real multiprocess mesh qualification: 3 consecutive passes.
- Earlier qualification set: 3 consecutive passes before an unrelated existing listener-link state timing failure; that assertion was not changed.
- Focused Ruff, isort, docformatter, and diff checks: passed.
- Repository pre-push formatting hook: passed.
- Hosted CI: triggered by this PR.