### PR TITLE
Record Manyfold ownership boundaries

### DIFF
--- a/docs/adr/0001-manyfold-ownership-boundaries.md
+++ b/docs/adr/0001-manyfold-ownership-boundaries.md
@@ -1,0 +1,75 @@
+# ADR 0001: Manyfold ownership boundaries
+
+- Status: Accepted
+- Date: 2026-07-26
+- Owners: Heart and Manyfold maintainers
+
+## Context
+
+Heart uses Manyfold at three distinct levels: application streams, a
+process-local graph, and a distributed node runtime. Similar vocabulary at
+these levels made it easy to imply duplicate owners or to treat migration
+adapters as new framework code.
+
+The supported package contract is Manyfold 0.1.42. The dependency declaration
+in [`pyproject.toml`](../../pyproject.toml) and its exact resolution in
+[`uv.lock`](../../uv.lock) are authoritative:
+
+| Checkpoint | Revision | Meaning |
+| --- | --- | --- |
+| Canonical A2 checkout | `726f64d72b36d8bd134bda63e29ebd80472736b6` | The clean local canonical worktree is pin-identical. The resolved A1 feature branch is `630c575`, whose parent is this revision and whose five-file commit preserves the recovered interface work. Neither ref is the current Heart pin. |
+| Current Heart dependency | `89c1c8b01cfee1785cbdc7c72cc3876b61b7b8a7` | The supported 0.1.42 revision recorded by the dependency declaration and lockfile. |
+
+## Decision
+
+Ownership follows construction and policy:
+
+| Boundary | Heart owns | Manyfold owns |
+| --- | --- | --- |
+| Streams | Domain route/topic schemas, semantic keys, retention and delivery policy, concrete bounds, and thin application adapters such as `GraphRouteStream`. | Subscription/value contracts, operators, publication, observation, and retention/delivery enforcement and diagnostics. |
+| Graph | The application composition root. `PeripheralManager` constructs the production peripheral graph, installs Heart nodes, retains their handles, and disposes them in reverse order. | Graph topology, routing, storage, backpressure, observation, and managed execution primitives. |
+| Managed graph node | Node bodies, hardware resources, routes, configuration, and concrete retry/backoff policy. The Heart installer retains the returned handle. | `ManagedGraphNode` policy enforcement, stop token, worker loop, control subscription, and handle disposal mechanics. |
+| Process node runtime | One `ManyfoldNodeRuntime` per Heart process, runtime configuration, topic policy, `TransportMesh` composition, startup before peripheral detection, bounded foreground polling, and process shutdown. | Canonical `NodeRuntime` signer acquisition, authenticated bootstrap, discovery, membership, SWIM, reconnect, snapshots, and internal resource shutdown; `TransportMesh` owns mesh transport mechanics. |
+
+A component that constructs a graph, subscription, managed-node handle, or
+runtime resource must dispose it. Borrowing adapters must not close resources
+owned by their caller. The current `PeripheralManager.stop()` disposes input
+subscriptions and managed-node handles but does not call `Graph.dispose()`.
+That is an explicit lifecycle gap; this ADR does not treat manager shutdown as
+complete graph cleanup until focused code and tests close it.
+
+Isolated tests and tools may construct and own a whole graph. Production
+adapters must receive the application graph. The fallback graph constructors in
+`AccelerometerInput` and `ExternalSensorInput` are migration debt, not supported
+precedent; they may not proliferate and should disappear in the planned graph
+consolidation.
+
+The method assignments to `RoutePipeline` in
+[`streams.py`](../../src/heart/peripheral/core/streams.py) are migration shims:
+they translate existing Heart calls to Manyfold observables and retain no
+runtime state. They do not transfer generic operator ownership to Heart. New
+operators and reusable execution behavior belong in Manyfold, followed by an
+intentional Heart pin update.
+
+`ManyfoldNodeRuntime` does not own the peripheral graph, and
+`PeripheralManager` does not own discovery, membership, SWIM, or mesh worker
+lifecycle. High-rate frame, microphone, and debug paths remain outside durable
+delivery and Raft as documented in
+[`manyfold_node_runtime.md`](../manyfold_node_runtime.md) and
+[`world_coordination.md`](../world_coordination.md).
+
+## Consequences
+
+- Heart policy remains visible at its composition roots; Manyfold machinery has
+  one reusable implementation.
+- Tests that change a boundary must exercise the real pinned Manyfold
+  implementation and the owning Heart lifecycle.
+- A Manyfold pin change requires reviewing this ADR, the node-runtime
+  qualification, and the stream/graph integration slice.
+- Compatibility aliases, runtime version probes, and duplicate Heart
+  transports are unsupported.
+
+This decision describes the current Heart baseline at Manyfold revision
+`89c1c8b01cfee1785cbdc7c72cc3876b61b7b8a7`. Later graph-consolidation or
+durable-ownership decisions must supersede this ADR rather than silently
+changing its ownership claims.

