### PR TITLE
Give the default microphone a stable identity

### DIFF
--- a/src/heart/peripheral/microphone.py
+++ b/src/heart/peripheral/microphone.py
@@ -18,7 +18,7 @@ from manyfold.architecture import NewValues
 from manyfold.sensor_io import (BackoffPolicy, ManagedRunLoop, RetryPolicy,
                                 SensorEvent, StopToken, sensor_event_schema)
 
-from heart.peripheral.core import Peripheral
+from heart.peripheral.core import Peripheral, PeripheralInfo, PeripheralTag
 from heart.peripheral.input_payloads.audio import MicrophoneLevel
 from heart.utilities.logging import get_logger
 from heart.utilities.optional_imports import optional_import
@@ -205,6 +205,14 @@ class Microphone(Peripheral[MicrophoneLevel]):
 
     def _event_stream(self) -> Subscribable[MicrophoneLevel]:
         return self._level_stream
+
+    def peripheral_info(self) -> PeripheralInfo:
+        return PeripheralInfo(
+            id="microphone:default",
+            tags=(
+                PeripheralTag(name="input_variant", variant="microphone"),
+            ),
+        )
 
     def stop(self) -> None:
         """Signal the run-loop to stop on the next iteration."""

--- a/src/heart/peripheral/microphone.py
+++ b/src/heart/peripheral/microphone.py
@@ -17,6 +17,7 @@ from manyfold import (DetectionNode, Graph, Layer, ManagedGraphNode,
 from manyfold.architecture import NewValues
 from manyfold.sensor_io import (BackoffPolicy, ManagedRunLoop, RetryPolicy,
                                 SensorEvent, StopToken, sensor_event_schema)
+from typing_extensions import override
 
 from heart.peripheral.core import Peripheral, PeripheralInfo, PeripheralTag
 from heart.peripheral.input_payloads.audio import MicrophoneLevel
@@ -115,6 +116,15 @@ class Microphone(Peripheral[MicrophoneLevel]):
             name="heart.peripheral.microphone.level"
         )
 
+    @override
+    def peripheral_info(self) -> PeripheralInfo:
+        return PeripheralInfo(
+            id="microphone:default",
+            tags=(
+                PeripheralTag(name="input_variant", variant="microphone"),
+            ),
+        )
+
     # ------------------------------------------------------------------
     # Detection lifecycle
     # ------------------------------------------------------------------
@@ -205,14 +215,6 @@ class Microphone(Peripheral[MicrophoneLevel]):
 
     def _event_stream(self) -> Subscribable[MicrophoneLevel]:
         return self._level_stream
-
-    def peripheral_info(self) -> PeripheralInfo:
-        return PeripheralInfo(
-            id="microphone:default",
-            tags=(
-                PeripheralTag(name="input_variant", variant="microphone"),
-            ),
-        )
 
     def stop(self) -> None:
         """Signal the run-loop to stop on the next iteration."""

--- a/tests/peripheral/test_microphone.py
+++ b/tests/peripheral/test_microphone.py
@@ -48,6 +48,20 @@ class TestPeripheralMicrophone:
         monkeypatch.setattr(microphone, "sd", None)
         assert list(Microphone.detect()) == []
 
