### PR TITLE
Add state similarity golden contract suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ node_modules
 .hypothesis
 **/target
 .captures
+tmp/state-similarity-review/
+sites/state-similarity-review/
 
 # Generated RP1 payloads that are built from checked-in assembly sources.
 rp1/linux/files/tools/testing/selftests/drivers/rp1-pio/rp1_core1_state32_dmapipeline4x4_rr01_cols128_frame11_dwell8_regular_p0p1_chain2_oeoffshift_preclk1_unroll8_addr8_lat2.bin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ heart = ["*.png", "**/*.png"]
 [project.scripts]
 totem = "heart.loop:main"
 totem_debug = "heart.x.cli:main"
+heart-state-review = "heart.testing.state_similarity_review_cli:main"
 
 [tool.docformatter]
 recursive = true

--- a/scripts/verify_manyfold_world_coordination.py
+++ b/scripts/verify_manyfold_world_coordination.py
@@ -42,6 +42,9 @@ from heart.world import (
 )
 
 _ARTIFACT_SCHEMA_VERSION = 1
+_PROTOCOL = "heart.manyfold-world-coordination-proof"
+_SCENARIO_ID = "heart-world-coordination-node-failure-v1"
+_SCENARIO_SEED = "heart-world-coordination-deterministic-v1"
 
 
 def run_proof(root: Path) -> dict[str, object]:
@@ -90,7 +93,15 @@ def run_proof(root: Path) -> dict[str, object]:
         )
 
         return {
+            "protocol": _PROTOCOL,
             "schema_version": _ARTIFACT_SCHEMA_VERSION,
+            "scenario": {
+                "id": _SCENARIO_ID,
+                "seed": _SCENARIO_SEED,
+                "node_ids": sorted(node_ids),
+                "failed_role": "initial_raft_leader",
+                "clock": "real_runtime_bounded",
+            },
             "manyfold_installation": _manyfold_installation(),
             "raft": {
                 "node_count": len(node_ids),

--- a/src/heart/navigation/__init__.py
+++ b/src/heart/navigation/__init__.py
@@ -8,8 +8,11 @@ from heart.renderers.slide_transition import \
 from .composed_renderer import ComposedRenderer as ComposedRenderer
 from .composed_renderer import ComposedRendererState as ComposedRendererState
 from .game_modes import GameModes as GameModes
+from .game_modes import GameModeEntrySnapshot as GameModeEntrySnapshot
+from .game_modes import GameModeSnapshot as GameModeSnapshot
 from .game_modes import GameModeState as GameModeState
 from .multi_scene import MultiScene as MultiScene
+from .multi_scene import MultiSceneSnapshot as MultiSceneSnapshot
 from .multi_scene import MultiSceneState as MultiSceneState
 from .native_scene_manager import \
     PythonSceneManagerBridge as PythonSceneManagerBridge

--- a/src/heart/navigation/game_modes.py
+++ b/src/heart/navigation/game_modes.py
@@ -48,6 +48,33 @@ INITIALIZATION_TERMINAL_BAR_WIDTH = 24
 class ModeEntry:
     title_renderer: StatefulBaseRenderer
     renderer: StatefulBaseRenderer
+    name: str = ""
+
+
+@dataclass(frozen=True)
+class GameModeEntrySnapshot:
+    name: str
+    title_renderer: str
+    renderer: str
+
+
+@dataclass(frozen=True)
+class GameModeSnapshot:
+    entries: tuple[GameModeEntrySnapshot, ...]
+    post_processors: tuple[str, ...]
+    in_select_mode: bool
+    last_long_button_value: int
+    committed_position: int
+    committed_index: int | None
+    preview_offset: int
+    preview_index: int | None
+    current_index: int | None
+    current_entry: str | None
+    previous_index: int | None
+    transition_renderer: str | None
+    transition_mode: str
+    static_mask_steps: int
+    gaussian_sigma: float
 
 
 @dataclass(frozen=True)
@@ -184,11 +211,17 @@ class GameModes(StatefulBaseRenderer[GameModeState]):
         self,
         title_renderer: StatefulBaseRenderer,
         renderer: StatefulBaseRenderer,
+        *,
+        name: str | None = None,
     ) -> None:
         if self._state is None:
             self.set_state(GameModeState())
         self.state.entries.append(
-            ModeEntry(title_renderer=title_renderer, renderer=renderer)
+            ModeEntry(
+                title_renderer=title_renderer,
+                renderer=renderer,
+                name=name or title_renderer.name,
+            )
         )
         if self.is_initialized() and self._initialization_context is not None:
             title_renderer.initialize(
@@ -230,7 +263,7 @@ class GameModes(StatefulBaseRenderer[GameModeState]):
             renderer_resolver=self._renderer_resolver,
         )
         title_renderer = self._build_title_renderer("Untitled")
-        self._register_mode(title_renderer, new_scene)
+        self._register_mode(title_renderer, new_scene, name="Untitled")
         return new_scene
 
     def add_mode(
@@ -240,6 +273,8 @@ class GameModes(StatefulBaseRenderer[GameModeState]):
         | type[StatefulBaseRenderer]
         | StatefulBaseRenderer
         | None = None,
+        *,
+        name: str | None = None,
     ):
         from .composed_renderer import ComposedRenderer
 
@@ -251,8 +286,59 @@ class GameModes(StatefulBaseRenderer[GameModeState]):
             title = "Untitled"
 
         title_renderer = self._build_title_renderer(title)
-        self._register_mode(title_renderer, result)
+        mode_name = name or (
+            title if isinstance(title, str) else title_renderer.name
+        )
+        self._register_mode(title_renderer, result, name=mode_name)
         return result
+
+    def snapshot_state(self) -> GameModeSnapshot:
+        entries = tuple(
+            GameModeEntrySnapshot(
+                name=entry.name or entry.renderer.name,
+                title_renderer=entry.title_renderer.name,
+                renderer=entry.renderer.name,
+            )
+            for entry in self.state.entries
+        )
+        entry_count = len(entries)
+        committed_index = (
+            self.state._active_mode_index % entry_count if entry_count else None
+        )
+        preview_index = (
+            (self.state._active_mode_index + self.state.mode_offset) % entry_count
+            if entry_count
+            else None
+        )
+        current_index = (
+            preview_index if self.state.in_select_mode else committed_index
+        )
+        current_entry = (
+            entries[current_index].name if current_index is not None else None
+        )
+        previous_index = (
+            self.state.previous_mode_index % entry_count if entry_count else None
+        )
+        transition = self.state.sliding_transition
+        return GameModeSnapshot(
+            entries=entries,
+            post_processors=tuple(
+                renderer.name for renderer in self.state.post_processors
+            ),
+            in_select_mode=self.state.in_select_mode,
+            last_long_button_value=self.state.last_long_button_value,
+            committed_position=self.state._active_mode_index,
+            committed_index=committed_index,
+            preview_offset=self.state.mode_offset,
+            preview_index=preview_index,
+            current_index=current_index,
+            current_entry=current_entry,
+            previous_index=previous_index,
+            transition_renderer=transition.name if transition is not None else None,
+            transition_mode=self.state.transition_mode.value,
+            static_mask_steps=self.state.static_mask_steps,
+            gaussian_sigma=self.state.gaussian_sigma,
+        )
 
     def get_renderers(self) -> list[StatefulBaseRenderer]:
         active_renderer = self.state.active_renderer()
@@ -280,6 +366,9 @@ class GameModes(StatefulBaseRenderer[GameModeState]):
         self.state._active_mode_index += self.state.mode_offset
         self.state.mode_offset = 0
         self.state.in_select_mode = False
+        self.state.previous_mode_index = (
+            self.state._active_mode_index % len(self.state.entries)
+        )
         self._initialize_active_renderer_if_needed(self._active_mode_entry().renderer)
 
     def _handle_alternate_activate(self, _event: object) -> None:

--- a/src/heart/navigation/multi_scene.py
+++ b/src/heart/navigation/multi_scene.py
@@ -23,6 +23,19 @@ class MultiSceneState:
     peripheral_manager: PeripheralManager | None = None
 
 
+@dataclass(frozen=True)
+class MultiSceneSnapshot:
+    scene_names: tuple[str, ...]
+    current_button_value: int
+    offset_of_button_value: int | None
+    active_scene_index: int | None
+    active_scene_name: str | None
+    previous_scene_index: int | None
+    dpad_scene_selection_enabled: bool
+    dpad_armed: bool
+    dpad_center_frames: int
+
+
 class MultiScene(StatefulBaseRenderer[MultiSceneState]):
     def __init__(
         self,
@@ -52,6 +65,26 @@ class MultiScene(StatefulBaseRenderer[MultiSceneState]):
         active_scene = self.scenes[index]
         self.device_display_mode = active_scene.device_display_mode
         return [*active_scene.get_renderers()]
+
+    def snapshot_state(self) -> MultiSceneSnapshot:
+        scene_names = tuple(scene.name for scene in self.scenes)
+        active_scene_index = self._active_scene_index() if scene_names else None
+        active_scene_name = (
+            scene_names[active_scene_index]
+            if active_scene_index is not None
+            else None
+        )
+        return MultiSceneSnapshot(
+            scene_names=scene_names,
+            current_button_value=self.state.current_button_value,
+            offset_of_button_value=self.state.offset_of_button_value,
+            active_scene_index=active_scene_index,
+            active_scene_name=active_scene_name,
+            previous_scene_index=self._last_active_scene_index,
+            dpad_scene_selection_enabled=self._enable_dpad_scene_selection,
+            dpad_armed=self._dpad_armed,
+            dpad_center_frames=self._dpad_center_frames,
+        )
 
     def _create_initial_state(
         self,

--- a/src/heart/runtime/peripheral_runtime.py
+++ b/src/heart/runtime/peripheral_runtime.py
@@ -268,15 +268,16 @@ class PeripheralRuntime:
     def poll(self) -> None:
         self._manyfold_node.poll()
         keyboard, gamepads = self._peripheral_manager.input_io.poll()
-        self._poll_navigation(keyboard, gamepads)
+        self.process_navigation_input(keyboard, gamepads)
         self._drain_control_messages()
         drain_main_thread_queue(max_items=MAIN_THREAD_DRAIN_MAX_ITEMS)
 
-    def _poll_navigation(
+    def process_navigation_input(
         self,
         keyboard: KeyboardSnapshot,
         events: tuple[GamepadSnapshotEvent, ...],
     ) -> None:
+        """Translate one typed input frame into ordered navigation intents."""
         navigation = self._peripheral_manager.input_io.navigation
         if self._key_pressed(keyboard, pygame.K_LEFT):
             navigation.inject_browse(-1, source="keyboard.left")
@@ -291,6 +292,7 @@ class PeripheralRuntime:
             self._rearm_gamepad_navigation()
             return
 
+        self._process_gamepad_browse(events)
         for event in events:
             snapshot = event.snapshot
             if self._button_pressed(snapshot, GamepadButton.SOUTH):
@@ -300,6 +302,11 @@ class PeripheralRuntime:
                     source=f"gamepad.{event.joystick_id}.north"
                 )
 
+    def _process_gamepad_browse(
+        self,
+        events: tuple[GamepadSnapshotEvent, ...],
+    ) -> None:
+        navigation = self._peripheral_manager.input_io.navigation
         direction = max(
             -1,
             min(

--- a/src/heart/testing/__init__.py
+++ b/src/heart/testing/__init__.py
@@ -1,0 +1,41 @@
+from heart.testing.state_similarity import (
+    JsonScalar,
+    JsonValue,
+    StateSimilarityAction,
+    StateSimilarityInitial,
+    StateSimilarityScenario,
+    StateSimilaritySnapshot,
+    assert_rgb_similar,
+    canonicalize_state,
+    capture_surface_rgb,
+    load_state_similarity_scenario,
+    parse_state_similarity_scenario,
+    run_state_workflow,
+)
+from heart.testing.system_contract import (
+    SystemContractProjection,
+    project_world_coordination_contract,
+    render_system_contract_rgb,
+    system_contract_review_html,
+    write_system_contract_review,
+)
+
+__all__ = [
+    "JsonScalar",
+    "JsonValue",
+    "StateSimilarityAction",
+    "StateSimilarityInitial",
+    "StateSimilarityScenario",
+    "StateSimilaritySnapshot",
+    "SystemContractProjection",
+    "assert_rgb_similar",
+    "canonicalize_state",
+    "capture_surface_rgb",
+    "load_state_similarity_scenario",
+    "parse_state_similarity_scenario",
+    "project_world_coordination_contract",
+    "render_system_contract_rgb",
+    "run_state_workflow",
+    "system_contract_review_html",
+    "write_system_contract_review",
+]

--- a/src/heart/testing/state_similarity.py
+++ b/src/heart/testing/state_similarity.py
@@ -1,0 +1,733 @@
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass, fields, is_dataclass
+from enum import Enum
+from pathlib import Path
+from typing import TypeAlias, cast, final
+
+import numpy as np
+import pygame
+from numpy.typing import NDArray
+
+
+JsonScalar: TypeAlias = None | bool | int | float | str
+JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+
+_SIMPLE_FIELD_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SCENARIO_REQUIRED_FIELDS = frozenset(
+    {"name", "kind", "initial", "actions", "expected"}
+)
+_ACTION_FIELDS = frozenset({"type", "config"})
+_EXPECTED_FIELDS = frozenset({"state", "screen"})
+
+
+def load_state_similarity_scenario(path: str | Path) -> StateSimilarityScenario:
+    """Load and strictly validate one machine-readable JSON scenario."""
+
+    scenario_path = Path(path)
+    try:
+        with scenario_path.open(encoding="utf-8") as scenario_file:
+            document = json.load(scenario_file)
+    except json.JSONDecodeError as error:
+        raise ValueError(
+            f"{scenario_path}: invalid JSON at line {error.lineno}, "
+            f"column {error.colno}: {error.msg}"
+        ) from error
+    return parse_state_similarity_scenario(document, source=str(scenario_path))
+
+
+def parse_state_similarity_scenario(
+    document: object,
+    *,
+    source: str = "<scenario>",
+) -> StateSimilarityScenario:
+    """Validate a decoded JSON document and materialize its expected RGB."""
+
+    _validate_json_value(document, path="$", source=source)
+    scenario = _require_object(document, path="$", source=source)
+    _validate_object_fields(
+        scenario,
+        required=_SCENARIO_REQUIRED_FIELDS,
+        optional=frozenset(),
+        path="$",
+        source=source,
+    )
+
+    name = _require_non_empty_string(scenario["name"], path="$.name", source=source)
+    kind = _require_non_empty_string(scenario["kind"], path="$.kind", source=source)
+    initial = _parse_scenario_initial(scenario["initial"], source=source)
+    actions = _parse_scenario_actions(scenario["actions"], source=source)
+    expected = _require_object(
+        scenario["expected"],
+        path="$.expected",
+        source=source,
+    )
+    _validate_object_fields(
+        expected,
+        required=_EXPECTED_FIELDS,
+        optional=frozenset(),
+        path="$.expected",
+        source=source,
+    )
+    expected_state = _canonicalize_json_object(
+        expected["state"],
+        path="$.expected.state",
+        source=source,
+    )
+    (
+        expected_rgb,
+        channel_tolerance,
+        max_outlier_fraction,
+    ) = _parse_expected_screen(expected["screen"], source=source)
+
+    return StateSimilarityScenario(
+        name=name,
+        kind=kind,
+        initial=initial,
+        actions=actions,
+        expected_state=expected_state,
+        expected_rgb=expected_rgb,
+        channel_tolerance=channel_tolerance,
+        max_outlier_fraction=max_outlier_fraction,
+    )
+
+
+def run_state_workflow(
+    commands: Iterable[Callable[[], object]],
+    *,
+    project_state: Callable[[], object],
+    render: Callable[[], pygame.Surface],
+) -> StateSimilaritySnapshot:
+    """Run commands in order, then capture state and its rendered output."""
+
+    for command in commands:
+        command()
+
+    state = canonicalize_state(project_state())
+    rgb = capture_surface_rgb(render())
+    return StateSimilaritySnapshot(state=state, rgb=rgb)
+
+
+def canonicalize_state(value: object) -> JsonValue:
+    """Convert an explicit state projection to deterministic JSON-compatible data."""
+
+    return _canonicalize_state(value, path="$", active_ids=set())
+
+
+def capture_surface_rgb(surface: pygame.Surface) -> NDArray[np.uint8]:
+    """Copy a pygame surface into conventional ``(height, width, 3)`` RGB order."""
+
+    if not isinstance(surface, pygame.Surface):
+        raise TypeError(
+            "render must return pygame.Surface, "
+            f"got {type(surface).__qualname__}"
+        )
+
+    width_first_rgb = pygame.surfarray.array3d(surface)
+    return np.ascontiguousarray(width_first_rgb.transpose(1, 0, 2), dtype=np.uint8)
+
+
+def assert_rgb_similar(
+    actual: NDArray[np.generic],
+    expected: NDArray[np.generic],
+    *,
+    channel_tolerance: int = 0,
+    max_outlier_fraction: float = 0.0,
+) -> None:
+    """Assert that only a bounded fraction of pixels exceed a channel tolerance."""
+
+    channel_tolerance = _validate_channel_tolerance(channel_tolerance)
+    max_outlier_fraction = _validate_max_outlier_fraction(max_outlier_fraction)
+
+    actual_rgb = _validate_rgb_array(actual, label="actual")
+    expected_rgb = _validate_rgb_array(expected, label="expected")
+    if actual_rgb.shape != expected_rgb.shape:
+        raise AssertionError(
+            "RGB shape mismatch: "
+            f"actual {actual_rgb.shape}, expected {expected_rgb.shape}"
+        )
+
+    channel_delta = np.abs(actual_rgb.astype(np.int16) - expected_rgb.astype(np.int16))
+    pixel_delta = channel_delta.max(axis=2)
+    outlier_mask = pixel_delta > channel_tolerance
+    outlier_count = int(np.count_nonzero(outlier_mask))
+    pixel_count = int(outlier_mask.size)
+    outlier_fraction = outlier_count / pixel_count
+    if outlier_fraction <= max_outlier_fraction:
+        return
+
+    worst_y, worst_x = np.unravel_index(int(pixel_delta.argmax()), pixel_delta.shape)
+    worst_actual = tuple(int(channel) for channel in actual_rgb[worst_y, worst_x])
+    worst_expected = tuple(int(channel) for channel in expected_rgb[worst_y, worst_x])
+    worst_delta = tuple(int(channel) for channel in channel_delta[worst_y, worst_x])
+    raise AssertionError(
+        "RGB similarity failed: "
+        f"{outlier_count}/{pixel_count} pixels "
+        f"({outlier_fraction:.6%}) exceeded channel tolerance "
+        f"{channel_tolerance}; allowed {max_outlier_fraction:.6%}. "
+        f"Maximum channel delta {int(pixel_delta[worst_y, worst_x])} at "
+        f"(y={worst_y}, x={worst_x}); actual={worst_actual}, "
+        f"expected={worst_expected}, delta={worst_delta}"
+    )
+
+
+@final
+@dataclass(frozen=True)
+class StateSimilarityInitial:
+    """Exactly one initial configuration or explicit initial state."""
+
+    config: dict[str, JsonValue] | None = None
+    state: dict[str, JsonValue] | None = None
+
+
+@final
+@dataclass(frozen=True)
+class StateSimilarityAction:
+    """One typed action and its JSON-compatible configuration."""
+
+    type: str
+    config: dict[str, JsonValue]
+
+
+@final
+@dataclass(frozen=True)
+class StateSimilarityScenario:
+    """A validated state and RGB workflow scenario loaded from JSON."""
+
+    name: str
+    kind: str
+    initial: StateSimilarityInitial
+    actions: tuple[StateSimilarityAction, ...]
+    expected_state: dict[str, JsonValue]
+    expected_rgb: NDArray[np.uint8]
+    channel_tolerance: int
+    max_outlier_fraction: float
+
+
+@final
+@dataclass(frozen=True)
+class StateSimilaritySnapshot:
+    """Canonical state and the RGB output rendered from that state."""
+
+    state: JsonValue
+    rgb: NDArray[np.uint8]
+
+
+def _validate_json_value(value: object, *, path: str, source: str) -> None:
+    if value is None or type(value) in (bool, int, str):
+        return
+    if type(value) is float:
+        if not math.isfinite(cast(float, value)):
+            raise _scenario_error(source, path, "number must be finite")
+        return
+    if type(value) is list:
+        for index, item in enumerate(cast(list[object], value)):
+            _validate_json_value(item, path=f"{path}[{index}]", source=source)
+        return
+    if type(value) is dict:
+        for key, item in cast(dict[object, object], value).items():
+            if type(key) is not str:
+                raise _scenario_error(
+                    source,
+                    path,
+                    f"object key must be a string, got {key!r}",
+                )
+            _validate_json_value(
+                item,
+                path=_field_path(path, cast(str, key)),
+                source=source,
+            )
+        return
+    raise _scenario_error(
+        source,
+        path,
+        f"expected a JSON value, got {type(value).__qualname__}",
+    )
+
+
+def _parse_scenario_initial(
+    value: object,
+    *,
+    source: str,
+) -> StateSimilarityInitial:
+    path = "$.initial"
+    initial = _require_object(value, path=path, source=source)
+    unknown = sorted(set(initial) - {"config", "state"})
+    if unknown:
+        raise _scenario_error(
+            source,
+            path,
+            f"unknown fields: {', '.join(unknown)}",
+        )
+    if len(initial) != 1:
+        raise _scenario_error(
+            source,
+            path,
+            "expected exactly one initial field: config or state",
+        )
+    if "config" in initial:
+        return StateSimilarityInitial(
+            config=_canonicalize_json_object(
+                initial["config"],
+                path="$.initial.config",
+                source=source,
+            )
+        )
+    return StateSimilarityInitial(
+        state=_canonicalize_json_object(
+            initial["state"],
+            path="$.initial.state",
+            source=source,
+        )
+    )
+
+
+def _parse_scenario_actions(
+    value: object,
+    *,
+    source: str,
+) -> tuple[StateSimilarityAction, ...]:
+    if type(value) is not list:
+        raise _scenario_error(source, "$.actions", "expected an array")
+
+    actions: list[StateSimilarityAction] = []
+    for index, action_value in enumerate(cast(list[object], value)):
+        action_path = f"$.actions[{index}]"
+        action = _require_object(
+            action_value,
+            path=action_path,
+            source=source,
+        )
+        _validate_object_fields(
+            action,
+            required=_ACTION_FIELDS,
+            optional=frozenset(),
+            path=action_path,
+            source=source,
+        )
+        action_type = _require_non_empty_string(
+            action["type"],
+            path=f"{action_path}.type",
+            source=source,
+        )
+        action_config = _canonicalize_json_object(
+            action["config"],
+            path=f"{action_path}.config",
+            source=source,
+        )
+        if action_type == "tick" and "count" in action_config:
+            count = action_config["count"]
+            if type(count) is not int or cast(int, count) <= 0:
+                raise _scenario_error(
+                    source,
+                    f"{action_path}.config.count",
+                    "expected a positive integer",
+                )
+        actions.append(
+            StateSimilarityAction(
+                type=action_type,
+                config=action_config,
+            )
+        )
+    return tuple(actions)
+
+
+def _parse_expected_screen(
+    value: object,
+    *,
+    source: str,
+) -> tuple[NDArray[np.uint8], int, float]:
+    rgb_path = "$.expected.screen"
+    rgb = _require_object(value, path=rgb_path, source=source)
+    _validate_object_fields(
+        rgb,
+        required=frozenset({"shape"}),
+        optional=frozenset(
+            {
+                "fill",
+                "pixels",
+                "rows",
+                "channel_tolerance",
+                "max_outlier_fraction",
+            }
+        ),
+        path=rgb_path,
+        source=source,
+    )
+    encoding_fields = {"fill", "pixels", "rows"}.intersection(rgb)
+    if len(encoding_fields) != 1:
+        raise _scenario_error(
+            source,
+            rgb_path,
+            "expected exactly one RGB encoding field: fill, pixels, or rows",
+        )
+
+    shape = _parse_rgb_shape(rgb["shape"], source=source)
+    if "fill" in rgb:
+        fill = rgb["fill"]
+        if type(fill) is not list or len(cast(list[object], fill)) != 3:
+            raise _scenario_error(
+                source,
+                f"{rgb_path}.fill",
+                "expected exactly three RGB channel values",
+            )
+        candidate = np.asarray([[cast(list[object], fill)]])
+        validated = _validate_scenario_rgb(
+            candidate,
+            path=f"{rgb_path}.fill",
+            source=source,
+        )
+        expected_rgb = np.full(shape, validated[0, 0], dtype=np.uint8)
+    elif "pixels" in rgb:
+        try:
+            candidate = np.asarray(rgb["pixels"])
+        except (TypeError, ValueError) as error:
+            raise _scenario_error(
+                source,
+                f"{rgb_path}.pixels",
+                f"could not form an RGB array: {error}",
+            ) from error
+        validated = _validate_scenario_rgb(
+            candidate,
+            path=f"{rgb_path}.pixels",
+            source=source,
+        )
+        if validated.shape != shape:
+            raise _scenario_error(
+                source,
+                f"{rgb_path}.shape",
+                f"declared {list(shape)} but pixels have shape "
+                f"{list(validated.shape)}",
+            )
+        expected_rgb = np.ascontiguousarray(validated, dtype=np.uint8)
+    else:
+        try:
+            candidate = np.asarray(rgb["rows"])
+        except (TypeError, ValueError) as error:
+            raise _scenario_error(
+                source,
+                f"{rgb_path}.rows",
+                f"could not form an RGB row array: {error}",
+            ) from error
+        validated = _validate_scenario_rows(
+            candidate,
+            path=f"{rgb_path}.rows",
+            source=source,
+        )
+        if validated.shape[0] != shape[0]:
+            raise _scenario_error(
+                source,
+                f"{rgb_path}.shape",
+                f"declared height {shape[0]} but rows have height "
+                f"{validated.shape[0]}",
+            )
+        expected_rgb = np.ascontiguousarray(
+            np.repeat(validated[:, np.newaxis, :], shape[1], axis=1),
+            dtype=np.uint8,
+        )
+
+    channel_tolerance_value = rgb.get("channel_tolerance", 0)
+    try:
+        channel_tolerance = _validate_channel_tolerance(channel_tolerance_value)
+    except ValueError as error:
+        raise _scenario_error(
+            source,
+            f"{rgb_path}.channel_tolerance",
+            str(error),
+        ) from error
+    max_outlier_fraction_value = rgb.get("max_outlier_fraction", 0.0)
+    try:
+        max_outlier_fraction = _validate_max_outlier_fraction(
+            max_outlier_fraction_value
+        )
+    except ValueError as error:
+        raise _scenario_error(
+            source,
+            f"{rgb_path}.max_outlier_fraction",
+            str(error),
+        ) from error
+    return expected_rgb, channel_tolerance, max_outlier_fraction
+
+
+def _parse_rgb_shape(value: object, *, source: str) -> tuple[int, int, int]:
+    path = "$.expected.screen.shape"
+    if type(value) is not list or len(cast(list[object], value)) != 3:
+        raise _scenario_error(
+            source,
+            path,
+            "expected [height, width, 3]",
+        )
+    shape_values = cast(list[object], value)
+    if any(type(dimension) is not int for dimension in shape_values):
+        raise _scenario_error(source, path, "dimensions must be integers")
+    height, width, channels = cast(tuple[int, int, int], tuple(shape_values))
+    if height <= 0 or width <= 0 or channels != 3:
+        raise _scenario_error(
+            source,
+            path,
+            "expected positive height and width with exactly 3 channels",
+        )
+    return height, width, channels
+
+
+def _validate_scenario_rgb(
+    value: NDArray[np.generic],
+    *,
+    path: str,
+    source: str,
+) -> NDArray[np.generic]:
+    try:
+        return _validate_rgb_array(value, label=path)
+    except AssertionError as error:
+        raise _scenario_error(source, path, str(error)) from error
+
+
+def _validate_scenario_rows(
+    value: NDArray[np.generic],
+    *,
+    path: str,
+    source: str,
+) -> NDArray[np.generic]:
+    rows = np.asarray(value)
+    if rows.ndim != 2 or rows.shape[1] != 3:
+        raise _scenario_error(
+            source,
+            path,
+            f"RGB rows must have shape (height, 3), got {rows.shape}",
+        )
+    return _validate_scenario_rgb(
+        rows[:, np.newaxis, :],
+        path=path,
+        source=source,
+    )[:, 0, :]
+
+
+def _require_object(
+    value: object,
+    *,
+    path: str,
+    source: str,
+) -> dict[str, object]:
+    if type(value) is not dict:
+        raise _scenario_error(source, path, "expected an object")
+    return cast(dict[str, object], value)
+
+
+def _canonicalize_json_object(
+    value: object,
+    *,
+    path: str,
+    source: str,
+) -> dict[str, JsonValue]:
+    json_object = _require_object(value, path=path, source=source)
+    return cast(dict[str, JsonValue], canonicalize_state(json_object))
+
+
+def _validate_object_fields(
+    value: dict[str, object],
+    *,
+    required: frozenset[str],
+    optional: frozenset[str],
+    path: str,
+    source: str,
+) -> None:
+    actual = set(value)
+    missing = sorted(required - actual)
+    if missing:
+        raise _scenario_error(
+            source,
+            path,
+            f"missing required fields: {', '.join(missing)}",
+        )
+    unknown = sorted(actual - required - optional)
+    if unknown:
+        raise _scenario_error(
+            source,
+            path,
+            f"unknown fields: {', '.join(unknown)}",
+        )
+
+
+def _require_non_empty_string(value: object, *, path: str, source: str) -> str:
+    if type(value) is not str or not cast(str, value).strip():
+        raise _scenario_error(source, path, "expected a non-empty string")
+    return cast(str, value)
+
+
+def _scenario_error(source: str, path: str, message: str) -> ValueError:
+    return ValueError(f"{source} {path}: {message}")
+
+
+def _validate_channel_tolerance(value: object) -> int:
+    if type(value) is not int or not 0 <= cast(int, value) <= 255:
+        raise ValueError("must be an integer from 0 through 255")
+    return cast(int, value)
+
+
+def _validate_max_outlier_fraction(value: object) -> float:
+    if (
+        type(value) not in (int, float)
+        or not math.isfinite(cast(int | float, value))
+        or not 0.0 <= cast(int | float, value) <= 1.0
+    ):
+        raise ValueError("must be a number from 0.0 through 1.0")
+    return float(cast(int | float, value))
+
+
+def _canonicalize_state(
+    value: object,
+    *,
+    path: str,
+    active_ids: set[int],
+) -> JsonValue:
+    if value is None or isinstance(value, bool | str):
+        return value
+    if isinstance(value, Enum):
+        return _canonicalize_state(value.value, path=path, active_ids=active_ids)
+    if isinstance(value, np.generic):
+        return _canonicalize_state(value.item(), path=path, active_ids=active_ids)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"non-finite float at {path}: {value!r}")
+        return value
+    if isinstance(value, np.ndarray):
+        return _canonicalize_container(
+            value,
+            {
+                "dtype": str(value.dtype),
+                "shape": list(value.shape),
+                "values": value.tolist(),
+            },
+            path=path,
+            active_ids=active_ids,
+        )
+    if is_dataclass(value) and not isinstance(value, type):
+        projected_fields = {
+            field.name: getattr(value, field.name) for field in fields(value)
+        }
+        return _canonicalize_container(
+            value,
+            projected_fields,
+            path=path,
+            active_ids=active_ids,
+        )
+    if isinstance(value, Mapping):
+        return _canonicalize_mapping(value, path=path, active_ids=active_ids)
+    if isinstance(value, bytes | bytearray | memoryview):
+        raise TypeError(
+            f"unsupported state value at {path}: {type(value).__qualname__}"
+        )
+    if isinstance(value, Sequence):
+        return _canonicalize_sequence(value, path=path, active_ids=active_ids)
+    raise TypeError(f"unsupported state value at {path}: {type(value).__qualname__}")
+
+
+def _canonicalize_container(
+    owner: object,
+    contents: object,
+    *,
+    path: str,
+    active_ids: set[int],
+) -> JsonValue:
+    owner_id = id(owner)
+    if owner_id in active_ids:
+        raise ValueError(f"cyclic state value at {path}")
+    active_ids.add(owner_id)
+    try:
+        return _canonicalize_state(contents, path=path, active_ids=active_ids)
+    finally:
+        active_ids.remove(owner_id)
+
+
+def _canonicalize_mapping(
+    value: Mapping[object, object],
+    *,
+    path: str,
+    active_ids: set[int],
+) -> dict[str, JsonValue]:
+    value_id = id(value)
+    if value_id in active_ids:
+        raise ValueError(f"cyclic state value at {path}")
+
+    active_ids.add(value_id)
+    try:
+        for key in value:
+            if not isinstance(key, str):
+                raise TypeError(
+                    f"unsupported mapping key at {path}: expected str, "
+                    f"got {type(key).__qualname__} {key!r}"
+                )
+        return {
+            key: _canonicalize_state(
+                value[key],
+                path=_field_path(path, key),
+                active_ids=active_ids,
+            )
+            for key in sorted(value)
+        }
+    finally:
+        active_ids.remove(value_id)
+
+
+def _canonicalize_sequence(
+    value: Sequence[object],
+    *,
+    path: str,
+    active_ids: set[int],
+) -> list[JsonValue]:
+    value_id = id(value)
+    if value_id in active_ids:
+        raise ValueError(f"cyclic state value at {path}")
+
+    active_ids.add(value_id)
+    try:
+        return [
+            _canonicalize_state(
+                item,
+                path=f"{path}[{index}]",
+                active_ids=active_ids,
+            )
+            for index, item in enumerate(value)
+        ]
+    finally:
+        active_ids.remove(value_id)
+
+
+def _field_path(path: str, field_name: str) -> str:
+    if _SIMPLE_FIELD_NAME.fullmatch(field_name):
+        return f"{path}.{field_name}"
+    escaped_name = field_name.replace("\\", "\\\\").replace('"', '\\"')
+    return f'{path}["{escaped_name}"]'
+
+
+def _validate_rgb_array(
+    value: NDArray[np.generic],
+    *,
+    label: str,
+) -> NDArray[np.generic]:
+    rgb = np.asarray(value)
+    if rgb.ndim != 3 or rgb.shape[2] != 3:
+        raise AssertionError(
+            f"{label} RGB must have shape (height, width, 3), got {rgb.shape}"
+        )
+    if rgb.shape[0] == 0 or rgb.shape[1] == 0:
+        raise AssertionError(f"{label} RGB must contain at least one pixel")
+    if not np.issubdtype(rgb.dtype, np.number) or np.issubdtype(
+        rgb.dtype, np.complexfloating
+    ):
+        raise AssertionError(
+            f"{label} RGB must have a real numeric dtype, got {rgb.dtype}"
+        )
+    if not bool(np.all(np.isfinite(rgb))):
+        raise AssertionError(f"{label} RGB contains non-finite values")
+    if not bool(np.all((rgb >= 0) & (rgb <= 255))):
+        raise AssertionError(f"{label} RGB values must be between 0 and 255")
+    if not bool(np.all(rgb == np.floor(rgb))):
+        raise AssertionError(f"{label} RGB values must be integers")
+    return rgb

--- a/src/heart/testing/state_similarity_review.py
+++ b/src/heart/testing/state_similarity_review.py
@@ -1,0 +1,553 @@
+from __future__ import annotations
+
+import base64
+import html
+import json
+import re
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, replace
+from io import BytesIO
+from pathlib import Path
+from typing import final
+
+import numpy as np
+from numpy.typing import NDArray
+from PIL import Image
+
+from heart.renderers.slide_transition.provider import DEFAULT_SLIDE_DURATION_MS
+from heart.testing.state_similarity import (
+    JsonValue,
+    StateSimilarityAction,
+    StateSimilarityScenario,
+    assert_rgb_similar,
+    canonicalize_state,
+    capture_surface_rgb,
+    load_state_similarity_scenario,
+)
+from heart.testing.state_similarity_workflows import (
+    StateSimilarityTransition,
+    StateSimilarityWorkflow,
+    build_state_similarity_workflow,
+)
+
+DEFAULT_REVIEW_OUTPUT = Path("tmp/state-similarity-review")
+DEFAULT_TRANSITION_FRAMES = 5
+
+_SCENE_IDENTITY_KEYS = (
+    "active_scene_index",
+    "current_index",
+    "scene_index",
+    "current_entry",
+    "active_scene_name",
+)
+_SLUG_CHARACTERS = re.compile(r"[^a-z0-9]+")
+_SCENARIO_USER_STORIES = {
+    "keyboard right twice then activate":
+        "A person uses keyboard navigation to move two modes to the right and "
+        "commit the highlighted mode. The test proves that edge-triggered "
+        "keyboard input selects the intended program and that the committed "
+        "state renders the expected nonuniform screen.",
+    "gamepad right and south in one frame":
+        "A controller sends D-pad right and confirm in the same sampled input "
+        "frame. The test proves Heart handles the combined navigation event "
+        "deterministically instead of dropping either the move or the commit.",
+    "multi scene activate advances one scene":
+        "A mode with multiple internal scenes receives an activation command "
+        "from the shared navigation bus. The test proves the scene controller "
+        "advances exactly one scene and renders that scene's visible output.",
+    "controller tixyland":
+        "A player changes Tixyland parameters with controller buttons and "
+        "triggers over several frame ticks. The test proves renderer-local IO "
+        "updates semantic state and produces a stable representative RGB frame.",
+    "controller water cube":
+        "A sensor update and controller input arrive while Water Cube advances "
+        "physics ticks. The test proves external acceleration, trigger input, "
+        "and frame timing converge into the expected state and visible water "
+        "output.",
+}
+_PAGE_STYLE = """
+:root {
+  color-scheme: dark;
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  background: #111318;
+  color: #edf0f7;
+}
+body { margin: 0 auto; max-width: 1200px; padding: 2rem; }
+a { color: #8fc7ff; }
+.summary, .checkpoint {
+  background: #1a1e27;
+  border: 1px solid #303746;
+  border-radius: 12px;
+  margin: 1rem 0;
+  padding: 1rem;
+}
+.user-story {
+  border-left: 3px solid #8fc7ff;
+  color: #d6deeb;
+  line-height: 1.55;
+  margin: 1rem 0;
+  padding-left: 1rem;
+}
+.checkpoint.scene-transition { border-color: #d4a72c; }
+.status-pass { color: #57d38c; }
+.status-diff { color: #ff7b72; }
+.frame {
+  background: #07080b;
+  border-radius: 8px;
+  overflow: auto;
+  padding: 1rem;
+}
+.frame img {
+  display: block;
+  height: auto;
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
+  max-width: none;
+  min-width: min(100%, 768px);
+  width: 768px;
+}
+.data-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+pre {
+  background: #0d0f14;
+  border-radius: 8px;
+  max-height: 36rem;
+  overflow: auto;
+  padding: 1rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+small { color: #aab2c0; }
+"""
+
+
+@final
+@dataclass(frozen=True)
+class StateSimilarityReviewCheckpoint:
+    """One faithful or isolated transition checkpoint rendered for review."""
+
+    label: str
+    kind: str
+    state: JsonValue
+    rgb: NDArray[np.uint8]
+    action: JsonValue | None = None
+    transition_fraction: float | None = None
+
+
+@final
+@dataclass(frozen=True)
+class StateSimilarityReviewResult:
+    """Generated static review artifacts."""
+
+    index_path: Path
+    scenario_pages: tuple[Path, ...]
+
+
+WorkflowBuilder = Callable[[StateSimilarityScenario], StateSimilarityWorkflow]
+
+
+def generate_state_similarity_review(
+    scenario_paths: Iterable[str | Path],
+    *,
+    output_dir: str | Path = DEFAULT_REVIEW_OUTPUT,
+    transition_frames: int = DEFAULT_TRANSITION_FRAMES,
+    workflow_builder: WorkflowBuilder = build_state_similarity_workflow,
+) -> StateSimilarityReviewResult:
+    """Replay scenarios and write a self-contained static HTML review."""
+
+    if isinstance(transition_frames, bool) or not isinstance(transition_frames, int):
+        raise TypeError("transition_frames must be an integer")
+    if transition_frames < 0:
+        raise ValueError("transition_frames must be non-negative")
+
+    resolved_paths = discover_state_similarity_scenarios(scenario_paths)
+    target = Path(output_dir)
+    target.mkdir(parents=True, exist_ok=True)
+    pages: list[Path] = []
+    summaries: list[tuple[str, str, bool]] = []
+    used_names: set[str] = set()
+    for scenario_path in resolved_paths:
+        scenario = load_state_similarity_scenario(scenario_path)
+        checkpoints = _replay_scenario(
+            scenario,
+            transition_frames=transition_frames,
+            workflow_builder=workflow_builder,
+        )
+        page_name = _unique_page_name(scenario_path.stem, used_names)
+        page_path = target / page_name
+        faithful_final = next(
+            checkpoint
+            for checkpoint in reversed(checkpoints)
+            if checkpoint.kind != "transition-sample"
+        )
+        matches_expected = _matches_expected(faithful_final, scenario)
+        page_path.write_text(
+            _scenario_page(
+                scenario,
+                source=scenario_path,
+                checkpoints=checkpoints,
+                matches_expected=matches_expected,
+            ),
+            encoding="utf-8",
+        )
+        pages.append(page_path)
+        summaries.append((scenario.name, page_name, matches_expected))
+
+    index_path = target / "index.html"
+    index_path.write_text(_index_page(summaries), encoding="utf-8")
+    return StateSimilarityReviewResult(
+        index_path=index_path,
+        scenario_pages=tuple(pages),
+    )
+
+
+def discover_state_similarity_scenarios(
+    paths: Iterable[str | Path],
+) -> tuple[Path, ...]:
+    """Resolve JSON files from an explicit set of scenario files and directories."""
+
+    discovered: list[Path] = []
+    seen: set[Path] = set()
+    for raw_path in paths:
+        path = Path(raw_path)
+        if path.is_dir():
+            candidates = sorted(path.glob("*.json"))
+        elif path.is_file():
+            candidates = [path]
+        else:
+            raise FileNotFoundError(f"Scenario path does not exist: {path}")
+        for candidate in candidates:
+            if candidate.suffix.lower() != ".json":
+                continue
+            resolved = candidate.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            discovered.append(candidate)
+    if not discovered:
+        raise ValueError("No JSON state-similarity scenarios were found")
+    return tuple(discovered)
+
+
+def _replay_scenario(
+    scenario: StateSimilarityScenario,
+    *,
+    transition_frames: int,
+    workflow_builder: WorkflowBuilder,
+) -> tuple[StateSimilarityReviewCheckpoint, ...]:
+    checkpoints: list[StateSimilarityReviewCheckpoint] = []
+    initial, _ = _capture_faithful_prefix(
+        scenario,
+        action_count=0,
+        label="Initial state",
+        kind="initial",
+        workflow_builder=workflow_builder,
+    )
+    checkpoints.append(initial)
+    previous_identity = _scene_identity(initial.state)
+    for action_index, action in enumerate(scenario.actions):
+        checkpoint, transition = _capture_faithful_prefix(
+            scenario,
+            action_count=action_index + 1,
+            label=f"After action {action_index + 1}",
+            kind="action",
+            action=_action_json(action),
+            workflow_builder=workflow_builder,
+        )
+        current_identity = _scene_identity(checkpoint.state)
+        is_scene_transition = (
+            previous_identity is not None
+            and current_identity is not None
+            and previous_identity != current_identity
+        )
+        if is_scene_transition:
+            checkpoint = replace(
+                checkpoint,
+                label=f"After action {action_index + 1} · scene transition",
+                kind="scene-transition",
+            )
+        checkpoints.append(checkpoint)
+        if (
+            is_scene_transition
+            and transition is not None
+            and transition.sliding
+            and transition_frames > 0
+        ):
+            checkpoints.extend(
+                _sample_transition(
+                    scenario,
+                    action_index=action_index,
+                    frame_count=transition_frames,
+                    workflow_builder=workflow_builder,
+                )
+            )
+        previous_identity = current_identity
+    return tuple(checkpoints)
+
+
+def _capture_faithful_prefix(
+    scenario: StateSimilarityScenario,
+    *,
+    action_count: int,
+    label: str,
+    kind: str,
+    workflow_builder: WorkflowBuilder,
+    action: JsonValue | None = None,
+) -> tuple[StateSimilarityReviewCheckpoint, StateSimilarityTransition | None]:
+    """Capture one prefix without letting review rendering affect later prefixes."""
+
+    workflow = workflow_builder(scenario)
+    try:
+        for prefix_action in scenario.actions[:action_count]:
+            workflow.execute_action(prefix_action)
+        return _capture_checkpoint(
+            workflow,
+            label=label,
+            kind=kind,
+            action=action,
+        )
+    finally:
+        workflow.cleanup()
+
+
+def _sample_transition(
+    scenario: StateSimilarityScenario,
+    *,
+    action_index: int,
+    frame_count: int,
+    workflow_builder: WorkflowBuilder,
+) -> tuple[StateSimilarityReviewCheckpoint, ...]:
+    """Sample injected ticks on an isolated replay of the scenario prefix."""
+
+    workflow = workflow_builder(scenario)
+    samples: list[StateSimilarityReviewCheckpoint] = []
+    try:
+        for prefix_action in scenario.actions[: action_index + 1]:
+            workflow.execute_action(prefix_action)
+        _capture_checkpoint(workflow, label="Replay checkpoint", kind="replay")
+
+        delta_ms = DEFAULT_SLIDE_DURATION_MS / (frame_count + 1)
+        for sample_index in range(frame_count):
+            transition = workflow.transition_progress()
+            if transition is None or not transition.sliding:
+                break
+            workflow.advance_frame(delta_ms)
+            checkpoint, sampled_transition = _capture_checkpoint(
+                workflow,
+                label=(
+                    f"Transition sample {sample_index + 1}/{frame_count} "
+                    f"after action {action_index + 1}"
+                ),
+                kind="transition-sample",
+                action={
+                    "type": "transition-sample",
+                    "config": {
+                        "source_action_index": action_index,
+                        "sample_index": sample_index,
+                        "delta_ms": delta_ms,
+                    },
+                },
+            )
+            samples.append(
+                replace(
+                    checkpoint,
+                    transition_fraction=(
+                        sampled_transition.fraction
+                        if sampled_transition is not None
+                        else None
+                    ),
+                )
+            )
+    finally:
+        workflow.cleanup()
+    return tuple(samples)
+
+
+def _capture_checkpoint(
+    workflow: StateSimilarityWorkflow,
+    *,
+    label: str,
+    kind: str,
+    action: JsonValue | None = None,
+) -> tuple[StateSimilarityReviewCheckpoint, StateSimilarityTransition | None]:
+    state = canonicalize_state(workflow.project_state())
+    rgb = capture_surface_rgb(workflow.render())
+    transition = workflow.transition_progress()
+    return (
+        StateSimilarityReviewCheckpoint(
+            label=label,
+            kind=kind,
+            state=state,
+            rgb=rgb,
+            action=action,
+            transition_fraction=(
+                transition.fraction if transition is not None else None
+            ),
+        ),
+        transition,
+    )
+
+
+def _scene_identity(state: JsonValue) -> tuple[str, JsonValue] | None:
+    if isinstance(state, dict):
+        for key in _SCENE_IDENTITY_KEYS:
+            if key in state:
+                return (key, state[key])
+        for key, value in state.items():
+            nested = _scene_identity(value)
+            if nested is not None:
+                return (f"{key}.{nested[0]}", nested[1])
+    if isinstance(state, list):
+        for index, value in enumerate(state):
+            nested = _scene_identity(value)
+            if nested is not None:
+                return (f"[{index}].{nested[0]}", nested[1])
+    return None
+
+
+def _action_json(action: StateSimilarityAction) -> dict[str, JsonValue]:
+    return {
+        "type": action.type,
+        "config": action.config,
+    }
+
+
+def _matches_expected(
+    checkpoint: StateSimilarityReviewCheckpoint,
+    scenario: StateSimilarityScenario,
+) -> bool:
+    if checkpoint.state != scenario.expected_state:
+        return False
+    try:
+        assert_rgb_similar(
+            checkpoint.rgb,
+            scenario.expected_rgb,
+            channel_tolerance=scenario.channel_tolerance,
+            max_outlier_fraction=scenario.max_outlier_fraction,
+        )
+    except AssertionError:
+        return False
+    return True
+
+
+def _scenario_page(
+    scenario: StateSimilarityScenario,
+    *,
+    source: Path,
+    checkpoints: tuple[StateSimilarityReviewCheckpoint, ...],
+    matches_expected: bool,
+) -> str:
+    status_class = "status-pass" if matches_expected else "status-diff"
+    status_text = "Matches expected final state and screen" if matches_expected else (
+        "Final output differs from expected"
+    )
+    user_story = _SCENARIO_USER_STORIES.get(scenario.name)
+    user_story_html = (
+        "" if user_story is None else f'<p class="user-story">{_escape(user_story)}</p>'
+    )
+    checkpoint_html = "\n".join(_checkpoint_html(item) for item in checkpoints)
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{_escape(scenario.name)} · State similarity review</title>
+<style>{_PAGE_STYLE}</style>
+</head>
+<body>
+<p><a href="index.html">← All scenarios</a></p>
+<h1>{_escape(scenario.name)}</h1>
+<section class="summary">
+  <p class="{status_class}"><strong>{status_text}</strong></p>
+  {user_story_html}
+  <p><small>Kind: {_escape(scenario.kind)} · Source: {_escape(str(source))}</small></p>
+  <p>{len(checkpoints)} checkpoints, including isolated transition samples.</p>
+</section>
+{checkpoint_html}
+<section class="checkpoint expected">
+  <h2>Expected final output</h2>
+  <div class="frame"><img alt="Expected final screen" src="{_png_data_uri(scenario.expected_rgb)}"></div>
+  <h3>Expected state</h3>
+  <pre><code>{_json_html(scenario.expected_state)}</code></pre>
+</section>
+</body>
+</html>
+"""
+
+
+def _checkpoint_html(checkpoint: StateSimilarityReviewCheckpoint) -> str:
+    action = (
+        "<p><small>No action — initial program state.</small></p>"
+        if checkpoint.action is None
+        else f"<h3>Action</h3><pre><code>{_json_html(checkpoint.action)}</code></pre>"
+    )
+    fraction = (
+        ""
+        if checkpoint.transition_fraction is None
+        else f"<p><small>Transition fraction: {checkpoint.transition_fraction:.4f}</small></p>"
+    )
+    return f"""<section class="checkpoint {_escape(checkpoint.kind)}">
+  <h2>{_escape(checkpoint.label)}</h2>
+  {fraction}
+  <div class="frame"><img alt="{_escape(checkpoint.label)} screen" src="{_png_data_uri(checkpoint.rgb)}"></div>
+  <div class="data-grid">
+    <div>{action}</div>
+    <div><h3>State</h3><pre><code>{_json_html(checkpoint.state)}</code></pre></div>
+  </div>
+</section>"""
+
+
+def _index_page(summaries: list[tuple[str, str, bool]]) -> str:
+    items = "\n".join(
+        (
+            f'<li><a href="{_escape(page_name)}">{_escape(name)}</a> '
+            f'<span class="{"status-pass" if passed else "status-diff"}">'
+            f'{"matches expected" if passed else "differs"}</span></li>'
+        )
+        for name, page_name, passed in summaries
+    )
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>State similarity review</title>
+<style>{_PAGE_STYLE}</style>
+</head>
+<body>
+<h1>State similarity review</h1>
+<p>Static replay artifacts for {len(summaries)} scenarios.</p>
+<ul>{items}</ul>
+</body>
+</html>
+"""
+
+
+def _png_data_uri(rgb: NDArray[np.uint8]) -> str:
+    output = BytesIO()
+    Image.fromarray(rgb, mode="RGB").save(output, format="PNG")
+    encoded = base64.b64encode(output.getvalue()).decode("ascii")
+    return f"data:image/png;base64,{encoded}"
+
+
+def _json_html(value: JsonValue) -> str:
+    return _escape(json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False))
+
+
+def _escape(value: str) -> str:
+    return html.escape(value, quote=True)
+
+
+def _unique_page_name(stem: str, used_names: set[str]) -> str:
+    slug = _SLUG_CHARACTERS.sub("-", stem.lower()).strip("-") or "scenario"
+    candidate = f"{slug}.html"
+    suffix = 2
+    while candidate in used_names:
+        candidate = f"{slug}-{suffix}.html"
+        suffix += 1
+    used_names.add(candidate)
+    return candidate

--- a/src/heart/testing/state_similarity_review_cli.py
+++ b/src/heart/testing/state_similarity_review_cli.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import final
+
+from heart.testing.state_similarity_review import (
+    DEFAULT_REVIEW_OUTPUT,
+    DEFAULT_TRANSITION_FRAMES,
+    generate_state_similarity_review,
+)
+from heart.testing.system_contract import write_system_contract_review
+
+DEFAULT_SCENARIO_DIRECTORY = Path("tests/state_similarity/scenarios")
+_SLUG_CHARACTERS = re.compile(r"[^a-z0-9]+")
+
+
+@final
+@dataclass(frozen=True)
+class ReviewCliArguments:
+    paths: tuple[Path, ...]
+    output: Path
+    transition_frames: int
+    contract_artifacts: tuple[Path, ...]
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Generate static state-similarity review pages."""
+
+    arguments = parse_args(argv)
+    result = generate_state_similarity_review(
+        arguments.paths,
+        output_dir=arguments.output,
+        transition_frames=arguments.transition_frames,
+    )
+    for artifact_path in arguments.contract_artifacts:
+        artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+        write_system_contract_review(
+            artifact,
+            arguments.output / f"{_slug(artifact_path.stem)}-system-contract.html",
+        )
+    print(result.index_path)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> ReviewCliArguments:
+    parser = argparse.ArgumentParser(
+        prog="heart-state-review",
+        description="Replay state-similarity JSON scenarios into static HTML.",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        help="Scenario JSON files or directories containing scenario JSON files.",
+    )
+    parser.add_argument(
+        "--scenario-dir",
+        action="append",
+        default=[],
+        type=Path,
+        help="Additional directory containing scenario JSON files.",
+    )
+    parser.add_argument(
+        "--output",
+        default=DEFAULT_REVIEW_OUTPUT,
+        type=Path,
+        help=f"Output directory (default: {DEFAULT_REVIEW_OUTPUT}).",
+    )
+    parser.add_argument(
+        "--transition-frames",
+        default=DEFAULT_TRANSITION_FRAMES,
+        type=_non_negative_integer,
+        help=(
+            "Maximum isolated frames sampled for each animated scene transition "
+            f"(default: {DEFAULT_TRANSITION_FRAMES})."
+        ),
+    )
+    parser.add_argument(
+        "--contract-artifact",
+        action="append",
+        default=[],
+        type=Path,
+        help=(
+            "Machine-readable system qualification artifact to render as an "
+            "additional contract review page."
+        ),
+    )
+    namespace = parser.parse_args(argv)
+    paths = tuple(namespace.paths) + tuple(namespace.scenario_dir)
+    if not paths:
+        paths = (DEFAULT_SCENARIO_DIRECTORY,)
+    return ReviewCliArguments(
+        paths=paths,
+        output=namespace.output,
+        transition_frames=namespace.transition_frames,
+        contract_artifacts=tuple(namespace.contract_artifact),
+    )
+
+
+def _non_negative_integer(raw_value: str) -> int:
+    value = int(raw_value)
+    if value < 0:
+        raise argparse.ArgumentTypeError("must be non-negative")
+    return value
+
+
+def _slug(stem: str) -> str:
+    return _SLUG_CHARACTERS.sub("-", stem.lower()).strip("-") or "artifact"

--- a/src/heart/testing/state_similarity_workflows.py
+++ b/src/heart/testing/state_similarity_workflows.py
@@ -1,0 +1,714 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import final
+
+import numpy as np
+import pygame
+
+from heart.device import Cube, Device, Orientation, Rectangle
+from heart.device.local import LocalScreen
+from heart.display.color import Color
+from heart.navigation import ComposedRenderer, GameModes, MultiScene
+from heart.peripheral.core.input import (
+    GamepadButton,
+    GamepadDpadValue,
+    GamepadSnapshot,
+    GamepadSnapshotEvent,
+    KeyboardSnapshot,
+)
+from heart.peripheral.core.manager import PeripheralManager
+from heart.peripheral.gamepad import Gamepad
+from heart.peripheral.sensor import Acceleration
+from heart.renderers import StatefulBaseRenderer
+from heart.renderers.color import RenderColor
+from heart.renderers.pixels.renderer import Border
+from heart.renderers.tixyland.provider import TixylandStateProvider
+from heart.renderers.tixyland.renderer import Tixyland
+from heart.renderers.water_cube.provider import WaterCubeStateProvider
+from heart.renderers.water_cube.renderer import WaterCube
+from heart.runtime.display_context import DisplayContext
+from heart.runtime.peripheral_runtime import PeripheralRuntime
+from heart.testing.state_similarity import (
+    StateSimilarityAction,
+    StateSimilarityScenario,
+)
+
+_KEY_CODES = {
+    "left": pygame.K_LEFT,
+    "right": pygame.K_RIGHT,
+    "down": pygame.K_DOWN,
+    "up": pygame.K_UP,
+}
+_GAMEPAD_BUTTONS = {button.value: button for button in GamepadButton}
+_SWITCH_PRO_AXES = {
+    "trigger_left": 4,
+    "trigger_right": 5,
+}
+_SWITCH_PRO_BUTTONS = {
+    "zl": 9,
+    "zr": 10,
+}
+_EMPTY_KEYBOARD = KeyboardSnapshot(pressed_keys=frozenset(), timestamp_ms=0.0)
+
+
+def build_state_similarity_workflow(
+    scenario: StateSimilarityScenario,
+    *,
+    device: Device | None = None,
+) -> StateSimilarityWorkflow:
+    """Build a replayable real Heart workflow for a serialized scenario."""
+
+    if scenario.initial.config is None:
+        raise ValueError(f"Scenario {scenario.name!r} requires initial.config")
+    config = _mapping(scenario.initial.config, label="initial.config")
+    if scenario.kind == "game_modes":
+        return _build_game_modes_workflow(
+            scenario,
+            config,
+            device=device or _navigation_device(config),
+        )
+    if scenario.kind == "multi_scene":
+        return _build_multi_scene_workflow(
+            scenario,
+            config,
+            device=device or _navigation_device(config),
+        )
+    if scenario.kind == "scene_controller":
+        return _build_scene_controller_workflow(scenario, config)
+    raise ValueError(f"Unsupported state-similarity scenario kind {scenario.kind!r}")
+
+
+@final
+@dataclass(frozen=True)
+class StateSimilarityTransition:
+    """Serializable progress for an active renderer transition."""
+
+    fraction: float
+    sliding: bool
+
+
+@final
+class StateSimilarityWorkflow:
+    """Replay actions and inspect state, frames, and transitions for one scenario."""
+
+    def __init__(
+        self,
+        *,
+        scenario: StateSimilarityScenario,
+        execute_action: Callable[[StateSimilarityAction], None],
+        project_state: Callable[[], object],
+        render: Callable[[], pygame.Surface],
+        cleanup: Callable[[], None],
+        advance_frame: Callable[[float], None],
+        transition_progress: Callable[[], StateSimilarityTransition | None],
+    ) -> None:
+        self.scenario = scenario
+        self._execute_action = execute_action
+        self._project_state = project_state
+        self._render = render
+        self._cleanup = cleanup
+        self._advance_frame = advance_frame
+        self._transition_progress = transition_progress
+        self._is_cleaned_up = False
+
+    def execute_action(self, action: StateSimilarityAction) -> None:
+        self._ensure_active()
+        self._execute_action(action)
+
+    def project_state(self) -> object:
+        self._ensure_active()
+        return self._project_state()
+
+    def render(self) -> pygame.Surface:
+        self._ensure_active()
+        return self._render()
+
+    def cleanup(self) -> None:
+        if self._is_cleaned_up:
+            return
+        self._cleanup()
+        self._is_cleaned_up = True
+
+    def advance_frame(self, delta_ms: float) -> None:
+        self._ensure_active()
+        if (
+            isinstance(delta_ms, bool)
+            or not isinstance(delta_ms, int | float)
+            or not math.isfinite(delta_ms)
+            or delta_ms < 0
+        ):
+            raise ValueError("delta_ms must be a finite non-negative number")
+        self._advance_frame(float(delta_ms))
+
+    def transition_progress(self) -> StateSimilarityTransition | None:
+        self._ensure_active()
+        return self._transition_progress()
+
+    def _ensure_active(self) -> None:
+        if self._is_cleaned_up:
+            raise RuntimeError(
+                f"State-similarity workflow {self.scenario.name!r} is cleaned up"
+            )
+
+
+@final
+class _FrameClock:
+    def __init__(self, delta_ms: float) -> None:
+        self._delta_ms = delta_ms
+
+    def get_fps(self) -> float:
+        return 60.0
+
+    def get_time(self) -> float:
+        return self._delta_ms
+
+
+@final
+class _VirtualJoystick:
+    """Mutable pygame joystick boundary for ordered controller workflows."""
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+        self._axes: dict[int, float] = {}
+        self._buttons: dict[int, bool] = {}
+
+    def set_input(
+        self,
+        *,
+        axes: Mapping[int, float],
+        buttons: Mapping[int, bool],
+    ) -> None:
+        self._axes = dict(axes)
+        self._buttons = dict(buttons)
+
+    def get_name(self) -> str:
+        return self._name
+
+    def get_numbuttons(self) -> int:
+        return 16
+
+    def get_numaxes(self) -> int:
+        return 6
+
+    def get_button(self, button_id: int) -> bool:
+        return self._buttons.get(button_id, False)
+
+    def get_axis(self, axis_id: int) -> float:
+        return self._axes.get(axis_id, 0.0)
+
+    def get_hat(self, _hat_id: int) -> tuple[int, int]:
+        return (0, 0)
+
+    def quit(self) -> None:
+        pass
+
+
+@final
+@dataclass
+class _FixedDevice(Device):
+    width: int
+    height: int
+
+    def individual_display_size(self) -> tuple[int, int]:
+        return (self.width, self.height)
+
+
+def _build_game_modes_workflow(
+    scenario: StateSimilarityScenario,
+    config: Mapping[str, object],
+    *,
+    device: Device,
+) -> StateSimilarityWorkflow:
+    peripheral_manager = PeripheralManager()
+    runtime = PeripheralRuntime(peripheral_manager)
+    game_modes = GameModes()
+    modes = _sequence(config["modes"], label="config.modes")
+    for index, value in enumerate(modes):
+        mode_config = _mapping(value, label=f"config.modes[{index}]")
+        mode = game_modes.add_mode(
+            RenderColor(
+                _color(mode_config["title_rgb"], label=f"config.modes[{index}].title_rgb")
+            ),
+            name=_string(mode_config["name"], label=f"config.modes[{index}].name"),
+        )
+        for renderer in _build_navigation_renderers(
+            mode_config,
+            legacy_rgb_key="rgb",
+            label=f"config.modes[{index}]",
+        ):
+            mode.add_renderer(renderer)
+
+    window = DisplayContext(
+        device=device,
+        screen=pygame.display.set_mode(device.full_display_size()),
+        clock=pygame.time.Clock(),
+    )
+    game_modes.initialize(
+        window=window,
+        peripheral_manager=peripheral_manager,
+        orientation=device.orientation,
+    )
+    return StateSimilarityWorkflow(
+        scenario=scenario,
+        execute_action=lambda action: _execute_navigation_action(runtime, action),
+        project_state=game_modes.snapshot_state,
+        render=lambda: _render_navigation(
+            game_modes.get_renderers(),
+            peripheral_manager,
+            window,
+            device,
+        ),
+        cleanup=lambda: _cleanup_renderer(game_modes, peripheral_manager),
+        advance_frame=lambda delta_ms: _advance_frame(peripheral_manager, delta_ms),
+        transition_progress=lambda: _game_modes_transition(game_modes),
+    )
+
+
+def _build_multi_scene_workflow(
+    scenario: StateSimilarityScenario,
+    config: Mapping[str, object],
+    *,
+    device: Device,
+) -> StateSimilarityWorkflow:
+    peripheral_manager = PeripheralManager()
+    runtime = PeripheralRuntime(peripheral_manager)
+    scenes = _sequence(config["scenes"], label="config.scenes")
+    multi_scene = MultiScene(
+        [
+            _compose_navigation_scene(
+                _build_navigation_renderers(
+                    _mapping(value, label=f"config.scenes[{index}]"),
+                    legacy_rgb_key="rgb",
+                    label=f"config.scenes[{index}]",
+                )
+            )
+            for index, value in enumerate(scenes)
+        ],
+        enable_dpad_scene_selection=_boolean(
+            config["enable_dpad_scene_selection"],
+            label="config.enable_dpad_scene_selection",
+        ),
+    )
+    window = _window(device)
+    multi_scene.initialize(
+        window=window,
+        peripheral_manager=peripheral_manager,
+        orientation=device.orientation,
+    )
+    return StateSimilarityWorkflow(
+        scenario=scenario,
+        execute_action=lambda action: _execute_navigation_action(runtime, action),
+        project_state=multi_scene.snapshot_state,
+        render=lambda: _render_navigation(
+            multi_scene.get_renderers(),
+            peripheral_manager,
+            window,
+            device,
+        ),
+        cleanup=lambda: _cleanup_renderer(multi_scene, peripheral_manager),
+        advance_frame=lambda delta_ms: _advance_frame(peripheral_manager, delta_ms),
+        transition_progress=lambda: None,
+    )
+
+
+def _build_scene_controller_workflow(
+    scenario: StateSimilarityScenario,
+    config: Mapping[str, object],
+) -> StateSimilarityWorkflow:
+    device = _build_device(_mapping(config["device"], label="config.device"))
+    gamepad_config = _mapping(config["gamepad"], label="config.gamepad")
+    manager, joystick = _manager_with_gamepad(
+        _string(gamepad_config["name"], label="config.gamepad.name")
+    )
+    renderer = _build_scene_renderer(config, device=device, manager=manager)
+    window = _window(device)
+    renderer.initialize(window, manager, device.orientation)
+    return StateSimilarityWorkflow(
+        scenario=scenario,
+        execute_action=lambda action: _execute_scene_action(
+            action,
+            manager=manager,
+            joystick=joystick,
+        ),
+        project_state=lambda: renderer.state,
+        render=lambda: _render_scene_renderer(renderer, window, device.orientation),
+        cleanup=lambda: _cleanup_renderer(renderer, manager),
+        advance_frame=lambda delta_ms: _advance_frame(manager, delta_ms),
+        transition_progress=lambda: None,
+    )
+
+
+def _execute_navigation_action(
+    runtime: PeripheralRuntime,
+    action: StateSimilarityAction,
+) -> None:
+    config = _mapping(action.config, label=f"{action.type}.config")
+    if action.type == "keyboard":
+        pressed = _sequence(config["pressed"], label="keyboard.pressed")
+        snapshot = KeyboardSnapshot(
+            pressed_keys=frozenset(
+                _KEY_CODES[_string(key, label="keyboard.pressed[]")]
+                for key in pressed
+            ),
+            timestamp_ms=_number(
+                config["timestamp_ms"],
+                label="keyboard.timestamp_ms",
+            ),
+        )
+        runtime.process_navigation_input(snapshot, ())
+        return
+    if action.type == "gamepad":
+        dpad = _sequence(config["dpad"], label="gamepad.dpad")
+        if len(dpad) != 2:
+            raise ValueError("gamepad.dpad must contain x and y")
+        held_buttons = _sequence(
+            config["held_buttons"],
+            label="gamepad.held_buttons",
+        )
+        event = GamepadSnapshotEvent(
+            joystick_id=_integer(config["joystick_id"], label="gamepad.joystick_id"),
+            snapshot=GamepadSnapshot(
+                connected=True,
+                identifier=_string(config["identifier"], label="gamepad.identifier"),
+                buttons={
+                    _GAMEPAD_BUTTONS[
+                        _string(button, label="gamepad.held_buttons[]")
+                    ]: True
+                    for button in held_buttons
+                },
+                dpad=GamepadDpadValue(
+                    x=_integer(dpad[0], label="gamepad.dpad[0]"),
+                    y=_integer(dpad[1], label="gamepad.dpad[1]"),
+                ),
+            ),
+        )
+        runtime.process_navigation_input(_EMPTY_KEYBOARD, (event,))
+        return
+    raise ValueError(f"Unsupported navigation action {action.type!r}")
+
+
+def _execute_scene_action(
+    action: StateSimilarityAction,
+    *,
+    manager: PeripheralManager,
+    joystick: _VirtualJoystick,
+) -> None:
+    config = _mapping(action.config, label=f"{action.type}.config")
+    if action.type == "gamepad":
+        axes = {
+            _SWITCH_PRO_AXES[name]: _number(value, label=f"gamepad.axes.{name}")
+            for name, value in _mapping(
+                config["axes"],
+                label="gamepad.axes",
+            ).items()
+        }
+        buttons = {
+            _SWITCH_PRO_BUTTONS[name]: _boolean(
+                value,
+                label=f"gamepad.buttons.{name}",
+            )
+            for name, value in _mapping(
+                config["buttons"],
+                label="gamepad.buttons",
+            ).items()
+        }
+        joystick.set_input(axes=axes, buttons=buttons)
+        manager.input_io.gamepad.poll()
+        return
+    if action.type == "sensor":
+        acceleration = _mapping(
+            config["acceleration"],
+            label="sensor.acceleration",
+        )
+        _set_external_acceleration(
+            manager,
+            x=_number(acceleration["x"], label="sensor.acceleration.x"),
+            y=_number(acceleration["y"], label="sensor.acceleration.y"),
+            z=_number(acceleration["z"], label="sensor.acceleration.z"),
+        )
+        return
+    if action.type == "tick":
+        delta_ms = _number(config["delta_ms"], label="tick.delta_ms")
+        count = _integer(config.get("count", 1), label="tick.count")
+        if count <= 0:
+            raise ValueError("tick.count must be positive")
+        for _ in range(count):
+            _advance_frame(manager, delta_ms)
+        return
+    raise ValueError(f"Unsupported scene-controller action {action.type!r}")
+
+
+def _game_modes_transition(
+    game_modes: GameModes,
+) -> StateSimilarityTransition | None:
+    transition = game_modes.state.sliding_transition
+    if transition is None:
+        return None
+    if not transition.initialized:
+        return StateSimilarityTransition(fraction=0.0, sliding=True)
+    return StateSimilarityTransition(
+        fraction=transition.state.fraction_offset,
+        sliding=transition.state.sliding,
+    )
+
+
+def _advance_frame(manager: PeripheralManager, delta_ms: float) -> None:
+    manager.input_io.frame_ticks.advance(_FrameClock(delta_ms))
+
+
+def _render_navigation(
+    renderers: Sequence[StatefulBaseRenderer],
+    peripheral_manager: PeripheralManager,
+    window: DisplayContext,
+    device: Device,
+) -> pygame.Surface:
+    surface = ComposedRenderer.render_batch(
+        renderers,
+        window=window,
+        peripheral_manager=peripheral_manager,
+        orientation=device.orientation,
+    )
+    if surface is None:
+        raise RuntimeError("State-similarity workflow produced no render surface")
+    return surface
+
+
+def _render_scene_renderer(
+    renderer: Tixyland | WaterCube,
+    window: DisplayContext,
+    orientation: Orientation,
+) -> pygame.Surface:
+    if window.screen is None:
+        raise RuntimeError("State-similarity workflow requires a display surface")
+    window.screen.fill((0, 0, 0))
+    renderer.real_process(window, orientation)
+    return window.screen
+
+
+def _build_device(config: Mapping[str, object]) -> Device:
+    orientation_config = _mapping(
+        config["orientation"],
+        label="config.device.orientation",
+    )
+    orientation_type = _string(
+        orientation_config["type"],
+        label="config.device.orientation.type",
+    )
+    if orientation_type == "rectangle":
+        orientation: Orientation = Rectangle.with_layout(
+            columns=_integer(
+                orientation_config["columns"],
+                label="config.device.orientation.columns",
+            ),
+            rows=_integer(
+                orientation_config["rows"],
+                label="config.device.orientation.rows",
+            ),
+        )
+    elif orientation_type == "cube_sides":
+        orientation = Cube.sides()
+    else:
+        raise ValueError(f"Unsupported scenario orientation {orientation_type!r}")
+
+    width = _integer(config["width"], label="config.device.width")
+    height = _integer(config["height"], label="config.device.height")
+    device_type = _string(config["type"], label="config.device.type")
+    if device_type == "local_screen":
+        return LocalScreen(width=width, height=height, orientation=orientation)
+    if device_type == "fixed":
+        return _FixedDevice(
+            orientation=orientation,
+            width=width,
+            height=height,
+        )
+    raise ValueError(f"Unsupported scenario device {device_type!r}")
+
+
+def _build_scene_renderer(
+    config: Mapping[str, object],
+    *,
+    device: Device,
+    manager: PeripheralManager,
+) -> Tixyland | WaterCube:
+    renderer_type = _string(config["renderer"], label="config.renderer")
+    if renderer_type == "tixyland":
+        pattern = _string(config["pattern"], label="config.pattern")
+        if pattern != "sin_time_x_half_minus_y_quarter":
+            raise ValueError(f"Unsupported Tixyland scenario pattern {pattern!r}")
+        return Tixyland(
+            builder=TixylandStateProvider(manager),
+            fn=_tixyland_pattern,
+        )
+    if renderer_type == "water_cube":
+        return WaterCube(builder=WaterCubeStateProvider(device=device))
+    raise ValueError(f"Unsupported scenario renderer {renderer_type!r}")
+
+
+def _navigation_device(config: Mapping[str, object]) -> Device:
+    device_config = config.get("device")
+    if device_config is None:
+        return _default_navigation_device()
+    return _build_device(_mapping(device_config, label="config.device"))
+
+
+def _build_navigation_renderers(
+    config: Mapping[str, object],
+    *,
+    legacy_rgb_key: str,
+    label: str,
+) -> list[StatefulBaseRenderer]:
+    renderers_config = config.get("renderers")
+    if renderers_config is None:
+        return [
+            RenderColor(
+                _color(
+                    config[legacy_rgb_key],
+                    label=f"{label}.{legacy_rgb_key}",
+                )
+            )
+        ]
+    return [
+        _build_navigation_renderer(
+            _mapping(value, label=f"{label}.renderers[{index}]"),
+            label=f"{label}.renderers[{index}]",
+        )
+        for index, value in enumerate(
+            _sequence(renderers_config, label=f"{label}.renderers")
+        )
+    ]
+
+
+def _compose_navigation_scene(
+    renderers: Sequence[StatefulBaseRenderer],
+) -> StatefulBaseRenderer:
+    if not renderers:
+        raise ValueError("Navigation scene must contain at least one renderer")
+    if len(renderers) == 1:
+        return renderers[0]
+    scene = ComposedRenderer()
+    scene.add_renderer(*renderers)
+    return scene
+
+
+def _build_navigation_renderer(
+    config: Mapping[str, object],
+    *,
+    label: str,
+) -> StatefulBaseRenderer:
+    renderer_type = _string(config["type"], label=f"{label}.type")
+    if renderer_type == "color":
+        return RenderColor(_color(config["rgb"], label=f"{label}.rgb"))
+    if renderer_type == "border":
+        return Border(
+            width=_integer(config["width"], label=f"{label}.width"),
+            color=_color(config["rgb"], label=f"{label}.rgb"),
+        )
+    raise ValueError(f"Unsupported navigation renderer {renderer_type!r}")
+
+
+def _tixyland_pattern(
+    time: float,
+    _index: np.ndarray,
+    y: np.ndarray,
+    x: np.ndarray,
+) -> np.ndarray:
+    return np.sin(time + x * 0.5 - y * 0.25)
+
+
+def _manager_with_gamepad(
+    name: str,
+) -> tuple[PeripheralManager, _VirtualJoystick]:
+    manager = PeripheralManager()
+    joystick = _VirtualJoystick(name)
+    manager.register(Gamepad(joystick_id=0, joystick=joystick))
+    return manager, joystick
+
+
+def _set_external_acceleration(
+    manager: PeripheralManager,
+    *,
+    x: float,
+    y: float,
+    z: float,
+) -> None:
+    sensors = manager.input_io.external_sensors
+    sensors.set_value("workflow-accelerometer:x", x)
+    sensors.set_value("workflow-accelerometer:y", y)
+    sensors.set_value("workflow-accelerometer:z", z)
+    manager.input_io.accelerometer.node().on_next(Acceleration(x=x, y=y, z=z))
+
+
+def _window(device: Device) -> DisplayContext:
+    return DisplayContext(
+        device=device,
+        screen=pygame.Surface(device.full_display_size()),
+        clock=pygame.time.Clock(),
+    )
+
+
+def _default_navigation_device() -> Device:
+    return _FixedDevice(
+        orientation=Cube.sides(),
+        width=64,
+        height=64,
+    )
+
+
+def _cleanup_renderer(
+    renderer: StatefulBaseRenderer,
+    peripheral_manager: PeripheralManager,
+) -> None:
+    renderer.reset()
+    peripheral_manager.stop()
+
+
+def _color(value: object, *, label: str) -> Color:
+    rgb = _sequence(value, label=label)
+    if len(rgb) != 3:
+        raise ValueError(f"{label} must contain three channels")
+    return Color(
+        _integer(rgb[0], label=f"{label}[0]"),
+        _integer(rgb[1], label=f"{label}[1]"),
+        _integer(rgb[2], label=f"{label}[2]"),
+    )
+
+
+def _mapping(value: object, *, label: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{label} must be an object")
+    if not all(isinstance(key, str) for key in value):
+        raise TypeError(f"{label} must use string keys")
+    return value
+
+
+def _sequence(value: object, *, label: str) -> Sequence[object]:
+    if isinstance(value, str | bytes) or not isinstance(value, Sequence):
+        raise TypeError(f"{label} must be an array")
+    return value
+
+
+def _string(value: object, *, label: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{label} must be a string")
+    return value
+
+
+def _integer(value: object, *, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{label} must be an integer")
+    return value
+
+
+def _number(value: object, *, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise TypeError(f"{label} must be a number")
+    return float(value)
+
+
+def _boolean(value: object, *, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise TypeError(f"{label} must be a boolean")
+    return value

--- a/src/heart/testing/system_contract.py
+++ b/src/heart/testing/system_contract.py
@@ -1,0 +1,454 @@
+from __future__ import annotations
+
+import base64
+import html
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+from typing import final
+
+import numpy as np
+from numpy.typing import NDArray
+from PIL import Image
+
+from heart.testing.state_similarity import JsonValue, canonicalize_state
+
+CONTRACT_SCHEMA_VERSION = 1
+SYSTEM_CONTRACT_SCENARIO_ID = "heart-world-coordination-node-failure-v1"
+SYSTEM_CONTRACT_SEED = "heart-world-coordination-deterministic-v1"
+SYSTEM_CONTRACT_RGB_WIDTH = 8
+
+_PASS = (57, 211, 140)
+_BOUND = (143, 199, 255)
+_GAP = (212, 167, 44)
+_FAIL = (255, 123, 114)
+
+_EXPECTED_HOT_PATH_EXCLUSIONS = [
+    "debug",
+    "frame_tick",
+    "microphone_sample",
+    "navigation_event",
+    "rendered_frame",
+    "sensor_sample",
+]
+
+_API_GAPS: tuple[tuple[str, str], ...] = (
+    (
+        "peer_discovered_connected_recovered",
+        "Heart exposes these through heart.node.status changed snapshots, but "
+        "not as distinct ordered peer lifecycle events.",
+    ),
+    (
+        "transport_retry_scheduled_attempted",
+        "World coordination exposes final durable transport state but not "
+        "ordered public retry scheduled/attempted events.",
+    ),
+    (
+        "durable_queued_retry_replay_acknowledged",
+        "Durable delivery exposes health counters and received messages, but no "
+        "public PubSub lifecycle topic for queued, retried, or acknowledged "
+        "records.",
+    ),
+    (
+        "watermark_coalesced_dropped_expired",
+        "No public Heart or ManyFold event in this qualification trace currently "
+        "reports watermark coalescing, drops, or expiry.",
+    ),
+    (
+        "signer_renewal_restart",
+        "Signer renewal and restart are visible through status and health calls, "
+        "but not through a public lifecycle event topic.",
+    ),
+    (
+        "raft_leader_change",
+        "Raft leader changes are visible through coordinator or DevelopmentCluster "
+        "status, but not through a public ordered leader-change topic.",
+    ),
+    (
+        "clean_shutdown_stopped",
+        "Heart publishes stopping but not a terminal stopped lifecycle event "
+        "after resources close.",
+    ),
+)
+
+_STYLE = """
+:root{color-scheme:dark;font-family:ui-sans-serif,system-ui,sans-serif;background:#111318;color:#edf0f7}
+body{margin:0 auto;max-width:1200px;padding:2rem}
+section{background:#1a1e27;border:1px solid #303746;border-radius:8px;margin:1rem 0;padding:1rem}
+table{border-collapse:collapse;width:100%}th,td{border-bottom:1px solid #303746;padding:.5rem;text-align:left}
+pre{background:#0d0f14;border-radius:8px;max-height:28rem;overflow:auto;padding:1rem}
+.frame{background:#07080b;border-radius:8px;overflow:auto;padding:1rem}.frame img{display:block;image-rendering:pixelated;width:640px}
+"""
+
+
+@final
+@dataclass(frozen=True)
+class SystemContractProjection:
+    state: dict[str, JsonValue]
+    rgb: NDArray[np.uint8]
+
+
+def project_world_coordination_contract(
+    artifact: Mapping[str, object],
+) -> SystemContractProjection:
+    """Project a ManyFold world-coordination artifact into stable contract data."""
+
+    raft = _object(artifact, "raft")
+    durable = _object(artifact, "durable_delivery")
+    world_rpc = _object(artifact, "world_rpc")
+    boundary = _object(artifact, "boundary")
+
+    node_revisions = _string_ints(raft, "node_revisions")
+    expected_revision = _integer(world_rpc, "revision")
+    mode_sequence = _integer(raft, "mode_sequence")
+    duplicate_sequence = _integer(raft, "duplicate_mode_sequence")
+    acknowledgements = _integer(durable, "receiver_acknowledgements")
+    outbox_items = _integer(durable, "sender_outbox_items")
+    observed_revisions = sorted(set(node_revisions.values()))
+
+    checks = {
+        "leader_changed": _boolean(raft, "leader_changed"),
+        "restarted_process_changed": _boolean(raft, "restarted_process_changed"),
+        "revisions_converged": observed_revisions == [expected_revision],
+        "rpc_read_matches_revision": expected_revision == 2,
+        "durable_receiver_restarted": _boolean(durable, "receiver_restarted"),
+        "durable_item_applied_once": _integer(durable, "applied_count") == 1,
+        "durable_replay_acknowledged": acknowledgements >= 1,
+        "durable_sender_outbox_drained": outbox_items == 0,
+        "no_duplicate_mode_commit": duplicate_sequence == mode_sequence,
+        "no_duplicate_after_ack": not _boolean(durable, "duplicate_exposed_after_ack"),
+        "no_hot_path_data_in_durable_contract": (
+            _strings(boundary, "excluded_hot_path_data")
+            == _EXPECTED_HOT_PATH_EXCLUSIONS
+        ),
+    }
+    state = canonicalize_state(
+        {
+            "schema_version": CONTRACT_SCHEMA_VERSION,
+            "scenario": _scenario(artifact, node_revisions),
+            "event_timeline": _timeline(
+                node_count=_integer(raft, "node_count"),
+                mode_sequence=mode_sequence,
+            ),
+            "role_by_failure_impact_matrix": _impact_matrix(checks),
+            "bounds": [
+                {
+                    "name": "raft_revision_convergence",
+                    "expected_revision": expected_revision,
+                    "observed_revisions": observed_revisions,
+                    "passed": checks["revisions_converged"],
+                },
+                {
+                    "name": "duplicate_command_coalescence",
+                    "original_sequence": mode_sequence,
+                    "duplicate_sequence": duplicate_sequence,
+                    "passed": checks["no_duplicate_mode_commit"],
+                },
+                {
+                    "name": "durable_ack_convergence",
+                    "acknowledgements": acknowledgements,
+                    "sender_outbox_items": outbox_items,
+                    "passed": (
+                        checks["durable_replay_acknowledged"]
+                        and checks["durable_sender_outbox_drained"]
+                    ),
+                },
+            ],
+            "negative_assertions": [
+                _check("no_duplicate_mode_commit", checks),
+                _check("no_duplicate_after_ack", checks),
+                _check("no_hot_path_data_in_durable_contract", checks),
+            ],
+            "api_gaps": [
+                {"transition": transition, "gap": gap, "passed": False}
+                for transition, gap in _API_GAPS
+            ],
+        }
+    )
+    if not isinstance(state, dict):
+        raise TypeError("system contract projection must canonicalize to an object")
+    return SystemContractProjection(state=state, rgb=render_system_contract_rgb(state))
+
+
+def render_system_contract_rgb(state: Mapping[str, JsonValue]) -> NDArray[np.uint8]:
+    rows: list[tuple[int, int, int]] = []
+    for section in (
+        "event_timeline",
+        "role_by_failure_impact_matrix",
+        "bounds",
+        "negative_assertions",
+        "api_gaps",
+    ):
+        rows.extend(_row_colors(state.get(section)))
+    if not rows:
+        rows.append(_FAIL)
+    return np.repeat(
+        np.asarray(rows, dtype=np.uint8)[:, np.newaxis, :],
+        SYSTEM_CONTRACT_RGB_WIDTH,
+        axis=1,
+    )
+
+
+def write_system_contract_review(
+    artifact: Mapping[str, object],
+    output_path: str | Path,
+) -> Path:
+    projection = project_world_coordination_contract(artifact)
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(system_contract_review_html(projection), encoding="utf-8")
+    return path
+
+
+def system_contract_review_html(projection: SystemContractProjection) -> str:
+    state = projection.state
+    scenario = state.get("scenario", {})
+    title = (
+        str(scenario.get("id", "system contract"))
+        if isinstance(scenario, Mapping)
+        else "system contract"
+    )
+    return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{_escape(title)} · System contract</title><style>{_STYLE}</style></head><body>
+<h1>{_escape(title)}</h1>
+<section><h2>Scenario Metadata</h2><pre><code>{_json_html(scenario)}</code></pre></section>
+<section><h2>RGB Contract Strip</h2><div class="frame"><img alt="System contract RGB strip" src="{_png_data_uri(projection.rgb)}"></div></section>
+<section><h2>Event Timeline</h2>{_table(state.get("event_timeline"), ("step", "topic", "transition", "state"))}</section>
+<section><h2>Role By Failure Impact Matrix</h2>{_table(state.get("role_by_failure_impact_matrix"), ("role", "failure", "observable_transition", "expected_state", "passed"))}</section>
+<section><h2>Bounds And Negative Assertions</h2>{_table(_joined(state.get("bounds"), state.get("negative_assertions")), ("name", "passed"))}</section>
+<section><h2>Public API Gaps</h2>{_table(state.get("api_gaps"), ("transition", "gap", "passed"))}</section>
+</body></html>
+"""
+
+
+def _scenario(
+    artifact: Mapping[str, object],
+    node_revisions: Mapping[str, int],
+) -> dict[str, object]:
+    return {
+        "id": SYSTEM_CONTRACT_SCENARIO_ID,
+        "seed": SYSTEM_CONTRACT_SEED,
+        "source_protocol": artifact.get(
+            "protocol",
+            "heart.manyfold-world-coordination-proof",
+        ),
+        "node_ids": sorted(node_revisions),
+        "clock": {"type": "real_runtime_bounded", "semantic_bounds_only": True},
+    }
+
+
+def _timeline(*, node_count: int, mode_sequence: int) -> list[dict[str, object]]:
+    return [
+        _event(1, "manyfold.lifecycle.raft", "cluster_started", "started", node_count),
+        _event(2, "manyfold.raft.log", "device_state_committed", "revision_1"),
+        _event(
+            3,
+            "manyfold.lifecycle.raft",
+            "leader_process_failed",
+            "failed_leader_unavailable",
+            role="failed_leader",
+        ),
+        _event(4, "manyfold.lifecycle.raft", "leader_changed", "replacement_elected"),
+        _event(
+            5,
+            "manyfold.raft.log",
+            "mode_state_committed_after_failure",
+            f"revision_{mode_sequence}",
+        ),
+        _event(
+            6,
+            "manyfold.durable_delivery",
+            "durable_item_queued",
+            "committed_mode_command",
+        ),
+        _event(
+            7,
+            "manyfold.durable_delivery",
+            "receiver_restarted_before_ack",
+            "receiver_restarted",
+        ),
+        _event(
+            8,
+            "manyfold.durable_delivery",
+            "replay_acknowledged",
+            "sender_outbox_drained",
+        ),
+    ]
+
+
+def _event(
+    step: int,
+    topic: str,
+    transition: str,
+    state: str,
+    node_count: int | None = None,
+    *,
+    role: str | None = None,
+) -> dict[str, object]:
+    event: dict[str, object] = {
+        "step": step,
+        "topic": topic,
+        "transition": transition,
+        "state": state,
+        "passed": True,
+    }
+    if node_count is not None:
+        event["node_count"] = node_count
+    if role is not None:
+        event["role"] = role
+    return event
+
+
+def _impact_matrix(checks: Mapping[str, bool]) -> list[dict[str, object]]:
+    return [
+        _impact(
+            "failed_leader",
+            "process_killed",
+            "leader_changed",
+            "restarted_and_converged",
+            checks["leader_changed"]
+            and checks["restarted_process_changed"]
+            and checks["revisions_converged"],
+        ),
+        _impact(
+            "replacement_leader",
+            "leader_loss",
+            "mode_commit_after_failure",
+            "world_rpc_reads_revision_2",
+            checks["leader_changed"] and checks["rpc_read_matches_revision"],
+        ),
+        _impact(
+            "durable_receiver",
+            "restart_before_ack",
+            "replay_acknowledged",
+            "applied_once_outbox_empty",
+            checks["durable_receiver_restarted"]
+            and checks["durable_item_applied_once"]
+            and checks["durable_replay_acknowledged"]
+            and checks["durable_sender_outbox_drained"]
+            and checks["no_duplicate_after_ack"],
+        ),
+        _impact(
+            "all_nodes",
+            "duplicate_mode_command",
+            "duplicate_command_coalesced",
+            "single_mode_revision",
+            checks["no_duplicate_mode_commit"],
+        ),
+    ]
+
+
+def _impact(
+    role: str,
+    failure: str,
+    transition: str,
+    expected_state: str,
+    passed: bool,
+) -> dict[str, object]:
+    return {
+        "role": role,
+        "failure": failure,
+        "observable_transition": transition,
+        "expected_state": expected_state,
+        "passed": passed,
+    }
+
+
+def _check(name: str, checks: Mapping[str, bool]) -> dict[str, object]:
+    return {"name": name, "passed": checks[name]}
+
+
+def _row_colors(value: object) -> list[tuple[int, int, int]]:
+    if not isinstance(value, list):
+        return []
+    rows: list[tuple[int, int, int]] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            continue
+        if "gap" in item:
+            rows.append(_GAP)
+        elif item.get("passed") is not True:
+            rows.append(_FAIL)
+        elif "expected_revision" in item or "original_sequence" in item:
+            rows.append(_BOUND)
+        else:
+            rows.append(_PASS)
+    return rows
+
+
+def _object(value: Mapping[str, object], key: str) -> Mapping[str, object]:
+    item = value.get(key)
+    if not isinstance(item, Mapping):
+        raise ValueError(f"qualification artifact field {key!r} must be an object")
+    return item
+
+
+def _string_ints(value: Mapping[str, object], key: str) -> dict[str, int]:
+    raw = _object(value, key)
+    result: dict[str, int] = {}
+    for item_key, item_value in raw.items():
+        if not isinstance(item_key, str):
+            raise ValueError(f"{key} keys must be strings")
+        if isinstance(item_value, bool) or not isinstance(item_value, int):
+            raise ValueError(f"{key}.{item_key} must be an integer")
+        result[item_key] = item_value
+    return result
+
+
+def _strings(value: Mapping[str, object], key: str) -> list[str]:
+    raw = value.get(key)
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise ValueError(f"qualification artifact field {key!r} must be a string list")
+    return sorted(raw)
+
+
+def _integer(value: Mapping[str, object], key: str) -> int:
+    raw = value.get(key)
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        raise ValueError(f"qualification artifact field {key!r} must be an integer")
+    return raw
+
+
+def _boolean(value: Mapping[str, object], key: str) -> bool:
+    raw = value.get(key)
+    if not isinstance(raw, bool):
+        raise ValueError(f"qualification artifact field {key!r} must be a boolean")
+    return raw
+
+
+def _table(value: object, columns: tuple[str, ...]) -> str:
+    rows = [item for item in value if isinstance(item, Mapping)] if isinstance(value, list) else []
+    heading = "".join(f"<th>{_escape(column)}</th>" for column in columns)
+    body = "".join(
+        "<tr>"
+        + "".join(f"<td>{_escape(str(row.get(column, '')))}</td>" for column in columns)
+        + "</tr>"
+        for row in rows
+    )
+    return f"<table><thead><tr>{heading}</tr></thead><tbody>{body}</tbody></table>"
+
+
+def _joined(first: object, second: object) -> list[object]:
+    rows: list[object] = []
+    if isinstance(first, list):
+        rows.extend(first)
+    if isinstance(second, list):
+        rows.extend(second)
+    return rows
+
+
+def _png_data_uri(rgb: NDArray[np.uint8]) -> str:
+    output = BytesIO()
+    Image.fromarray(rgb, mode="RGB").save(output, format="PNG")
+    return f"data:image/png;base64,{base64.b64encode(output.getvalue()).decode('ascii')}"
+
+
+def _json_html(value: object) -> str:
+    return _escape(json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False))
+
+
+def _escape(value: str) -> str:
+    return html.escape(value, quote=True)

--- a/tests/runtime/test_peripheral_runtime.py
+++ b/tests/runtime/test_peripheral_runtime.py
@@ -284,8 +284,8 @@ class TestPeripheralRuntimeStreaming:
             subscription.dispose()
 
         assert observed == [
-            ("ActivateIntent", 0, "gamepad.0.south"),
             ("BrowseIntent", 1, "gamepad.dpad"),
+            ("ActivateIntent", 0, "gamepad.0.south"),
             ("AlternateActivateIntent", 0, "gamepad.0.north"),
         ]
 

--- a/tests/state_similarity/README.md
+++ b/tests/state_similarity/README.md
@@ -1,0 +1,138 @@
+# State similarity tests
+
+State similarity tests exercise an ordered workflow, project the resulting
+program state into strict JSON-compatible data, and render that same state into
+an RGB golden. The two checks catch both behavioral drift and visual drift.
+
+## Scenario files
+
+Workflow definitions live in JSON so the input sequence and both expected
+outputs are reviewable without running Python. The loader rejects missing or
+unknown fields and reports validation failures with JSON-style paths.
+
+```json
+{
+  "name": "move right twice",
+  "kind": "navigation",
+  "initial": {"config": {"start": "home"}},
+  "actions": [
+    {"type": "navigate", "config": {"direction": "right"}},
+    {"type": "tick", "config": {"count": 2}}
+  ],
+  "expected": {
+    "state": {"screen": "settings"},
+    "screen": {
+      "fill": [10, 20, 30],
+      "shape": [64, 256, 3],
+      "channel_tolerance": 2,
+      "max_outlier_fraction": 0.001
+    }
+  }
+}
+```
+
+The required top-level fields are `name`, `kind`, `initial`, `actions`, and
+`expected`. They mirror Given/When/Then:
+
+- `initial` has exactly one object: `config` for configuration-driven setup or
+  `state` for an explicit starting state.
+- `actions` is ordered. Each action has exactly `type` and `config`. A `tick`
+  action may use a positive integer `count`; adapters can expand it into
+  repeated ticks.
+- `expected` has exactly `state` and `screen`.
+
+`expected.screen` has a positive `[height, width, 3]` shape and exactly one RGB
+encoding:
+
+- `fill`: one `[red, green, blue]` value repeated over the declared shape.
+- `pixels`: the complete nested `[height][width][3]` channel values. Its actual
+  shape must match the declared shape.
+- `rows`: one `[red, green, blue]` value per output row, repeated across the
+  declared width. This keeps timeline-style contract goldens compact.
+
+`channel_tolerance` and `max_outlier_fraction` are optional screen fields and
+default to zero.
+
+Load a scenario with
+`load_state_similarity_scenario("tests/state_similarity/scenarios/example.json")`.
+The result contains immutable typed action metadata, canonical expected state,
+and a materialized contiguous `uint8` RGB array.
+
+## Execution adapters
+
+Scenario authors only edit JSON. The Python test modules are thin execution
+adapters that map each `kind`, initial source, and action type onto real Heart
+objects. Add adapter code only when introducing a new production boundary or
+action vocabulary.
+
+The projected state is an explicit contract. Include every field needed to
+explain the behavior under test, but do not serialize an entire runtime object
+implicitly. Dataclasses, enums, string-keyed mappings, sequences, NumPy arrays,
+and NumPy scalars are normalized recursively. State arrays retain their full
+representation as
+`{"dtype": "uint8", "shape": [2, 3], "values": [...]}`. Unsupported values,
+non-finite floats, cycles, and non-string mapping keys fail with the path to the
+offending field.
+
+An RGB pixel is an outlier when any channel differs by more than
+`channel_tolerance`. The assertion passes when the outlier fraction is less
+than or equal to `max_outlier_fraction`. Keep both bounds as tight as the
+renderer permits; deterministic renderers should normally use the zero
+defaults.
+
+## HTML review
+
+Generate self-contained review pages for every scenario:
+
+```console
+uv run heart-state-review
+```
+
+The command writes an index and one HTML page per scenario to
+`tmp/state-similarity-review/`. Each page embeds the rendered RGB output and
+canonical state for initialization and after every action. Scene changes are
+marked explicitly, and animated transitions include five evenly spaced frame
+samples by default.
+
+Review checkpoints replay each action prefix independently. Rendering a
+checkpoint therefore cannot mutate a later checkpoint or change the workflow
+being compared with the final golden. Transition samples run in their own
+replay and do not inject ticks into the tested action sequence.
+
+Use `--output PATH` to choose another destination,
+`--transition-frames N` to change the transition sample count, and pass JSON
+files or directories to review a subset:
+
+```console
+uv run heart-state-review \
+  tests/state_similarity/scenarios/navigation_keyboard_right_twice.json \
+  --output tmp/navigation-review \
+  --transition-frames 8
+```
+
+Machine-readable system qualification artifacts can be rendered into additional
+contract review pages with `--contract-artifact`:
+
+```console
+uv run heart-state-review \
+  --contract-artifact tmp/world-coordination.json
+```
+
+The contract projector keeps deterministic semantic fields: scenario metadata,
+ordered lifecycle events, role-by-failure impact rows, convergence bounds,
+negative assertions, explicit public API gaps, and a compact RGB strip. It
+intentionally excludes process IDs, command IDs, host paths, timestamps, and
+incidental log formatting.
+
+## ManyFold StateMachine gap
+
+ManyFold PR 281 at `3c62dd1` adds the right public surfaces for future
+navigation contracts: `machine.commands`, `machine.state.latest`,
+`machine.transitions`, `machine.events`, and `flush()`. Do not add Heart tests
+around a toy reducer to prove that API. ManyFold owns StateMachine internals.
+
+The Heart-side migration should wait until navigation exposes a real typed
+command/reducer boundary for `GameModes` and `MultiScene`. At that point the
+existing user-story scenarios can assert the reducer-owned state, ordered
+domain transitions, ordered audit events, and final RGB render from the same
+workflow. Until then, `snapshot_state()` remains an explicit Heart projection.

--- a/tests/state_similarity/contracts/world_coordination_node_failure_expected.json
+++ b/tests/state_similarity/contracts/world_coordination_node_failure_expected.json
@@ -1,0 +1,206 @@
+{
+  "screen": {
+    "rows": [
+      [57, 211, 140],
+      [57, 211, 140],
+      [57, 211, 140],
+      [57, 211, 140],
+      [57, 211, 140],
+      [57, 211, 140],
+      [57, 211, 140],
+      [57, 211, 140],
+      [57, 211, 140],
+      [57, 211, 140],
+      [57, 211, 140],
+      [57, 211, 140],
+      [143, 199, 255],
+      [143, 199, 255],
+      [57, 211, 140],
+      [57, 211, 140],
+      [57, 211, 140],
+      [57, 211, 140],
+      [212, 167, 44],
+      [212, 167, 44],
+      [212, 167, 44],
+      [212, 167, 44],
+      [212, 167, 44],
+      [212, 167, 44],
+      [212, 167, 44]
+    ],
+    "shape": [25, 8, 3]
+  },
+  "state": {
+    "api_gaps": [
+      {
+        "gap": "Heart exposes these through heart.node.status changed snapshots, but not as distinct ordered peer lifecycle events.",
+        "passed": false,
+        "transition": "peer_discovered_connected_recovered"
+      },
+      {
+        "gap": "World coordination exposes final durable transport state but not ordered public retry scheduled/attempted events.",
+        "passed": false,
+        "transition": "transport_retry_scheduled_attempted"
+      },
+      {
+        "gap": "Durable delivery exposes health counters and received messages, but no public PubSub lifecycle topic for queued, retried, or acknowledged records.",
+        "passed": false,
+        "transition": "durable_queued_retry_replay_acknowledged"
+      },
+      {
+        "gap": "No public Heart or ManyFold event in this qualification trace currently reports watermark coalescing, drops, or expiry.",
+        "passed": false,
+        "transition": "watermark_coalesced_dropped_expired"
+      },
+      {
+        "gap": "Signer renewal and restart are visible through status and health calls, but not through a public lifecycle event topic.",
+        "passed": false,
+        "transition": "signer_renewal_restart"
+      },
+      {
+        "gap": "Raft leader changes are visible through coordinator or DevelopmentCluster status, but not through a public ordered leader-change topic.",
+        "passed": false,
+        "transition": "raft_leader_change"
+      },
+      {
+        "gap": "Heart publishes stopping but not a terminal stopped lifecycle event after resources close.",
+        "passed": false,
+        "transition": "clean_shutdown_stopped"
+      }
+    ],
+    "bounds": [
+      {
+        "expected_revision": 2,
+        "name": "raft_revision_convergence",
+        "observed_revisions": [2],
+        "passed": true
+      },
+      {
+        "duplicate_sequence": 2,
+        "name": "duplicate_command_coalescence",
+        "original_sequence": 2,
+        "passed": true
+      },
+      {
+        "acknowledgements": 1,
+        "name": "durable_ack_convergence",
+        "passed": true,
+        "sender_outbox_items": 0
+      }
+    ],
+    "event_timeline": [
+      {
+        "node_count": 3,
+        "passed": true,
+        "state": "started",
+        "step": 1,
+        "topic": "manyfold.lifecycle.raft",
+        "transition": "cluster_started"
+      },
+      {
+        "passed": true,
+        "state": "revision_1",
+        "step": 2,
+        "topic": "manyfold.raft.log",
+        "transition": "device_state_committed"
+      },
+      {
+        "passed": true,
+        "role": "failed_leader",
+        "state": "failed_leader_unavailable",
+        "step": 3,
+        "topic": "manyfold.lifecycle.raft",
+        "transition": "leader_process_failed"
+      },
+      {
+        "passed": true,
+        "state": "replacement_elected",
+        "step": 4,
+        "topic": "manyfold.lifecycle.raft",
+        "transition": "leader_changed"
+      },
+      {
+        "passed": true,
+        "state": "revision_2",
+        "step": 5,
+        "topic": "manyfold.raft.log",
+        "transition": "mode_state_committed_after_failure"
+      },
+      {
+        "passed": true,
+        "state": "committed_mode_command",
+        "step": 6,
+        "topic": "manyfold.durable_delivery",
+        "transition": "durable_item_queued"
+      },
+      {
+        "passed": true,
+        "state": "receiver_restarted",
+        "step": 7,
+        "topic": "manyfold.durable_delivery",
+        "transition": "receiver_restarted_before_ack"
+      },
+      {
+        "passed": true,
+        "state": "sender_outbox_drained",
+        "step": 8,
+        "topic": "manyfold.durable_delivery",
+        "transition": "replay_acknowledged"
+      }
+    ],
+    "negative_assertions": [
+      {
+        "name": "no_duplicate_mode_commit",
+        "passed": true
+      },
+      {
+        "name": "no_duplicate_after_ack",
+        "passed": true
+      },
+      {
+        "name": "no_hot_path_data_in_durable_contract",
+        "passed": true
+      }
+    ],
+    "role_by_failure_impact_matrix": [
+      {
+        "expected_state": "restarted_and_converged",
+        "failure": "process_killed",
+        "observable_transition": "leader_changed",
+        "passed": true,
+        "role": "failed_leader"
+      },
+      {
+        "expected_state": "world_rpc_reads_revision_2",
+        "failure": "leader_loss",
+        "observable_transition": "mode_commit_after_failure",
+        "passed": true,
+        "role": "replacement_leader"
+      },
+      {
+        "expected_state": "applied_once_outbox_empty",
+        "failure": "restart_before_ack",
+        "observable_transition": "replay_acknowledged",
+        "passed": true,
+        "role": "durable_receiver"
+      },
+      {
+        "expected_state": "single_mode_revision",
+        "failure": "duplicate_mode_command",
+        "observable_transition": "duplicate_command_coalesced",
+        "passed": true,
+        "role": "all_nodes"
+      }
+    ],
+    "scenario": {
+      "clock": {
+        "semantic_bounds_only": true,
+        "type": "real_runtime_bounded"
+      },
+      "id": "heart-world-coordination-node-failure-v1",
+      "node_ids": ["node-1", "node-2", "node-3"],
+      "seed": "heart-world-coordination-deterministic-v1",
+      "source_protocol": "heart.manyfold-world-coordination-proof"
+    },
+    "schema_version": 1
+  }
+}

--- a/tests/state_similarity/scenarios/controller_tixyland.json
+++ b/tests/state_similarity/scenarios/controller_tixyland.json
@@ -1,0 +1,87 @@
+{
+  "name": "tixyland combined controller inputs",
+  "kind": "scene_controller",
+  "initial": {
+    "config": {
+      "renderer": "tixyland",
+      "pattern": "sin_time_x_half_minus_y_quarter",
+      "device": {
+        "type": "local_screen",
+        "width": 3,
+        "height": 2,
+        "orientation": {
+          "type": "rectangle",
+          "columns": 1,
+          "rows": 1
+        }
+      },
+      "gamepad": {
+        "name": "Nintendo Switch Pro Controller"
+      }
+    }
+  },
+  "actions": [
+    {
+      "type": "gamepad",
+      "config": {
+        "axes": {
+          "trigger_right": 1.0
+        },
+        "buttons": {
+          "zr": true
+        }
+      }
+    },
+    {
+      "type": "tick",
+      "config": {
+        "delta_ms": 100.0,
+        "count": 1
+      }
+    },
+    {
+      "type": "gamepad",
+      "config": {
+        "axes": {
+          "trigger_left": 0.25,
+          "trigger_right": 0.5
+        },
+        "buttons": {
+          "zl": true
+        }
+      }
+    },
+    {
+      "type": "tick",
+      "config": {
+        "delta_ms": 200.0,
+        "count": 2
+      }
+    }
+  ],
+  "expected": {
+    "state": {
+      "hue_degrees": 182.0,
+      "seed": 0,
+      "speed_scale": 1.225,
+      "time_seconds": 0.5975
+    },
+    "screen": {
+      "shape": [2, 3, 3],
+      "pixels": [
+        [
+          [93, 141, 143],
+          [147, 224, 226],
+          [165, 251, 254]
+        ],
+        [
+          [56, 85, 86],
+          [124, 188, 191],
+          [161, 245, 248]
+        ]
+      ],
+      "channel_tolerance": 1,
+      "max_outlier_fraction": 0.0
+    }
+  }
+}

--- a/tests/state_similarity/scenarios/controller_water_cube.json
+++ b/tests/state_similarity/scenarios/controller_water_cube.json
@@ -1,0 +1,157 @@
+{
+  "name": "water cube sensor and controller inputs",
+  "kind": "scene_controller",
+  "initial": {
+    "config": {
+      "renderer": "water_cube",
+      "device": {
+        "type": "fixed",
+        "width": 2,
+        "height": 2,
+        "orientation": {
+          "type": "cube_sides"
+        }
+      },
+      "gamepad": {
+        "name": "Nintendo Switch Pro Controller"
+      }
+    }
+  },
+  "actions": [
+    {
+      "type": "sensor",
+      "config": {
+        "acceleration": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 1.0
+        }
+      }
+    },
+    {
+      "type": "gamepad",
+      "config": {
+        "axes": {},
+        "buttons": {}
+      }
+    },
+    {
+      "type": "tick",
+      "config": {
+        "delta_ms": 100.0,
+        "count": 1
+      }
+    },
+    {
+      "type": "sensor",
+      "config": {
+        "acceleration": {
+          "x": 0.5,
+          "y": -0.25,
+          "z": 1.0
+        }
+      }
+    },
+    {
+      "type": "gamepad",
+      "config": {
+        "axes": {
+          "trigger_right": 1.0
+        },
+        "buttons": {
+          "zr": true
+        }
+      }
+    },
+    {
+      "type": "tick",
+      "config": {
+        "delta_ms": 100.0,
+        "count": 1
+      }
+    },
+    {
+      "type": "sensor",
+      "config": {
+        "acceleration": {
+          "x": -0.5,
+          "y": 0.25,
+          "z": 1.0
+        }
+      }
+    },
+    {
+      "type": "gamepad",
+      "config": {
+        "axes": {
+          "trigger_left": 0.5
+        },
+        "buttons": {
+          "zl": true
+        }
+      }
+    },
+    {
+      "type": "tick",
+      "config": {
+        "delta_ms": 100.0,
+        "count": 1
+      }
+    }
+  ],
+  "expected": {
+    "state": {
+      "acceleration_average": 0.5750000000000001,
+      "face_px": 2,
+      "gvec": {
+        "x": -0.07500000000000007,
+        "y": 0.03750000000000003,
+        "z": 1.0
+      },
+      "heights": {
+        "dtype": "float64",
+        "shape": [2, 2],
+        "values": [
+          [1.0101985876623376, 1.0305957629870128],
+          [0.969404237012987, 0.9898014123376623]
+        ]
+      },
+      "velocities": {
+        "dtype": "float64",
+        "shape": [2, 2],
+        "values": [
+          [0.0028184677822178017, 0.008455403346653375],
+          [-0.008455403346653354, -0.002818467782217808]
+        ]
+      },
+      "water_hue_degrees": 218.0
+    },
+    "screen": {
+      "shape": [2, 8, 3],
+      "pixels": [
+        [
+          [0, 0, 0],
+          [0, 0, 0],
+          [0, 0, 0],
+          [0, 0, 0],
+          [0, 0, 0],
+          [0, 0, 0],
+          [0, 0, 0],
+          [0, 0, 0]
+        ],
+        [
+          [0, 0, 0],
+          [0, 0, 0],
+          [0, 0, 0],
+          [0, 93, 255],
+          [0, 93, 255],
+          [0, 93, 255],
+          [0, 93, 255],
+          [0, 0, 0]
+        ]
+      ],
+      "channel_tolerance": 1,
+      "max_outlier_fraction": 0.0
+    }
+  }
+}

--- a/tests/state_similarity/scenarios/navigation_gamepad_combo.json
+++ b/tests/state_similarity/scenarios/navigation_gamepad_combo.json
@@ -1,0 +1,126 @@
+{
+  "name": "gamepad right and south in one frame",
+  "kind": "game_modes",
+  "initial": {
+    "config": {
+      "device": {
+        "type": "fixed",
+        "width": 8,
+        "height": 4,
+        "orientation": {
+          "type": "rectangle",
+          "columns": 1,
+          "rows": 1
+        }
+      },
+      "modes": [
+        {
+          "name": "red",
+          "title_rgb": [0, 0, 0],
+          "renderers": [
+            {
+              "type": "color",
+              "rgb": [10, 20, 30]
+            },
+            {
+              "type": "border",
+              "rgb": [200, 30, 30],
+              "width": 1
+            }
+          ]
+        },
+        {
+          "name": "green",
+          "title_rgb": [0, 0, 0],
+          "renderers": [
+            {
+              "type": "color",
+              "rgb": [40, 50, 60]
+            },
+            {
+              "type": "border",
+              "rgb": [40, 200, 80],
+              "width": 1
+            }
+          ]
+        },
+        {
+          "name": "blue",
+          "title_rgb": [0, 0, 0],
+          "renderers": [
+            {
+              "type": "color",
+              "rgb": [70, 80, 90]
+            },
+            {
+              "type": "border",
+              "rgb": [30, 120, 220],
+              "width": 1
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "actions": [
+    {
+      "type": "gamepad",
+      "config": {
+        "joystick_id": 0,
+        "identifier": "golden-pad",
+        "dpad": [1, 0],
+        "held_buttons": ["south"]
+      }
+    }
+  ],
+  "expected": {
+    "state": {
+      "entries": [
+        {
+          "name": "red",
+          "title_renderer": "RenderColor",
+          "renderer": "ComposedRenderer:RenderColor+Border"
+        },
+        {
+          "name": "green",
+          "title_renderer": "RenderColor",
+          "renderer": "ComposedRenderer:RenderColor+Border"
+        },
+        {
+          "name": "blue",
+          "title_renderer": "RenderColor",
+          "renderer": "ComposedRenderer:RenderColor+Border"
+        }
+      ],
+      "post_processors": [
+        "SaturationPostProcessor",
+        "HueShiftPostProcessor",
+        "EdgePostProcessor"
+      ],
+      "in_select_mode": false,
+      "last_long_button_value": 0,
+      "committed_position": 1,
+      "committed_index": 1,
+      "preview_offset": 0,
+      "preview_index": 1,
+      "current_index": 1,
+      "current_entry": "green",
+      "previous_index": 1,
+      "transition_renderer": null,
+      "transition_mode": "slide",
+      "static_mask_steps": 20,
+      "gaussian_sigma": 1.5
+    },
+    "screen": {
+      "shape": [4, 8, 3],
+      "pixels": [
+        [[40, 200, 80], [40, 200, 80], [40, 200, 80], [40, 200, 80], [40, 200, 80], [40, 200, 80], [40, 200, 80], [40, 200, 80]],
+        [[40, 200, 80], [40, 50, 60], [40, 50, 60], [40, 50, 60], [40, 50, 60], [40, 50, 60], [40, 50, 60], [40, 200, 80]],
+        [[40, 200, 80], [40, 50, 60], [40, 50, 60], [40, 50, 60], [40, 50, 60], [40, 50, 60], [40, 50, 60], [40, 200, 80]],
+        [[40, 200, 80], [40, 200, 80], [40, 200, 80], [40, 200, 80], [40, 200, 80], [40, 200, 80], [40, 200, 80], [40, 200, 80]]
+      ],
+      "channel_tolerance": 0,
+      "max_outlier_fraction": 0.0
+    }
+  }
+}

--- a/tests/state_similarity/scenarios/navigation_keyboard_right_twice.json
+++ b/tests/state_similarity/scenarios/navigation_keyboard_right_twice.json
@@ -1,0 +1,152 @@
+{
+  "name": "keyboard right twice then activate",
+  "kind": "game_modes",
+  "initial": {
+    "config": {
+      "device": {
+        "type": "fixed",
+        "width": 8,
+        "height": 4,
+        "orientation": {
+          "type": "rectangle",
+          "columns": 1,
+          "rows": 1
+        }
+      },
+      "modes": [
+        {
+          "name": "red",
+          "title_rgb": [120, 20, 20],
+          "renderers": [
+            {
+              "type": "color",
+              "rgb": [10, 20, 30]
+            },
+            {
+              "type": "border",
+              "rgb": [200, 30, 30],
+              "width": 1
+            }
+          ]
+        },
+        {
+          "name": "green",
+          "title_rgb": [20, 120, 20],
+          "renderers": [
+            {
+              "type": "color",
+              "rgb": [40, 50, 60]
+            },
+            {
+              "type": "border",
+              "rgb": [40, 200, 80],
+              "width": 1
+            }
+          ]
+        },
+        {
+          "name": "blue",
+          "title_rgb": [20, 20, 120],
+          "renderers": [
+            {
+              "type": "color",
+              "rgb": [70, 80, 90]
+            },
+            {
+              "type": "border",
+              "rgb": [30, 120, 220],
+              "width": 1
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "actions": [
+    {
+      "type": "keyboard",
+      "config": {
+        "pressed": ["right"],
+        "timestamp_ms": 1.0
+      }
+    },
+    {
+      "type": "keyboard",
+      "config": {
+        "pressed": [],
+        "timestamp_ms": 2.0
+      }
+    },
+    {
+      "type": "keyboard",
+      "config": {
+        "pressed": ["right"],
+        "timestamp_ms": 3.0
+      }
+    },
+    {
+      "type": "keyboard",
+      "config": {
+        "pressed": [],
+        "timestamp_ms": 4.0
+      }
+    },
+    {
+      "type": "keyboard",
+      "config": {
+        "pressed": ["down"],
+        "timestamp_ms": 5.0
+      }
+    }
+  ],
+  "expected": {
+    "state": {
+      "entries": [
+        {
+          "name": "red",
+          "title_renderer": "RenderColor",
+          "renderer": "ComposedRenderer:RenderColor+Border"
+        },
+        {
+          "name": "green",
+          "title_renderer": "RenderColor",
+          "renderer": "ComposedRenderer:RenderColor+Border"
+        },
+        {
+          "name": "blue",
+          "title_renderer": "RenderColor",
+          "renderer": "ComposedRenderer:RenderColor+Border"
+        }
+      ],
+      "post_processors": [
+        "SaturationPostProcessor",
+        "HueShiftPostProcessor",
+        "EdgePostProcessor"
+      ],
+      "in_select_mode": false,
+      "last_long_button_value": 0,
+      "committed_position": 2,
+      "committed_index": 2,
+      "preview_offset": 0,
+      "preview_index": 2,
+      "current_index": 2,
+      "current_entry": "blue",
+      "previous_index": 2,
+      "transition_renderer": null,
+      "transition_mode": "slide",
+      "static_mask_steps": 20,
+      "gaussian_sigma": 1.5
+    },
+    "screen": {
+      "shape": [4, 8, 3],
+      "pixels": [
+        [[30, 120, 220], [30, 120, 220], [30, 120, 220], [30, 120, 220], [30, 120, 220], [30, 120, 220], [30, 120, 220], [30, 120, 220]],
+        [[30, 120, 220], [70, 80, 90], [70, 80, 90], [70, 80, 90], [70, 80, 90], [70, 80, 90], [70, 80, 90], [30, 120, 220]],
+        [[30, 120, 220], [70, 80, 90], [70, 80, 90], [70, 80, 90], [70, 80, 90], [70, 80, 90], [70, 80, 90], [30, 120, 220]],
+        [[30, 120, 220], [30, 120, 220], [30, 120, 220], [30, 120, 220], [30, 120, 220], [30, 120, 220], [30, 120, 220], [30, 120, 220]]
+      ],
+      "channel_tolerance": 0,
+      "max_outlier_fraction": 0.0
+    }
+  }
+}

--- a/tests/state_similarity/scenarios/navigation_multi_scene.json
+++ b/tests/state_similarity/scenarios/navigation_multi_scene.json
@@ -1,0 +1,97 @@
+{
+  "name": "multi scene activate advances one scene",
+  "kind": "multi_scene",
+  "initial": {
+    "config": {
+      "device": {
+        "type": "fixed",
+        "width": 8,
+        "height": 4,
+        "orientation": {
+          "type": "rectangle",
+          "columns": 1,
+          "rows": 1
+        }
+      },
+      "enable_dpad_scene_selection": true,
+      "scenes": [
+        {
+          "renderers": [
+            {
+              "type": "color",
+              "rgb": [10, 20, 30]
+            },
+            {
+              "type": "border",
+              "rgb": [200, 30, 30],
+              "width": 1
+            }
+          ]
+        },
+        {
+          "renderers": [
+            {
+              "type": "color",
+              "rgb": [40, 50, 60]
+            },
+            {
+              "type": "border",
+              "rgb": [40, 200, 80],
+              "width": 1
+            }
+          ]
+        },
+        {
+          "renderers": [
+            {
+              "type": "color",
+              "rgb": [70, 80, 90]
+            },
+            {
+              "type": "border",
+              "rgb": [30, 120, 220],
+              "width": 1
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "actions": [
+    {
+      "type": "keyboard",
+      "config": {
+        "pressed": ["down"],
+        "timestamp_ms": 1.0
+      }
+    }
+  ],
+  "expected": {
+    "state": {
+      "scene_names": [
+        "ComposedRenderer:RenderColor+Border",
+        "ComposedRenderer:RenderColor+Border",
+        "ComposedRenderer:RenderColor+Border"
+      ],
+      "current_button_value": 1,
+      "offset_of_button_value": null,
+      "active_scene_index": 1,
+      "active_scene_name": "ComposedRenderer:RenderColor+Border",
+      "previous_scene_index": 1,
+      "dpad_scene_selection_enabled": true,
+      "dpad_armed": true,
+      "dpad_center_frames": 2
+    },
+    "screen": {
+      "shape": [4, 8, 3],
+      "pixels": [
+        [[40, 200, 80], [40, 200, 80], [40, 200, 80], [40, 200, 80], [40, 200, 80], [40, 200, 80], [40, 200, 80], [40, 200, 80]],
+        [[40, 200, 80], [40, 50, 60], [40, 50, 60], [40, 50, 60], [40, 50, 60], [40, 50, 60], [40, 50, 60], [40, 200, 80]],
+        [[40, 200, 80], [40, 50, 60], [40, 50, 60], [40, 50, 60], [40, 50, 60], [40, 50, 60], [40, 50, 60], [40, 200, 80]],
+        [[40, 200, 80], [40, 200, 80], [40, 200, 80], [40, 200, 80], [40, 200, 80], [40, 200, 80], [40, 200, 80], [40, 200, 80]]
+      ],
+      "channel_tolerance": 0,
+      "max_outlier_fraction": 0.0
+    }
+  }
+}

--- a/tests/state_similarity/test_harness.py
+++ b/tests/state_similarity/test_harness.py
@@ -1,0 +1,426 @@
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+import numpy as np
+import pygame
+import pytest
+
+from heart.testing import (
+    StateSimilarityAction,
+    StateSimilarityInitial,
+    assert_rgb_similar,
+    canonicalize_state,
+    capture_surface_rgb,
+    load_state_similarity_scenario,
+    parse_state_similarity_scenario,
+    run_state_workflow,
+)
+
+
+class _Mode(Enum):
+    ACTIVE = "active"
+
+
+@dataclass(frozen=True)
+class _NestedState:
+    mode: _Mode
+    samples: np.ndarray
+    count: np.int64
+
+
+@dataclass(frozen=True)
+class _ProgramState:
+    nested: _NestedState
+    labels: tuple[str, ...]
+
+
+def _scenario_document() -> dict[str, object]:
+    return {
+        "name": "move right twice",
+        "kind": "navigation",
+        "initial": {"config": {"start": "home"}},
+        "actions": [
+            {"type": "navigate", "config": {"direction": "right"}},
+            {"type": "tick", "config": {"count": 2}},
+        ],
+        "expected": {
+            "state": {"screen": "settings"},
+            "screen": {
+                "fill": [10, 20, 30],
+                "shape": [1, 2, 3],
+                "channel_tolerance": 2,
+                "max_outlier_fraction": 0.01,
+            },
+        },
+    }
+
+
+def test_load_state_similarity_scenario_materializes_typed_contract(
+    tmp_path: Path,
+) -> None:
+    scenario_path = tmp_path / "navigation.json"
+    scenario_path.write_text(json.dumps(_scenario_document()), encoding="utf-8")
+
+    scenario = load_state_similarity_scenario(scenario_path)
+
+    assert scenario.name == "move right twice"
+    assert scenario.kind == "navigation"
+    assert scenario.initial == StateSimilarityInitial(config={"start": "home"})
+    assert scenario.actions == (
+        StateSimilarityAction(
+            type="navigate",
+            config={"direction": "right"},
+        ),
+        StateSimilarityAction(
+            type="tick",
+            config={"count": 2},
+        ),
+    )
+    assert scenario.expected_state == {"screen": "settings"}
+    np.testing.assert_array_equal(
+        scenario.expected_rgb,
+        np.array([[[10, 20, 30], [10, 20, 30]]], dtype=np.uint8),
+    )
+    assert scenario.channel_tolerance == 2
+    assert scenario.max_outlier_fraction == 0.01
+
+
+def test_parse_state_similarity_scenario_accepts_full_pixel_rgb() -> None:
+    document = _scenario_document()
+    expected = document["expected"]
+    assert isinstance(expected, dict)
+    expected["screen"] = {
+        "pixels": [[[1, 2, 3], [4, 5, 6]]],
+        "shape": [1, 2, 3],
+    }
+
+    scenario = parse_state_similarity_scenario(document)
+
+    np.testing.assert_array_equal(
+        scenario.expected_rgb,
+        np.array([[[1, 2, 3], [4, 5, 6]]], dtype=np.uint8),
+    )
+    assert scenario.channel_tolerance == 0
+    assert scenario.max_outlier_fraction == 0.0
+
+
+def test_parse_state_similarity_scenario_accepts_compact_rgb_rows() -> None:
+    document = _scenario_document()
+    expected = document["expected"]
+    assert isinstance(expected, dict)
+    expected["screen"] = {
+        "rows": [[1, 2, 3], [4, 5, 6]],
+        "shape": [2, 3, 3],
+    }
+
+    scenario = parse_state_similarity_scenario(document)
+
+    np.testing.assert_array_equal(
+        scenario.expected_rgb,
+        np.array(
+            [
+                [[1, 2, 3], [1, 2, 3], [1, 2, 3]],
+                [[4, 5, 6], [4, 5, 6], [4, 5, 6]],
+            ],
+            dtype=np.uint8,
+        ),
+    )
+
+
+def test_parse_state_similarity_scenario_rejects_missing_and_unknown_fields() -> None:
+    missing = _scenario_document()
+    missing.pop("expected")
+    with pytest.raises(
+        ValueError,
+        match=r"<scenario> \$: missing required fields: expected",
+    ):
+        parse_state_similarity_scenario(missing)
+
+    unknown = _scenario_document()
+    actions = unknown["actions"]
+    assert isinstance(actions, list)
+    actions[0]["repeat"] = 2
+    with pytest.raises(
+        ValueError,
+        match=r"<scenario> \$\.actions\[0\]: unknown fields: repeat",
+    ):
+        parse_state_similarity_scenario(unknown)
+
+
+def test_parse_state_similarity_scenario_requires_one_initial_source() -> None:
+    document = _scenario_document()
+    document["initial"] = {
+        "config": {"start": "home"},
+        "state": {"screen": "home"},
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"<scenario> \$\.initial: "
+            r"expected exactly one initial field: config or state"
+        ),
+    ):
+        parse_state_similarity_scenario(document)
+
+    document["initial"] = {"state": {"screen": "home"}}
+    scenario = parse_state_similarity_scenario(document)
+    assert scenario.initial == StateSimilarityInitial(state={"screen": "home"})
+
+
+def test_parse_state_similarity_scenario_validates_tick_count() -> None:
+    document = _scenario_document()
+    actions = document["actions"]
+    assert isinstance(actions, list)
+    actions[1]["config"] = {"count": 0}
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"<scenario> \$\.actions\[1\]\.config\.count: "
+            r"expected a positive integer"
+        ),
+    ):
+        parse_state_similarity_scenario(document)
+
+
+def test_parse_state_similarity_scenario_requires_strict_json_values() -> None:
+    document = _scenario_document()
+    initial = document["initial"]
+    assert isinstance(initial, dict)
+    config = initial["config"]
+    assert isinstance(config, dict)
+    config["sequence"] = ("left", "right")
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"<scenario> \$\.initial\.config\.sequence: "
+            r"expected a JSON value, got tuple"
+        ),
+    ):
+        parse_state_similarity_scenario(document)
+
+
+@pytest.mark.parametrize(
+    ("expected_rgb", "error_path", "message"),
+    [
+        (
+            {"fill": [0, 0, 256], "shape": [1, 1, 3]},
+            r"\$\.expected\.screen\.fill",
+            "RGB values must be between 0 and 255",
+        ),
+        (
+            {"pixels": [[[0, 0, 0]]], "shape": [1, 2, 3]},
+            r"\$\.expected\.screen\.shape",
+            r"declared \[1, 2, 3\] but pixels have shape \[1, 1, 3\]",
+        ),
+        (
+            {
+                "fill": [0, 0, 0],
+                "pixels": [[[0, 0, 0]]],
+                "shape": [1, 1, 3],
+            },
+            r"\$\.expected\.screen",
+            "expected exactly one RGB encoding field",
+        ),
+    ],
+)
+def test_parse_state_similarity_scenario_validates_rgb(
+    expected_rgb: object,
+    error_path: str,
+    message: str,
+) -> None:
+    document = _scenario_document()
+    expected = document["expected"]
+    assert isinstance(expected, dict)
+    expected["screen"] = expected_rgb
+
+    with pytest.raises(ValueError, match=rf"{error_path}: .*{message}"):
+        parse_state_similarity_scenario(document)
+
+
+def test_parse_state_similarity_scenario_validates_similarity_bounds() -> None:
+    document = _scenario_document()
+    expected = document["expected"]
+    assert isinstance(expected, dict)
+    screen = expected["screen"]
+    assert isinstance(screen, dict)
+    screen["channel_tolerance"] = True
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"<scenario> \$\.expected\.screen\.channel_tolerance: "
+            r"must be an integer from 0 through 255"
+        ),
+    ):
+        parse_state_similarity_scenario(document)
+
+
+def test_load_state_similarity_scenario_reports_invalid_json_location(
+    tmp_path: Path,
+) -> None:
+    scenario_path = tmp_path / "invalid.json"
+    scenario_path.write_text('{"name":\n}', encoding="utf-8")
+
+    with pytest.raises(
+        ValueError,
+        match=r"invalid\.json: invalid JSON at line 2, column 1",
+    ):
+        load_state_similarity_scenario(scenario_path)
+
+
+def test_canonicalize_state_preserves_supported_values_as_strict_json() -> None:
+    state = _ProgramState(
+        nested=_NestedState(
+            mode=_Mode.ACTIVE,
+            samples=np.array([[1, 2], [3, 4]], dtype=np.uint8),
+            count=np.int64(2),
+        ),
+        labels=("left", "right"),
+    )
+
+    canonical = canonicalize_state(state)
+
+    assert canonical == {
+        "labels": ["left", "right"],
+        "nested": {
+            "count": 2,
+            "mode": "active",
+            "samples": {
+                "dtype": "uint8",
+                "shape": [2, 2],
+                "values": [[1, 2], [3, 4]],
+            },
+        },
+    }
+    assert json.loads(json.dumps(canonical, allow_nan=False)) == canonical
+
+
+def test_canonicalize_state_preserves_empty_array_shape_and_dtype() -> None:
+    canonical = canonicalize_state(np.empty((0, 3), dtype=np.float32))
+
+    assert canonical == {
+        "dtype": "float32",
+        "shape": [0, 3],
+        "values": [],
+    }
+
+
+def test_canonicalize_state_sorts_mapping_keys() -> None:
+    canonical = canonicalize_state({"z": 1, "a": {"second": 2, "first": 1}})
+
+    assert list(canonical) == ["a", "z"]
+    assert list(canonical["a"]) == ["first", "second"]
+
+
+def test_canonicalize_state_reports_unsupported_value_path() -> None:
+    with pytest.raises(
+        TypeError,
+        match=r"unsupported state value at \$\.screens\[1\]\.controller: object",
+    ):
+        canonicalize_state(
+            {"screens": [{"controller": "supported"}, {"controller": object()}]}
+        )
+
+
+def test_canonicalize_state_rejects_non_string_keys_and_cycles() -> None:
+    with pytest.raises(TypeError, match=r"unsupported mapping key at \$\.inputs"):
+        canonicalize_state({"inputs": {1: "south"}})
+
+    cyclic: list[object] = []
+    cyclic.append(cyclic)
+    with pytest.raises(ValueError, match=r"cyclic state value at \$\[0\]"):
+        canonicalize_state(cyclic)
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), np.float32("-inf")])
+def test_canonicalize_state_rejects_non_finite_numbers(value: object) -> None:
+    with pytest.raises(ValueError, match=r"non-finite float at \$\.sensor"):
+        canonicalize_state({"sensor": value})
+
+
+def test_run_state_workflow_orders_commands_then_captures_state_and_rgb() -> None:
+    events: list[str] = []
+    position = {"x": 0}
+
+    def move_right() -> None:
+        events.append("right")
+        position["x"] += 1
+
+    def project_state() -> object:
+        events.append("project")
+        return {"position": position}
+
+    def render() -> pygame.Surface:
+        events.append("render")
+        surface = pygame.Surface((2, 1))
+        surface.set_at((0, 0), (10, 20, 30))
+        surface.set_at((1, 0), (40, 50, 60))
+        return surface
+
+    snapshot = run_state_workflow(
+        [move_right, move_right],
+        project_state=project_state,
+        render=render,
+    )
+
+    assert events == ["right", "right", "project", "render"]
+    assert snapshot.state == {"position": {"x": 2}}
+    np.testing.assert_array_equal(
+        snapshot.rgb,
+        np.array([[[10, 20, 30], [40, 50, 60]]], dtype=np.uint8),
+    )
+    assert snapshot.rgb.flags.c_contiguous
+
+
+def test_capture_surface_rgb_uses_height_width_channel_order() -> None:
+    surface = pygame.Surface((2, 3))
+    surface.set_at((1, 2), (7, 8, 9))
+
+    rgb = capture_surface_rgb(surface)
+
+    assert rgb.shape == (3, 2, 3)
+    assert tuple(rgb[2, 1]) == (7, 8, 9)
+
+
+def test_assert_rgb_similar_applies_channel_and_outlier_bounds() -> None:
+    expected = np.zeros((2, 2, 3), dtype=np.uint8)
+    actual = expected.copy()
+    actual[0, 0] = (2, 2, 2)
+    actual[1, 1] = (3, 0, 0)
+
+    assert_rgb_similar(
+        actual,
+        expected,
+        channel_tolerance=2,
+        max_outlier_fraction=0.25,
+    )
+
+
+def test_assert_rgb_similar_reports_actionable_pixel_diagnostics() -> None:
+    expected = np.zeros((1, 2, 3), dtype=np.uint8)
+    actual = expected.copy()
+    actual[0, 1] = (3, 5, 4)
+
+    with pytest.raises(AssertionError) as failure:
+        assert_rgb_similar(actual, expected, channel_tolerance=2)
+
+    message = str(failure.value)
+    assert "1/2 pixels (50.000000%)" in message
+    assert "Maximum channel delta 5 at (y=0, x=1)" in message
+    assert "actual=(3, 5, 4), expected=(0, 0, 0), delta=(3, 5, 4)" in message
+
+
+def test_assert_rgb_similar_reports_shape_mismatch() -> None:
+    with pytest.raises(
+        AssertionError,
+        match=r"RGB shape mismatch: actual \(1, 2, 3\), expected \(2, 1, 3\)",
+    ):
+        assert_rgb_similar(
+            np.zeros((1, 2, 3), dtype=np.uint8),
+            np.zeros((2, 1, 3), dtype=np.uint8),
+        )

--- a/tests/state_similarity/test_navigation_workflows.py
+++ b/tests/state_similarity/test_navigation_workflows.py
@@ -1,0 +1,92 @@
+from functools import partial
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from heart.testing.state_similarity import (
+    StateSimilarityScenario,
+    assert_rgb_similar,
+    load_state_similarity_scenario,
+    run_state_workflow,
+)
+from heart.testing.state_similarity_workflows import (
+    build_state_similarity_workflow,
+)
+
+SCENARIO_PATHS = tuple(
+    sorted(Path(__file__).with_name("scenarios").glob("navigation*.json"))
+)
+SCENARIOS = tuple(load_state_similarity_scenario(path) for path in SCENARIO_PATHS)
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    SCENARIOS,
+    ids=[scenario.name for scenario in SCENARIOS],
+)
+def test_navigation_workflow_matches_serialized_state_and_rgb(
+    scenario: StateSimilarityScenario,
+) -> None:
+    workflow = build_state_similarity_workflow(scenario)
+    try:
+        result = run_state_workflow(
+            (partial(workflow.execute_action, action) for action in scenario.actions),
+            project_state=workflow.project_state,
+            render=workflow.render,
+        )
+    finally:
+        workflow.cleanup()
+
+    assert result.state == scenario.expected_state
+    assert_rgb_similar(
+        result.rgb,
+        scenario.expected_rgb,
+        channel_tolerance=scenario.channel_tolerance,
+        max_outlier_fraction=scenario.max_outlier_fraction,
+    )
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    SCENARIOS,
+    ids=[scenario.name for scenario in SCENARIOS],
+)
+def test_navigation_rgb_goldens_are_visually_discriminating(
+    scenario: StateSimilarityScenario,
+) -> None:
+    unique_colors = np.unique(scenario.expected_rgb.reshape(-1, 3), axis=0)
+    assert unique_colors.shape[0] >= 2
+
+
+def test_game_modes_workflow_exposes_real_transition_progress() -> None:
+    scenario = next(
+        scenario
+        for scenario in SCENARIOS
+        if scenario.name == "keyboard right twice then activate"
+    )
+    workflow = build_state_similarity_workflow(scenario)
+    try:
+        workflow.execute_action(scenario.actions[0])
+        workflow.render()
+
+        initial_progress = workflow.transition_progress()
+        assert initial_progress is not None
+        assert initial_progress.fraction == 0.0
+        assert initial_progress.sliding is True
+
+        workflow.advance_frame(166.5)
+
+        midpoint_progress = workflow.transition_progress()
+        assert midpoint_progress is not None
+        assert midpoint_progress.fraction == pytest.approx(0.5)
+        assert midpoint_progress.sliding is True
+
+        workflow.advance_frame(166.5)
+
+        completed_progress = workflow.transition_progress()
+        assert completed_progress is not None
+        assert completed_progress.fraction == 1.0
+        assert completed_progress.sliding is False
+    finally:
+        workflow.cleanup()

--- a/tests/state_similarity/test_review.py
+++ b/tests/state_similarity/test_review.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pygame
+
+from heart.testing.state_similarity import (
+    StateSimilarityAction,
+    StateSimilarityScenario,
+)
+from heart.testing.state_similarity_review import (
+    discover_state_similarity_scenarios,
+    generate_state_similarity_review,
+)
+from heart.testing.state_similarity_review_cli import parse_args
+from heart.testing.state_similarity_workflows import StateSimilarityTransition
+
+
+class _WorkflowProbe:
+    def __init__(
+        self,
+        scenario: StateSimilarityScenario,
+        instances: list["_WorkflowProbe"],
+    ) -> None:
+        self.scenario = scenario
+        self.scene_index = 0
+        self.transition_fraction: float | None = None
+        self.executed_actions: list[StateSimilarityAction] = []
+        self.advance_deltas: list[float] = []
+        self.was_cleaned_up = False
+        instances.append(self)
+
+    def execute_action(self, action: StateSimilarityAction) -> None:
+        self.executed_actions.append(action)
+        if action.type in {"navigate", "navigate-static"}:
+            self.scene_index += 1
+            self.transition_fraction = (
+                0.0 if action.type == "navigate" else None
+            )
+
+    def project_state(self) -> object:
+        return {
+            "scene_index": self.scene_index,
+            "unsafe": "<state & value>",
+        }
+
+    def render(self) -> pygame.Surface:
+        surface = pygame.Surface((2, 1))
+        color = (10, 20, 30) if self.scene_index == 0 else (40, 50, 60)
+        surface.fill(color)
+        return surface
+
+    def advance_frame(self, delta_ms: float) -> None:
+        self.advance_deltas.append(delta_ms)
+        if self.transition_fraction is not None:
+            self.transition_fraction = min(
+                1.0,
+                self.transition_fraction + delta_ms / 333.0,
+            )
+
+    def transition_progress(self) -> StateSimilarityTransition | None:
+        if self.transition_fraction is None:
+            return None
+        return StateSimilarityTransition(
+            fraction=self.transition_fraction,
+            sliding=self.transition_fraction < 1.0,
+        )
+
+    def cleanup(self) -> None:
+        self.was_cleaned_up = True
+
+
+def test_review_embeds_escaped_checkpoints_and_isolates_transition_ticks(
+    tmp_path: Path,
+) -> None:
+    scenario_path = tmp_path / "unsafe-scenario.json"
+    scenario_path.write_text(
+        json.dumps(
+            {
+                "name": "<script>unsafe scenario</script>",
+                "kind": "review-probe",
+                "initial": {"config": {"scene_index": 0}},
+                "actions": [
+                    {
+                        "type": "navigate",
+                        "config": {"label": "<b>next & scene</b>"},
+                    }
+                ],
+                "expected": {
+                    "state": {
+                        "scene_index": 1,
+                        "unsafe": "<state & value>",
+                    },
+                    "screen": {
+                        "shape": [1, 2, 3],
+                        "fill": [40, 50, 60],
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    instances: list[_WorkflowProbe] = []
+
+    result = generate_state_similarity_review(
+        [scenario_path],
+        output_dir=tmp_path / "review",
+        transition_frames=2,
+        workflow_builder=lambda scenario: _WorkflowProbe(scenario, instances),
+    )
+
+    assert result.index_path == tmp_path / "review" / "index.html"
+    assert len(result.scenario_pages) == 1
+    assert len(instances) == 3
+    initial_replay, faithful, transition_replay = instances
+    assert initial_replay.advance_deltas == []
+    assert initial_replay.executed_actions == []
+    assert faithful.advance_deltas == []
+    assert len(faithful.executed_actions) == 1
+    assert len(transition_replay.executed_actions) == 1
+    assert len(transition_replay.advance_deltas) == 2
+    assert initial_replay.was_cleaned_up
+    assert faithful.was_cleaned_up
+    assert transition_replay.was_cleaned_up
+
+    page = result.scenario_pages[0].read_text(encoding="utf-8")
+    assert page.count("data:image/png;base64,") == 5
+    assert "image-rendering: pixelated" in page
+    assert "After action 1 · scene transition" in page
+    assert "Transition sample 2/2 after action 1" in page
+    assert "&lt;script&gt;unsafe scenario&lt;/script&gt;" in page
+    assert "&lt;b&gt;next &amp; scene&lt;/b&gt;" in page
+    assert "&lt;state &amp; value&gt;" in page
+    assert "<script>unsafe scenario</script>" not in page
+
+    index = result.index_path.read_text(encoding="utf-8")
+    assert result.scenario_pages[0].name in index
+    assert "matches expected" in index
+    assert "&lt;script&gt;unsafe scenario&lt;/script&gt;" in index
+
+
+def test_nonanimated_scene_change_is_still_labeled_as_transition(
+    tmp_path: Path,
+) -> None:
+    scenario_path = tmp_path / "static-scene-change.json"
+    scenario_path.write_text(
+        json.dumps(
+            {
+                "name": "static scene change",
+                "kind": "review-probe",
+                "initial": {"config": {"scene_index": 0}},
+                "actions": [{"type": "navigate-static", "config": {}}],
+                "expected": {
+                    "state": {
+                        "scene_index": 1,
+                        "unsafe": "<state & value>",
+                    },
+                    "screen": {
+                        "shape": [1, 2, 3],
+                        "fill": [40, 50, 60],
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    instances: list[_WorkflowProbe] = []
+
+    result = generate_state_similarity_review(
+        [scenario_path],
+        output_dir=tmp_path / "review",
+        transition_frames=3,
+        workflow_builder=lambda scenario: _WorkflowProbe(scenario, instances),
+    )
+
+    page = result.scenario_pages[0].read_text(encoding="utf-8")
+    assert "After action 1 · scene transition" in page
+    assert "Transition sample" not in page
+    assert len(instances) == 2
+    assert all(instance.advance_deltas == [] for instance in instances)
+
+
+def test_review_includes_scenario_user_story(tmp_path: Path) -> None:
+    scenario_path = tmp_path / "keyboard-navigation.json"
+    scenario_path.write_text(
+        json.dumps(
+            {
+                "name": "keyboard right twice then activate",
+                "kind": "review-probe",
+                "initial": {"config": {"scene_index": 0}},
+                "actions": [],
+                "expected": {
+                    "state": {
+                        "scene_index": 0,
+                        "unsafe": "<state & value>",
+                    },
+                    "screen": {
+                        "shape": [1, 2, 3],
+                        "fill": [10, 20, 30],
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    instances: list[_WorkflowProbe] = []
+
+    result = generate_state_similarity_review(
+        [scenario_path],
+        output_dir=tmp_path / "review",
+        transition_frames=0,
+        workflow_builder=lambda scenario: _WorkflowProbe(scenario, instances),
+    )
+
+    page = result.scenario_pages[0].read_text(encoding="utf-8")
+    assert (
+        "A person uses keyboard navigation to move two modes to the right"
+        in page
+    )
+    assert "committed state renders the expected nonuniform screen" in page
+
+
+def test_scenario_discovery_accepts_files_and_directories_without_duplicates(
+    tmp_path: Path,
+) -> None:
+    scenario_path = tmp_path / "scenario.json"
+    scenario_path.write_text("{}", encoding="utf-8")
+    (tmp_path / "notes.txt").write_text("not a scenario", encoding="utf-8")
+
+    discovered = discover_state_similarity_scenarios([scenario_path, tmp_path])
+
+    assert discovered == (scenario_path,)
+
+
+def test_review_cli_parses_output_scenario_directories_and_transition_bound(
+    tmp_path: Path,
+) -> None:
+    scenario_path = tmp_path / "one.json"
+    scenario_directory = tmp_path / "scenarios"
+    artifact_path = tmp_path / "qualification.json"
+    output = tmp_path / "html"
+
+    arguments = parse_args(
+        [
+            str(scenario_path),
+            "--scenario-dir",
+            str(scenario_directory),
+            "--contract-artifact",
+            str(artifact_path),
+            "--output",
+            str(output),
+            "--transition-frames",
+            "3",
+        ]
+    )
+
+    assert arguments.paths == (scenario_path, scenario_directory)
+    assert arguments.output == output
+    assert arguments.transition_frames == 3
+    assert arguments.contract_artifacts == (artifact_path,)

--- a/tests/state_similarity/test_scene_controller_workflows.py
+++ b/tests/state_similarity/test_scene_controller_workflows.py
@@ -1,0 +1,43 @@
+from functools import partial
+from pathlib import Path
+
+import pytest
+
+from heart.testing.state_similarity import (
+    assert_rgb_similar,
+    load_state_similarity_scenario,
+    run_state_workflow,
+)
+from heart.testing.state_similarity_workflows import (
+    build_state_similarity_workflow,
+)
+
+SCENARIO_PATHS = tuple(
+    sorted(Path(__file__).with_name("scenarios").glob("controller*.json"))
+)
+
+
+@pytest.mark.parametrize(
+    "scenario_path",
+    SCENARIO_PATHS,
+    ids=lambda path: path.stem,
+)
+def test_scene_controller_workflow(scenario_path: Path) -> None:
+    scenario = load_state_similarity_scenario(scenario_path)
+    workflow = build_state_similarity_workflow(scenario)
+    try:
+        snapshot = run_state_workflow(
+            (partial(workflow.execute_action, action) for action in scenario.actions),
+            project_state=workflow.project_state,
+            render=workflow.render,
+        )
+    finally:
+        workflow.cleanup()
+
+    assert snapshot.state == scenario.expected_state
+    assert_rgb_similar(
+        snapshot.rgb,
+        scenario.expected_rgb,
+        channel_tolerance=scenario.channel_tolerance,
+        max_outlier_fraction=scenario.max_outlier_fraction,
+    )

--- a/tests/state_similarity/test_system_contract.py
+++ b/tests/state_similarity/test_system_contract.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from heart.testing.system_contract import write_system_contract_review
+
+
+def test_world_coordination_contract_html_renders_timeline_and_matrix(
+    tmp_path: Path,
+) -> None:
+    path = write_system_contract_review(
+        _world_artifact(),
+        tmp_path / "world-contract.html",
+    )
+
+    html = path.read_text(encoding="utf-8")
+    assert "heart-world-coordination-node-failure-v1" in html
+    assert "leader_process_failed" in html
+    assert "Role By Failure Impact Matrix" in html
+    assert "transport_retry_scheduled_attempted" in html
+    assert "data:image/png;base64," in html
+
+
+def _world_artifact() -> dict[str, object]:
+    return {
+        "protocol": "heart.manyfold-world-coordination-proof",
+        "schema_version": 1,
+        "manyfold_installation": {
+            "distribution_version": "1.0",
+            "install_kind": "wheel",
+            "installation_root": "/tmp/random-installation",
+        },
+        "raft": {
+            "node_count": 3,
+            "initial_process_ids": {
+                "node-1": "process-random-a",
+                "node-2": "process-random-b",
+                "node-3": "process-random-c",
+            },
+            "initial_leader": "node-1",
+            "failed_process_id": "process-random-a",
+            "recovered_leader": "node-2",
+            "restarted_process_id": "process-random-d",
+            "leader_changed": True,
+            "restarted_process_changed": True,
+            "device_sequence": 1,
+            "mode_sequence": 2,
+            "duplicate_mode_sequence": 2,
+            "node_command_ids": {
+                "node-1": ["random-command-id-1", "random-command-id-2"],
+                "node-2": ["random-command-id-1", "random-command-id-2"],
+                "node-3": ["random-command-id-1", "random-command-id-2"],
+            },
+            "node_revisions": {
+                "node-1": 2,
+                "node-2": 2,
+                "node-3": 2,
+            },
+        },
+        "world_rpc": {
+            "revision": 2,
+            "device_id": "totem3",
+            "capabilities": ["hub75", "gamepad"],
+        },
+        "durable_delivery": {
+            "message_id": "random-command-id-2",
+            "received_before_restart": "random-command-id-2",
+            "receiver_restarted": True,
+            "applied_count": 1,
+            "duplicate_exposed_after_ack": False,
+            "sender_outbox_items": 0,
+            "receiver_acknowledgements": 1,
+            "revision": 2,
+        },
+        "boundary": {
+            "raft_command_kinds": [
+                "heart.world.device.put",
+                "heart.world.mode.select",
+            ],
+            "durable_channel": "heart.world.mode.delivery",
+            "excluded_hot_path_data": [
+                "debug",
+                "frame_tick",
+                "microphone_sample",
+                "navigation_event",
+                "rendered_frame",
+                "sensor_sample",
+            ],
+        },
+    }

--- a/tests/test_world_coordination.py
+++ b/tests/test_world_coordination.py
@@ -5,6 +5,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+import numpy as np
+
+from heart.testing import assert_rgb_similar
+from heart.testing.system_contract import project_world_coordination_contract
+
+CONTRACT_GOLDEN_PATH = (
+    Path(__file__).parent
+    / "state_similarity"
+    / "contracts"
+    / "world_coordination_node_failure_expected.json"
+)
+
 
 def test_three_process_world_coordination_proof(tmp_path: Path) -> None:
     artifact_path = tmp_path / "coordination.json"
@@ -49,3 +61,19 @@ def test_three_process_world_coordination_proof(tmp_path: Path) -> None:
         "rendered_frame",
         "sensor_sample",
     ]
+    contract = project_world_coordination_contract(artifact)
+    golden = json.loads(CONTRACT_GOLDEN_PATH.read_text(encoding="utf-8"))
+    assert contract.state == golden["state"]
+    assert_rgb_similar(contract.rgb, _rgb_from_rows(golden["screen"]))
+    serialized_contract = json.dumps(contract.state, sort_keys=True)
+    assert "initial_process_ids" not in serialized_contract
+    assert "node_command_ids" not in serialized_contract
+    assert "installation_root" not in serialized_contract
+
+
+def _rgb_from_rows(screen: dict[str, object]) -> np.ndarray:
+    rows = np.asarray(screen["rows"], dtype=np.uint8)
+    shape = screen["shape"]
+    assert isinstance(shape, list)
+    assert shape == [len(rows), 8, 3]
+    return np.repeat(rows[:, np.newaxis, :], 8, axis=1)


### PR DESCRIPTION
## Summary

Adds a machine-readable state-similarity and golden-render test suite for Heart user workflows. The suite exercises real navigation/runtime/controller paths, compares canonical state projections, and verifies representative RGB output against JSON goldens so regressions are reviewable without inspecting private runtime flags.

## How it works

The new `heart.testing` helpers load strict JSON scenarios, replay ordered actions through real Heart workflows, canonicalize state into deterministic JSON, and compare rendered RGB output with exact or bounded similarity checks. Navigation and scene-controller scenarios cover keyboard/gamepad navigation, multi-scene activation, Tixyland controller IO, and Water Cube sensor/controller/tick input. The review CLI renders static HTML pages with action-by-action checkpoints, transition samples, expected final state/screen, and concise user stories for each scenario.

The system contract projection now anchors the world-coordination proof to stable semantic fields from the real qualification artifact, including lifecycle timelines, role-by-failure impact, convergence bounds, negative assertions, and explicit upstream API gaps for transitions that are not observable through public Heart/ManyFold events.

## How you can try this right now

Run the focused validation:

```bash
uv run ruff check tests/state_similarity tests/test_world_coordination.py src/heart/testing
uv run pytest tests/test_world_coordination.py tests/state_similarity -q
```

Generate the review site locally:

```bash
uv run heart-state-review
open tmp/state-similarity-review/index.html
```

Expected result: all focused tests pass, and the review index links to each scenario page with initial/action/transition/final checkpoints and RGB previews.

## Appendix

### Performance

Not applicable. This adds deterministic contract and review tests; it does not change production runtime hot paths beyond exposing focused snapshot state needed for assertions.

### Testing

Validated on the rebased `main` branch with:

```bash
uv run ruff check tests/state_similarity tests/test_world_coordination.py src/heart/testing
uv run pytest tests/test_world_coordination.py tests/state_similarity -q
```

Result: 41 passed.

`git diff --cached --check` also passed before commit. Local git hooks could not run because the installed hooks point at a removed uv archive interpreter and no `pre-commit` binary is installed in this environment; the equivalent focused checks above were run directly.