--- a/docs/manyfold_node_runtime.md
+++ b/docs/manyfold_node_runtime.md
@@ -4,8 +4,12 @@ Heart owns one `ManyfoldNodeRuntime` per process. The runtime container starts i
 before peripheral detection, the game loop calls its bounded `poll()`, and
 shutdown closes it before the process exits.
 
-The integration uses only public APIs from ManyFold main commit
-`726f64d72b36d8bd134bda63e29ebd80472736b6`. Canonical
+The integration targets public APIs from ManyFold 0.1.42. The exact supported
+revision is the Git dependency in `pyproject.toml`, resolved again in `uv.lock`;
+those files are authoritative. The node-runtime integration originally landed
+against
+`726f64d72b36d8bd134bda63e29ebd80472736b6`, which remains provenance rather
+than the current Heart dependency pin. Canonical
 `manyfold.cluster.NodeRuntime` owns signer acquisition, discovery,
 mutually-authenticated bootstrap links, membership, SWIM, reconnect, and
 shutdown. Heart composes the public `TransportMesh` beside it because PubSub


### PR DESCRIPTION
## Summary

Make Heart's Manyfold baseline truthful and explicit. The node-runtime documentation now names Manyfold 0.1.42 and treats `pyproject.toml` plus `uv.lock` as authoritative, while a new ADR assigns stream, graph, and node-runtime policy and mechanism ownership between Heart and Manyfold.

The documentation-only change was authored from clean baseline `a2f60dd1bc54cf95f99685000260e774f1000810`; that commit records its original authoring provenance, not the current `origin/main`. It does not publish or absorb the stale 0.1.40 worktree or its untracked files.

## How it works

The ADR records four boundaries:

- Heart chooses domain schemas, semantic keys, retention/delivery policy and concrete bounds; Manyfold owns the contracts, operators, enforcement, and diagnostics.
- Heart owns the production graph composition root; Manyfold owns graph topology, routing, storage, backpressure, observation, and managed execution primitives.
- Heart chooses managed-node bodies, resources, routes, configuration, and concrete retry/backoff; Manyfold owns worker, control, stop, enforcement, and disposal mechanics.
- Heart composes one process runtime and its topic policy; Manyfold owns authenticated node-runtime and mesh mechanics.

It also records current truth rather than idealized intent: adapter fallback graphs are migration debt, `RoutePipeline` assignments are temporary shims, and `PeripheralManager.stop()` does not yet call `Graph.dispose()`.

The provenance table distinguishes the clean local A2 checkpoint at exact `726f64d`, recovered A1 interface commit `630c575` one commit above it, and Heart's current supported 0.1.42 dependency at exact `89c1c8b01cfee1785cbdc7c72cc3876b61b7b8a7`.

## How you can try this right now

```bash
git diff --check origin/main...HEAD
rg -n 'manyfold\.git@|name = "manyfold"|source = .*manyfold' pyproject.toml uv.lock
rg -n '0\.1\.40|integrate-manyfold-0\.1\.40' docs pyproject.toml uv.lock .github
```