+    def test_default_microphone_has_stable_sensor_identity(self) -> None:
+        peripheral = Microphone()
+
+        identity = peripheral.peripheral_info().to_sensor_identity()
+        event = peripheral._level_to_sensor_event(
+            peripheral._process_audio_chunk(
+                np.array([[0.0], [0.5], [-1.0]], dtype=float),
+                frames=3,
+            )
+        )
+
+        assert identity.id == "microphone:default"
+        assert event.identity == identity
+
     def test_detection_node_publishes_microphone_to_manyfold_route(
         self,
         monkeypatch,

--- a/tests/peripheral/test_microphone.py
+++ b/tests/peripheral/test_microphone.py
@@ -6,6 +6,7 @@ import numpy as np
 from manyfold import Graph
 
 from heart.peripheral import microphone
+from heart.peripheral.core import PeripheralTag
 from heart.peripheral.microphone import (Microphone,
                                          microphone_detection_route,
                                          microphone_level_event_route)
@@ -51,7 +52,8 @@ class TestPeripheralMicrophone:
     def test_default_microphone_has_stable_sensor_identity(self) -> None:
         peripheral = Microphone()
 
-        identity = peripheral.peripheral_info().to_sensor_identity()
+        peripheral_info = peripheral.peripheral_info()
+        identity = peripheral_info.to_sensor_identity()
         event = peripheral._level_to_sensor_event(
             peripheral._process_audio_chunk(
                 np.array([[0.0], [0.5], [-1.0]], dtype=float),
@@ -59,7 +61,10 @@ class TestPeripheralMicrophone:
             )
         )
 
-        assert identity.id == "microphone:default"
+        assert peripheral_info.id == "microphone:default"
+        assert peripheral_info.tags == (
+            PeripheralTag(name="input_variant", variant="microphone"),
+        )
         assert event.identity == identity
 
     def test_detection_node_publishes_microphone_to_manyfold_route(
@@ -100,8 +105,15 @@ class TestPeripheralMicrophone:
         spawned.loop_handle.token.set()
         spawned.loop_handle.loop.run(spawned.loop_handle.token)
 
+        latest_detection = graph.latest(microphone_detection_route())
         latest_level = graph.latest(microphone_level_event_route())
+        assert latest_detection is not None
         assert latest_level is not None
+        assert latest_detection.value.identity == latest_level.value.identity
+        assert latest_level.value.identity.id == "microphone:default"
+        assert tuple(
+            (tag.name, tag.variant) for tag in latest_level.value.identity.tags
+        ) == (("input_variant", "microphone"),)
         assert latest_level.value.event_type == "peripheral.microphone.level"
         assert latest_level.value.data["frames"] == 3
         assert latest_level.value.data["samplerate"] == 16_000


### PR DESCRIPTION
## Summary

Give Heart's single system-default microphone the stable producer identity `microphone:default`. This unblocks ManyFold durable-latest topic binding without a runtime fallback and ensures microphone level events retain a restart-stable source key.

Production code changes: 11 additions, 1 deletion, net +10 non-test lines.

## How it works

`Microphone.peripheral_info()` now returns `microphone:default` with the existing peripheral tagging shape (`input_variant=microphone`). Detection and level-event conversion already derive their `SensorIdentity` from `peripheral_info()`, so both paths now publish the same concrete identity.

The durable source-key contract is `(origin_node_id, topic, producer_id)`. The origin node keeps the intentionally local `microphone:default` value unique across the mesh.

## How you can try this right now

Run:

```sh
/Users/lampe/.local/bin/uv run pytest tests/peripheral/test_microphone.py -q
/Users/lampe/.local/bin/uv run ruff check src/heart/peripheral/microphone.py tests/peripheral/test_microphone.py
```

The microphone suite should pass all four tests, including installed detection and level publications sharing the exact identity, and Ruff should report no errors.

## Appendix

### Performance

Not applicable. The change adds one immutable metadata object lookup outside the audio calculation and does not alter sampling or delivery rate.

### Testing

- Focused microphone suite: 4 passed.
- Changed-file Ruff: passed.
- Focused Mypy reached the module and reported only the pre-existing `NewValues[MicrophoneLevel]` versus `Subscribable[MicrophoneLevel]` mismatch at `_event_stream`; the new identity method produced no type errors.
- Hosted CI replacement run `30236704425`, job `89885759386`: passed on checkout merge `775bb062351af2da9acb663f734d3364bcff0fd9`, merging current main `fc0c991f953560d9dcb3f21939499867ae2ed22a` with unchanged PR head `d86556c6ac749e3dab9539ff8124926b66ccc02c`; test summary `645 passed, 5 skipped`.
- Hosted run `30236492793` is superseded because it checked stale pre-#957 merge `34746ce` into old main `a2f60dd1`, so it is not the post-#957 gate evidence.

### Risk

Low. Heart detects one system-default microphone today. If explicit multi-device microphone selection is added later, each selected device will need its own stable hardware-derived ID.