Expected result: the diff check passes, the declaration and lock resolve to `89c1c8b`, and the stale-reference search prints no matches.

## Appendix

### Performance

Not applicable. This PR changes documentation only.

### Testing

Validated the exact dependency/lock pin match, all ADR relative-link targets, absence of stale 0.1.40 branch/documentation language, and `git diff --check`.

Historical hosted CI exposed a pre-existing `controller_water_cube` state-similarity order dependency. Both [the initial PR run](https://github.com/Organization5762/heart/actions/runs/30233964864/attempts/1) and [its rerun](https://github.com/Organization5762/heart/actions/runs/30233964864/attempts/2) failed only that assertion with identical observed and expected values; formatting passed and 640 tests passed. The [exact original base commit's push CI](https://github.com/Organization5762/heart/actions/runs/30233154407) failed the same assertion with the same values. A focused local run of `tests/state_similarity/test_scene_controller_workflows.py::test_scene_controller_workflow` passed both scenarios.

Baseline-fix PR #957 merged as `fc0c991f953560d9dcb3f21939499867ae2ed22a`. Run `30236494332` is explicitly excluded because it checked a stale pre-#957 PR merge ref. Run `30236705836` checked intermediate merge `16795725` (`fc0c991f + 35880424`) and was cancelled while its test step was still running; it is neither failure nor green evidence.

Heart #954 subsequently merged exactly once as `92b010dedb0e46c1f1efe51896f722f839db31bc` from accepted head `d86556c6`. Run `30237037298` finished green, but its checkout log proves it fetched and tested stale merge `2363463b` (`fc0c991f + 35880424`), so it is not current-base evidence. [Run 30237133742](https://github.com/Organization5762/heart/actions/runs/30237133742) is valid green evidence for merge `2b70a1d9c042c87b30d6afc9369d9bd4a176c1b1`, whose exact ordered parents are `92b010dedb0e46c1f1efe51896f722f839db31bc` and `35880424f5f160b31a3603c171c3cd8bac884d5a`; formatting passed and 645 tests passed with 5 skips. It was superseded as final current-main evidence when #958 merged as `c8ef69b6d742b23cc43fa5ab4a7f592da2ea7ede` during that run.

Current `main` at `c8ef69b6d742b23cc43fa5ab4a7f592da2ea7ede` is independently green in [push run 30237177832](https://github.com/Organization5762/heart/actions/runs/30237177832). Run `30237537773` also finished green, but its archived checkout log proves it tested stale merge `48eba488` (`92b010de + 35880424`), so it is explicitly excluded as final current-main evidence.

[Final run 30237610341, job 89888280773](https://github.com/Organization5762/heart/actions/runs/30237610341/job/89888280773) is terminal green. Its archived checkout log proves `HEAD` was `ed4db66e1707c19092d787babf3a982dfef4ad59`, whose exact ordered parents are current `main` `c8ef69b6d742b23cc43fa5ab4a7f592da2ea7ede` and unchanged PR head `35880424f5f160b31a3603c171c3cd8bac884d5a`. Formatting passed; the suite finished with 707 passing tests and 5 skips. This satisfies the final current-main CI and checkout-provenance gate. No unrelated golden or runtime change is included in this docs-only PR.

The repository's sole pre-commit hook runs `make format` over the whole tree and rewrote ten unrelated clean-upstream Python files. Those outputs were not discarded or committed: the exact staged/unstaged snapshot is preserved remotely on `agent/preserve-heart-hook-spillover-20260726` at `db64cd9e1712ee35d2ace51db6722ef37ef59da7`. This docs-only commit was rebuilt in a fresh clean worktree from exact `a2f60dd1`, and only the broken whole-tree `make-format` hook was skipped for commit/push.

### Scope

Commit `35880424f5f160b31a3603c171c3cd8bac884d5a` changes exactly two documentation files: 81 additions, 2 deletions, net +79 non-test lines.